### PR TITLE
Add an idempotency key for each chain in each step

### DIFF
--- a/permchain/pregel/__init__.py
+++ b/permchain/pregel/__init__.py
@@ -552,4 +552,4 @@ def _apply_writes_and_prepare_next_tasks(
 
                 tasks.append((proc, val, name))
 
-    return add_idempotency_keys(tasks, channels)
+    return add_idempotency_keys(tasks, channels, config)

--- a/permchain/pregel/debug.py
+++ b/permchain/pregel/debug.py
@@ -7,14 +7,16 @@ from langchain.utils.input import get_bolded_text, get_colored_text
 from permchain.channels.base import BaseChannel, EmptyChannelError
 
 
-def print_step_start(step: int, next_tasks: list[tuple[Runnable, Any, str]]) -> None:
+def print_step_start(
+    step: int, next_tasks: list[tuple[Runnable, Any, str, str]]
+) -> None:
     n_tasks = len(next_tasks)
     print(
         f"{get_colored_text('[pregel/step]', color='blue')} "
         + get_bolded_text(
             f"Starting step {step} with {n_tasks} task{'s' if n_tasks > 1 else ''}. Next tasks:\n"
         )
-        + "\n".join(f"- {name}({pformat(val)})" for _, val, name in next_tasks)
+        + "\n".join(f"- {name}({pformat(val)})" for _, val, name, _ in next_tasks)
     )
 
 

--- a/permchain/pregel/idempotency.py
+++ b/permchain/pregel/idempotency.py
@@ -1,0 +1,32 @@
+import hashlib
+import pickle
+from typing import Any, Mapping
+
+from langchain.schema.runnable import Runnable
+
+from permchain.channels.base import BaseChannel, EmptyChannelError
+
+
+def get_channel_values(channels: Mapping[str, BaseChannel]) -> Mapping[str, Any]:
+    """Create a checkpoint for the given channels."""
+    values = {}
+    for k, v in channels.items():
+        try:
+            values[k] = v.get()
+        except EmptyChannelError:
+            pass
+    return values
+
+
+def add_idempotency_keys(
+    tasks: list[tuple[Runnable, Any, str]], channels: Mapping[str, BaseChannel]
+) -> list[tuple[Runnable, Any, str, str]]:
+    base = hashlib.sha256(
+        pickle.dumps(get_channel_values(channels), protocol=pickle.HIGHEST_PROTOCOL)
+    )
+    tasks_w_keys: list[tuple[Runnable, Any, str, str]] = []
+    for task in tasks:
+        h = base.copy()
+        h.update(pickle.dumps(task[1:], protocol=pickle.HIGHEST_PROTOCOL))
+        tasks_w_keys.append((*task, h.hexdigest()))
+    return tasks_w_keys

--- a/permchain/pregel/reserved.py
+++ b/permchain/pregel/reserved.py
@@ -6,3 +6,7 @@ class ReservedChannels(StrEnum):
 
     is_last_step = "is_last_step"
     """A channel that is True if the current step is the last step, False otherwise."""
+
+    idempotency_key = "idempotency_key"
+    """A channel that contains a stable string id for the current step.
+    Can be used for caching or ensuring idempotency of side effects."""

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -101,15 +101,15 @@ def test_invoke_single_process_in_out_reserved_id_key() -> None:
     assert app.output_schema.schema() == {"title": "PregelOutput"}
     assert app.invoke(2) == {
         "input": 2,
-        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+        "idempotency_key": "b85046bb798101e60bbe82d15e18fd530eadb2c0064114ec4fae1de68d57174b",
     }
     assert app.invoke(2) == {
         "input": 2,
-        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+        "idempotency_key": "b85046bb798101e60bbe82d15e18fd530eadb2c0064114ec4fae1de68d57174b",
     }
     assert app.invoke(3) == {
         "input": 3,
-        "idempotency_key": "4d254a25824a081472e5eb3a8688f6b843bd8d04a9bcc5bf2525b227122dc8b4",
+        "idempotency_key": "5d45520557a38c1bb2e12b4e09161d5c095c38e92df5ea914e076177f117863c",
     }
 
 

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -107,15 +107,15 @@ async def test_invoke_single_process_in_out_reserved_id_key() -> None:
     assert app.output_schema.schema() == {"title": "PregelOutput"}
     assert await app.ainvoke(2) == {
         "input": 2,
-        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+        "idempotency_key": "b85046bb798101e60bbe82d15e18fd530eadb2c0064114ec4fae1de68d57174b",
     }
     assert await app.ainvoke(2) == {
         "input": 2,
-        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+        "idempotency_key": "b85046bb798101e60bbe82d15e18fd530eadb2c0064114ec4fae1de68d57174b",
     }
     assert await app.ainvoke(3) == {
         "input": 3,
-        "idempotency_key": "4d254a25824a081472e5eb3a8688f6b843bd8d04a9bcc5bf2525b227122dc8b4",
+        "idempotency_key": "5d45520557a38c1bb2e12b4e09161d5c095c38e92df5ea914e076177f117863c",
     }
 
 

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -96,6 +96,29 @@ async def test_invoke_single_process_in_out_reserved_is_last(
     }
 
 
+async def test_invoke_single_process_in_out_reserved_id_key() -> None:
+    chain = Channel.subscribe_to(["input"]).join(
+        [ReservedChannels.idempotency_key]
+    ) | Channel.write_to("output")
+
+    app = Pregel(chains={"one": chain})
+
+    assert app.input_schema.schema() == {"title": "PregelInput"}
+    assert app.output_schema.schema() == {"title": "PregelOutput"}
+    assert await app.ainvoke(2) == {
+        "input": 2,
+        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+    }
+    assert await app.ainvoke(2) == {
+        "input": 2,
+        "idempotency_key": "6e6ec8f84f6c02e24a58440f77e9de1ba4413287f1f0d7057cb86fc5756ced88",
+    }
+    assert await app.ainvoke(3) == {
+        "input": 3,
+        "idempotency_key": "4d254a25824a081472e5eb3a8688f6b843bd8d04a9bcc5bf2525b227122dc8b4",
+    }
+
+
 async def test_invoke_single_process_in_out_dict(mocker: MockerFixture) -> None:
     add_one = mocker.Mock(side_effect=lambda x: x + 1)
     chain = Channel.subscribe_to("input") | add_one | Channel.write_to("output")


### PR DESCRIPTION
The idea is this should be a stable, unique id for the execution, so it can be used eg. for caching or making side effects idempotent. It should change if the channel values have changed, and remain same otherwise, even across separate invocations.

If we don't like pickle for this alternatively we can use eg. https://zepworks.com/deepdiff/5.6.0/deephash.html