### PR TITLE
Remove double channelwrite

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -149,8 +149,8 @@ class Channel:
         """Writes to channels the result of the lambda, or None to skip writing."""
         return ChannelWrite(
             channels=(
-                [(c, None) for c in channels]
-                + [(k, _coerce_write_value(v)) for k, v in kwargs.items()]
+                [(c, None, False) for c in channels]
+                + [(k, _coerce_write_value(v), True) for k, v in kwargs.items()]
             )
         )
 

--- a/langgraph/pregel/write.py
+++ b/langgraph/pregel/write.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Callable, Optional, Sequence
 
 from langchain_core.runnables import (
@@ -14,8 +15,11 @@ from langgraph.constants import CONFIG_KEY_SEND
 TYPE_SEND = Callable[[Sequence[tuple[str, Any]]], None]
 
 
+SKIP_WRITE = object()
+
+
 class ChannelWrite(RunnablePassthrough):
-    channels: Sequence[tuple[str, Optional[Runnable]]]
+    channels: Sequence[tuple[str, Optional[Runnable], bool]]
     """
     Mapping of write channels to Runnables that return the value to be written,
     or None to skip writing.
@@ -27,10 +31,10 @@ class ChannelWrite(RunnablePassthrough):
     def __init__(
         self,
         *,
-        channels: Sequence[tuple[str, Optional[Runnable]]],
+        channels: Sequence[tuple[str, Optional[Runnable], bool]],
     ):
         super().__init__(func=self._write, afunc=self._awrite, channels=channels)
-        self.name = f"ChannelWrite<{','.join(chan for chan, _ in self.channels)}>"
+        self.name = f"ChannelWrite<{','.join(chan for chan, _, _ in self.channels)}>"
 
     def __repr_args__(self) -> Any:
         return [("channels", self.channels)]
@@ -49,25 +53,28 @@ class ChannelWrite(RunnablePassthrough):
 
     def _write(self, input: Any, config: RunnableConfig) -> None:
         values = [
-            (chan, r.invoke(input, config) if r else input) for chan, r in self.channels
+            (chan, r.invoke(input, config) if r else input)
+            for chan, r, _ in self.channels
         ]
         values = [
             write
-            for write, chan in zip(values, self.channels)
-            if chan[1] is None or write[1] is not None
+            for write, (_, _, skip_none) in zip(values, self.channels)
+            if not skip_none or write[1] is not None
         ]
 
         self.do_write(config, **dict(values))
 
     async def _awrite(self, input: Any, config: RunnableConfig) -> None:
+        values = await asyncio.gather(
+            *(
+                r.ainvoke(input, config) if r else _mk_future(input)
+                for _, r, _ in self.channels
+            )
+        )
         values = [
-            (chan, await r.ainvoke(input, config) if r else input)
-            for chan, r in self.channels
-        ]
-        values = [
-            write
-            for write, chan in zip(values, self.channels)
-            if chan[1] is None or write[1] is not None
+            (chan, val)
+            for val, (chan, _, skip_none) in zip(values, self.channels)
+            if not skip_none or val is not None
         ]
 
         self.do_write(config, **dict(values))
@@ -75,4 +82,10 @@ class ChannelWrite(RunnablePassthrough):
     @staticmethod
     def do_write(config: RunnableConfig, **values: Any) -> None:
         write: TYPE_SEND = config["configurable"][CONFIG_KEY_SEND]
-        write([(chan, val) for chan, val in values.items()])
+        write([(chan, val) for chan, val in values.items() if val is not SKIP_WRITE])
+
+
+def _mk_future(val: Any) -> asyncio.Future:
+    fut = asyncio.Future()
+    fut.set_result(val)
+    return fut


### PR DESCRIPTION
- this removes one unnamed run from langsmith trace for each node, and ensures that output is streamed from each node to folks listening to that w stream_events