### PR TITLE
Fixed rewoo.ipynb

### DIFF
--- a/examples/rewoo/rewoo.ipynb
+++ b/examples/rewoo/rewoo.ipynb
@@ -342,6 +342,7 @@
     "        _results = state[\"results\"] or {}\n",
     "        for k, v in _results.items():\n",
     "            tool_input = tool_input.replace(k, v)\n",
+    "            step_name = step_name.replace(k, v)\n",
     "        plan += f\"Plan: {_plan}\\n{step_name} = {tool}[{tool_input}]\"\n",
     "    prompt = solve_prompt.format(plan=plan, task=state[\"task\"])\n",
     "    result = model.invoke(prompt)\n",


### PR DESCRIPTION
The way the current implementation works, the solver never has access to the tools results, only to the steps and the question.

This is because the replacement process only updates the references in the tool input not on the results.

For example, without this change, the prompt we give to the solver is:

```
prompt
Solve the following task or problem. To solve the problem, we have made step-by-step Plan and retrieved corresponding Evidence to each Plan. Use them with caution since long evidence might contain irrelevant information.

Plan: Calculate the square root of 342142. 
#E1 = calculate[square root of 342142]Plan: Calculate 23 to the power of 2. 
#E2 = calculate[23 to the power of 2]Plan: Multiply #E1 by #E2. 
#E3 = calculate[584.9290555272494 multiplied by 529]

Now solve the question or task according to provided Evidence above.

Task: What's the square root of 342142 multiplied by 23 to the power of 2?
Response:
{'solve': {'result': 'The square root of 342142 is 584.9290555272494, and 23 to the power of 2 is 529. Multiplying these two values together gives us:\n\n\\[584.9290555272494 \\times 529 = 309368.382384\\]\n\nTherefore, the square root of 342142 multiplied by 23 to the power of 2 is approximately 309368.382384.'}}
```

Which is incorrect and doesn't use the tool results

With the change in the PR:
```
prompt
Solve the following task or problem. To solve the problem, we have made step-by-step Plan and retrieved corresponding Evidence to each Plan. Use them with caution since long evidence might contain irrelevant information.

Plan: Calculate the square root of 342142. 
584.9290555272494 = calculate[square root of 342142]Plan: Calculate 23 to the power of 2. 
529 = calculate[23 to the power of 2]Plan: Multiply the results of #E1 and #E2. 
309427.4703739149 = calculate[584.9290555272494 multiplied by 529]

Now solve the question or task according to provided Evidence above.

Task: What's the square root of 342142 multiplied by 23 to the power of 2?
Response:
{'solve': {'result': 'The square root of 342142 multiplied by 23 to the power of 2 is 309427.4703739149.'}}
```
Which is the correct result and uses the tool's outputs

This is also noticeable with questions with followups that can be looked up with search and the LLM doesn't know, where it just talks about his knowledge cutoff and gives outdated information vs using the search results and providing the correct answer

I believe this was not noticed in the video because the last call is to the LLM tool which itself contains the answer, but otherwise this will fail for every other question

