### PR TITLE
Add history tracking to in-memory, sqlite and aiosqlite checkpointers

### DIFF
--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -28,10 +28,10 @@ class AsyncSqliteSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
 
     async def __aexit__(
         self,
-        __exc_type: type[BaseException] | None,
-        __exc_value: BaseException | None,
-        __traceback: TracebackType | None,
-    ) -> bool | None:
+        __exc_type: Optional[type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
         return await self.conn.close()
 
     async def setup(self) -> None:

--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -1,15 +1,16 @@
 import pickle
-from typing import Optional
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
+from typing import AsyncIterator, Optional, Self
 
 import aiosqlite
 from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import RunnableConfig
-from langchain_core.runnables.utils import ConfigurableFieldSpec
 
-from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint
+from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
 
 
-class AsyncSqliteSaver(BaseCheckpointSaver):
+class AsyncSqliteSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
     conn: aiosqlite.Connection
 
     is_setup: bool = Field(False, init=False, repr=False)
@@ -21,65 +22,92 @@ class AsyncSqliteSaver(BaseCheckpointSaver):
     def from_conn_string(cls, conn_string: str) -> "AsyncSqliteSaver":
         return AsyncSqliteSaver(conn=aiosqlite.connect(conn_string))
 
-    @property
-    def config_specs(self) -> list[ConfigurableFieldSpec]:
-        return [
-            ConfigurableFieldSpec(
-                id="thread_id",
-                annotation=str,
-                name="Thread ID",
-                description=None,
-                default="",
-                is_shared=True,
-            ),
-        ]
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        __exc_type: type[BaseException] | None,
+        __exc_value: BaseException | None,
+        __traceback: TracebackType | None,
+    ) -> bool | None:
+        return await self.conn.close()
 
     async def setup(self) -> None:
-        print("hello")
         if self.is_setup:
             return
 
-        try:
-            await self.conn
-            await self.conn.executescript(
-                """
-                CREATE TABLE IF NOT EXISTS checkpoints (
-                    thread_id TEXT PRIMARY KEY,
-                    checkpoint BLOB
-                );
-                """
-            )
+        await self.conn
+        async with self.conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS checkpoints (
+                thread_id TEXT NOT NULL,
+                thread_ts TEXT NOT NULL,
+                checkpoint BLOB,
+                PRIMARY KEY (thread_id, thread_ts)
+            );
+            """
+        ):
             await self.conn.commit()
 
-            print("good bye")
+        self.is_setup = True
 
-            self.is_setup = True
-        except BaseException as e:
-            print(e)
-            raise e
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        await self.setup()
+        if config["configurable"].get("thread_ts"):
+            async with self.conn.execute(
+                "SELECT checkpoint FROM checkpoints WHERE thread_id = ? AND thread_ts = ?",
+                (
+                    config["configurable"]["thread_id"],
+                    config["configurable"]["thread_ts"],
+                ),
+            ) as cursor:
+                if value := await cursor.fetchone():
+                    return CheckpointTuple(config, pickle.loads(value[0]))
+        else:
+            async with self.conn.execute(
+                "SELECT thread_id, thread_ts, checkpoint FROM checkpoints WHERE thread_id = ? ORDER BY thread_ts DESC LIMIT 1",
+                (config["configurable"]["thread_id"],),
+            ) as cursor:
+                if value := await cursor.fetchone():
+                    return CheckpointTuple(
+                        {
+                            "configurable": {
+                                "thread_id": value[0],
+                                "thread_ts": value[1],
+                            }
+                        },
+                        pickle.loads(value[2]),
+                    )
 
-    def get(self, config: RunnableConfig) -> Optional[Checkpoint]:
-        raise NotImplementedError
-
-    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> None:
-        raise NotImplementedError
-
-    async def aget(self, config: RunnableConfig) -> Optional[Checkpoint]:
+    async def alist(self, config: RunnableConfig) -> AsyncIterator[CheckpointTuple]:
         await self.setup()
         async with self.conn.execute(
-            "SELECT checkpoint FROM checkpoints WHERE thread_id = ?",
+            "SELECT thread_id, thread_ts, checkpoint FROM checkpoints WHERE thread_id = ? ORDER BY thread_ts DESC",
             (config["configurable"]["thread_id"],),
         ) as cursor:
-            if value := await cursor.fetchone():
-                return pickle.loads(value[0])
+            async for thread_id, thread_ts, value in cursor:
+                yield CheckpointTuple(
+                    {"configurable": {"thread_id": thread_id, "thread_ts": thread_ts}},
+                    pickle.loads(value),
+                )
 
-    async def aput(self, config: RunnableConfig, checkpoint: Checkpoint) -> None:
+    async def aput(
+        self, config: RunnableConfig, checkpoint: Checkpoint
+    ) -> RunnableConfig:
         await self.setup()
-        await self.conn.execute(
-            "INSERT OR REPLACE INTO checkpoints (thread_id, checkpoint) VALUES (?, ?)",
+        async with self.conn.execute(
+            "INSERT OR REPLACE INTO checkpoints (thread_id, thread_ts, checkpoint) VALUES (?, ?, ?)",
             (
                 config["configurable"]["thread_id"],
+                checkpoint["ts"],
                 pickle.dumps(checkpoint),
             ),
-        )
-        await self.conn.commit()
+        ):
+            await self.conn.commit()
+        return {
+            "configurable": {
+                "thread_id": config["configurable"]["thread_id"],
+                "thread_ts": checkpoint["ts"],
+            }
+        }

--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -1,11 +1,12 @@
 import pickle
 from contextlib import AbstractAsyncContextManager
 from types import TracebackType
-from typing import AsyncIterator, Optional, Self
+from typing import AsyncIterator, Optional
 
 import aiosqlite
 from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import RunnableConfig
+from typing_extensions import Self
 
 from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
 

--- a/langgraph/checkpoint/base.py
+++ b/langgraph/checkpoint/base.py
@@ -1,9 +1,9 @@
 import asyncio
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, Optional, TypedDict
+from typing import Any, AsyncIterator, Iterator, NamedTuple, Optional, TypedDict
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.runnables import RunnableConfig
@@ -49,25 +49,71 @@ class CheckpointAt(StrEnum):
     END_OF_RUN = "end_of_run"
 
 
+class CheckpointTuple(NamedTuple):
+    config: RunnableConfig
+    checkpoint: Checkpoint
+
+
+CheckpointThreadId = ConfigurableFieldSpec(
+    id="thread_id",
+    annotation=str,
+    name="Thread ID",
+    description=None,
+    default="",
+    is_shared=True,
+)
+
+CheckpointThreadTs = ConfigurableFieldSpec(
+    id="thread_ts",
+    annotation=Optional[str],
+    name="Thread Timestamp",
+    description="Pass to fetch a past checkpoint. If None, fetches the latest checkpoint.",
+    default=None,
+    is_shared=True,
+)
+
+
 class BaseCheckpointSaver(Serializable, ABC):
     at: CheckpointAt = CheckpointAt.END_OF_RUN
 
     @property
     def config_specs(self) -> list[ConfigurableFieldSpec]:
-        return []
+        return [CheckpointThreadId, CheckpointThreadTs]
 
-    @abstractmethod
     def get(self, config: RunnableConfig) -> Optional[Checkpoint]:
-        ...
+        if value := self.get_tuple(config):
+            return value.checkpoint
 
-    @abstractmethod
-    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> None:
-        ...
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        raise NotImplementedError
+
+    def list(self, config: RunnableConfig) -> Iterator[CheckpointTuple]:
+        raise NotImplementedError
+
+    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> RunnableConfig:
+        raise NotImplementedError
 
     async def aget(self, config: RunnableConfig) -> Optional[Checkpoint]:
-        return await asyncio.get_running_loop().run_in_executor(None, self.get, config)
+        if value := await self.aget_tuple(config):
+            return value.checkpoint
 
-    async def aput(self, config: RunnableConfig, checkpoint: Checkpoint) -> None:
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.get_tuple, config
+        )
+
+    async def alist(self, config: RunnableConfig) -> AsyncIterator[CheckpointTuple]:
+        loop = asyncio.get_running_loop()
+        iter = loop.run_in_executor(None, self.list, config)
+        while True:
+            try:
+                yield await loop.run_in_executor(None, next, iter)
+            except StopIteration:
+                return
+
+    async def aput(
+        self, config: RunnableConfig, checkpoint: Checkpoint
+    ) -> RunnableConfig:
         return await asyncio.get_running_loop().run_in_executor(
             None, self.put, config, checkpoint
         )

--- a/langgraph/checkpoint/memory.py
+++ b/langgraph/checkpoint/memory.py
@@ -1,30 +1,47 @@
+from collections import defaultdict
 from typing import Optional
 
 from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import RunnableConfig
-from langchain_core.runnables.utils import ConfigurableFieldSpec
 
-from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint
+from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
 
 
 class MemorySaver(BaseCheckpointSaver):
-    storage: dict[str, Checkpoint] = Field(default_factory=dict)
-
-    @property
-    def config_specs(self) -> list[ConfigurableFieldSpec]:
-        return [
-            ConfigurableFieldSpec(
-                id="thread_id",
-                annotation=str,
-                name="Thread ID",
-                description=None,
-                default="",
-                is_shared=True,
-            ),
-        ]
+    storage: defaultdict[str, dict[str, Checkpoint]] = Field(
+        default_factory=lambda: defaultdict(dict)
+    )
 
     def get(self, config: RunnableConfig) -> Optional[Checkpoint]:
-        return self.storage.get(config["configurable"]["thread_id"], None)
+        if value := self.get_tuple(config):
+            return value.checkpoint
 
-    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> None:
-        return self.storage.update({config["configurable"]["thread_id"]: checkpoint})
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        if config["configurable"].get("thread_ts"):
+            if checkpoint := self.storage[config["configurable"]["thread_id"]].get(
+                config["configurable"]["thread_ts"]
+            ):
+                return CheckpointTuple(config=config, checkpoint=checkpoint)
+        else:
+            if checkpoints := self.storage[config["configurable"]["thread_id"]]:
+                thread_ts = max(checkpoints.keys())
+                return CheckpointTuple(
+                    config={
+                        "configurable": {
+                            "thread_id": config["configurable"]["thread_id"],
+                            "thread_ts": thread_ts,
+                        }
+                    },
+                    checkpoint=checkpoints[thread_ts],
+                )
+
+    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> RunnableConfig:
+        self.storage[config["configurable"]["thread_id"]].update(
+            {checkpoint["ts"]: checkpoint}
+        )
+        return {
+            "configurable": {
+                "thread_id": config["configurable"]["thread_id"],
+                "thread_ts": checkpoint["ts"],
+            }
+        }

--- a/langgraph/checkpoint/sqlite.py
+++ b/langgraph/checkpoint/sqlite.py
@@ -119,14 +119,14 @@ class SqliteSaver(BaseCheckpointSaver, AbstractContextManager):
         }
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
-        raise NotImplementedError
+        raise NotImplementedError("Use AsyncSqliteSaver instead")
 
     async def alist(
         self, config: RunnableConfig
     ) -> AsyncIterator[tuple[RunnableConfig, Checkpoint]]:
-        raise NotImplementedError
+        raise NotImplementedError("Use AsyncSqliteSaver instead")
 
     async def aput(
         self, config: RunnableConfig, checkpoint: Checkpoint
     ) -> RunnableConfig:
-        raise NotImplementedError
+        raise NotImplementedError("Use AsyncSqliteSaver instead")

--- a/langgraph/checkpoint/sqlite.py
+++ b/langgraph/checkpoint/sqlite.py
@@ -2,10 +2,11 @@ import pickle
 import sqlite3
 from contextlib import AbstractContextManager, contextmanager
 from types import TracebackType
-from typing import AsyncIterator, Iterator, Optional, Self
+from typing import AsyncIterator, Iterator, Optional
 
 from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import RunnableConfig
+from typing_extensions import Self
 
 from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
 

--- a/langgraph/checkpoint/sqlite.py
+++ b/langgraph/checkpoint/sqlite.py
@@ -28,10 +28,10 @@ class SqliteSaver(BaseCheckpointSaver, AbstractContextManager):
 
     def __exit__(
         self,
-        __exc_type: type[BaseException] | None,
-        __exc_value: BaseException | None,
-        __traceback: TracebackType | None,
-    ) -> bool | None:
+        __exc_type: Optional[type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
         return self.conn.close()
 
     def setup(self) -> None:

--- a/tests/memory_assert.py
+++ b/tests/memory_assert.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from langchain_core.pydantic_v1 import Field
 
 from langgraph.checkpoint.base import Checkpoint, CheckpointAt, copy_checkpoint
@@ -5,15 +7,19 @@ from langgraph.checkpoint.memory import MemorySaver
 
 
 class MemorySaverAssertImmutable(MemorySaver):
-    storage_for_copies: dict[str, Checkpoint] = Field(default_factory=dict)
+    storage_for_copies: defaultdict[str, dict[str, Checkpoint]] = Field(
+        default_factory=lambda: defaultdict(dict)
+    )
 
     at = CheckpointAt.END_OF_STEP
 
-    def put(self, config: dict, checkpoint: dict) -> None:
+    def put(self, config: dict, checkpoint: Checkpoint) -> None:
         # assert checkpoint hasn't been modified since last written
         thread_id = config["configurable"]["thread_id"]
         if saved := super().get(config):
-            assert self.storage_for_copies[thread_id] == saved
-        self.storage_for_copies[thread_id] = copy_checkpoint(checkpoint)
+            assert self.storage_for_copies[thread_id][saved["ts"]] == saved
+        self.storage_for_copies[thread_id][checkpoint["ts"]] = copy_checkpoint(
+            checkpoint
+        )
         # call super to write checkpoint
         super().put(config, checkpoint)


### PR DESCRIPTION
- Add Pregel.get_state_history and .aget_state_history methods to get history iterator
- Update checkpointer base class with new list and get_tuple methods
- Rewrite in-memory checkpointer class to track history
- Rewrite sqlite and aiosqlite checkpointers to track history
- Add new tests for history tracking