### PR TITLE
Utility to create tool invocation

### DIFF
--- a/langgraph/prebuilt/__init__.py
+++ b/langgraph/prebuilt/__init__.py
@@ -1,6 +1,9 @@
 from langgraph.prebuilt import chat_agent_executor
 from langgraph.prebuilt.agent_executor import create_agent_executor
-from langgraph.prebuilt.tool_executor import ToolExecutor, ToolInvocation
+from langgraph.prebuilt.tool_executor import (
+    ToolExecutor,
+    ToolInvocation,
+)
 
 __all__ = [
     "create_agent_executor",


### PR DESCRIPTION
Context: our readme and examples have a lot of `message.additional_kwargs["function"]` stuff  that make me always scratch my head - it's a lot of superfluous code that make the tool invocation interface less friendly. Would be nice to be able to just go from message -> tool invocation.

TODO: Add docstring, etc. 

Open to other names, class methods, and other suggestions.

