### PR TITLE
Added postgresql sync and async checkpoint classes

### DIFF
--- a/langgraph/checkpoint/aiopostgresql.py
+++ b/langgraph/checkpoint/aiopostgresql.py
@@ -1,0 +1,163 @@
+import pickle
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
+from typing import AsyncIterator, Optional
+
+import psycopg
+from langchain_core.pydantic_v1 import Field
+from langchain_core.runnables import RunnableConfig
+from typing_extensions import Self
+
+from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
+
+
+class AsyncPostgresqlSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
+    conn: psycopg.AsyncConnection
+
+    is_setup: bool = Field(False, init=False, repr=False)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    async def from_conn_string(cls, conn_string: str) -> "AsyncPostgresqlSaver":
+        return AsyncPostgresqlSaver(conn=await psycopg.AsyncConnection.connect(conn_string))
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        __exc_type: Optional[type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        return await self.conn.close()
+
+    async def setup(self) -> None:
+        if self.is_setup:
+            return
+
+        async with self.conn.cursor() as acur:
+            await acur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checkpoints (
+                    thread_id TEXT NOT NULL,
+                    thread_ts TEXT NOT NULL,
+                    parent_ts TEXT,
+                    checkpoint BYTEA,
+                    PRIMARY KEY (thread_id, thread_ts)
+                );
+                """
+            )
+            await self.conn.commit()
+
+        self.is_setup = True
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        await self.setup()
+        if config["configurable"].get("thread_ts"):
+            async with self.conn.cursor() as acur:
+                await acur.execute(
+                    """
+                    SELECT checkpoint, parent_ts
+                    FROM checkpoints
+                    WHERE thread_id = %s
+                    AND thread_ts = %s
+                    """,
+                    (
+                        config["configurable"]["thread_id"],
+                        config["configurable"]["thread_ts"],
+                    ),
+                )
+                if value := await acur.fetchone():
+                    return CheckpointTuple(
+                        config,
+                        pickle.loads(value[0]),
+                        {
+                            "configurable": {
+                                "thread_id": config["configurable"]["thread_id"],
+                                "thread_ts": value[1],
+                            }
+                        }
+                        if value[1]
+                        else None,
+                    )
+        else:
+            async with self.conn.cursor() as acur:
+                await acur.execute(
+                    """
+                    SELECT thread_id, thread_ts, parent_ts, checkpoint
+                    FROM checkpoints
+                    WHERE thread_id = %s
+                    ORDER BY thread_ts DESC
+                    LIMIT 1
+                    """,
+                    (config["configurable"]["thread_id"],),
+                )
+                if value := await acur.fetchone():
+                    return CheckpointTuple(
+                        {
+                            "configurable": {
+                                "thread_id": value[0],
+                                "thread_ts": value[1],
+                            }
+                        },
+                        pickle.loads(value[3]),
+                        {
+                            "configurable": {
+                                "thread_id": value[0],
+                                "thread_ts": value[2],
+                            }
+                        }
+                        if value[2]
+                        else None,
+                    )
+
+    async def alist(self, config: RunnableConfig) -> AsyncIterator[CheckpointTuple]:
+        await self.setup()
+        async with self.conn.cursor() as acur:
+            await acur.execute(
+                """
+                SELECT thread_id, thread_ts, parent_ts, checkpoint
+                FROM checkpoints
+                WHERE thread_id = %s
+                ORDER BY thread_ts DESC
+                """,
+                (config["configurable"]["thread_id"],),
+            )
+            async for thread_id, thread_ts, parent_ts, value in acur:
+                yield CheckpointTuple(
+                    {"configurable": {"thread_id": thread_id, "thread_ts": thread_ts}},
+                    pickle.loads(value),
+                    {"configurable": {"thread_id": thread_id, "thread_ts": parent_ts}}
+                    if parent_ts
+                    else None,
+                )
+
+    async def aput(
+            self, config: RunnableConfig, checkpoint: Checkpoint
+    ) -> RunnableConfig:
+        await self.setup()
+        async with self.conn.cursor() as acur:
+            await acur.execute(
+                """
+                INSERT INTO checkpoints (thread_id, thread_ts, parent_ts, checkpoint)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (thread_id, thread_ts) DO UPDATE 
+                SET parent_ts = EXCLUDED.parent_ts, checkpoint = EXCLUDED.checkpoint
+                """,
+                (
+                    config["configurable"]["thread_id"],
+                    checkpoint["ts"],
+                    config["configurable"].get("thread_ts"),
+                    pickle.dumps(checkpoint),
+                ),
+            )
+            await self.conn.commit()
+        return {
+            "configurable": {
+                "thread_id": config["configurable"]["thread_id"],
+                "thread_ts": checkpoint["ts"],
+            }
+        }

--- a/langgraph/checkpoint/aiopostgresql.py
+++ b/langgraph/checkpoint/aiopostgresql.py
@@ -21,7 +21,9 @@ class AsyncPostgresqlSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
 
     @classmethod
     async def from_conn_string(cls, conn_string: str) -> "AsyncPostgresqlSaver":
-        return AsyncPostgresqlSaver(conn=await psycopg.AsyncConnection.connect(conn_string))
+        return AsyncPostgresqlSaver(
+            conn=await psycopg.AsyncConnection.connect(conn_string)
+        )
 
     async def __aenter__(self) -> Self:
         return self
@@ -136,7 +138,7 @@ class AsyncPostgresqlSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
                 )
 
     async def aput(
-            self, config: RunnableConfig, checkpoint: Checkpoint
+        self, config: RunnableConfig, checkpoint: Checkpoint
     ) -> RunnableConfig:
         await self.setup()
         async with self.conn.cursor() as acur:

--- a/langgraph/checkpoint/postgresql.py
+++ b/langgraph/checkpoint/postgresql.py
@@ -27,10 +27,10 @@ class PostgresqlSaver(BaseCheckpointSaver, AbstractContextManager):
         return self
 
     def __exit__(
-            self,
-            __exc_type: Optional[type[BaseException]],
-            __exc_value: Optional[BaseException],
-            __traceback: Optional[TracebackType],
+        self,
+        __exc_type: Optional[type[BaseException]],
+        __exc_value: Optional[BaseException],
+        __traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         return self.conn.close()
 
@@ -76,7 +76,7 @@ class PostgresqlSaver(BaseCheckpointSaver, AbstractContextManager):
                     """,
                     (
                         config["configurable"]["thread_id"],
-                        config["configurable"]["thread_ts"]
+                        config["configurable"]["thread_ts"],
                     ),
                 )
                 if value := cur.fetchone():
@@ -174,11 +174,11 @@ class PostgresqlSaver(BaseCheckpointSaver, AbstractContextManager):
         raise NotImplementedError("Use AsyncPostgresqlSaver instead")
 
     async def alist(
-            self, config: RunnableConfig
+        self, config: RunnableConfig
     ) -> AsyncIterator[tuple[RunnableConfig, Checkpoint]]:
         raise NotImplementedError("Use AsyncPostgresqlSaver instead")
 
     async def aput(
-            self, config: RunnableConfig, checkpoint: Checkpoint
+        self, config: RunnableConfig, checkpoint: Checkpoint
     ) -> RunnableConfig:
         raise NotImplementedError("Use AsyncPostgresqlSaver instead")

--- a/langgraph/checkpoint/postgresql.py
+++ b/langgraph/checkpoint/postgresql.py
@@ -1,0 +1,184 @@
+import pickle
+from contextlib import AbstractContextManager, contextmanager
+from types import TracebackType
+from typing import AsyncIterator, Iterator, Optional
+
+import psycopg
+from langchain_core.pydantic_v1 import Field
+from langchain_core.runnables import RunnableConfig
+from typing_extensions import Self
+
+from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
+
+
+class PostgresqlSaver(BaseCheckpointSaver, AbstractContextManager):
+    conn: psycopg.Connection
+
+    is_setup: bool = Field(False, init=False, repr=False)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def from_conn_string(cls, conn_string: str) -> "PostgresqlSaver":
+        return PostgresqlSaver(conn=psycopg.connect(conn_string))
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+            self,
+            __exc_type: Optional[type[BaseException]],
+            __exc_value: Optional[BaseException],
+            __traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        return self.conn.close()
+
+    def setup(self) -> None:
+        if self.is_setup:
+            return
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checkpoints (
+                    thread_id TEXT NOT NULL,
+                    thread_ts TEXT NOT NULL,
+                    parent_ts TEXT,
+                    checkpoint BYTEA,
+                    PRIMARY KEY (thread_id, thread_ts)
+                );
+                """
+            )
+
+        self.is_setup = True
+
+    @contextmanager
+    def cursor(self, transaction: bool = True):
+        self.setup()
+        cur = self.conn.cursor()
+        try:
+            yield cur
+        finally:
+            if transaction:
+                self.conn.commit()
+            cur.close()
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        with self.cursor(transaction=False) as cur:
+            if config["configurable"].get("thread_ts"):
+                cur.execute(
+                    """
+                    SELECT * 
+                    FROM checkpoints 
+                    WHERE thread_id = %s
+                    AND thread_ts = %s
+                    """,
+                    (
+                        config["configurable"]["thread_id"],
+                        config["configurable"]["thread_ts"]
+                    ),
+                )
+                if value := cur.fetchone():
+                    return CheckpointTuple(
+                        config=config,
+                        checkpoint=pickle.loads(value[3]),
+                        parent_config={
+                            "configurable": {
+                                "thread_id": config["configurable"]["thread_id"],
+                                "thread_ts": value[1],
+                            }
+                        }
+                        if value[1]
+                        else None,
+                    )
+            else:
+                cur.execute(
+                    """
+                    SELECT thread_id, thread_ts, parent_ts, checkpoint
+                    FROM checkpoints 
+                    WHERE thread_id = %s
+                    ORDER BY thread_ts DESC 
+                    LIMIT 1
+                    """,
+                    (config["configurable"]["thread_id"],),
+                )
+                if value := cur.fetchone():
+                    return CheckpointTuple(
+                        {
+                            "configurable": {
+                                "thread_id": value[0],
+                                "thread_ts": value[1],
+                            }
+                        },
+                        pickle.loads(value[3]),
+                        {
+                            "configurable": {
+                                "thread_id": value[0],
+                                "thread_ts": value[2],
+                            }
+                        }
+                        if value[2]
+                        else None,
+                    )
+
+    def list(self, config: RunnableConfig) -> Iterator[CheckpointTuple]:
+        with self.cursor(transaction=False) as cur:
+            cur.execute(
+                """
+                SELECT thread_id, thread_ts, parent_ts, checkpoint 
+                FROM checkpoints 
+                WHERE thread_id = %s 
+                ORDER BY thread_ts DESC
+                """,
+                (config["configurable"]["thread_id"],),
+            )
+            for thread_id, thread_ts, parent_ts, value in cur:
+                yield CheckpointTuple(
+                    {"configurable": {"thread_id": thread_id, "thread_ts": thread_ts}},
+                    pickle.loads(value),
+                    {
+                        "configurable": {
+                            "thread_id": thread_id,
+                            "thread_ts": parent_ts,
+                        }
+                    }
+                    if parent_ts
+                    else None,
+                )
+
+    def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> RunnableConfig:
+        with self.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO checkpoints (thread_id, thread_ts, parent_ts, checkpoint)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (thread_id, thread_ts) DO UPDATE 
+                SET parent_ts = EXCLUDED.parent_ts, checkpoint = EXCLUDED.checkpoint
+                """,
+                (
+                    config["configurable"]["thread_id"],
+                    checkpoint["ts"],
+                    config["configurable"].get("thread_ts"),
+                    pickle.dumps(checkpoint),
+                ),
+            )
+        return {
+            "configurable": {
+                "thread_id": config["configurable"]["thread_id"],
+                "thread_ts": checkpoint["ts"],
+            }
+        }
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        raise NotImplementedError("Use AsyncPostgresqlSaver instead")
+
+    async def alist(
+            self, config: RunnableConfig
+    ) -> AsyncIterator[tuple[RunnableConfig, Checkpoint]]:
+        raise NotImplementedError("Use AsyncPostgresqlSaver instead")
+
+    async def aput(
+            self, config: RunnableConfig, checkpoint: Checkpoint
+    ) -> RunnableConfig:
+        raise NotImplementedError("Use AsyncPostgresqlSaver instead")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ pytest-watcher = "^0.4.1"
 langchain = "^0.1.0"
 aiosqlite = "^0.19.0"
 grandalf = "^0.8"
+psycopg = "^3.1.18"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.1.4"

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -16,9 +16,8 @@ from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.context import Context
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
-from langgraph.checkpoint.sqlite import SqliteSaver
-
 from langgraph.checkpoint.postgresql import PostgresqlSaver
+from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, Graph
 from langgraph.graph.message import MessageGraph
 from langgraph.graph.state import StateGraph
@@ -639,8 +638,8 @@ def test_invoke_checkpoint_postgresql(mocker: MockerFixture) -> None:
         assert len(thread_1_history) == 2
         # sorted descending
         assert (
-                thread_1_history[0].config["configurable"]["thread_ts"]
-                > thread_1_history[1].config["configurable"]["thread_ts"]
+            thread_1_history[0].config["configurable"]["thread_ts"]
+            > thread_1_history[1].config["configurable"]["thread_ts"]
         )
         # the second checkpoint
         assert thread_1_history[0].values["total"] == 7
@@ -648,12 +647,12 @@ def test_invoke_checkpoint_postgresql(mocker: MockerFixture) -> None:
         assert thread_1_history[1].values["total"] == 2
         # can get each checkpoint using aget with config
         assert (
-                memory.get(thread_1_history[0].config)["ts"]
-                == thread_1_history[0].config["configurable"]["thread_ts"]
+            memory.get(thread_1_history[0].config)["ts"]
+            == thread_1_history[0].config["configurable"]["thread_ts"]
         )
         assert (
-                memory.get(thread_1_history[1].config)["ts"]
-                == thread_1_history[1].config["configurable"]["thread_ts"]
+            memory.get(thread_1_history[1].config)["ts"]
+            == thread_1_history[1].config["configurable"]["thread_ts"]
         )
 
         thread_1_next_config = app.update_state(
@@ -661,13 +660,14 @@ def test_invoke_checkpoint_postgresql(mocker: MockerFixture) -> None:
         )
         # update creates a new checkpoint
         assert (
-                thread_1_next_config["configurable"]["thread_ts"]
-                > thread_1_history[0].config["configurable"]["thread_ts"]
+            thread_1_next_config["configurable"]["thread_ts"]
+            > thread_1_history[0].config["configurable"]["thread_ts"]
         )
         # 1 more checkpoint in history
         assert len(list(app.get_state_history(thread_1))) == 3
         # the latest checkpoint is the updated one
         assert app.get_state(thread_1) == app.get_state(thread_1_next_config)
+
 
 def test_invoke_two_processes_two_in_join_two_out(mocker: MockerFixture) -> None:
     add_one = mocker.Mock(side_effect=lambda x: x + 1)

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -22,8 +22,8 @@ from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.context import Context
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
-from langgraph.checkpoint.aiosqlite import AsyncSqliteSaver
 from langgraph.checkpoint.aiopostgresql import AsyncPostgresqlSaver
+from langgraph.checkpoint.aiosqlite import AsyncSqliteSaver
 from langgraph.graph import END, Graph, StateGraph
 from langgraph.graph.message import MessageGraph
 from langgraph.prebuilt.chat_agent_executor import (
@@ -615,7 +615,9 @@ async def test_invoke_checkpoint_aiopostgresql(mocker: MockerFixture) -> None:
         | raise_if_above_10
     )
 
-    async with await AsyncPostgresqlSaver.from_conn_string("postgresql://localhost:5432") as memory:
+    async with await AsyncPostgresqlSaver.from_conn_string(
+        "postgresql://localhost:5432"
+    ) as memory:
         app = Pregel(
             nodes={"one": one},
             channels={"total": BinaryOperatorAggregate(int, operator.add)},


### PR DESCRIPTION
I have added the postgresql sync and async checkpoints classes using psycopg3.
To run the test we need to have a postgresql installed locally and then change the connection string in the both sync and async pregal test files.