### PR TITLE
Collect pending writes for each node separately

### DIFF
--- a/langgraph/pregel/debug.py
+++ b/langgraph/pregel/debug.py
@@ -1,3 +1,4 @@
+from collections import deque
 from pprint import pformat
 from typing import Any, Iterator, Mapping
 
@@ -7,14 +8,16 @@ from langchain_core.utils.input import get_bolded_text, get_colored_text
 from langgraph.channels.base import BaseChannel, EmptyChannelError
 
 
-def print_step_start(step: int, next_tasks: list[tuple[Runnable, Any, str]]) -> None:
+def print_step_start(
+    step: int, next_tasks: list[tuple[Runnable, Any, str, deque[tuple[str, Any]]]]
+) -> None:
     n_tasks = len(next_tasks)
     print(
         f"{get_colored_text('[langgraph/step]', color='blue')} "
         + get_bolded_text(
             f"Starting step {step} with {n_tasks} task{'s' if n_tasks > 1 else ''}. Next tasks:\n"
         )
-        + "\n".join(f"- {name}({pformat(val)})" for _, val, name in next_tasks)
+        + "\n".join(f"- {name}({pformat(val)})" for _, val, name, _ in next_tasks)
     )
 
 


### PR DESCRIPTION
- ensures that order of updates sent to channels is independent of timing differences when parallel executing multiple nodes
- enables future features