### PR TITLE
fix storm.ipynb error for duckduckgo_search

### DIFF
--- a/examples/storm/storm.ipynb
+++ b/examples/storm/storm.ipynb
@@ -695,6 +695,7 @@
     "from langchain_community.tools.tavily_search import TavilySearchResults\n",
     "from langchain_community.utilities.duckduckgo_search import DuckDuckGoSearchAPIWrapper\n",
     "from langchain_core.tools import tool\n",
+    "from duckduckgo_search import AsyncDDGS\n",
     "\n",
     "'''\n",
     "# Tavily is typically a better search engine, but your free queries are limited\n",
@@ -713,7 +714,8 @@
     "@tool\n",
     "async def search_engine(query: str):\n",
     "    \"\"\"Search engine to the internet.\"\"\"\n",
-    "    results = DuckDuckGoSearchAPIWrapper()._ddgs_text(query)\n",
+    "    #results = DuckDuckGoSearchAPIWrapper()._ddgs_text(query)\n",
+    "    results = await AsyncDDGS().text(query)\n",
     "    return [{\"content\": r[\"body\"], \"url\": r[\"href\"]} for r in results]"
    ]
   },


### PR DESCRIPTION
results = DuckDuckGoSearchAPIWrapper()._ddgs_text(query) has following error:
RuntimeError                              Traceback (most recent call last)
Cell In[31], line 9
      6     return result
      8 # Run the async function and get the result
----> 9 result = asyncio.run(search())
     10 print(result)

File ~/miniconda3/envs/langgraph/lib/python3.11/asyncio/runners.py:186, in run(main, debug)
    161 """Execute the coroutine and return the result.
    162 
    163 This function runs the passed coroutine, taking care of
   (...)
    182     asyncio.run(main())
    183 """
    184 if events._get_running_loop() is not None:
    185     # fail fast with short traceback
--> 186     raise RuntimeError(
    187         "asyncio.run() cannot be called from a running event loop")
    189 with Runner(debug=debug) as runner:
    190     return runner.run(main)

RuntimeError: asyncio.run() cannot be called from a running event loop