### PR TITLE
Rename BaseChannel.empty() to BaseChannel.from_checkpoint()

### DIFF
--- a/langgraph/channels/any_value.py
+++ b/langgraph/channels/any_value.py
@@ -23,8 +23,16 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
         """The type of the update received by the channel."""
         return self.typ
 
+    def checkpoint(self) -> Value:
+        try:
+            return self.value
+        except AttributeError:
+            raise EmptyChannelError()
+
     @contextmanager
-    def empty(self, checkpoint: Optional[Value] = None) -> Generator[Self, None, None]:
+    def from_checkpoint(
+        self, checkpoint: Optional[Value] = None
+    ) -> Generator[Self, None, None]:
         empty = self.__class__(self.typ)
         if checkpoint is not None:
             empty.value = checkpoint
@@ -47,12 +55,6 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
         self.value = values[-1]
 
     def get(self) -> Value:
-        try:
-            return self.value
-        except AttributeError:
-            raise EmptyChannelError()
-
-    def checkpoint(self) -> Value:
         try:
             return self.value
         except AttributeError:

--- a/langgraph/channels/binop.py
+++ b/langgraph/channels/binop.py
@@ -34,8 +34,16 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
         """The type of the update received by the channel."""
         return self.typ
 
+    def checkpoint(self) -> Value:
+        try:
+            return self.value
+        except AttributeError:
+            raise EmptyChannelError()
+
     @contextmanager
-    def empty(self, checkpoint: Optional[Value] = None) -> Generator[Self, None, None]:
+    def from_checkpoint(
+        self, checkpoint: Optional[Value] = None
+    ) -> Generator[Self, None, None]:
         empty = self.__class__(self.typ, self.operator)
         if checkpoint is not None:
             empty.value = checkpoint
@@ -58,12 +66,6 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
             self.value = self.operator(self.value, value)
 
     def get(self) -> Value:
-        try:
-            return self.value
-        except AttributeError:
-            raise EmptyChannelError()
-
-    def checkpoint(self) -> Value:
         try:
             return self.value
         except AttributeError:

--- a/langgraph/channels/context.py
+++ b/langgraph/channels/context.py
@@ -65,8 +65,11 @@ class Context(Generic[Value], BaseChannel[Value, None, None]):
         """The type of the update received by the channel."""
         raise InvalidUpdateError()
 
+    def checkpoint(self) -> None:
+        raise EmptyChannelError()
+
     @contextmanager
-    def empty(self, checkpoint: None = None) -> Generator[Self, None, None]:
+    def from_checkpoint(self, checkpoint: None = None) -> Generator[Self, None, None]:
         if self.ctx is None:
             raise ValueError("Cannot enter sync context manager.")
 
@@ -80,7 +83,7 @@ class Context(Generic[Value], BaseChannel[Value, None, None]):
             ctx.__exit__(None, None, None)
 
     @asynccontextmanager
-    async def aempty(
+    async def afrom_checkpoint(
         self, checkpoint: Optional[str] = None
     ) -> AsyncGenerator[Self, None]:
         if self.actx is not None:
@@ -93,7 +96,7 @@ class Context(Generic[Value], BaseChannel[Value, None, None]):
             finally:
                 await actx.__aexit__(None, None, None)
         else:
-            with self.empty() as empty:
+            with self.from_checkpoint() as empty:
                 yield empty
 
     def update(self, values: Sequence[None]) -> None:
@@ -105,6 +108,3 @@ class Context(Generic[Value], BaseChannel[Value, None, None]):
             return self.value
         except AttributeError:
             raise EmptyChannelError()
-
-    def checkpoint(self) -> None:
-        raise EmptyChannelError()

--- a/langgraph/channels/ephemeral_value.py
+++ b/langgraph/channels/ephemeral_value.py
@@ -28,8 +28,16 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
         """The type of the update received by the channel."""
         return self.typ
 
+    def checkpoint(self) -> Value:
+        try:
+            return self.value
+        except AttributeError:
+            raise EmptyChannelError()
+
     @contextmanager
-    def empty(self, checkpoint: Optional[Value] = None) -> Generator[Self, None, None]:
+    def from_checkpoint(
+        self, checkpoint: Optional[Value] = None
+    ) -> Generator[Self, None, None]:
         empty = self.__class__(self.typ, self.guard)
         if checkpoint is not None:
             empty.value = checkpoint
@@ -55,12 +63,6 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
         self.value = values[-1]
 
     def get(self) -> Value:
-        try:
-            return self.value
-        except AttributeError:
-            raise EmptyChannelError()
-
-    def checkpoint(self) -> Value:
         try:
             return self.value
         except AttributeError:

--- a/langgraph/channels/last_value.py
+++ b/langgraph/channels/last_value.py
@@ -27,8 +27,16 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
         """The type of the update received by the channel."""
         return self.typ
 
+    def checkpoint(self) -> Value:
+        try:
+            return self.value
+        except AttributeError:
+            raise EmptyChannelError()
+
     @contextmanager
-    def empty(self, checkpoint: Optional[Value] = None) -> Generator[Self, None, None]:
+    def from_checkpoint(
+        self, checkpoint: Optional[Value] = None
+    ) -> Generator[Self, None, None]:
         empty = self.__class__(self.typ)
         if checkpoint is not None:
             empty.value = checkpoint
@@ -49,12 +57,6 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
         self.value = values[-1]
 
     def get(self) -> Value:
-        try:
-            return self.value
-        except AttributeError:
-            raise EmptyChannelError()
-
-    def checkpoint(self) -> Value:
         try:
             return self.value
         except AttributeError:

--- a/langgraph/channels/topic.py
+++ b/langgraph/channels/topic.py
@@ -49,14 +49,17 @@ class Topic(
         """The type of the update received by the channel."""
         return Union[self.typ, list[self.typ]]  # type: ignore[name-defined]
 
+    def checkpoint(self) -> tuple[set[Value], list[Value]]:
+        return (self.seen, self.values)
+
     @contextmanager
-    def empty(
+    def from_checkpoint(
         self, checkpoint: Optional[tuple[set[Value], list[Value]]] = None
     ) -> Generator[Self, None, None]:
         empty = self.__class__(self.typ, self.unique, self.accumulate)
         if checkpoint is not None:
-            empty.seen = checkpoint[0]
-            empty.values = checkpoint[1]
+            empty.seen = checkpoint[0].copy()
+            empty.values = checkpoint[1].copy()
         try:
             yield empty
         finally:
@@ -76,6 +79,3 @@ class Topic(
 
     def get(self) -> Sequence[Value]:
         return list(self.values)
-
-    def checkpoint(self) -> tuple[set[Value], list[Value]]:
-        return (self.seen, self.values)


### PR DESCRIPTION
- clearer name
- channels with complex data structures in checkpoint (eg a set or list) now copy the checkpointed data structures before creating the new channel