### PR TITLE
Remove some noisy frames from stack traces

### DIFF
--- a/tests/__snapshots__/test_pregel.ambr
+++ b/tests/__snapshots__/test_pregel.ambr
@@ -51,29 +51,13 @@
       },
       {
         "id": "__start___should_start",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_start"
-        }
+        "type": "unknown",
+        "data": "__start___should_start"
       },
       {
         "id": "left_condition",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "condition"
-        }
+        "type": "unknown",
+        "data": "left_condition"
       }
     ],
     "edges": [
@@ -235,29 +219,13 @@
       },
       {
         "id": "__start___should_start",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_start"
-        }
+        "type": "unknown",
+        "data": "__start___should_start"
       },
       {
         "id": "left_condition",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "condition"
-        }
+        "type": "unknown",
+        "data": "left_condition"
       }
     ],
     "edges": [
@@ -385,16 +353,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [
@@ -632,16 +592,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [
@@ -1006,16 +958,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [
@@ -1825,16 +1769,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [
@@ -2068,16 +2004,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [
@@ -2311,16 +2239,8 @@
       },
       {
         "id": "agent_should_continue",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langchain_core",
-            "runnables",
-            "base",
-            "RunnableLambda"
-          ],
-          "name": "should_continue"
-        }
+        "type": "unknown",
+        "data": "agent_should_continue"
       }
     ],
     "edges": [

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -2269,7 +2269,7 @@ def test_message_graph(
         FunctionMessage(
             content="result for query",
             name="search_api",
-            id="00000000-0000-4000-8000-000000000019",
+            id="00000000-0000-4000-8000-000000000018",
         ),
         AIMessage(
             content="",
@@ -2281,7 +2281,7 @@ def test_message_graph(
         FunctionMessage(
             content="result for another",
             name="search_api",
-            id="00000000-0000-4000-8000-000000000033",
+            id="00000000-0000-4000-8000-000000000031",
         ),
         AIMessage(content="answer", id="ai3"),
     ]
@@ -2291,7 +2291,7 @@ def test_message_graph(
             "__start__": [
                 HumanMessage(
                     content="what is weather in sf",
-                    id="00000000-0000-4000-8000-000000000045",
+                    id="00000000-0000-4000-8000-000000000042",
                 )
             ]
         },
@@ -2308,7 +2308,7 @@ def test_message_graph(
             "action": FunctionMessage(
                 content="result for query",
                 name="search_api",
-                id="00000000-0000-4000-8000-000000000059",
+                id="00000000-0000-4000-8000-000000000055",
             )
         },
         {
@@ -2324,7 +2324,7 @@ def test_message_graph(
             "action": FunctionMessage(
                 content="result for another",
                 name="search_api",
-                id="00000000-0000-4000-8000-000000000073",
+                id="00000000-0000-4000-8000-000000000068",
             )
         },
         {"agent": AIMessage(content="answer", id="ai3")},


### PR DESCRIPTION
- The less frames in library code the less confused the user is
- This doesn't remove all library frames (not possible), but it's a start