### PR TITLE
(WIP) Add support for early stopping in agent executor

### DIFF
--- a/langgraph/prebuilt/agent_executor.py
+++ b/langgraph/prebuilt/agent_executor.py
@@ -1,4 +1,5 @@
 import operator
+import time
 from typing import Annotated, Optional, Sequence, TypedDict, Union
 
 from langchain_core.agents import AgentAction, AgentFinish
@@ -24,10 +25,14 @@ def _get_agent_state(input_schema=None):
             # Here we annotate this with `operator.add` to indicate that operations to
             # this state should be ADDED to the existing values (not overwrite it)
             intermediate_steps: Annotated[list[tuple[AgentAction, str]], operator.add]
-            # Iteration count, tracked to enable early stopping
-            iteration_count: int
             # Maximum number of iterations
             max_iterations: Optional[int]
+            # Iteration count, tracked to enable early stopping
+            iteration_count: int
+            # # Maximum wall time
+            # max_execution_time: Optional[float]
+            # # Start time
+            # start_time: float
 
     else:
 
@@ -39,10 +44,14 @@ def _get_agent_state(input_schema=None):
             # Here we annotate this with `operator.add` to indicate that operations to
             # this state should be ADDED to the existing values (not overwrite it)
             intermediate_steps: Annotated[list[tuple[AgentAction, str]], operator.add]
-            # Iteration count, tracked to enable early stopping
-            iteration_count: int
             # Maximum number of iterations
             max_iterations: Optional[int]
+            # Iteration count, tracked to enable early stopping
+            iteration_count: int
+            # # Maximum wall time
+            # max_execution_time: Optional[float]
+            # # Start time
+            # start_time: float
 
     return AgentState
 
@@ -50,8 +59,14 @@ def _get_agent_state(input_schema=None):
 def _should_abort(data) -> bool:
     """Check if exceeding max iterations."""
     return (
-        data["max_iterations"] is not None
-        and data.get("iteration_count", 0) >= data["max_iterations"]
+        (
+            data.get("max_iterations") is not None
+            and data.get("iteration_count", 0) >= data["max_iterations"]
+        )
+        # or (
+        #     data.get("max_execution_time") is not None
+        #     and time.time() - data["start_time"] >= data["max_execution_time"]
+        # )
     )
 
 

--- a/langgraph/prebuilt/agent_executor.py
+++ b/langgraph/prebuilt/agent_executor.py
@@ -59,10 +59,8 @@ def _get_agent_state(input_schema=None):
 def _should_abort(data) -> bool:
     """Check if exceeding max iterations."""
     return (
-        (
-            data.get("max_iterations") is not None
-            and data.get("iteration_count", 0) >= data["max_iterations"]
-        )
+        data.get("max_iterations") is not None
+        and data.get("iteration_count", 0) >= data["max_iterations"]
         # or (
         #     data.get("max_execution_time") is not None
         #     and time.time() - data["start_time"] >= data["max_execution_time"]

--- a/langgraph/prebuilt/agent_executor.py
+++ b/langgraph/prebuilt/agent_executor.py
@@ -1,5 +1,4 @@
 import operator
-import time
 from typing import Annotated, Optional, Sequence, TypedDict, Union
 
 from langchain_core.agents import AgentAction, AgentFinish

--- a/tests/__snapshots__/test_agent_executor.ambr
+++ b/tests/__snapshots__/test_agent_executor.ambr
@@ -1,0 +1,481 @@
+# serializer version: 1
+# name: test_agent_executor
+  '{"title": "LangGraphInput", "$ref": "#/definitions/AgentState", "definitions": {"BaseMessage": {"title": "BaseMessage", "description": "Base abstract Message class.\\n\\nMessages are the inputs and outputs of ChatModels.", "type": "object", "properties": {"content": {"title": "Content", "anyOf": [{"type": "string"}, {"type": "array", "items": {"anyOf": [{"type": "string"}, {"type": "object"}]}}]}, "additional_kwargs": {"title": "Additional Kwargs", "type": "object"}, "type": {"title": "Type", "type": "string"}, "name": {"title": "Name", "type": "string"}, "id": {"title": "Id", "type": "string"}}, "required": ["content", "type"]}, "AgentAction": {"title": "AgentAction", "description": "A full description of an action for an ActionAgent to execute.", "type": "object", "properties": {"tool": {"title": "Tool", "type": "string"}, "tool_input": {"title": "Tool Input", "anyOf": [{"type": "string"}, {"type": "object"}]}, "log": {"title": "Log", "type": "string"}, "type": {"title": "Type", "default": "AgentAction", "enum": ["AgentAction"], "type": "string"}}, "required": ["tool", "tool_input", "log"]}, "AgentFinish": {"title": "AgentFinish", "description": "The final return value of an ActionAgent.", "type": "object", "properties": {"return_values": {"title": "Return Values", "type": "object"}, "log": {"title": "Log", "type": "string"}, "type": {"title": "Type", "default": "AgentFinish", "enum": ["AgentFinish"], "type": "string"}}, "required": ["return_values", "log"]}, "AgentState": {"title": "AgentState", "type": "object", "properties": {"input": {"title": "Input", "type": "string"}, "chat_history": {"title": "Chat History", "type": "array", "items": {"$ref": "#/definitions/BaseMessage"}}, "agent_outcome": {"title": "Agent Outcome", "anyOf": [{"$ref": "#/definitions/AgentAction"}, {"$ref": "#/definitions/AgentFinish"}]}, "intermediate_steps": {"title": "Intermediate Steps", "type": "array", "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": [{"$ref": "#/definitions/AgentAction"}, {"type": "string"}]}}, "max_iterations": {"title": "Max Iterations", "type": "integer"}, "iteration_count": {"title": "Iteration Count", "type": "integer"}}, "required": ["input", "chat_history", "agent_outcome", "intermediate_steps", "max_iterations", "iteration_count"]}}}'
+# ---
+# name: test_agent_executor.1
+  '{"title": "LangGraphOutput", "type": "object", "properties": {"input": {"title": "Input", "type": "string"}, "chat_history": {"title": "Chat History", "type": "array", "items": {"$ref": "#/definitions/BaseMessage"}}, "agent_outcome": {"title": "Agent Outcome", "anyOf": [{"$ref": "#/definitions/AgentAction"}, {"$ref": "#/definitions/AgentFinish"}]}, "intermediate_steps": {"title": "Intermediate Steps", "type": "array", "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": [{"$ref": "#/definitions/AgentAction"}, {"type": "string"}]}}, "max_iterations": {"title": "Max Iterations", "type": "integer"}, "iteration_count": {"title": "Iteration Count", "type": "integer"}}, "definitions": {"BaseMessage": {"title": "BaseMessage", "description": "Base abstract Message class.\\n\\nMessages are the inputs and outputs of ChatModels.", "type": "object", "properties": {"content": {"title": "Content", "anyOf": [{"type": "string"}, {"type": "array", "items": {"anyOf": [{"type": "string"}, {"type": "object"}]}}]}, "additional_kwargs": {"title": "Additional Kwargs", "type": "object"}, "type": {"title": "Type", "type": "string"}, "name": {"title": "Name", "type": "string"}, "id": {"title": "Id", "type": "string"}}, "required": ["content", "type"]}, "AgentAction": {"title": "AgentAction", "description": "A full description of an action for an ActionAgent to execute.", "type": "object", "properties": {"tool": {"title": "Tool", "type": "string"}, "tool_input": {"title": "Tool Input", "anyOf": [{"type": "string"}, {"type": "object"}]}, "log": {"title": "Log", "type": "string"}, "type": {"title": "Type", "default": "AgentAction", "enum": ["AgentAction"], "type": "string"}}, "required": ["tool", "tool_input", "log"]}, "AgentFinish": {"title": "AgentFinish", "description": "The final return value of an ActionAgent.", "type": "object", "properties": {"return_values": {"title": "Return Values", "type": "object"}, "log": {"title": "Log", "type": "string"}, "type": {"title": "Type", "default": "AgentFinish", "enum": ["AgentFinish"], "type": "string"}}, "required": ["return_values", "log"]}}}'
+# ---
+# name: test_agent_executor.2
+  '''
+  {
+    "nodes": [
+      {
+        "id": "__start__",
+        "type": "schema",
+        "data": {
+          "title": "LangGraphInput",
+          "$ref": "#/definitions/AgentState",
+          "definitions": {
+            "BaseMessage": {
+              "title": "BaseMessage",
+              "description": "Base abstract Message class.\n\nMessages are the inputs and outputs of ChatModels.",
+              "type": "object",
+              "properties": {
+                "content": {
+                  "title": "Content",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "additional_kwargs": {
+                  "title": "Additional Kwargs",
+                  "type": "object"
+                },
+                "type": {
+                  "title": "Type",
+                  "type": "string"
+                },
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "id": {
+                  "title": "Id",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "content",
+                "type"
+              ]
+            },
+            "AgentAction": {
+              "title": "AgentAction",
+              "description": "A full description of an action for an ActionAgent to execute.",
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "title": "Tool",
+                  "type": "string"
+                },
+                "tool_input": {
+                  "title": "Tool Input",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "log": {
+                  "title": "Log",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Type",
+                  "default": "AgentAction",
+                  "enum": [
+                    "AgentAction"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tool",
+                "tool_input",
+                "log"
+              ]
+            },
+            "AgentFinish": {
+              "title": "AgentFinish",
+              "description": "The final return value of an ActionAgent.",
+              "type": "object",
+              "properties": {
+                "return_values": {
+                  "title": "Return Values",
+                  "type": "object"
+                },
+                "log": {
+                  "title": "Log",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Type",
+                  "default": "AgentFinish",
+                  "enum": [
+                    "AgentFinish"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "return_values",
+                "log"
+              ]
+            },
+            "AgentState": {
+              "title": "AgentState",
+              "type": "object",
+              "properties": {
+                "input": {
+                  "title": "Input",
+                  "type": "string"
+                },
+                "chat_history": {
+                  "title": "Chat History",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/BaseMessage"
+                  }
+                },
+                "agent_outcome": {
+                  "title": "Agent Outcome",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/AgentAction"
+                    },
+                    {
+                      "$ref": "#/definitions/AgentFinish"
+                    }
+                  ]
+                },
+                "intermediate_steps": {
+                  "title": "Intermediate Steps",
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": [
+                      {
+                        "$ref": "#/definitions/AgentAction"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                },
+                "max_iterations": {
+                  "title": "Max Iterations",
+                  "type": "integer"
+                },
+                "iteration_count": {
+                  "title": "Iteration Count",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "input",
+                "chat_history",
+                "agent_outcome",
+                "intermediate_steps",
+                "max_iterations",
+                "iteration_count"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "__end__",
+        "type": "schema",
+        "data": {
+          "title": "LangGraphOutput",
+          "type": "object",
+          "properties": {
+            "input": {
+              "title": "Input",
+              "type": "string"
+            },
+            "chat_history": {
+              "title": "Chat History",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/BaseMessage"
+              }
+            },
+            "agent_outcome": {
+              "title": "Agent Outcome",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AgentAction"
+                },
+                {
+                  "$ref": "#/definitions/AgentFinish"
+                }
+              ]
+            },
+            "intermediate_steps": {
+              "title": "Intermediate Steps",
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": [
+                  {
+                    "$ref": "#/definitions/AgentAction"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "max_iterations": {
+              "title": "Max Iterations",
+              "type": "integer"
+            },
+            "iteration_count": {
+              "title": "Iteration Count",
+              "type": "integer"
+            }
+          },
+          "definitions": {
+            "BaseMessage": {
+              "title": "BaseMessage",
+              "description": "Base abstract Message class.\n\nMessages are the inputs and outputs of ChatModels.",
+              "type": "object",
+              "properties": {
+                "content": {
+                  "title": "Content",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                "additional_kwargs": {
+                  "title": "Additional Kwargs",
+                  "type": "object"
+                },
+                "type": {
+                  "title": "Type",
+                  "type": "string"
+                },
+                "name": {
+                  "title": "Name",
+                  "type": "string"
+                },
+                "id": {
+                  "title": "Id",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "content",
+                "type"
+              ]
+            },
+            "AgentAction": {
+              "title": "AgentAction",
+              "description": "A full description of an action for an ActionAgent to execute.",
+              "type": "object",
+              "properties": {
+                "tool": {
+                  "title": "Tool",
+                  "type": "string"
+                },
+                "tool_input": {
+                  "title": "Tool Input",
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "log": {
+                  "title": "Log",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Type",
+                  "default": "AgentAction",
+                  "enum": [
+                    "AgentAction"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tool",
+                "tool_input",
+                "log"
+              ]
+            },
+            "AgentFinish": {
+              "title": "AgentFinish",
+              "description": "The final return value of an ActionAgent.",
+              "type": "object",
+              "properties": {
+                "return_values": {
+                  "title": "Return Values",
+                  "type": "object"
+                },
+                "log": {
+                  "title": "Log",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "Type",
+                  "default": "AgentFinish",
+                  "enum": [
+                    "AgentFinish"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "return_values",
+                "log"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "agent",
+        "type": "runnable",
+        "data": {
+          "id": [
+            "langchain_core",
+            "runnables",
+            "base",
+            "RunnableLambda"
+          ],
+          "name": "run_agent"
+        }
+      },
+      {
+        "id": "action",
+        "type": "runnable",
+        "data": {
+          "id": [
+            "langchain_core",
+            "runnables",
+            "base",
+            "RunnableLambda"
+          ],
+          "name": "execute_tools"
+        }
+      },
+      {
+        "id": "abort",
+        "type": "runnable",
+        "data": {
+          "id": [
+            "langchain_core",
+            "runnables",
+            "base",
+            "RunnableLambda"
+          ],
+          "name": "abort"
+        }
+      },
+      {
+        "id": "agent_should_continue",
+        "type": "unknown",
+        "data": "agent_should_continue"
+      }
+    ],
+    "edges": [
+      {
+        "source": "__start__",
+        "target": "agent"
+      },
+      {
+        "source": "abort",
+        "target": "__end__"
+      },
+      {
+        "source": "action",
+        "target": "agent"
+      },
+      {
+        "source": "agent",
+        "target": "agent_should_continue"
+      },
+      {
+        "source": "agent_should_continue",
+        "target": "action",
+        "data": "continue"
+      },
+      {
+        "source": "agent_should_continue",
+        "target": "abort",
+        "data": "abort"
+      },
+      {
+        "source": "agent_should_continue",
+        "target": "__end__",
+        "data": "end"
+      }
+    ]
+  }
+  '''
+# ---
+# name: test_agent_executor.3
+  '''
+                       +-----------+                    
+                       | __start__ |                    
+                       +-----------+                    
+                              *                         
+                              *                         
+                              *                         
+                         +-------+                      
+                         | agent |*                     
+                        *+-------+ ***                  
+                      **              ****              
+                    **                    ***           
+                  **                         ***        
+    +-----------------------+                   **      
+    | agent_should_continue |                    *      
+    +-----------------------+*                   *      
+           *         **       ******             *      
+         **            *            ******       *      
+        *               **                ***    *      
+  +-------+               *                 +--------+  
+  | abort |             **                  | action |  
+  +-------+            *                    +--------+  
+           *         **                                 
+            **     **                                   
+              *   *                                     
+          +---------+                                   
+          | __end__ |                                   
+          +---------+                                   
+  '''
+# ---

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -12,12 +12,16 @@ from syrupy import SnapshotAssertion
 from langgraph.prebuilt.agent_executor import create_agent_executor
 
 
-def _make_agent_runnable(tools: List[BaseTool], response_messages: List[BaseMessage]) -> Runnable:
+def _make_agent_runnable(
+    tools: List[BaseTool], response_messages: List[BaseMessage]
+) -> Runnable:
     """Make fake agent runnable."""
     from langchain.agents.format_scratchpad.openai_tools import (
         format_to_openai_tool_messages,
     )
-    from langchain.agents.output_parsers.openai_tools import OpenAIToolsAgentOutputParser
+    from langchain.agents.output_parsers.openai_tools import (
+        OpenAIToolsAgentOutputParser,
+    )
     from langchain.chat_models.fake import FakeMessagesListChatModel
 
     chat_model = FakeMessagesListChatModel(responses=response_messages)
@@ -29,7 +33,9 @@ def _make_agent_runnable(tools: List[BaseTool], response_messages: List[BaseMess
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ]
     )
-    llm_with_tools = chat_model.bind(tools=[convert_to_openai_tool(tool) for tool in tools])
+    llm_with_tools = chat_model.bind(
+        tools=[convert_to_openai_tool(tool) for tool in tools]
+    )
 
     return (
         RunnablePassthrough.assign(
@@ -118,7 +124,9 @@ def test_agent_executor(snapshot: SnapshotAssertion) -> None:
             # "start_time": time.time()
         }
     )
-    assert result["agent_outcome"] == AgentFinish(return_values={'output': 'answer'}, log='answer')
+    assert result["agent_outcome"] == AgentFinish(
+        return_values={"output": "answer"}, log="answer"
+    )
     result = app.invoke(
         {
             "input": "what is the weather in sf?",
@@ -129,4 +137,7 @@ def test_agent_executor(snapshot: SnapshotAssertion) -> None:
             # "start_time": time.time()
         }
     )
-    assert result["agent_outcome"] == AgentFinish(return_values={'output': 'Agent stopped due to max iterations.'}, log='Agent stopped due to max iterations.')
+    assert result["agent_outcome"] == AgentFinish(
+        return_values={"output": "Agent stopped due to max iterations."},
+        log="Agent stopped due to max iterations.",
+    )

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -1,0 +1,132 @@
+import json
+from typing import List
+
+from langchain_core.agents import AgentFinish
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.runnables import Runnable, RunnablePassthrough
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from syrupy import SnapshotAssertion
+
+from langgraph.prebuilt.agent_executor import create_agent_executor
+
+
+def _make_agent_runnable(tools: List[BaseTool], response_messages: List[BaseMessage]) -> Runnable:
+    """Make fake agent runnable."""
+    from langchain.agents.format_scratchpad.openai_tools import (
+        format_to_openai_tool_messages,
+    )
+    from langchain.agents.output_parsers.openai_tools import OpenAIToolsAgentOutputParser
+    from langchain.chat_models.fake import FakeMessagesListChatModel
+
+    chat_model = FakeMessagesListChatModel(responses=response_messages)
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a helpful assistant"),
+            MessagesPlaceholder(variable_name="chat_history", optional=True),
+            ("user", "{input}"),
+            MessagesPlaceholder(variable_name="agent_scratchpad"),
+        ]
+    )
+    llm_with_tools = chat_model.bind(tools=[convert_to_openai_tool(tool) for tool in tools])
+
+    return (
+        RunnablePassthrough.assign(
+            agent_scratchpad=lambda x: format_to_openai_tool_messages(
+                x["intermediate_steps"]
+            )
+        )
+        | prompt
+        | llm_with_tools
+        | OpenAIToolsAgentOutputParser()
+    )
+
+
+def test_agent_executor(snapshot: SnapshotAssertion) -> None:
+    from langchain.agents import tool
+
+    @tool()
+    def search_api(query: str) -> str:
+        """Searches the API for the query."""
+        return f"result for {query}"
+
+    tools = [search_api]
+    responses = [
+        AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "tool_call123",
+                        "type": "function",
+                        "function": {
+                            "name": "search_api",
+                            "arguments": json.dumps("query"),
+                        },
+                    }
+                ]
+            },
+        ),
+        AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "tool_call234",
+                        "type": "function",
+                        "function": {
+                            "name": "search_api",
+                            "arguments": json.dumps("another one"),
+                        },
+                    }
+                ]
+            },
+        ),
+        AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "tool_call345",
+                        "type": "function",
+                        "function": {
+                            "name": "search_api",
+                            "arguments": json.dumps("another one"),
+                        },
+                    }
+                ]
+            },
+        ),
+        AIMessage(content="answer"),
+    ]
+    agent_runnable = _make_agent_runnable(tools, responses)
+    app = create_agent_executor(agent_runnable, tools)
+
+    assert app.get_input_schema().schema_json() == snapshot
+    assert app.get_output_schema().schema_json() == snapshot
+    assert json.dumps(app.get_graph().to_json(), indent=2) == snapshot
+    assert app.get_graph().draw_ascii() == snapshot
+
+    result = app.invoke(
+        {
+            "input": "what is the weather in sf?",
+            "chat_history": [],
+            "max_iterations": None,
+            "iteration_count": 0,
+            # "max_execution_time": None,
+            # "start_time": time.time()
+        }
+    )
+    assert result["agent_outcome"] == AgentFinish(return_values={'output': 'answer'}, log='answer')
+    result = app.invoke(
+        {
+            "input": "what is the weather in sf?",
+            "chat_history": [],
+            "max_iterations": 2,
+            "iteration_count": 0,
+            # "max_execution_time": None,
+            # "start_time": time.time()
+        }
+    )
+    assert result["agent_outcome"] == AgentFinish(return_values={'output': 'Agent stopped due to max iterations.'}, log='Agent stopped due to max iterations.')


### PR DESCRIPTION
Following https://github.com/langchain-ai/langgraph/issues/265, here we add support for early stopping (e.g., via `max_iterations` or `max_execution_time`) as in AgentExecutor.

WIP: looking for feedback on the general strategy for incorporating AgentExecutor's attributes, eventually including
- `return_intermediate_steps`
- `max_iterations`
- `max_execution_time`
- `early_stopping_method`
- `handle_parsing_errors`
- `trim_intermediate_steps`

Here I've added some to `AgentState`, but it's unclear to me how to set defaults when they are not passed in by the caller on invoke, stream, etc. For example, even if I set `iteration_count: int = 0` in AgentState, it gets set to 0 if not included in the input. Looking for suggestions on other ways to do this!