### PR TITLE
Fix/call the correct variable `authoring_graph` during compilation

### DIFF
--- a/examples/multi_agent/hierarchical_agent_teams.ipynb
+++ b/examples/multi_agent/hierarchical_agent_teams.ipynb
@@ -626,7 +626,7 @@
     ")\n",
     "\n",
     "authoring_graph.set_entry_point(\"supervisor\")\n",
-    "chain = research_graph.compile()\n",
+    "chain = authoring_graph.compile()\n",
     "\n",
     "\n",
     "# The following functions interoperate between the top level graph state\n",


### PR DESCRIPTION
In the `hierarchical_agent_teams.ipynb` example, `research_graph` should be replaced by `authoring_graph` during compilation. 