### PR TITLE
Checkpointer: Support more types of serializable states using `dill`

### DIFF
--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -1,4 +1,4 @@
-import pickle
+import dill as pickle
 from contextlib import AbstractAsyncContextManager
 from types import TracebackType
 from typing import AsyncIterator, Optional

--- a/langgraph/checkpoint/sqlite.py
+++ b/langgraph/checkpoint/sqlite.py
@@ -1,4 +1,4 @@
-import pickle
+import dill as pickle
 import sqlite3
 from contextlib import AbstractContextManager, contextmanager
 from types import TracebackType

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,21 @@ files = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.3.8"
+description = "serialize all of Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "dill-0.3.8-py3-none-any.whl", hash = "sha256:c36ca9ffb54365bdd2f8eb3eff7d2a21237f8452b57ace88b1ac615b7e815bd7"},
+    {file = "dill-0.3.8.tar.gz", hash = "sha256:3ebe3c479ad625c4553aca177444d89b486b1d84982eeacded644afc0cf797ca"},
+]
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+profile = ["gprof2dot (>=2022.7.29)"]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 description = "Distro - an OS platform information API"
@@ -3859,4 +3874,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<4.0"
-content-hash = "3f31fdccb53a66dc294a53d63bcef0233f38c9909170113c44b8dc215fc77d7c"
+content-hash = "9c41a80316ec7dda8527c03b94d4a5bd58c70da380fe565ad60435f945a4fe1f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ repository = "https://www.github.com/langchain-ai/langgraph"
 [tool.poetry.dependencies]
 python = ">=3.9.0,<4.0"
 langchain-core = "^0.1.38"
+dill = "^0.3.8"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
This PR solves the `PicklingError` when using states with [types that `pickle` doesn't support but `dill` does](https://github.com/uqfoundation/dill?tab=readme-ov-file#major-features).