### PR TITLE
Pregel: Add support for falsy outputs in Pregel class

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -557,6 +557,7 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
+        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
     ) -> Iterator[Union[dict[str, Any], Any]]:
         config = ensure_config(config)
@@ -698,12 +699,16 @@ class Pregel(
 
                     # yield current value or updates
                     if stream_mode == "values":
-                        if step_output := map_output_values(
-                            output_keys, pending_writes, channels
-                        ):
+                        if (
+                            step_output := map_output_values(
+                                output_keys, pending_writes, channels
+                            )
+                        ) or allow_falsy_output:
                             yield step_output
                     else:
-                        if step_output := map_output_updates(output_keys, next_tasks):
+                        if (
+                            step_output := map_output_updates(output_keys, next_tasks)
+                        ) or allow_falsy_output:
                             yield step_output
 
                     # save end of step checkpoint
@@ -755,6 +760,7 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
+        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
     ) -> AsyncIterator[Union[dict[str, Any], Any]]:
         config = ensure_config(config)
@@ -912,12 +918,16 @@ class Pregel(
 
                     # yield current value or updates
                     if stream_mode == "values":
-                        if step_output := map_output_values(
-                            output_keys, pending_writes, channels
-                        ):
+                        if (
+                            step_output := map_output_values(
+                                output_keys, pending_writes, channels
+                            )
+                        ) or allow_falsy_output:
                             yield step_output
                     else:
-                        if step_output := map_output_updates(output_keys, next_tasks):
+                        if (
+                            step_output := map_output_updates(output_keys, next_tasks)
+                        ) or allow_falsy_output:
                             yield step_output
 
                     # save end of step checkpoint
@@ -969,6 +979,7 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
+        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[dict[str, Any], Any]:
@@ -986,6 +997,7 @@ class Pregel(
             input_keys=input_keys,
             interrupt_before_nodes=interrupt_before_nodes,
             interrupt_after_nodes=interrupt_after_nodes,
+            allow_falsy_output=allow_falsy_output,
             debug=debug,
             **kwargs,
         ):
@@ -1008,6 +1020,7 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
+        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[dict[str, Any], Any]:
@@ -1025,6 +1038,7 @@ class Pregel(
             input_keys=input_keys,
             interrupt_before_nodes=interrupt_before_nodes,
             interrupt_after_nodes=interrupt_after_nodes,
+            allow_falsy_output=allow_falsy_output,
             debug=debug,
             **kwargs,
         ):

--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -557,7 +557,6 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
-        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
     ) -> Iterator[Union[dict[str, Any], Any]]:
         config = ensure_config(config)
@@ -699,17 +698,11 @@ class Pregel(
 
                     # yield current value or updates
                     if stream_mode == "values":
-                        if (
-                            step_output := map_output_values(
-                                output_keys, pending_writes, channels
-                            )
-                        ) or allow_falsy_output:
-                            yield step_output
+                        yield from map_output_values(
+                            output_keys, pending_writes, channels
+                        )
                     else:
-                        if (
-                            step_output := map_output_updates(output_keys, next_tasks)
-                        ) or allow_falsy_output:
-                            yield step_output
+                        yield from map_output_updates(output_keys, next_tasks)
 
                     # save end of step checkpoint
                     if self.checkpointer is not None and (
@@ -760,7 +753,6 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
-        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
     ) -> AsyncIterator[Union[dict[str, Any], Any]]:
         config = ensure_config(config)
@@ -918,17 +910,13 @@ class Pregel(
 
                     # yield current value or updates
                     if stream_mode == "values":
-                        if (
-                            step_output := map_output_values(
-                                output_keys, pending_writes, channels
-                            )
-                        ) or allow_falsy_output:
-                            yield step_output
+                        for chunk in map_output_values(
+                            output_keys, pending_writes, channels
+                        ):
+                            yield chunk
                     else:
-                        if (
-                            step_output := map_output_updates(output_keys, next_tasks)
-                        ) or allow_falsy_output:
-                            yield step_output
+                        for chunk in map_output_updates(output_keys, next_tasks):
+                            yield chunk
 
                     # save end of step checkpoint
                     if self.checkpointer is not None and (
@@ -979,7 +967,6 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
-        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[dict[str, Any], Any]:
@@ -997,7 +984,6 @@ class Pregel(
             input_keys=input_keys,
             interrupt_before_nodes=interrupt_before_nodes,
             interrupt_after_nodes=interrupt_after_nodes,
-            allow_falsy_output=allow_falsy_output,
             debug=debug,
             **kwargs,
         ):
@@ -1020,7 +1006,6 @@ class Pregel(
         input_keys: Optional[Union[str, Sequence[str]]] = None,
         interrupt_before_nodes: Optional[Sequence[str]] = None,
         interrupt_after_nodes: Optional[Sequence[str]] = None,
-        allow_falsy_output: bool = False,
         debug: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[dict[str, Any], Any]:
@@ -1038,7 +1023,6 @@ class Pregel(
             input_keys=input_keys,
             interrupt_before_nodes=interrupt_before_nodes,
             interrupt_after_nodes=interrupt_after_nodes,
-            allow_falsy_output=allow_falsy_output,
             debug=debug,
             **kwargs,
         ):

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -74,9 +74,9 @@ def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
 )
 def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> None:
     graph = Graph()
-    graph.add_node("add_one", lambda *args, **kwargs: falsy_value)
-    graph.set_entry_point("add_one")
-    graph.set_finish_point("add_one")
+    graph.add_node("return_falsy_const", lambda *args, **kwargs: falsy_value)
+    graph.set_entry_point("return_falsy_const")
+    graph.set_finish_point("return_falsy_const")
     gapp = graph.compile()
     assert gapp.invoke(1, allow_falsy_output=True) == falsy_value
     assert gapp.invoke(1) is None

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -68,6 +68,20 @@ def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
     assert gapp.invoke(2, debug=True) == 3
 
 
+@pytest.mark.parametrize(
+    "falsy_value",
+    [None, False, 0, "", [], {}, set(), frozenset(), 0.0, 0j],
+)
+def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> None:
+    graph = Graph()
+    graph.add_node("add_one", lambda *args, **kwargs: falsy_value)
+    graph.set_entry_point("add_one")
+    graph.set_finish_point("add_one")
+    gapp = graph.compile()
+    assert gapp.invoke(1, allow_falsy_output=True) == falsy_value
+    assert gapp.invoke(1) is None
+
+
 def test_invoke_single_process_in_out_implicit_channels(mocker: MockerFixture) -> None:
     add_one = mocker.Mock(side_effect=lambda x: x + 1)
     chain = Channel.subscribe_to("input") | add_one | Channel.write_to("output")

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -78,8 +78,7 @@ def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> None:
     graph.set_entry_point("return_falsy_const")
     graph.set_finish_point("return_falsy_const")
     gapp = graph.compile()
-    assert gapp.invoke(1, allow_falsy_output=True) == falsy_value
-    assert gapp.invoke(1) is None
+    assert gapp.invoke(1) == falsy_value
 
 
 def test_invoke_single_process_in_out_implicit_channels(mocker: MockerFixture) -> None:

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -71,9 +71,9 @@ async def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
 )
 async def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> None:
     graph = Graph()
-    graph.add_node("add_one", lambda *args, **kwargs: falsy_value)
-    graph.set_entry_point("add_one")
-    graph.set_finish_point("add_one")
+    graph.add_node("return_falsy_const", lambda *args, **kwargs: falsy_value)
+    graph.set_entry_point("return_falsy_const")
+    graph.set_finish_point("return_falsy_const")
     gapp = graph.compile()
     assert (await gapp.ainvoke(1, allow_falsy_output=True)) == falsy_value
     assert (await gapp.ainvoke(1)) is None

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -75,8 +75,7 @@ async def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> No
     graph.set_entry_point("return_falsy_const")
     graph.set_finish_point("return_falsy_const")
     gapp = graph.compile()
-    assert (await gapp.ainvoke(1, allow_falsy_output=True)) == falsy_value
-    assert (await gapp.ainvoke(1)) is None
+    assert falsy_value == await gapp.ainvoke(1)
 
 
 async def test_invoke_single_process_in_out_implicit_channels(

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -65,6 +65,20 @@ async def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
     assert await gapp.ainvoke(2) == 3
 
 
+@pytest.mark.parametrize(
+    "falsy_value",
+    [None, False, 0, "", [], {}, set(), frozenset(), 0.0, 0j],
+)
+async def test_invoke_single_process_in_out_falsy_values(falsy_value: Any) -> None:
+    graph = Graph()
+    graph.add_node("add_one", lambda *args, **kwargs: falsy_value)
+    graph.set_entry_point("add_one")
+    graph.set_finish_point("add_one")
+    gapp = graph.compile()
+    assert (await gapp.ainvoke(1, allow_falsy_output=True)) == falsy_value
+    assert (await gapp.ainvoke(1)) is None
+
+
 async def test_invoke_single_process_in_out_implicit_channels(
     mocker: MockerFixture,
 ) -> None:


### PR DESCRIPTION
## Description

This PR addresses a specific issue where a graph unexpectedly returns None for falsy values instead of the actual falsy output. This behavior was identified during operations where the expected behavior is to output falsy values, such as 0, False, or an empty collection, but instead, the graph outputs None.

The issue is illustrated with the following example:

```python
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from langchain_core.runnables import RunnableLambda
>>> from langgraph.graph import Graph, END
>>> workflow = Graph()
>>> workflow.add_node('minus1', RunnableLambda(lambda n: n-1))
>>> workflow.set_entry_point('minus1')
>>> workflow.add_edge('minus1', END)
>>> runnable = workflow.compile()
>>> print(runnable.invoke(1))
None
>>> print(runnable.invoke(2))
1
>>> print(runnable.invoke(-1))
-2
```

For more details, refer to　https://github.com/langchain-ai/langchain/discussions/20201 .

The solution implemented in this PR introduces a new parameter allow_falsy_output to decide whether the graph should return None or the actual output when the result is falsy. This allows for more accurate output representation, as demonstrated below:

```python
>>> print(runnable.invoke(1, allow_falsy_output=True))
0
```

## Issues

https://github.com/langchain-ai/langchain/discussions/20201

## Dependencies

Nothing

## Question

The purpose of the following if statements in the langgraph/pregel/__init__.py file is unclear:

- https://github.com/langchain-ai/langgraph/blob/114137059350b95068db9e96f79924fdc379bbe2/langgraph/pregel/__init__.py#L701
- https://github.com/langchain-ai/langgraph/blob/114137059350b95068db9e96f79924fdc379bbe2/langgraph/pregel/__init__.py#L706
- https://github.com/langchain-ai/langgraph/blob/114137059350b95068db9e96f79924fdc379bbe2/langgraph/pregel/__init__.py#L915
- https://github.com/langchain-ai/langgraph/blob/114137059350b95068db9e96f79924fdc379bbe2/langgraph/pregel/__init__.py#L920

Could someone provide clarity on the intention behind these conditions?