### PR TITLE
fix: plan execute example response state

### DIFF
--- a/examples/plan-and-execute/plan-and-execute.ipynb
+++ b/examples/plan-and-execute/plan-and-execute.ipynb
@@ -398,7 +398,7 @@
     "\n",
     "\n",
     "def should_end(state: PlanExecute):\n",
-    "    if state[\"response\"]:\n",
+    "    if \"response\" in state and state[\"response\"]:\n",
     "        return True\n",
     "    else:\n",
     "        return False"


### PR DESCRIPTION
This pull request resolves issue in https://github.com/langchain-ai/langchain/discussions/20158

Error:
```
---> [23](vscode-notebook-cell:?execution_count=22&line=23)     if state["response"]:
     [24](vscode-notebook-cell:?execution_count=22&line=24)         return True
     [25](vscode-notebook-cell:?execution_count=22&line=25)     else:

KeyError: 'response'
```

Changes: Check if `response` exists in state