### PR TITLE
Make ser/de configurable in checkpointer classes

### DIFF
--- a/langgraph/checkpoint/__init__.py
+++ b/langgraph/checkpoint/__init__.py
@@ -1,9 +1,15 @@
-from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointAt
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    Checkpoint,
+    CheckpointAt,
+    SerializerProtocol,
+)
 from langgraph.checkpoint.memory import MemorySaver
 
 __all__ = [
+    "BaseCheckpointSaver",
     "Checkpoint",
     "CheckpointAt",
-    "BaseCheckpointSaver",
     "MemorySaver",
+    "SerializerProtocol",
 ]

--- a/langgraph/checkpoint/memory.py
+++ b/langgraph/checkpoint/memory.py
@@ -1,43 +1,59 @@
+import asyncio
+import pickle
 from collections import defaultdict
-from typing import Optional
+from typing import AsyncIterator, Iterator, Optional
 
-from langchain_core.pydantic_v1 import Field
 from langchain_core.runnables import RunnableConfig
 
-from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointTuple
+from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
+    Checkpoint,
+    CheckpointAt,
+    CheckpointTuple,
+    SerializerProtocol,
+)
 
 
 class MemorySaver(BaseCheckpointSaver):
-    storage: defaultdict[str, dict[str, Checkpoint]] = Field(
-        default_factory=lambda: defaultdict(dict)
-    )
+    serde = pickle
 
-    def get(self, config: RunnableConfig) -> Optional[Checkpoint]:
-        if value := self.get_tuple(config):
-            return value.checkpoint
+    storage: defaultdict[str, dict[str, Checkpoint]]
+
+    def __init__(
+        self,
+        *,
+        serde: Optional[SerializerProtocol] = None,
+        at: Optional[CheckpointAt] = None,
+    ) -> None:
+        super().__init__(serde=serde, at=at)
+        self.storage = defaultdict(dict)
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
-        if config["configurable"].get("thread_ts"):
-            if checkpoint := self.storage[config["configurable"]["thread_id"]].get(
-                config["configurable"]["thread_ts"]
-            ):
-                return CheckpointTuple(config=config, checkpoint=checkpoint)
-        else:
-            if checkpoints := self.storage[config["configurable"]["thread_id"]]:
-                thread_ts = max(checkpoints.keys())
+        thread_id = config["configurable"]["thread_id"]
+        if ts := config["configurable"].get("thread_ts"):
+            if checkpoint := self.storage[thread_id].get(ts):
                 return CheckpointTuple(
-                    config={
-                        "configurable": {
-                            "thread_id": config["configurable"]["thread_id"],
-                            "thread_ts": thread_ts,
-                        }
-                    },
-                    checkpoint=checkpoints[thread_ts],
+                    config=config, checkpoint=self.serde.loads(checkpoint)
                 )
+        else:
+            if checkpoints := self.storage[thread_id]:
+                ts = max(checkpoints.keys())
+                return CheckpointTuple(
+                    config={"configurable": {"thread_id": thread_id, "thread_ts": ts}},
+                    checkpoint=self.serde.loads(checkpoints[ts]),
+                )
+
+    def list(self, config: RunnableConfig) -> Iterator[CheckpointTuple]:
+        thread_id = config["configurable"]["thread_id"]
+        for ts, checkpoint in self.storage[thread_id].items():
+            yield CheckpointTuple(
+                config={"configurable": {"thread_id": thread_id, "thread_ts": ts}},
+                checkpoint=self.serde.loads(checkpoint),
+            )
 
     def put(self, config: RunnableConfig, checkpoint: Checkpoint) -> RunnableConfig:
         self.storage[config["configurable"]["thread_id"]].update(
-            {checkpoint["ts"]: checkpoint}
+            {checkpoint["ts"]: self.serde.dumps(checkpoint)}
         )
         return {
             "configurable": {
@@ -45,3 +61,24 @@ class MemorySaver(BaseCheckpointSaver):
                 "thread_ts": checkpoint["ts"],
             }
         }
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.get_tuple, config
+        )
+
+    async def alist(self, config: RunnableConfig) -> AsyncIterator[CheckpointTuple]:
+        loop = asyncio.get_running_loop()
+        iter = loop.run_in_executor(None, self.list, config)
+        while True:
+            try:
+                yield await loop.run_in_executor(None, next, iter)
+            except StopIteration:
+                return
+
+    async def aput(
+        self, config: RunnableConfig, checkpoint: Checkpoint
+    ) -> RunnableConfig:
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.put, config, checkpoint
+        )

--- a/tests/memory_assert.py
+++ b/tests/memory_assert.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any
+from typing import Any, Optional
 
 from langgraph.checkpoint.base import (
     Checkpoint,
@@ -26,7 +26,10 @@ class MemorySaverAssertImmutable(MemorySaver):
     storage_for_copies: defaultdict[str, dict[str, Checkpoint]]
 
     def __init__(
-        self, *, serde: SerializerProtocol | None = None, at: CheckpointAt | None = None
+        self,
+        *,
+        serde: Optional[SerializerProtocol] = None,
+        at: Optional[CheckpointAt] = None,
     ) -> None:
         super().__init__(serde=serde, at=at)
         self.storage_for_copies = defaultdict(dict)

--- a/tests/memory_assert.py
+++ b/tests/memory_assert.py
@@ -1,17 +1,35 @@
 from collections import defaultdict
+from typing import Any
 
-from langchain_core.pydantic_v1 import Field
-
-from langgraph.checkpoint.base import Checkpoint, CheckpointAt, copy_checkpoint
+from langgraph.checkpoint.base import (
+    Checkpoint,
+    CheckpointAt,
+    SerializerProtocol,
+    copy_checkpoint,
+)
 from langgraph.checkpoint.memory import MemorySaver
 
 
+class NoopSerializer(SerializerProtocol):
+    def loads(self, data: bytes) -> Any:
+        return data
+
+    def dumps(self, obj: Any) -> bytes:
+        return obj
+
+
 class MemorySaverAssertImmutable(MemorySaver):
-    storage_for_copies: defaultdict[str, dict[str, Checkpoint]] = Field(
-        default_factory=lambda: defaultdict(dict)
-    )
+    serde = NoopSerializer()
 
     at = CheckpointAt.END_OF_STEP
+
+    storage_for_copies: defaultdict[str, dict[str, Checkpoint]]
+
+    def __init__(
+        self, *, serde: SerializerProtocol | None = None, at: CheckpointAt | None = None
+    ) -> None:
+        super().__init__(serde=serde, at=at)
+        self.storage_for_copies = defaultdict(dict)
 
     def put(self, config: dict, checkpoint: Checkpoint) -> None:
         # assert checkpoint hasn't been modified since last written


### PR DESCRIPTION
- Remove pydantic usage from base checkpointer class
- Make serialization configurable for all existing checkpointer classes, you can eg use dill or json instead of pickle