### PR TITLE
Fix astream_events modifying output format unexpectedly

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -512,6 +512,7 @@ class Pregel(
 
     def _defaults(
         self,
+        config: Optional[RunnableConfig] = None,
         *,
         stream_mode: Optional[StreamMode] = None,
         input_keys: Optional[Union[str, Sequence[str]]] = None,
@@ -542,9 +543,13 @@ class Pregel(
             validate_keys(input_keys, self.channels)
         interrupt_before_nodes = interrupt_before_nodes or self.interrupt_before_nodes
         interrupt_after_nodes = interrupt_after_nodes or self.interrupt_after_nodes
+        stream_mode = stream_mode if stream_mode is not None else self.stream_mode
+        if config is not None and config.get("configurable", {}).get(CONFIG_KEY_READ):
+            # if being called as a node in another graph, always use values mode
+            stream_mode = "values"
         return (
             debug,
-            stream_mode if stream_mode is not None else self.stream_mode,
+            stream_mode,
             input_keys,
             output_keys,
             interrupt_before_nodes,
@@ -567,7 +572,10 @@ class Pregel(
         config = ensure_config(config)
         callback_manager = get_callback_manager_for_config(config)
         run_manager = callback_manager.on_chain_start(
-            dumpd(self), input, name=config.get("run_name", self.get_name())
+            dumpd(self),
+            input,
+            name=config.get("run_name", self.get_name()),
+            run_id=config.get("run_id"),
         )
         try:
             if config["recursion_limit"] < 1:
@@ -581,6 +589,7 @@ class Pregel(
                 interrupt_before_nodes,
                 interrupt_after_nodes,
             ) = self._defaults(
+                config,
                 stream_mode=stream_mode,
                 input_keys=input_keys,
                 output_keys=output_keys,
@@ -763,7 +772,10 @@ class Pregel(
         config = ensure_config(config)
         callback_manager = get_async_callback_manager_for_config(config)
         run_manager = await callback_manager.on_chain_start(
-            dumpd(self), input, name=config.get("run_name", self.get_name())
+            dumpd(self),
+            input,
+            name=config.get("run_name", self.get_name()),
+            run_id=config.get("run_id"),
         )
         # if running from astream_log() run each proc with streaming
         do_stream = next(
@@ -786,6 +798,7 @@ class Pregel(
                 interrupt_before_nodes,
                 interrupt_after_nodes,
             ) = self._defaults(
+                config,
                 stream_mode=stream_mode,
                 input_keys=input_keys,
                 output_keys=output_keys,

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -8,13 +8,16 @@ from typing import (
     AsyncGenerator,
     AsyncIterator,
     Generator,
+    Iterator,
     Optional,
     TypedDict,
     Union,
 )
+from uuid import UUID
 
+from langchain_core.runnables.config import RunnableConfig
 import pytest
-from langchain_core.runnables import RunnableLambda, RunnablePassthrough
+from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
 from pytest_mock import MockerFixture
 
 from langgraph.channels.base import InvalidUpdateError
@@ -3310,3 +3313,95 @@ async def test_in_one_fan_out_state_graph_waiting_edge_multiple_cond_edge() -> N
         },
         {"qa": {"answer": "doc1,doc1,doc2,doc2,doc3,doc3,doc4,doc4"}},
     ]
+
+
+async def test_nested_graph() -> None:
+    class State(TypedDict):
+        my_key: str
+
+    async def up(state: State):
+        return {"my_key": state["my_key"] + " there"}
+
+    inner = StateGraph(State)
+    inner.add_node("up", up)
+    inner.set_entry_point("up")
+    inner.set_finish_point("up")
+
+    async def side(state: State):
+        return {"my_key": state["my_key"] + " and back again"}
+
+    graph = StateGraph(State)
+    graph.add_node("inner", inner.compile())
+    graph.add_node("side", side)
+    graph.set_entry_point("inner")
+    graph.add_edge("inner", "side")
+    graph.set_finish_point("side")
+
+    app = graph.compile()
+
+    assert app.get_graph().draw_ascii() == (
+        """+-----------+  
+| __start__ |  
++-----------+  
+      *        
+      *        
+      *        
+  +-------+    
+  | inner |    
+  +-------+    
+      *        
+      *        
+      *        
+  +------+     
+  | side |     
+  +------+     
+      *        
+      *        
+      *        
+ +---------+   
+ | __end__ |   
+ +---------+   """
+    )
+    assert await app.ainvoke({"my_key": "my value"}) == {
+        "my_key": "my value there and back again"
+    }
+    assert [chunk async for chunk in app.astream({"my_key": "my value"})] == [
+        {"inner": {"my_key": "my value there"}},
+        {"side": {"my_key": "my value there and back again"}},
+    ]
+    assert [
+        chunk
+        async for chunk in app.astream({"my_key": "my value"}, stream_mode="values")
+    ] == [
+        {"my_key": "my value"},
+        {"my_key": "my value there"},
+        {"my_key": "my value there and back again"},
+    ]
+    times_called = 0
+    async for event in app.astream_events(
+        {"my_key": "my value"},
+        version="v1",
+        config={"run_id": UUID(int=0)},
+        stream_mode="values",
+    ):
+        if event["event"] == "on_chain_end" and event["run_id"] == str(UUID(int=0)):
+            times_called += 1
+            assert event["data"] == {
+                "output": {"my_key": "my value there and back again"}
+            }
+    assert times_called == 1
+    times_called = 0
+    async for event in app.astream_events(
+        {"my_key": "my value"},
+        version="v1",
+        config={"run_id": UUID(int=0)},
+    ):
+        if event["event"] == "on_chain_end" and event["run_id"] == str(UUID(int=0)):
+            times_called += 1
+            assert event["data"] == {
+                "output": [
+                    {"inner": {"my_key": "my value there"}},
+                    {"side": {"my_key": "my value there and back again"}},
+                ]
+            }
+    assert times_called == 1

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -8,16 +8,14 @@ from typing import (
     AsyncGenerator,
     AsyncIterator,
     Generator,
-    Iterator,
     Optional,
     TypedDict,
     Union,
 )
 from uuid import UUID
 
-from langchain_core.runnables.config import RunnableConfig
 import pytest
-from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
+from langchain_core.runnables import RunnableLambda, RunnablePassthrough
 from pytest_mock import MockerFixture
 
 from langgraph.channels.base import InvalidUpdateError


### PR DESCRIPTION
- (unrelated) use run_id passed in
- if using a graph as node in another graph ensure stream_mode for inner call is always values
- ensure langchain-core doesn't auto promote streamed dicts to addable dicts, which results in unexpected output (only) when calling astream_events