### PR TITLE
Default state value (`StateGraph`) to `None` if channel is empty

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -316,7 +316,7 @@ class Pregel(
             )
             values = read_channels(channels, self.stream_channels_list)
             return StateSnapshot(
-                values[self.stream_channels]
+                values.get(self.stream_channels, None)
                 if isinstance(self.stream_channels, str)
                 else values,
                 tuple(name for name, _ in next_tasks),
@@ -337,7 +337,7 @@ class Pregel(
             )
             values = read_channels(channels, self.stream_channels_list)
             return StateSnapshot(
-                values[self.stream_channels]
+                values.get(self.stream_channels, None)
                 if isinstance(self.stream_channels, str)
                 else values,
                 tuple(name for name, _ in next_tasks),
@@ -356,7 +356,7 @@ class Pregel(
                 )
                 values = read_channels(channels, self.stream_channels_list)
                 yield StateSnapshot(
-                    values[self.stream_channels]
+                    values.get(self.stream_channels, None)
                     if isinstance(self.stream_channels, str)
                     else values,
                     tuple(name for name, _ in next_tasks),
@@ -378,7 +378,7 @@ class Pregel(
                 )
                 values = read_channels(channels, self.stream_channels_list)
                 yield StateSnapshot(
-                    values[self.stream_channels]
+                    values.get(self.stream_channels, None)
                     if isinstance(self.stream_channels, str)
                     else values,
                     tuple(name for name, _ in next_tasks),


### PR DESCRIPTION
### Summary
The following error will occur when retrieving state (`StateGraph`) on an empty channel.
```python
    async def aget_state(self, config: RunnableConfig) -> StateSnapshot:
        if not self.checkpointer:
            raise ValueError("No checkpointer set")
    
        saved = await self.checkpointer.aget_tuple(config)
        checkpoint = saved.checkpoint if saved else empty_checkpoint()
        config = saved.config if saved else config
    
        async with AsyncChannelsManager(self.channels, checkpoint) as channels:
            _, next_tasks = _prepare_next_tasks(
                checkpoint, self.nodes, channels, for_execution=False
            )
            values = read_channels(channels, self.stream_channels_list)
            return StateSnapshot(
>               values[self.stream_channels]
                if isinstance(self.stream_channels, str)
                else values,
                tuple(name for name, _ in next_tasks),
                config,
            )
E           KeyError: '__root__'

env/lib/python3.11/site-packages/langgraph/pregel/__init__.py:343: KeyError
```
`langgraph.pregel.io.read_channels()` will return an empty `dict` (`EmptyChannelError` is raised and silently excepted).

### Implementation
1. Default `StateSnapshot.values` to `None`.