### PR TITLE
Add required `gpt4all` dependency

### DIFF
--- a/examples/rag/langgraph_rag_agent_llama3_local.ipynb
+++ b/examples/rag/langgraph_rag_agent_llama3_local.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U langchain-nomic langchain_community tiktoken langchainhub chromadb langchain langgraph tavily-python"
+    "! pip install -U langchain-nomic langchain_community tiktoken langchainhub chromadb langchain langgraph tavily-python gpt4all"
    ]
   },
   {
@@ -229,7 +229,7 @@
     "# Prompt\n",
     "prompt = PromptTemplate(\n",
     "    template=\"\"\" <|begin_of_text|><|start_header_id|>system<|end_header_id|> You are a grader assessing whether \n",
-    "    an answer is grounded in / supported by a set of facts. Give a binary score 'yes' or 'no' score to indicate \n",
+    "    an answer is grounded in / supported by a set of facts. Give a binary 'yes' or 'no' score to indicate \n",
     "    whether the answer is grounded in / supported by a set of facts. Provide the binary score as a JSON with a \n",
     "    single key 'score' and no preamble or explanation. <|eot_id|><|start_header_id|>user<|end_header_id|>\n",
     "    Here are the facts:\n",


### PR DESCRIPTION
For the GPT4AllEmbeddings to work (in the Indexing part) the `gpt4all` package is required. This PR adds it to the list of required dependencies at the top of the notebook