### PR TITLE
Pregel: Remove implicit creation of channels referenced by nodes

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -54,7 +54,6 @@ from langgraph.channels.base import (
     InvalidUpdateError,
     create_checkpoint,
 )
-from langgraph.channels.last_value import LastValue
 from langgraph.checkpoint.base import (
     BaseCheckpointSaver,
     Checkpoint,
@@ -185,13 +184,11 @@ class Pregel(
 
     channels: Mapping[str, BaseChannel] = Field(default_factory=dict)
 
-    default_channel_cls: Type[BaseChannel] = Field(default=LastValue)
-
     auto_validate: bool = True
 
     stream_mode: StreamMode = "values"
 
-    output_channels: Union[str, Sequence[str]] = "output"
+    output_channels: Union[str, Sequence[str]]
     """Channels to output, defaults to channel named 'output'."""
 
     stream_channels: Optional[Union[str, Sequence[str]]] = None
@@ -201,7 +198,7 @@ class Pregel(
 
     interrupt_before_nodes: Sequence[str] = Field(default_factory=list)
 
-    input_channels: Union[str, Sequence[str]] = "input"
+    input_channels: Union[str, Sequence[str]]
 
     step_timeout: Optional[float] = None
 
@@ -226,7 +223,6 @@ class Pregel(
             values["stream_channels"],
             values["interrupt_after_nodes"],
             values["interrupt_before_nodes"],
-            values["default_channel_cls"],
         )
         if values["interrupt_after_nodes"] or values["interrupt_before_nodes"]:
             if not values["checkpointer"]:
@@ -242,7 +238,6 @@ class Pregel(
             self.stream_channels,
             self.interrupt_after_nodes,
             self.interrupt_before_nodes,
-            self.default_channel_cls,
         )
         if self.interrupt_after_nodes or self.interrupt_before_nodes:
             if not self.checkpointer:

--- a/langgraph/pregel/validate.py
+++ b/langgraph/pregel/validate.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence, Type, Union
+from typing import Mapping, Optional, Sequence, Union
 
 from langgraph.channels.base import BaseChannel
 from langgraph.constants import INTERRUPT
@@ -13,7 +13,6 @@ def validate_graph(
     stream_channels: Optional[Union[str, Sequence[str]]],
     interrupt_after_nodes: Sequence[str],
     interrupt_before_nodes: Sequence[str],
-    default_channel_cls: Type[BaseChannel],
 ) -> None:
     subscribed_channels = set[str]()
     for name, node in nodes.items():
@@ -28,11 +27,11 @@ def validate_graph(
 
     for chan in subscribed_channels:
         if chan not in channels:
-            channels[chan] = default_channel_cls(Any)  # type: ignore[arg-type]
+            raise ValueError(f"Subscribed channel '{chan}' not in 'channels'")
 
     if isinstance(input_channels, str):
         if input_channels not in channels:
-            channels[input_channels] = default_channel_cls(Any)  # type: ignore[arg-type]
+            raise ValueError(f"Input channel '{input_channels}' not in 'channels'")
         if input_channels not in subscribed_channels:
             raise ValueError(
                 f"Input channel {input_channels} is not subscribed to by any node"
@@ -40,7 +39,7 @@ def validate_graph(
     else:
         for chan in input_channels:
             if chan not in channels:
-                channels[chan] = default_channel_cls(Any)  # type: ignore[arg-type]
+                raise ValueError(f"Input channel '{chan}' not in 'channels'")
         if all(chan not in subscribed_channels for chan in input_channels):
             raise ValueError(
                 f"None of the input channels {input_channels} are subscribed to by any node"
@@ -58,7 +57,7 @@ def validate_graph(
 
     for chan in all_output_channels:
         if chan not in channels:
-            channels[chan] = default_channel_cls(Any)  # type: ignore[arg-type]
+            raise ValueError(f"Output channel '{chan}' not in 'channels'")
 
     for node in interrupt_after_nodes:
         if node not in nodes:

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -740,7 +740,7 @@ def test_invoke_two_processes_two_in_join_two_out(mocker: MockerFixture) -> None
         assert [*executor.map(app.invoke, [2] * 100)] == [[13, 13]] * 100
 
 
-def test_invoke_join_then_call_other_app(mocker: MockerFixture) -> None:
+def test_invoke_join_then_call_other_pregel(mocker: MockerFixture) -> None:
     add_one = mocker.Mock(side_effect=lambda x: x + 1)
     add_10_each = mocker.Mock(side_effect=lambda x: [y + 10 for y in x])
 


### PR DESCRIPTION
- channels must be declared in the constructor args