### PR TITLE
Check if conn is alive

### DIFF
--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -52,8 +52,8 @@ class AsyncSqliteSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
     async def setup(self) -> None:
         if self.is_setup:
             return
-
-        await self.conn
+        if not self.conn.is_alive():
+            await self.conn
         async with self.conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS checkpoints (


### PR DESCRIPTION
If you're adding tables to the same connection that you use for the checkpointer, this line raises an error (since you will have already had to `await conn`