### PR TITLE
Add pointers to create_react_agent in how-tos where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean docs_build docs_clean docs_linkcheck api_docs_build api_docs_clean api_docs_linkcheck format lint test tests test_watch integration_tests docker_tests help extended_tests coverage spell_check spell_fix build-docs serve-docs
+.PHONY: all clean format lint test tests test_watch integration_tests docker_tests help extended_tests coverage spell_check spell_fix build-docs serve-docs serve-clean-docs clean-docs
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -51,10 +51,20 @@ spell_fix:
 
 build-docs:
 	poetry run python docs/_scripts/copy_notebooks.py
-	poetry run mkdocs build --clean -f docs/mkdocs.yml --strict
+	poetry run mkdocs build --clean -f docs/mkdocs.yml --strict -d docs/site
 
-serve-docs: build-docs
-	poetry run mkdocs serve -f docs/mkdocs.yml
+serve-clean-docs: clean-docs
+	poetry run python docs/_scripts/copy_notebooks.py
+	poetry run python -m mkdocs serve -c -f mkdocs.yml --strict -w ./langgraph
+
+serve-docs:
+	poetry run python docs/_scripts/copy_notebooks.py
+	poetry run python -m mkdocs serve -f docs/mkdocs.yml -w ./langgraph --dirty
+
+clean-docs:
+	find ./docs/docs -name "*.ipynb" -type f -delete
+	rm -rf docs/site
+
 
 ######################
 # HELP
@@ -63,13 +73,7 @@ serve-docs: build-docs
 help:
 	@echo '===================='
 	@echo '-- DOCUMENTATION --'
-	@echo 'clean                        - run docs_clean and api_docs_clean'
-	@echo 'docs_build                   - build the documentation'
-	@echo 'docs_clean                   - clean the documentation build artifacts'
-	@echo 'docs_linkcheck               - run linkchecker on the documentation'
-	@echo 'api_docs_build               - build the API Reference documentation'
-	@echo 'api_docs_clean               - clean the API Reference documentation build artifacts'
-	@echo 'api_docs_linkcheck           - run linkchecker on the API Reference documentation'
+	
 	@echo '-- LINTING --'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ spell_fix:
 
 build-docs:
 	poetry run python docs/_scripts/copy_notebooks.py
-	poetry run mkdocs build --clean -f docs/mkdocs.yml --strict -d docs/site
+	poetry run mkdocs build --clean -f docs/mkdocs.yml --strict
 
 serve-clean-docs: clean-docs
 	poetry run python docs/_scripts/copy_notebooks.py

--- a/docs/_scripts/copy_notebooks.py
+++ b/docs/_scripts/copy_notebooks.py
@@ -19,7 +19,6 @@ _MANUAL = {
         "visualization.ipynb",
         "state-model.ipynb",
         "subgraph.ipynb",
-        "persistence_postgres.ipynb",
         "force-calling-a-tool-first.ipynb",
         "dynamic-returning-direct.ipynb",
         "managing-agent-steps.ipynb",

--- a/examples/async.ipynb
+++ b/examples/async.ipynb
@@ -10,7 +10,15 @@
     "In this example we will build a ReAct agent with native [async](https://docs.python.org/3/library/asyncio.html) implementations of the core logic. When Chat Models have async clients, this can give us some nice performance improvements if you\n",
     "are running concurrent branches in your graph or if your graph is running within a larger web server process.\n",
     "\n",
-    "In general, you don't need to change anything about your graph to add `async` support. That's one of the beauties of [Runnables](https://python.langchain.com/docs/expression_language/interface/). "
+    "In general, you don't need to change anything about your graph to add `async` support. That's one of the beauties of [Runnables](https://python.langchain.com/docs/expression_language/interface/). \n",
+    "\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note:</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using the <code>create_react_agent(model, tools=tool)</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {

--- a/examples/chat_agent_executor_with_function_calling/dynamically-returning-directly.ipynb
+++ b/examples/chat_agent_executor_with_function_calling/dynamically-returning-directly.ipynb
@@ -11,7 +11,15 @@
     "\n",
     "This examples builds off the base chat executor. It is highly recommended you learn about that executor before going through this notebook. You can find documentation for that example [here](./base.ipynb).\n",
     "\n",
-    "Any modifications of that example are called below with **MODIFICATION**, so if you are looking for the differences you can just search for that."
+    "Any modifications of that example are called below with **MODIFICATION**, so if you are looking for the differences you can just search for that.\n",
+    "\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using the <code>create_react_agent(model, tools=tool, interrupt_before=[\"agent\" | \"tools\"], interrupt_after=[\"agent\" | \"tools\"], checkpointer=checkpointer)</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {

--- a/examples/customer-support/customer-support.ipynb
+++ b/examples/customer-support/customer-support.ipynb
@@ -903,8 +903,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.runnables import RunnableLambda\n",
     "from langchain_core.messages import ToolMessage\n",
+    "from langchain_core.runnables import RunnableLambda\n",
     "\n",
     "from langgraph.prebuilt import ToolNode\n",
     "\n",

--- a/examples/customer-support/customer-support.ipynb
+++ b/examples/customer-support/customer-support.ipynb
@@ -903,8 +903,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.messages import ToolMessage\n",
     "from langchain_core.runnables import RunnableLambda\n",
+    "from langchain_core.messages import ToolMessage\n",
     "\n",
     "from langgraph.prebuilt import ToolNode\n",
     "\n",

--- a/examples/human-in-the-loop.ipynb
+++ b/examples/human-in-the-loop.ipynb
@@ -13,7 +13,14 @@
     "\n",
     "This can be in several ways, but the primary supported way is to add an \"interrupt\" before a node is executed.\n",
     "This interrupts execution at that node.\n",
-    "You can then resume from that spot to continue."
+    "You can then resume from that spot to continue.\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using either `interrupt_before` or `interrupt_after` in the <code>create_react_agent(model, tools=tool, interrupt_before=[\"tools\" | \"agent\"], interrupt_after=[\"tools\" | \"agent\"])</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {

--- a/examples/persistence.ipynb
+++ b/examples/persistence.ipynb
@@ -28,7 +28,14 @@
     "\n",
     "This works for [StateGraph](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.StateGraph) and all its subclasses, such as [MessageGraph](https://langchain-ai.github.io/langgraph/reference/graphs/#messagegraph).\n",
     "\n",
-    "Below is an example."
+    "Below is an example.\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using the <code>create_react_agent(model, tools=tool, checkpointer=checkpointer)</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {

--- a/examples/streaming-tokens.ipynb
+++ b/examples/streaming-tokens.ipynb
@@ -9,7 +9,14 @@
     "\n",
     "In this example we will stream tokens from the language model powering an agent. We will use a ReAct agent as an example. The main thing to bear in mind here is that using [async nodes](./async.ipynb) typically offers the best behavior for this, since we will be using the `async_log` method.\n",
     "\n",
-    "This how-to guide closely follows the others in this directory, so we will call out differences with the **STREAMING** tag below (if you just want to search for those)."
+    "This how-to guide closely follows the others in this directory, so we will call out differences with the **STREAMING** tag below (if you just want to search for those).\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using the <code>create_react_agent(model, tools=tool)</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {

--- a/examples/time-travel.ipynb
+++ b/examples/time-travel.ipynb
@@ -20,7 +20,14 @@
     "\n",
     "**Note:** this requires passing in a checkpointer.\n",
     "\n",
-    "Below is a quick example."
+    "Below is a quick example.\n",
+    "\n",
+    "<div class=\"admonition tip\">\n",
+    "    <p class=\"admonition-title\">Note:</p>\n",
+    "    <p>\n",
+    "        In this how-to, we will create our agent from scratch to be transparent (but verbose). You can accomplish similar functionality using the <code>create_react_agent(model, tools=tool, checkpointer=checkpointer)</code> (<a href=\"https://langchain-ai.github.io/langgraph/reference/prebuilt/#create_react_agent\">API doc</a>) constructor. This may be more appropriate if you are used to LangChain’s <a href=\"https://python.langchain.com/v0.1/docs/modules/agents/concepts/#agentexecutor\">AgentExecutor</a> class.\n",
+    "    </p>\n",
+    "</div>    "
    ]
   },
   {


### PR DESCRIPTION
It still makes sense to be verbose-yet-transparent I think so that the how-tos remain generally applicable. However ,for people coming from the AgentExecutor, this admonition will point them to the easier high level constructor