### PR TITLE
Enable WAL mode in `SqliteSaver` and `AsyncSqliteSaver`

### DIFF
--- a/langgraph/channels/ephemeral_value.py
+++ b/langgraph/channels/ephemeral_value.py
@@ -54,7 +54,7 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
             finally:
                 return
         if len(values) != 1 and self.guard:
-            raise InvalidUpdateError("LastValue can only receive one value per step.")
+            raise InvalidUpdateError("EphemeralValue can only receive one value per step.")
 
         self.value = values[-1]
 

--- a/langgraph/channels/ephemeral_value.py
+++ b/langgraph/channels/ephemeral_value.py
@@ -54,7 +54,9 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
             finally:
                 return
         if len(values) != 1 and self.guard:
-            raise InvalidUpdateError("EphemeralValue can only receive one value per step.")
+            raise InvalidUpdateError(
+                "EphemeralValue can only receive one value per step."
+            )
 
         self.value = values[-1]
 

--- a/langgraph/checkpoint/aiosqlite.py
+++ b/langgraph/checkpoint/aiosqlite.py
@@ -191,6 +191,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
                 await self.conn
             async with self.conn.executescript(
                 """
+                PRAGMA journal_mode=WAL;
                 CREATE TABLE IF NOT EXISTS checkpoints (
                     thread_id TEXT NOT NULL,
                     thread_ts TEXT NOT NULL,

--- a/langgraph/checkpoint/sqlite.py
+++ b/langgraph/checkpoint/sqlite.py
@@ -159,6 +159,7 @@ class SqliteSaver(BaseCheckpointSaver, AbstractContextManager):
 
         self.conn.executescript(
             """
+            PRAGMA journal_mode=WAL;
             CREATE TABLE IF NOT EXISTS checkpoints (
                 thread_id TEXT NOT NULL,
                 thread_ts TEXT NOT NULL,


### PR DESCRIPTION
This matches the LangGraphJS implementation: https://github.com/langchain-ai/langgraphjs/blob/main/langgraph/src/checkpoint/sqlite.ts#L41