### PR TITLE
Add support for passing `Callable` metadata filter to `FewShotExamples` managed value

### DIFF
--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -760,10 +760,11 @@ class Pregel(
                             )
                         )
                         checkpoint_config = {
+                            **checkpoint_config,
                             "configurable": {
                                 **checkpoint_config["configurable"],
                                 "thread_ts": checkpoint["id"],
-                            }
+                            },
                         }
                     # increment start to 0
                     start += 1
@@ -885,10 +886,11 @@ class Pregel(
                             )
                         )
                         checkpoint_config = {
+                            **checkpoint_config,
                             "configurable": {
                                 **checkpoint_config["configurable"],
                                 "thread_ts": checkpoint["id"],
-                            }
+                            },
                         }
                     # yield debug checkpoint
                     if stream_mode == "debug":
@@ -1031,10 +1033,11 @@ class Pregel(
                             )
                         )
                         checkpoint_config = {
+                            **checkpoint_config,
                             "configurable": {
                                 **checkpoint_config["configurable"],
                                 "thread_ts": checkpoint["id"],
-                            }
+                            },
                         }
                     # increment start to 0
                     start += 1
@@ -1162,10 +1165,11 @@ class Pregel(
                             )
                         )
                         checkpoint_config = {
+                            **checkpoint_config,
                             "configurable": {
                                 **checkpoint_config["configurable"],
                                 "thread_ts": checkpoint["id"],
-                            }
+                            },
                         }
                     # yield debug checkpoint
                     if stream_mode == "debug":

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -4372,10 +4372,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                 "step": 0,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value", "market": "DE"},
                 },
@@ -4407,10 +4412,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                 "step": 1,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value prepared", "market": "DE"},
                 },
@@ -4442,10 +4452,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                 "step": 2,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value prepared slow", "market": "DE"},
                 },
@@ -4477,10 +4492,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                 "step": 3,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {
                         "my_key": "value prepared slow finished",

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -3584,8 +3584,6 @@ async def test_start_branch_then() -> None:
 
 
 async def test_branch_then() -> None:
-    pass
-
     class State(TypedDict):
         my_key: Annotated[str, operator.add]
         market: str
@@ -3629,10 +3627,15 @@ async def test_branch_then() -> None:
                 "step": 0,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value", "market": "DE"},
                 },
@@ -3664,10 +3667,15 @@ async def test_branch_then() -> None:
                 "step": 1,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value prepared", "market": "DE"},
                 },
@@ -3699,10 +3707,15 @@ async def test_branch_then() -> None:
                 "step": 2,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {"my_key": "value prepared slow", "market": "DE"},
                 },
@@ -3734,10 +3747,15 @@ async def test_branch_then() -> None:
                 "step": 3,
                 "payload": {
                     "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
                         "configurable": {
                             "thread_id": "10",
                             "thread_ts": AnyStr(),
-                        }
+                        },
                     },
                     "values": {
                         "my_key": "value prepared slow finished",

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     AsyncGenerator,
     AsyncIterator,
+    Dict,
     Generator,
     Optional,
     Sequence,
@@ -2435,11 +2436,20 @@ async def test_state_graph_few_shot() -> None:
     from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
     from langchain_core.prompts import ChatPromptTemplate
 
+    def filter_by_source(config: RunnableConfig) -> Dict[str, Any]:
+        """This function is a trivial example that demonstrates that passing
+        a Callable to metadata_filter works as expected.
+        """
+        return {"source": "loop"}
+
     class BaseState(TypedDict):
         messages: Annotated[list[AnyMessage], add_messages]
 
     class AgentState(BaseState):
-        examples: Annotated[Sequence[BaseState], FewShotExamples[BaseState]]
+        examples: Annotated[
+            Sequence[BaseState],
+            FewShotExamples[BaseState].configure(k=1, metadata_filter=filter_by_source),
+        ]
 
     # Assemble the tools
     @tool()


### PR DESCRIPTION
### Summary
`Callable` metadata filters are used for filtering on checkpoint metadata that is only known at runtime. For example, in OpenGPTs, an `assistant_id` (an instance of a graph), is only known after it is created. In this scenario, a developer should define a function that retrieves the `assistant_id` from the passed `RunnableConfig`.

### Implementation
1. Update `FewShotExamples` to support passing a `Callable` metadata filter.
1. ???

### Next Steps
1. Update `langgraph` version in LangGraph API after this feature is merged and released.
1. Update OpenGPTs, pass function to `FewShotExamples` for filtering checkpoint metadata by `assistant_id`.