### PR TITLE
[Docs] Rm Integration Tutorial

### DIFF
--- a/docs/_scripts/copy_notebooks.py
+++ b/docs/_scripts/copy_notebooks.py
@@ -60,6 +60,7 @@ _HIDE = set(
         "chatbots/customer-support.ipynb",
         "rag/langgraph_rag_agent_llama3_local.ipynb",
         "rag/langgraph_self_rag_pinecone_movies.ipynb",
+        "rag/langgraph_adaptive_rag_cohere.ipynb",
     ]
 )
 

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -28,7 +28,6 @@ Learn from example implementations of graphs designed for specific scenarios and
 #### RAG
 
 - [Adaptive RAG](rag/langgraph_adaptive_rag.ipynb)
-    - [Adaptive RAG using Cohere](rag/langgraph_adaptive_rag_cohere.ipynb) 
     - [Adaptive RAG using local models](rag/langgraph_adaptive_rag_local.ipynb)
 - [Agentic RAG.ipynb](rag/langgraph_agentic_rag.ipynb)
 - [Corrective RAG](rag/langgraph_crag.ipynb)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,7 +100,6 @@ nav:
               - Hierarchical Teams: tutorials/multi_agent/hierarchical_agent_teams.ipynb
           - RAG:
               - tutorials/rag/langgraph_adaptive_rag.ipynb
-              - tutorials/rag/langgraph_adaptive_rag_cohere.ipynb
               - tutorials/rag/langgraph_adaptive_rag_local.ipynb
               - tutorials/rag/langgraph_agentic_rag.ipynb
               - tutorials/rag/langgraph_crag.ipynb


### PR DESCRIPTION
LangGraph docs shouldn't have docs that are duplicates of an existing how-to that just use a different provider.