### PR TITLE
docs: specify that configurables are added to LangSmith as metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,10 @@ We recommend starting with the [Introduction to LangGraph](https://langchain-ai.
 
 The [LangGraph how-to guides](https://langchain-ai.github.io/langgraph/how-tos/) show how to accomplish specific things within LangGraph, from streaming, to adding memory & persistence, to common design patterns (branching, subgraphs, etc.), these are the place to go if you want to copy and run a specific code snippet.
 
+### Conceptual Guides
+
+The [Conceptual Guides](https://langchain-ai.github.io/langgraph/concepts/) provide in-depth explanations of the key concepts and principles behind LangGraph, such as nodes, edges, state and more.
+
 ### Reference
 
 LangGraph's API has a few important classes and methods that are all covered in the [Reference Documents](https://langchain-ai.github.io/langgraph/reference/graphs/). Check these out to see the specific function arguments and simple examples of how to use the graph + checkpointing APIs or to see some of the higher-level prebuilt components.

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -237,7 +237,7 @@ Using checkpointing is as easy as calling `compile(checkpointer=my_checkpointer)
 
 For any given graph deployment, you'll likely want some amount of configurable values that you can control at runtime. These differ from the graph **inputs** in that they aren't meant to be treated as state variables. They are more akin to "[out-of-band](https://en.wikipedia.org/wiki/Out-of-band)" communication.
 
-A common example is a conversational `thread_id`, a `user_id`, a choice of which LLM to use, how many documents to return in a retriever, etc. While you **could** pass this within the state, it is nicer to separate out from the regular data flow.
+A common example is a conversational `thread_id`, a `user_id`, a choice of which LLM to use, how many documents to return in a retriever, etc. While you **could** pass this within the state, it is nicer to separate out from the regular data flow. Configurable values are also automatically added to LangSmith traces as [metadata](https://docs.smith.langchain.com/concepts/tracing#metadata).
 
 #### Example
 


### PR DESCRIPTION
- Emphasize by explicitly stating that configurables are added to LangSmith as metadata. I spent hours trying different solutions here before I discovered that this was possible.
- Add link to conceptual guides in readme