### PR TITLE
Add utilities to extract node and graph test cases from a thread

### DIFF
--- a/langgraph/eval/__init__.py
+++ b/langgraph/eval/__init__.py
@@ -1,0 +1,113 @@
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, TypedDict
+
+from langchain_core.runnables import RunnableConfig
+
+from langgraph.pregel import Pregel
+from langgraph.pregel.types import StateSnapshot
+
+
+class TestCase(TypedDict):
+    id: str
+    inputs: Dict[str, Any]
+    outputs: Dict[str, Any]
+    metadata: Dict[str, Any]
+
+
+def _node_test_cases(snapshots: Iterable[StateSnapshot]) -> Dict[str, List[TestCase]]:
+    test_cases = defaultdict(list)
+    partials: Dict[str, Dict[str, TestCase]] = defaultdict(dict)
+    for snapshot in snapshots:
+        thread_ts = snapshot.config["configurable"]["thread_ts"]
+        if partials[thread_ts]:
+            for node, partial in partials[thread_ts].items():
+                test_cases[node].append(
+                    {
+                        "id": partial["id"],
+                        "inputs": snapshot.values,
+                        "outputs": partial["outputs"],
+                        "metadata": partial["metadata"],
+                    }
+                )
+            partials[thread_ts].clear()
+        if (
+            (writes := snapshot.metadata["writes"])
+            and snapshot.parent_config
+            and isinstance(writes, dict)
+            and snapshot.metadata["source"] == "loop"
+        ):
+            parent_thread_ts = snapshot.parent_config["configurable"]["thread_ts"]
+            for node, outputs in writes.items():
+                partials[parent_thread_ts][node] = {
+                    "id": snapshot.config["configurable"]["thread_ts"],
+                    "inputs": None,
+                    "outputs": outputs,
+                    "metadata": {
+                        "source": snapshot.metadata["source"],
+                        "step": snapshot.metadata["step"],
+                        **snapshot.config["configurable"],
+                    },
+                }
+    return dict(test_cases)
+
+
+def extract_node_test_cases_from_thread(
+    graph: Pregel, config: RunnableConfig
+) -> Dict[str, List[TestCase]]:
+    return _node_test_cases(graph.get_state_history(config))
+
+
+async def aextract_node_test_cases_from_thread(
+    graph: Pregel, config: RunnableConfig
+) -> Dict[str, List[TestCase]]:
+    return _node_test_cases([s async for s in graph.get_state_history(config)])
+
+
+def _graph_test_case(snapshots: Iterable[StateSnapshot]) -> TestCase:
+    test_case = TestCase(
+        id=None,
+        inputs={
+            "input": [],
+        },
+        outputs={
+            "output": [],
+            "steps": [],
+        },
+    )
+    is_acc_steps = False
+    for snapshot in snapshots:
+        if not test_case["id"]:
+            test_case["id"] = snapshot.config["configurable"]["thread_id"]
+        if not snapshot.next:
+            is_acc_steps = True
+            test_case["outputs"]["output"].append(snapshot.values)
+            test_case["outputs"]["steps"].append([])
+            if not test_case.get("metadata"):
+                test_case["metadata"] = snapshot.config["configurable"]
+        if (
+            is_acc_steps
+            and snapshot.metadata["source"] == "loop"
+            and snapshot.metadata["writes"]
+        ):
+            for node in snapshot.metadata["writes"]:
+                test_case["outputs"]["steps"][-1].append(node)
+        if is_acc_steps and snapshot.metadata["source"] == "input":
+            test_case["inputs"]["input"].append(snapshot.metadata["writes"])
+    test_case["inputs"]["input"].reverse()
+    test_case["outputs"]["output"].reverse()
+    test_case["outputs"]["steps"].reverse()
+    for ss in test_case["outputs"]["steps"]:
+        ss.reverse()
+    return test_case
+
+
+def extract_graph_test_case_from_thread(
+    graph: Pregel, config: RunnableConfig
+) -> TestCase:
+    return _graph_test_case(graph.get_state_history(config))
+
+
+async def aextract_graph_test_case_from_thread(
+    graph: Pregel, config: RunnableConfig
+) -> TestCase:
+    return _graph_test_case([s async for s in graph.get_state_history(config)])

--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -684,8 +684,16 @@ class Pregel(
             input_keys = self.input_channels
         else:
             validate_keys(input_keys, self.channels)
-        interrupt_before = interrupt_before or self.interrupt_before_nodes
-        interrupt_after = interrupt_after or self.interrupt_after_nodes
+        interrupt_before = (
+            interrupt_before
+            if interrupt_before is not None
+            else self.interrupt_before_nodes
+        )
+        interrupt_after = (
+            interrupt_after
+            if interrupt_after is not None
+            else self.interrupt_after_nodes
+        )
         stream_mode = stream_mode if stream_mode is not None else self.stream_mode
         if not isinstance(stream_mode, list):
             stream_mode = [stream_mode]

--- a/langgraph/utils.py
+++ b/langgraph/utils.py
@@ -14,6 +14,7 @@ from langchain_core.runnables.base import (
     RunnableParallel,
 )
 from langchain_core.runnables.config import (
+    ensure_config,
     merge_configs,
     run_in_executor,
     var_child_runnable_config,
@@ -84,6 +85,7 @@ class RunnableCallable(Runnable):
                 self.func, input, merge_configs(self.config, config), **self.kwargs
             )
         else:
+            config = ensure_config(config)
             config = merge_configs(self.config, config)
             context = copy_context()
             context.run(var_child_runnable_config.set, config)
@@ -105,6 +107,7 @@ class RunnableCallable(Runnable):
                 self.afunc, input, merge_configs(self.config, config), **self.kwargs
             )
         else:
+            config = ensure_config(config)
             config = merge_configs(self.config, config)
             context = copy_context()
             context.run(var_child_runnable_config.set, config)

--- a/tests/memory_assert.py
+++ b/tests/memory_assert.py
@@ -90,6 +90,7 @@ class MemorySaverAssertCheckpointMetadata(MemorySaver):
                     self.serde.dumps(checkpoint),
                     # merge configurable fields and metadata
                     self.serde.dumps({**configurable, **metadata}),
+                    config["configurable"].get("thread_ts"),
                 )
             }
         )

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -342,33 +342,7 @@ async def test_invoke_two_processes_in_out_interrupt(mocker: MockerFixture) -> N
         c async for c in app.aget_state_history({"configurable": {"thread_id": 1}})
     ] == [
         StateSnapshot(
-            values={"input": 2},
-            next=("one",),
-            config={
-                "configurable": {
-                    "thread_id": 1,
-                    "thread_ts": AnyStr(),
-                }
-            },
-            created_at=AnyStr(),
-            metadata={"source": "input", "step": -1, "writes": 2},
-            parent_config=None,
-        ),
-        StateSnapshot(
-            values={"inbox": 3, "input": 2},
-            next=("two",),
-            config={
-                "configurable": {
-                    "thread_id": 1,
-                    "thread_ts": AnyStr(),
-                }
-            },
-            created_at=AnyStr(),
-            metadata={"source": "loop", "step": 0, "writes": None},
-            parent_config=None,
-        ),
-        StateSnapshot(
-            values={"inbox": 3, "output": 4, "input": 2},
+            values={"inbox": 4, "output": 5, "input": 3},
             next=(),
             config={
                 "configurable": {
@@ -377,47 +351,13 @@ async def test_invoke_two_processes_in_out_interrupt(mocker: MockerFixture) -> N
                 }
             },
             created_at=AnyStr(),
-            metadata={"source": "loop", "step": 1, "writes": 4},
-            parent_config=None,
-        ),
-        StateSnapshot(
-            values={"inbox": 3, "output": 4, "input": 20},
-            next=("one",),
-            config={
+            metadata={"source": "loop", "step": 6, "writes": 5},
+            parent_config={
                 "configurable": {
                     "thread_id": 1,
                     "thread_ts": AnyStr(),
                 }
             },
-            created_at=AnyStr(),
-            metadata={"source": "input", "step": 2, "writes": 20},
-            parent_config=None,
-        ),
-        StateSnapshot(
-            values={"inbox": 21, "output": 4, "input": 20},
-            next=("two",),
-            config={
-                "configurable": {
-                    "thread_id": 1,
-                    "thread_ts": AnyStr(),
-                }
-            },
-            created_at=AnyStr(),
-            metadata={"source": "loop", "step": 3, "writes": None},
-            parent_config=None,
-        ),
-        StateSnapshot(
-            values={"inbox": 21, "output": 4, "input": 3},
-            next=("one",),
-            config={
-                "configurable": {
-                    "thread_id": 1,
-                    "thread_ts": AnyStr(),
-                }
-            },
-            created_at=AnyStr(),
-            metadata={"source": "input", "step": 4, "writes": 3},
-            parent_config=None,
         ),
         StateSnapshot(
             values={"inbox": 4, "output": 4, "input": 3},
@@ -430,10 +370,69 @@ async def test_invoke_two_processes_in_out_interrupt(mocker: MockerFixture) -> N
             },
             created_at=AnyStr(),
             metadata={"source": "loop", "step": 5, "writes": None},
-            parent_config=None,
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
         ),
         StateSnapshot(
-            values={"inbox": 4, "output": 5, "input": 3},
+            values={"inbox": 21, "output": 4, "input": 3},
+            next=("one",),
+            config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+            created_at=AnyStr(),
+            metadata={"source": "input", "step": 4, "writes": 3},
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+        ),
+        StateSnapshot(
+            values={"inbox": 21, "output": 4, "input": 20},
+            next=("two",),
+            config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+            created_at=AnyStr(),
+            metadata={"source": "loop", "step": 3, "writes": None},
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+        ),
+        StateSnapshot(
+            values={"inbox": 3, "output": 4, "input": 20},
+            next=("one",),
+            config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+            created_at=AnyStr(),
+            metadata={"source": "input", "step": 2, "writes": 20},
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+        ),
+        StateSnapshot(
+            values={"inbox": 3, "output": 4, "input": 2},
             next=(),
             config={
                 "configurable": {
@@ -442,7 +441,43 @@ async def test_invoke_two_processes_in_out_interrupt(mocker: MockerFixture) -> N
                 }
             },
             created_at=AnyStr(),
-            metadata={"source": "loop", "step": 6, "writes": 5},
+            metadata={"source": "loop", "step": 1, "writes": 4},
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+        ),
+        StateSnapshot(
+            values={"inbox": 3, "input": 2},
+            next=("two",),
+            config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+            created_at=AnyStr(),
+            metadata={"source": "loop", "step": 0, "writes": None},
+            parent_config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+        ),
+        StateSnapshot(
+            values={"input": 2},
+            next=("one",),
+            config={
+                "configurable": {
+                    "thread_id": 1,
+                    "thread_ts": AnyStr(),
+                }
+            },
+            created_at=AnyStr(),
+            metadata={"source": "input", "step": -1, "writes": 2},
             parent_config=None,
         ),
     ]
@@ -1446,6 +1481,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     await app_w_interrupt.aupdate_state(
@@ -1490,6 +1526,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -1599,6 +1636,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     # test state get/update methods with interrupt_before
@@ -1654,6 +1692,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     await app_w_interrupt.aupdate_state(
@@ -1698,6 +1737,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -1807,6 +1847,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     # test re-invoke to continue with interrupt_before
@@ -1862,6 +1903,7 @@ async def test_conditional_graph() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -2197,6 +2239,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     await app_w_interrupt.aupdate_state(
@@ -2238,6 +2281,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -2311,6 +2355,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     # test state get/update methods with interrupt_before
@@ -2363,6 +2408,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     await app_w_interrupt.aupdate_state(
@@ -2404,6 +2450,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -2477,6 +2524,7 @@ async def test_conditional_graph_state() -> None:
                 }
             },
         },
+        parent_config={"configurable": {"thread_id": "2", "thread_ts": AnyStr()}},
     )
 
 
@@ -3271,6 +3319,7 @@ async def test_message_graph() -> None:
                 )
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     # modify ai message
@@ -3317,6 +3366,7 @@ async def test_message_graph() -> None:
                 )
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     assert [c async for c in app_w_interrupt.astream(None, config)] == [
@@ -3388,6 +3438,7 @@ async def test_message_graph() -> None:
                 )
             },
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
     await app_w_interrupt.aupdate_state(
@@ -3429,6 +3480,7 @@ async def test_message_graph() -> None:
             "step": 5,
             "writes": {"agent": AIMessage(content="answer", id="ai2")},
         },
+        parent_config={"configurable": {"thread_id": "1", "thread_ts": AnyStr()}},
     )
 
 


### PR DESCRIPTION
- node test cases are input/output pairs for each node in the graph
- graph test cases are multi-turn test cases with sequences of inputs, outputs and trajectories

These can eg. be saved to a LangSmith dataset, or used for evals directly