### PR TITLE
Add metadata to debug/checkpoint stream events

### DIFF
--- a/langgraph/pregel/debug.py
+++ b/langgraph/pregel/debug.py
@@ -9,6 +9,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langchain_core.utils.input import get_bolded_text, get_colored_text
 
 from langgraph.channels.base import BaseChannel
+from langgraph.checkpoint.base import CheckpointMetadata
 from langgraph.constants import TAG_HIDDEN
 from langgraph.pregel.io import read_channels
 from langgraph.pregel.types import PregelExecutableTask
@@ -29,6 +30,7 @@ class TaskResultPayload(TypedDict):
 
 class CheckpointPayload(TypedDict):
     config: Optional[RunnableConfig]
+    metadata: CheckpointMetadata
     values: dict[str, Any]
 
 
@@ -111,6 +113,7 @@ def map_debug_checkpoint(
     config: RunnableConfig,
     channels: Mapping[str, BaseChannel],
     stream_channels: Union[str, Sequence[str]],
+    metadata: CheckpointMetadata,
 ) -> Iterator[DebugOutputCheckpoint]:
     ts = datetime.now(timezone.utc).isoformat()
     yield {
@@ -120,6 +123,7 @@ def map_debug_checkpoint(
         "payload": {
             "config": config,
             "values": read_channels(channels, stream_channels),
+            "metadata": metadata,
         },
     }
 

--- a/tests/test_pregel.py
+++ b/tests/test_pregel.py
@@ -585,12 +585,6 @@ def test_invoke_two_processes_in_dict_out(mocker: MockerFixture) -> None:
             },
         },
         {
-            "type": "checkpoint",
-            "timestamp": AnyStr(),
-            "step": 0,
-            "payload": {"config": None, "values": {"output": 13, "inbox": [3]}},
-        },
-        {
             "type": "task",
             "timestamp": AnyStr(),
             "step": 1,
@@ -610,12 +604,6 @@ def test_invoke_two_processes_in_dict_out(mocker: MockerFixture) -> None:
                 "name": "two",
                 "result": [("output", 4)],
             },
-        },
-        {
-            "type": "checkpoint",
-            "timestamp": AnyStr(),
-            "step": 1,
-            "payload": {"config": None, "values": {"output": 4, "inbox": []}},
         },
     ]
 
@@ -5597,18 +5585,6 @@ def test_in_one_fan_out_out_one_graph_state() -> None:
         (
             "debug",
             {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 0,
-                "payload": {
-                    "config": None,
-                    "values": {"query": "what is weather in sf", "docs": []},
-                },
-            },
-        ),
-        (
-            "debug",
-            {
                 "type": "task",
                 "timestamp": AnyStr(),
                 "step": 1,
@@ -5639,18 +5615,6 @@ def test_in_one_fan_out_out_one_graph_state() -> None:
             },
         ),
         ("values", {"query": "query: what is weather in sf", "docs": []}),
-        (
-            "debug",
-            {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 1,
-                "payload": {
-                    "config": None,
-                    "values": {"query": "query: what is weather in sf", "docs": []},
-                },
-            },
-        ),
         (
             "debug",
             {
@@ -5730,21 +5694,6 @@ def test_in_one_fan_out_out_one_graph_state() -> None:
         (
             "debug",
             {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 2,
-                "payload": {
-                    "config": None,
-                    "values": {
-                        "query": "query: what is weather in sf",
-                        "docs": ["doc1", "doc2", "doc3", "doc4"],
-                    },
-                },
-            },
-        ),
-        (
-            "debug",
-            {
                 "type": "task",
                 "timestamp": AnyStr(),
                 "step": 3,
@@ -5780,22 +5729,6 @@ def test_in_one_fan_out_out_one_graph_state() -> None:
                 "query": "query: what is weather in sf",
                 "answer": "doc1,doc2,doc3,doc4",
                 "docs": ["doc1", "doc2", "doc3", "doc4"],
-            },
-        ),
-        (
-            "debug",
-            {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 3,
-                "payload": {
-                    "config": None,
-                    "values": {
-                        "query": "query: what is weather in sf",
-                        "answer": "doc1,doc2,doc3,doc4",
-                        "docs": ["doc1", "doc2", "doc3", "doc4"],
-                    },
-                },
             },
         ),
     ]
@@ -6012,6 +5945,30 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
             {
                 "type": "checkpoint",
                 "timestamp": AnyStr(),
+                "step": -1,
+                "payload": {
+                    "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
+                        "configurable": {
+                            "thread_id": "10",
+                            "thread_ts": AnyStr(),
+                        },
+                    },
+                    "values": {"my_key": ""},
+                    "metadata": {
+                        "source": "input",
+                        "step": -1,
+                        "writes": {"my_key": "value", "market": "DE"},
+                    },
+                },
+            },
+            {
+                "type": "checkpoint",
+                "timestamp": AnyStr(),
                 "step": 0,
                 "payload": {
                     "config": {
@@ -6025,7 +5982,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                             "thread_ts": AnyStr(),
                         },
                     },
-                    "values": {"my_key": "value", "market": "DE"},
+                    "values": {
+                        "my_key": "value",
+                        "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 0,
+                        "writes": None,
+                    },
                 },
             },
             {
@@ -6065,7 +6030,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                             "thread_ts": AnyStr(),
                         },
                     },
-                    "values": {"my_key": "value prepared", "market": "DE"},
+                    "values": {
+                        "my_key": "value prepared",
+                        "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 1,
+                        "writes": {"prepare": {"my_key": " prepared"}},
+                    },
                 },
             },
             {
@@ -6105,7 +6078,15 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                             "thread_ts": AnyStr(),
                         },
                     },
-                    "values": {"my_key": "value prepared slow", "market": "DE"},
+                    "values": {
+                        "my_key": "value prepared slow",
+                        "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 2,
+                        "writes": {"tool_two_slow": {"my_key": " slow"}},
+                    },
                 },
             },
             {
@@ -6148,6 +6129,11 @@ def test_branch_then(snapshot: SnapshotAssertion) -> None:
                     "values": {
                         "my_key": "value prepared slow finished",
                         "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 3,
+                        "writes": {"finish": {"my_key": " finished"}},
                     },
                 },
             },

--- a/tests/test_pregel_async.py
+++ b/tests/test_pregel_async.py
@@ -545,12 +545,6 @@ async def test_invoke_two_processes_in_dict_out(mocker: MockerFixture) -> None:
             },
         },
         {
-            "type": "checkpoint",
-            "timestamp": AnyStr(),
-            "step": 0,
-            "payload": {"config": None, "values": {"output": 13, "inbox": [3]}},
-        },
-        {
             "type": "task",
             "timestamp": AnyStr(),
             "step": 1,
@@ -570,12 +564,6 @@ async def test_invoke_two_processes_in_dict_out(mocker: MockerFixture) -> None:
                 "name": "two",
                 "result": [("output", 4)],
             },
-        },
-        {
-            "type": "checkpoint",
-            "timestamp": AnyStr(),
-            "step": 1,
-            "payload": {"config": None, "values": {"output": 4, "inbox": []}},
         },
     ]
 
@@ -4046,18 +4034,6 @@ async def test_in_one_fan_out_out_one_graph_state() -> None:
         (
             "debug",
             {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 0,
-                "payload": {
-                    "config": None,
-                    "values": {"query": "what is weather in sf", "docs": []},
-                },
-            },
-        ),
-        (
-            "debug",
-            {
                 "type": "task",
                 "timestamp": AnyStr(),
                 "step": 1,
@@ -4088,18 +4064,6 @@ async def test_in_one_fan_out_out_one_graph_state() -> None:
             },
         ),
         ("values", {"query": "query: what is weather in sf", "docs": []}),
-        (
-            "debug",
-            {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 1,
-                "payload": {
-                    "config": None,
-                    "values": {"query": "query: what is weather in sf", "docs": []},
-                },
-            },
-        ),
         (
             "debug",
             {
@@ -4179,21 +4143,6 @@ async def test_in_one_fan_out_out_one_graph_state() -> None:
         (
             "debug",
             {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 2,
-                "payload": {
-                    "config": None,
-                    "values": {
-                        "query": "query: what is weather in sf",
-                        "docs": ["doc1", "doc2", "doc3", "doc4"],
-                    },
-                },
-            },
-        ),
-        (
-            "debug",
-            {
                 "type": "task",
                 "timestamp": AnyStr(),
                 "step": 3,
@@ -4229,22 +4178,6 @@ async def test_in_one_fan_out_out_one_graph_state() -> None:
                 "query": "query: what is weather in sf",
                 "answer": "doc1,doc2,doc3,doc4",
                 "docs": ["doc1", "doc2", "doc3", "doc4"],
-            },
-        ),
-        (
-            "debug",
-            {
-                "type": "checkpoint",
-                "timestamp": AnyStr(),
-                "step": 3,
-                "payload": {
-                    "config": None,
-                    "values": {
-                        "query": "query: what is weather in sf",
-                        "answer": "doc1,doc2,doc3,doc4",
-                        "docs": ["doc1", "doc2", "doc3", "doc4"],
-                    },
-                },
             },
         ),
     ]
@@ -4461,6 +4394,27 @@ async def test_branch_then() -> None:
             {
                 "type": "checkpoint",
                 "timestamp": AnyStr(),
+                "step": -1,
+                "payload": {
+                    "config": {
+                        "tags": [],
+                        "metadata": {"thread_id": "10"},
+                        "callbacks": None,
+                        "recursion_limit": 25,
+                        "run_id": None,
+                        "configurable": {"thread_id": "10", "thread_ts": AnyStr()},
+                    },
+                    "values": {"my_key": ""},
+                    "metadata": {
+                        "source": "input",
+                        "step": -1,
+                        "writes": {"my_key": "value", "market": "DE"},
+                    },
+                },
+            },
+            {
+                "type": "checkpoint",
+                "timestamp": AnyStr(),
                 "step": 0,
                 "payload": {
                     "config": {
@@ -4474,7 +4428,11 @@ async def test_branch_then() -> None:
                             "thread_ts": AnyStr(),
                         },
                     },
-                    "values": {"my_key": "value", "market": "DE"},
+                    "values": {
+                        "my_key": "value",
+                        "market": "DE",
+                    },
+                    "metadata": {"source": "loop", "step": 0, "writes": None},
                 },
             },
             {
@@ -4515,6 +4473,11 @@ async def test_branch_then() -> None:
                         },
                     },
                     "values": {"my_key": "value prepared", "market": "DE"},
+                    "metadata": {
+                        "source": "loop",
+                        "step": 1,
+                        "writes": {"prepare": {"my_key": " prepared"}},
+                    },
                 },
             },
             {
@@ -4554,7 +4517,15 @@ async def test_branch_then() -> None:
                             "thread_ts": AnyStr(),
                         },
                     },
-                    "values": {"my_key": "value prepared slow", "market": "DE"},
+                    "values": {
+                        "my_key": "value prepared slow",
+                        "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 2,
+                        "writes": {"tool_two_slow": {"my_key": " slow"}},
+                    },
                 },
             },
             {
@@ -4597,6 +4568,11 @@ async def test_branch_then() -> None:
                     "values": {
                         "my_key": "value prepared slow finished",
                         "market": "DE",
+                    },
+                    "metadata": {
+                        "source": "loop",
+                        "step": 3,
+                        "writes": {"finish": {"my_key": " finished"}},
                     },
                 },
             },


### PR DESCRIPTION
- reorganize checkpointing code to share code between input and step checkpoints
- do not emit debug/checkpoint events when there is no checkpointer attached
- emit debug/checkpoint event for input checkpoint as well