### PR TITLE
Rm isinstance(..., NamedTuple)

### DIFF
--- a/langgraph/serde/jsonplus.py
+++ b/langgraph/serde/jsonplus.py
@@ -3,7 +3,7 @@ import importlib
 import json
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, NamedTuple, Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from langchain_core.load.load import Reviver
@@ -63,8 +63,6 @@ class JsonPlusSerializer(SerializerProtocol):
             )
         elif isinstance(obj, Enum):
             return self._encode_constructor_args(obj.__class__, args=[obj.value])
-        elif isinstance(obj, NamedTuple):
-            return self._encode_constructor_args(obj.__class__, args=[*obj])
         else:
             raise TypeError(
                 f"Object of type {obj.__class__.__name__} is not JSON serializable"


### PR DESCRIPTION
It's a function (not a type), so this line would raise an error.

If we want to custom serialize named tuples, would have to use orjson or separately recursively check for named tuples, since the json stdlib module doesn't permit overriding of stdlib types that are in the default conversion table: https://discuss.python.org/t/allowing-override-of-json-dumps-serialization-for-standard-types/16259/6