### PR TITLE
Fixup ToC in ref doc

### DIFF
--- a/docs/docs/reference/graphs.md
+++ b/docs/docs/reference/graphs.md
@@ -25,7 +25,9 @@ graph = StateGraph(MyState)
 ::: langgraph.graph.graph.CompiledGraph
     handler: python
 
-# Constants
+## Constants
+
+The following constants are used to help control graph execution.
 
 ## START
 

--- a/docs/docs/reference/graphs.md
+++ b/docs/docs/reference/graphs.md
@@ -27,7 +27,7 @@ graph = StateGraph(MyState)
 
 ## Constants
 
-The following constants are used to help control graph execution.
+The following constants and classes are used to help control graph execution.
 
 ## START
 


### PR DESCRIPTION
seems mkdocs stops inferring a ToC if you insert a H1