### PR TITLE
Fix for update_state mistakenly resetting barrier channels

### DIFF
--- a/langgraph/channels/base.py
+++ b/langgraph/channels/base.py
@@ -65,7 +65,8 @@ class BaseChannel(Generic[Value, Update, C], ABC):
     def update(self, values: Sequence[Update]) -> None:
         """Update the channel's value with the given sequence of updates.
         The order of the updates in the sequence is arbitrary.
-
+        This method is called by Pregel for all channels at the end of each step.
+        If there are no updates, it is called with an empty sequence.
         Raises InvalidUpdateError if the sequence of updates is invalid."""
 
     @abstractmethod
@@ -73,6 +74,13 @@ class BaseChannel(Generic[Value, Update, C], ABC):
         """Return the current value of the channel.
 
         Raises EmptyChannelError if the channel is empty (never updated yet)."""
+
+    def consume(self) -> None:
+        """Mark the current value of the channel as consumed. By default, no-op.
+        This is called by Pregel before the start of the next step, for all
+        channels that triggered a node.
+        """
+        pass
 
 
 @contextmanager

--- a/langgraph/channels/dynamic_barrier_value.py
+++ b/langgraph/channels/dynamic_barrier_value.py
@@ -60,11 +60,6 @@ class DynamicBarrierValue(
             pass
 
     def update(self, values: Sequence[Union[Value, WaitForNames]]) -> None:
-        # switch to "priming" state after reading
-        if self.seen == self.names:
-            self.seen = set()
-            self.names = None
-
         if wait_for_names := [v for v in values if isinstance(v, WaitForNames)]:
             if len(wait_for_names) > 1:
                 raise InvalidUpdateError(
@@ -83,3 +78,8 @@ class DynamicBarrierValue(
         if self.seen != self.names:
             raise EmptyChannelError()
         return None
+
+    def consume(self) -> None:
+        if self.seen == self.names:
+            self.seen = set()
+            self.names = None

--- a/langgraph/channels/named_barrier_value.py
+++ b/langgraph/channels/named_barrier_value.py
@@ -42,8 +42,6 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
             pass
 
     def update(self, values: Sequence[Value]) -> None:
-        if self.seen == self.names:
-            self.seen = set()
         for value in values:
             if value in self.names:
                 self.seen.add(value)
@@ -54,3 +52,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         if self.seen != self.names:
             raise EmptyChannelError()
         return None
+
+    def consume(self) -> None:
+        if self.seen == self.names:
+            self.seen = set()


### PR DESCRIPTION
- This introduces a new optional method BaseChannel.consume, which gets called when a channel triggers a node
- This is an alternative place to clean up channel state, in addition to the existing pattern of clearing state in the update() call for the next step
- Channels should implement consume() when they want to clean up state exactly if and only if the channel triggered a node
- Channels should clean up state in update() when they instead need to guarantee their value is available for a single step, irrespective of whether it was actually read