### PR TITLE
Accept dead-ends

### DIFF
--- a/langgraph/graph/graph.py
+++ b/langgraph/graph/graph.py
@@ -287,11 +287,8 @@ class Graph:
                             if node != start and node != branch.then:
                                 all_sources.add(node)
         # validate sources
-        for node in self.nodes:
-            if node not in all_sources:
-                raise ValueError(f"Node '{node}' is a dead-end")
         for source in all_sources:
-            if node not in self.nodes and source != START:
+            if source not in self.nodes and source != START:
                 raise ValueError(f"Found edge starting at unknown node '{source}'")
 
         # assemble targets

--- a/tests/__snapshots__/test_pregel.ambr
+++ b/tests/__snapshots__/test_pregel.ambr
@@ -114,67 +114,6 @@
   
   '''
 # ---
-# name: test_conditional_entrypoint_to_multiple_state_graph
-  '{"title": "LangGraphInput", "$ref": "#/definitions/OverallState", "definitions": {"OverallState": {"title": "OverallState", "type": "object", "properties": {"locations": {"title": "Locations", "type": "array", "items": {"type": "string"}}, "results": {"title": "Results", "type": "array", "items": {"type": "string"}}}, "required": ["locations", "results"]}}}'
-# ---
-# name: test_conditional_entrypoint_to_multiple_state_graph.1
-  '{"title": "LangGraphOutput", "type": "object", "properties": {"locations": {"title": "Locations", "type": "array", "items": {"type": "string"}}, "results": {"title": "Results", "type": "array", "items": {"type": "string"}}}}'
-# ---
-# name: test_conditional_entrypoint_to_multiple_state_graph.2
-  '''
-  {
-    "nodes": [
-      {
-        "id": "__start__",
-        "type": "schema",
-        "data": "__start__"
-      },
-      {
-        "id": "__end__",
-        "type": "schema",
-        "data": "__end__"
-      },
-      {
-        "id": "get_weather",
-        "type": "runnable",
-        "data": {
-          "id": [
-            "langgraph",
-            "utils",
-            "RunnableCallable"
-          ],
-          "name": "get_weather"
-        }
-      }
-    ],
-    "edges": [
-      {
-        "source": "get_weather",
-        "target": "__end__"
-      },
-      {
-        "source": "__start__",
-        "target": "get_weather",
-        "conditional": true
-      },
-      {
-        "source": "__start__",
-        "target": "__end__",
-        "conditional": true
-      }
-    ]
-  }
-  '''
-# ---
-# name: test_conditional_entrypoint_to_multiple_state_graph.3
-  '''
-  graph TD;
-  	get_weather --> __end__;
-  	__start__ -.-> get_weather;
-  	__start__ -.-> __end__;
-  
-  '''
-# ---
 # name: test_conditional_entrypoint_graph_state
   '{"title": "LangGraphInput", "$ref": "#/definitions/AgentState", "definitions": {"AgentState": {"title": "AgentState", "type": "object", "properties": {"input": {"title": "Input", "type": "string"}, "output": {"title": "Output", "type": "string"}, "steps": {"title": "Steps", "type": "array", "items": {"type": "string"}}}}}}'
 # ---
@@ -253,6 +192,67 @@
   	__start__ -. go-left .-> left;
   	__start__ -. go-right .-> right;
   	left -.-> __end__;
+  
+  '''
+# ---
+# name: test_conditional_entrypoint_to_multiple_state_graph
+  '{"title": "LangGraphInput", "$ref": "#/definitions/OverallState", "definitions": {"OverallState": {"title": "OverallState", "type": "object", "properties": {"locations": {"title": "Locations", "type": "array", "items": {"type": "string"}}, "results": {"title": "Results", "type": "array", "items": {"type": "string"}}}, "required": ["locations", "results"]}}}'
+# ---
+# name: test_conditional_entrypoint_to_multiple_state_graph.1
+  '{"title": "LangGraphOutput", "type": "object", "properties": {"locations": {"title": "Locations", "type": "array", "items": {"type": "string"}}, "results": {"title": "Results", "type": "array", "items": {"type": "string"}}}}'
+# ---
+# name: test_conditional_entrypoint_to_multiple_state_graph.2
+  '''
+  {
+    "nodes": [
+      {
+        "id": "__start__",
+        "type": "schema",
+        "data": "__start__"
+      },
+      {
+        "id": "__end__",
+        "type": "schema",
+        "data": "__end__"
+      },
+      {
+        "id": "get_weather",
+        "type": "runnable",
+        "data": {
+          "id": [
+            "langgraph",
+            "utils",
+            "RunnableCallable"
+          ],
+          "name": "get_weather"
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "get_weather",
+        "target": "__end__"
+      },
+      {
+        "source": "__start__",
+        "target": "get_weather",
+        "conditional": true
+      },
+      {
+        "source": "__start__",
+        "target": "__end__",
+        "conditional": true
+      }
+    ]
+  }
+  '''
+# ---
+# name: test_conditional_entrypoint_to_multiple_state_graph.3
+  '''
+  graph TD;
+  	get_weather --> __end__;
+  	__start__ -.-> get_weather;
+  	__start__ -.-> __end__;
   
   '''
 # ---

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic.v1 import BaseModel
 from typing_extensions import Annotated, TypedDict
 
-from langgraph.graph.state import _warn_invalid_state_schema, StateGraph
+from langgraph.graph.state import StateGraph, _warn_invalid_state_schema
 
 
 class State(BaseModel):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic.v1 import BaseModel
 from typing_extensions import Annotated, TypedDict
 
-from langgraph.graph.state import StateGraph, _warn_invalid_state_schema
+from langgraph.graph.state import _warn_invalid_state_schema
 
 
 class State(BaseModel):
@@ -46,21 +46,3 @@ def test_doesnt_warn_valid_schema(schema: Any):
     # Assert the function does not raise a warning
     with pytest.warns(None):
         _warn_invalid_state_schema(schema)
-
-
-def test_unknown_start_raises_error():
-    graph = StateGraph(State)
-    graph.add_node("start", lambda x: x)
-    graph.add_edge("__start__", "start")
-    graph.add_edge("unknown", "start")
-    graph.add_edge("start", "__end__")
-    with pytest.raises(ValueError, match="Found edge starting at unknown node "):
-        graph.compile()
-
-
-def test_unset_end_accepted():
-    graph = StateGraph(State)
-    graph.add_node("start", lambda x: x)
-    graph.add_edge("__start__", "start")
-    graph.add_edge("unknown", "start")
-    graph.compile()


### PR DESCRIPTION
Plus fix a small bug.

Previously, we validated that nodes explicitly route to END.
This feels a bit unnecessary, since graphs are expected to keep processing until no work is left to be done


This decision is a bit of a 1-way door, since once we relax it, if we change our minds, it would break otherwise working code. LMK if you have reservations