### PR TITLE
In Binop channels unwrap types before trying to instantiate

### DIFF
--- a/langgraph/channels/binop.py
+++ b/langgraph/channels/binop.py
@@ -4,14 +4,13 @@ from typing import (
     Callable,
     Generator,
     Generic,
-    NotRequired,
     Optional,
     Required,
     Sequence,
     Type,
 )
 
-from typing_extensions import Self
+from typing_extensions import NotRequired, Self
 
 from langgraph.channels.base import BaseChannel, Value
 from langgraph.errors import EmptyChannelError

--- a/langgraph/channels/binop.py
+++ b/langgraph/channels/binop.py
@@ -5,12 +5,11 @@ from typing import (
     Generator,
     Generic,
     Optional,
-    Required,
     Sequence,
     Type,
 )
 
-from typing_extensions import NotRequired, Self
+from typing_extensions import NotRequired, Required, Self
 
 from langgraph.channels.base import BaseChannel, Value
 from langgraph.errors import EmptyChannelError


### PR DESCRIPTION
- this makes List/Sequence annotations behave same as list