### PR TITLE
Allow checkpointer to customize assignment of channel versions

### DIFF
--- a/langgraph/channels/base.py
+++ b/langgraph/channels/base.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager, contextmanager
-from datetime import datetime, timezone
 from typing import (
     Any,
     AsyncGenerator,
     Generator,
     Generic,
-    Mapping,
     Optional,
     Sequence,
     TypeVar,
@@ -14,8 +12,6 @@ from typing import (
 
 from typing_extensions import Self
 
-from langgraph.checkpoint.base import Checkpoint
-from langgraph.checkpoint.id import uuid6
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
 Value = TypeVar("Value")
@@ -83,68 +79,8 @@ class BaseChannel(Generic[Value, Update, C], ABC):
         pass
 
 
-@contextmanager
-def ChannelsManager(
-    channels: Mapping[str, BaseChannel],
-    checkpoint: Checkpoint,
-) -> Generator[Mapping[str, BaseChannel], None, None]:
-    """Manage channels for the lifetime of a Pregel invocation (multiple steps)."""
-    # TODO use https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack
-    empty = {
-        k: v.from_checkpoint(checkpoint["channel_values"].get(k))
-        for k, v in channels.items()
-    }
-    try:
-        yield {k: v.__enter__() for k, v in empty.items()}
-    finally:
-        for v in empty.values():
-            v.__exit__(None, None, None)
-
-
-@asynccontextmanager
-async def AsyncChannelsManager(
-    channels: Mapping[str, BaseChannel],
-    checkpoint: Checkpoint,
-) -> AsyncGenerator[Mapping[str, BaseChannel], None]:
-    """Manage channels for the lifetime of a Pregel invocation (multiple steps)."""
-    empty = {
-        k: v.afrom_checkpoint(checkpoint["channel_values"].get(k))
-        for k, v in channels.items()
-    }
-    try:
-        yield {k: await v.__aenter__() for k, v in empty.items()}
-    finally:
-        for v in empty.values():
-            await v.__aexit__(None, None, None)
-
-
-def create_checkpoint(
-    checkpoint: Checkpoint, channels: Mapping[str, BaseChannel], step: int
-) -> Checkpoint:
-    """Create a checkpoint for the given channels."""
-    ts = datetime.now(timezone.utc).isoformat()
-    values: dict[str, Any] = {}
-    for k, v in channels.items():
-        try:
-            values[k] = v.checkpoint()
-        except EmptyChannelError:
-            pass
-    return Checkpoint(
-        v=1,
-        ts=ts,
-        id=str(uuid6(clock_seq=step)),
-        channel_values=values,
-        channel_versions=checkpoint["channel_versions"],
-        versions_seen=checkpoint["versions_seen"],
-        pending_sends=checkpoint.get("pending_sends", []),
-    )
-
-
 __all__ = [
     "BaseChannel",
-    "ChannelsManager",
-    "AsyncChannelsManager",
-    "create_checkpoint",
     "EmptyChannelError",
     "InvalidUpdateError",
 ]

--- a/langgraph/channels/manager.py
+++ b/langgraph/channels/manager.py
@@ -1,0 +1,65 @@
+from contextlib import asynccontextmanager, contextmanager
+from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, Generator, Mapping
+
+from langgraph.channels.base import BaseChannel
+from langgraph.checkpoint.base import Checkpoint
+from langgraph.checkpoint.id import uuid6
+from langgraph.errors import EmptyChannelError
+
+
+@contextmanager
+def ChannelsManager(
+    channels: Mapping[str, BaseChannel],
+    checkpoint: Checkpoint,
+) -> Generator[Mapping[str, BaseChannel], None, None]:
+    """Manage channels for the lifetime of a Pregel invocation (multiple steps)."""
+    # TODO use https://docs.python.org/3/library/contextlib.html#contextlib.ExitStack
+    empty = {
+        k: v.from_checkpoint(checkpoint["channel_values"].get(k))
+        for k, v in channels.items()
+    }
+    try:
+        yield {k: v.__enter__() for k, v in empty.items()}
+    finally:
+        for v in empty.values():
+            v.__exit__(None, None, None)
+
+
+@asynccontextmanager
+async def AsyncChannelsManager(
+    channels: Mapping[str, BaseChannel],
+    checkpoint: Checkpoint,
+) -> AsyncGenerator[Mapping[str, BaseChannel], None]:
+    """Manage channels for the lifetime of a Pregel invocation (multiple steps)."""
+    empty = {
+        k: v.afrom_checkpoint(checkpoint["channel_values"].get(k))
+        for k, v in channels.items()
+    }
+    try:
+        yield {k: await v.__aenter__() for k, v in empty.items()}
+    finally:
+        for v in empty.values():
+            await v.__aexit__(None, None, None)
+
+
+def create_checkpoint(
+    checkpoint: Checkpoint, channels: Mapping[str, BaseChannel], step: int
+) -> Checkpoint:
+    """Create a checkpoint for the given channels."""
+    ts = datetime.now(timezone.utc).isoformat()
+    values: dict[str, Any] = {}
+    for k, v in channels.items():
+        try:
+            values[k] = v.checkpoint()
+        except EmptyChannelError:
+            pass
+    return Checkpoint(
+        v=1,
+        ts=ts,
+        id=str(uuid6(clock_seq=step)),
+        channel_values=values,
+        channel_versions=checkpoint["channel_versions"],
+        versions_seen=checkpoint["versions_seen"],
+        pending_sends=checkpoint.get("pending_sends", []),
+    )

--- a/langgraph/checkpoint/base.py
+++ b/langgraph/checkpoint/base.py
@@ -15,6 +15,7 @@ from typing import (
 
 from langchain_core.runnables import ConfigurableFieldSpec, RunnableConfig
 
+from langgraph.channels.base import BaseChannel
 from langgraph.checkpoint.id import uuid6
 from langgraph.constants import Send
 from langgraph.serde.base import SerializerProtocol
@@ -187,6 +188,7 @@ class BaseCheckpointSaver(ABC):
         self,
         config: Optional[RunnableConfig],
         *,
+        filter: Optional[Dict[str, Any]] = None,
         before: Optional[RunnableConfig] = None,
         limit: Optional[int] = None,
     ) -> AsyncIterator[CheckpointTuple]:
@@ -200,3 +202,6 @@ class BaseCheckpointSaver(ABC):
         metadata: CheckpointMetadata,
     ) -> RunnableConfig:
         raise NotImplementedError
+
+    def get_next_version(self, current: int, channel: BaseChannel) -> int:
+        return current + 1

--- a/langgraph/checkpoint/base.py
+++ b/langgraph/checkpoint/base.py
@@ -11,6 +11,8 @@ from typing import (
     NamedTuple,
     Optional,
     TypedDict,
+    TypeVar,
+    Union,
 )
 
 from langchain_core.runnables import ConfigurableFieldSpec, RunnableConfig
@@ -20,6 +22,8 @@ from langgraph.checkpoint.id import uuid6
 from langgraph.constants import Send
 from langgraph.serde.base import SerializerProtocol
 from langgraph.serde.jsonplus import JsonPlusSerializer
+
+V = TypeVar("V", int, float, str)
 
 
 # Marked as total=False to allow for future expansion.
@@ -63,13 +67,13 @@ class Checkpoint(TypedDict):
     
     Mapping from channel name to channel snapshot value.
     """
-    channel_versions: defaultdict[str, int]
+    channel_versions: defaultdict[str, Union[str, int, float]]
     """The versions of the channels at the time of the checkpoint.
     
     The keys are channel names and the values are the logical time step
     at which the channel was last updated.
     """
-    versions_seen: defaultdict[str, defaultdict[str, int]]
+    versions_seen: defaultdict[str, defaultdict[str, Union[str, int, float]]]
     """Map from node ID to map from channel name to version seen.
     
     This keeps track of the versions of the channels that each node has seen.
@@ -203,5 +207,5 @@ class BaseCheckpointSaver(ABC):
     ) -> RunnableConfig:
         raise NotImplementedError
 
-    def get_next_version(self, current: int, channel: BaseChannel) -> int:
-        return current + 1
+    def get_next_version(self, current: Optional[V], channel: BaseChannel) -> V:
+        return current + 1 if current is not None else 1

--- a/langgraph/checkpoint/base.py
+++ b/langgraph/checkpoint/base.py
@@ -67,13 +67,13 @@ class Checkpoint(TypedDict):
     
     Mapping from channel name to channel snapshot value.
     """
-    channel_versions: defaultdict[str, Union[str, int, float]]
+    channel_versions: dict[str, Union[str, int, float]]
     """The versions of the channels at the time of the checkpoint.
     
     The keys are channel names and the values are the logical time step
     at which the channel was last updated.
     """
-    versions_seen: defaultdict[str, defaultdict[str, Union[str, int, float]]]
+    versions_seen: defaultdict[str, dict[str, Union[str, int, float]]]
     """Map from node ID to map from channel name to version seen.
     
     This keeps track of the versions of the channels that each node has seen.
@@ -85,18 +85,14 @@ class Checkpoint(TypedDict):
     Cleared by the next checkpoint."""
 
 
-def _seen_dict():
-    return defaultdict(int)
-
-
 def empty_checkpoint() -> Checkpoint:
     return Checkpoint(
         v=1,
         id=str(uuid6(clock_seq=-2)),
         ts=datetime.now(timezone.utc).isoformat(),
         channel_values={},
-        channel_versions=defaultdict(int),
-        versions_seen=defaultdict(_seen_dict),
+        channel_versions={},
+        versions_seen=defaultdict(dict),
         pending_sends=[],
     )
 
@@ -107,10 +103,10 @@ def copy_checkpoint(checkpoint: Checkpoint) -> Checkpoint:
         ts=checkpoint["ts"],
         id=checkpoint["id"],
         channel_values=checkpoint["channel_values"].copy(),
-        channel_versions=defaultdict(int, checkpoint["channel_versions"]),
+        channel_versions=checkpoint["channel_versions"].copy(),
         versions_seen=defaultdict(
-            _seen_dict,
-            {k: defaultdict(int, v) for k, v in checkpoint["versions_seen"].items()},
+            dict,
+            {k: v.copy() for k, v in checkpoint["versions_seen"].items()},
         ),
         pending_sends=checkpoint.get("pending_sends", []).copy(),
     )

--- a/langgraph/checkpoint/base.py
+++ b/langgraph/checkpoint/base.py
@@ -204,4 +204,6 @@ class BaseCheckpointSaver(ABC):
         raise NotImplementedError
 
     def get_next_version(self, current: Optional[V], channel: BaseChannel) -> V:
+        """Get the next version of a channel. Default is to use int versions, incrementing by 1. If you override, you can use str/int/float versions,
+        as long as they are monotonically increasing."""
         return current + 1 if current is not None else 1

--- a/langgraph/managed/few_shot.py
+++ b/langgraph/managed/few_shot.py
@@ -17,7 +17,7 @@ from typing import (
 from langchain_core.runnables import RunnableConfig
 from typing_extensions import Self
 
-from langgraph.channels.base import AsyncChannelsManager, ChannelsManager
+from langgraph.channels.manager import AsyncChannelsManager, ChannelsManager
 from langgraph.managed.base import ConfiguredManagedValue, ManagedValue, V
 from langgraph.pregel import Pregel
 from langgraph.pregel.io import read_channels

--- a/langgraph/pregel/__init__.py
+++ b/langgraph/pregel/__init__.py
@@ -1593,8 +1593,8 @@ def _local_write(
     commit(writes)
 
 
-def _increment(current: int, channel: BaseChannel) -> int:
-    return current + 1
+def _increment(current: Optional[int], channel: BaseChannel) -> int:
+    return current + 1 if current is not None else 1
 
 
 def _apply_writes(
@@ -1631,7 +1631,7 @@ def _apply_writes(
                     f"Invalid update for channel {chan} with values {vals}"
                 ) from e
             checkpoint["channel_versions"][chan] = get_next_version(
-                max_version, channels[chan]
+                max_version or None, channels[chan]
             )
             updated_channels.add(chan)
     # Channels that weren't updated in this step are notified of a new step

--- a/tests/checkpoint/test_aiosqlite.py
+++ b/tests/checkpoint/test_aiosqlite.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.runnables import RunnableConfig
 
-from langgraph.channels.base import create_checkpoint
+from langgraph.channels.manager import create_checkpoint
 from langgraph.checkpoint.aiosqlite import AsyncSqliteSaver
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, empty_checkpoint
 

--- a/tests/checkpoint/test_memory.py
+++ b/tests/checkpoint/test_memory.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.runnables import RunnableConfig
 
-from langgraph.channels.base import create_checkpoint
+from langgraph.channels.manager import create_checkpoint
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, empty_checkpoint
 from langgraph.checkpoint.memory import MemorySaver
 

--- a/tests/checkpoint/test_sqlite.py
+++ b/tests/checkpoint/test_sqlite.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.runnables import RunnableConfig
 
-from langgraph.channels.base import create_checkpoint
+from langgraph.channels.manager import create_checkpoint
 from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata, empty_checkpoint
 from langgraph.checkpoint.sqlite import (
     _AIO_ERROR_MSG,


### PR DESCRIPTION
- default is incrementing integers, starting at 1
- now support using str/int/float as versions, as long as they are monotically increasing