### PR TITLE
bug fix: expected a list got a tuple

### DIFF
--- a/examples/plan-and-execute/plan-and-execute.ipynb
+++ b/examples/plan-and-execute/plan-and-execute.ipynb
@@ -392,7 +392,7 @@
     "        {\"messages\": [(\"user\", task_formatted)]}\n",
     "    )\n",
     "    return {\n",
-    "        \"past_steps\": (task, agent_response[\"messages\"][-1].content),\n",
+    "        \"past_steps\": [task, agent_response[\"messages\"][-1].content],\n",
     "    }\n",
     "\n",
     "\n",


### PR DESCRIPTION
![image](https://github.com/langchain-ai/langgraph/assets/68109074/666a89ca-b696-46a1-b97e-27df396d897b)
it should have returned a list not a tuple, our state has past_steps: Annotated[List[Tuple], operator.add], yet this node returns a tuple 