### PR TITLE
docs: Create how-to for setting up LangGraph app and how-to for deploying to LangGraph Cloud

### DIFF
--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -16,7 +16,7 @@ Starting from the <a href="https://smith.langchain.com/" target="_blank">LangSmi
     1. `Deployment details`
         1. Select `Import from GitHub` and follow the GitHub OAuth workflow to install and authorize LangChain's `hosted-langserve` GitHub app to  access the selected repositories. After installation is complete, return to the `Create New Deployment` panel and select the GitHub repository to deploy from the dropdown menu.
         1. Specify a name for the deployment.
-        1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the respository, simply specify `langgraph.json`.
+        1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the repository, simply specify `langgraph.json`.
         1. Specify the desired `git` reference (e.g. branch name). For example, different branches of the repository can be deployed.
     1. Select the desired `Deployment Type`.
         1. `Development` deployments are meant for non-production use cases and are provisioned with minimal resources.
@@ -37,7 +37,7 @@ Starting from the <a href="https://smith.langchain.com/" target="_blank">LangSmi
 1. Select an existing deployment to create a new revision for.
 1. In the `Deployment` view, in the top-right corner, select `+ New Revision`.
 1. In the `New Revision` modal, fill out the required fields.
-    1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the respository, simply specify `langgraph.json`.
+    1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the repository, simply specify `langgraph.json`.
     1. Specify the desired `git` reference (e.g. branch name). For example, different branches of the repository can be deployed.
     1. Specify `Environment Variables` and secrets. Existing secrets and environment variables are prepopulated.
         1. Add new secrets or environment variables.

--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -1,0 +1,52 @@
+# How to Deploy to LangGraph Cloud
+
+LangGraph Cloud is available within <a href="https://www.langchain.com/langsmith" target="_blank">LangSmith</a>. To deploy a LangGraph Cloud API, navigate to the <a href="https://smith.langchain.com/" target="_blank">LangSmith UI</a>.
+
+## Setup GitHub Repository
+
+LangGraph Cloud applications are deployed from GitHub repositories. Configure and upload a LangGraph Cloud application to a GitHub repository in order to deploy it to LangGraph Cloud.
+
+## Create New Deployment
+
+Starting from the <a href="https://smith.langchain.com/" target="_blank">LangSmith UI</a>...
+
+1. In the left-hand navigation panel, select `Deployments`. The `Deployments` view contains a list of existing LangGraph Cloud deployments.
+1. In the top-right corner, select `+ New Deployment` to create a new deployment.
+1. In the `Create New Deployment` panel, fill out the required fields.
+    1. `Deployment details`
+        1. Select `Import from GitHub` and follow the GitHub OAuth workflow to install and authorize LangChain's `hosted-langserve` GitHub app to  access the selected repositories. After installation is complete, return to the `Create New Deployment` panel and select the GitHub repository to deploy from the dropdown menu.
+        1. Specify a name for the deployment.
+        1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the respository, simply specify `langgraph.json`.
+        1. Specify the desired `git` reference (e.g. branch name). For example, different branches of the repository can be deployed.
+    1. Select the desired `Deployment Type`.
+        1. `Development` deployments are meant for non-production use cases and are provisioned with minimal resources.
+        1. `Production` deployments can serve up to 500 requests/second and are provisioned with highly available storage with automatic backups.
+    1. Specify `Environment Variables` and secrets.
+        1. Sensitive values such as API keys (e.g. `OPENAI_API_KEY`) should be specified as secrets.
+        1. Additional non-secret environment variables can be specified as well.
+    1. A new LangSmith `Tracing Project` is automatically created with the same name as the deployment.
+1. In the top-right corner, select `Submit`. After a few seconds, the `Deployment` view appears and the new deployment will be queued for provisioning.
+
+## Create New Revision
+
+When [creating a new deployment](#create-a-new-deployment), a new revision is created by default. Subsequent revisions can be created to deploy new code changes.
+
+Starting from the <a href="https://smith.langchain.com/" target="_blank">LangSmith UI</a>...
+
+1. In the left-hand navigation panel, select `Deployments`. The `Deployments` view contains a list of existing LangGraph Cloud deployments.
+1. Select an existing deployment to create a new revision for.
+1. In the `Deployment` view, in the top-right corner, select `+ New Revision`.
+1. In the `New Revision` modal, fill out the required fields.
+    1. Specify the full path to the [LangGraph API config file](../reference/cli.md#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the respository, simply specify `langgraph.json`.
+    1. Specify the desired `git` reference (e.g. branch name). For example, different branches of the repository can be deployed.
+    1. Specify `Environment Variables` and secrets. Existing secrets and environment variables are prepopulated.
+        1. Add new secrets or environment variables.
+        1. Remove existing secrets or environment variables.
+        1. Update the value of existing secrets or environment variables.
+1. Select `Submit`. After a few seconds, the `New Revision` modal will close and the new revision will be queued for deployment.
+
+## Asynchronous Deployment
+
+New [deployments](#create-new-deployment) and [revisions](#create-new-revision) are provisioned and deployed asynchronously. They are not deployed immediately after submission. Currently, deployment can take up to several minutes.
+
+The `Deployment` view continually updates the status of pending revisions.

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -1,9 +1,3 @@
-### Run your server locally
+# How to Self-Host LangGraph Cloud API
 
-First, make sure that Docker is up and running. Test that your server works by running:
-
-```python
-langgraph up -c langgraph.json
-```
-
-This will bring up a local server with your graph! Access the auto-generated server for your playground to confirm everything works as planned at [http://localhost:8124](http://localhost:8124) .
+Coming soon...

--- a/docs/docs/cloud/deployment/setup.md
+++ b/docs/docs/cloud/deployment/setup.md
@@ -1,0 +1,99 @@
+# How to Set Up a LangGraph Application for Deployment
+
+A LangGraph application must be configured with a [LangGraph API configuration file](../reference/cli.md#configuration-file) in order to be deployed to LangGraph Cloud (or to be self-hosted). This how-to guide discusses the basic steps to setup a LangGraph application for deployment.
+
+After each step, an example file directory is provided to demonstrate how code can be organized.
+
+## Specify Dependencies
+
+Dependencies can optionally be specified in one of the following files: `pyproject.toml`, `setup.py`, or `requirements.txt`. If neither of these files is created, then dependencies can be specified later in the [LangGraph API configuration file](#create-langgraph-api-config).
+
+Example `requirements.txt` file:
+```
+langgraph
+langchain_openai
+```
+
+Example file directory:
+```
+my-app/
+|-- requirements.txt    # Python packages required for your graph
+```
+
+## Specify Environment Variables
+
+Environment variables can optionally be specified in a file (e.g. `.env`).
+
+Example `.env` file:
+```
+MY_ENV_VAR_1=foo
+MY_ENV_VAR_2=bar
+```
+
+Example file directory:
+```
+my-app/
+|-- requirements.txt
+|-- .env                # file with environment variables
+```
+
+## Define Graphs
+
+Implement your graphs! Graphs can be defined in a single file or multiple files. Make note of the variable names of each [CompiledGraph](../../../reference/graphs/#compiledgraph) to be included in the LangGraph application. The variable names will be used later when creating the [LangGraph API configuration file](../reference/cli.md#configuration-file).
+
+Example `openai_agent.py` file:
+```python
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, MessageGraph
+
+model = ChatOpenAI(temperature=0)
+
+graph_workflow = MessageGraph()
+
+graph_workflow.add_node("agent", model)
+graph_workflow.add_edge("agent", END)
+graph_workflow.set_entry_point("agent")
+
+agent = graph_workflow.compile()
+```
+
+Example file directory:
+```
+my-app/
+|-- requirements.txt
+|-- .env
+|-- openai_agent.py     # code for your graph
+|-- anthropic_agent.py  # code for your graph
+```
+
+## Create LangGraph API Config
+
+Create a [LangGraph API configuration file](../reference/cli.md#configuration-file) called `langgraph.json`. See the [LangGraph CLI reference](../reference/cli.md#configuration-file) for detailed explanations of each key in the JSON object of the configuration file.
+
+Example `langgraph.json` file:
+```json
+{
+    "dependencies": [
+        "./my-app"
+    ],
+    "graphs": {
+        "openai_agent": "./openai_agent.py:agent",
+        "anthropic_agent": "./anthropic_agent.py:agent"
+    },
+    "env": ".env"
+}
+```
+
+Example file directory:
+```
+my-app/
+|-- requirements.txt
+|-- .env
+|-- openai_agent.py
+|-- anthropic_agent.py
+|-- langgraph.json      # configuration file for LangGraph
+```
+
+## Upload to GitHub
+
+To deploy the LangGraph application to LangGraph Cloud, the code must be uploaded to a GitHub repository.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -171,10 +171,11 @@ nav:
       - 'cloud/index.md'
       - Tutorials:
           - Quick Start: 'cloud/quick_start.md'
-          - Deployment:
-              - Self-Hosted: 'cloud/deployment/self_hosted.md'
-              - Managed: 'cloud/deployment/managed.md'
       - How-to Guides:
+          - Deployment:
+              - Setup App: 'cloud/deployment/setup.md'
+              - Deploy to Cloud: 'cloud/deployment/cloud.md'
+              - Self-Host: 'cloud/deployment/self_hosted.md'
           - Streaming:
               - Stream Values: 'cloud/how-tos/cloud_examples/stream_values.ipynb'
               - Stream Updates: 'cloud/how-tos/cloud_examples/stream_updates.ipynb'


### PR DESCRIPTION
### Summary
1. Move `Deployment` pages under `How-to Guides`.
1. Create how-to page for how to set up a LangGraph application for deployment.
1. Create how-to page for how to deploy to LangGraph Cloud.