### PR TITLE
docs: Update self-hosted how-to page for LangGraph Cloud

### DIFF
--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -23,4 +23,7 @@ The public Helm chart for LangGraph Cloud is available [here](https://github.com
 
 ## Self-Host with Docker
 
+!!! warning "Under Construction"
+    This section of the documentation is in progress.
+
 Docker Compose can be used to deploy LangGraph Cloud to the compute infrastructure of your choice (e.g. VM).

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -18,7 +18,7 @@ LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key
 The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud).
 
 1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
-1. Publish the built Docker image to a respository that can be accessed by the target Kubernetes cluster.
+1. Publish the built Docker image to a repository that can be accessed by the target Kubernetes cluster.
 1. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure the Helm chart and deploy to Kubernetes.
 
 ## Self-Host with Docker

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -22,7 +22,7 @@ This section is for self-hosting LangGraph Cloud API on Kubernetes via Helm. A K
 
 1. Publish the built Docker image to a repository that can be accessed by the target Kubernetes cluster.
 1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
-1. Make note of all environment variables that are needed for the application to run (e.g. `OPENAI_API_KEY`). These values will need to be set in the Helm `values` YAML configuration.
+1. Make note of all environment variables that are needed for the application. These values will need to be set in the Helm `values` YAML configuration.
 1. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure the Helm chart and deploy to Kubernetes.
 
 ## Self-Host with Docker

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -1,6 +1,9 @@
 # How to Self-Host LangGraph Cloud API
 
-LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key. Self-hosted deployments are built with Docker and Helm. Ensure that both the [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) and [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) are installed.
+!!! warning "Enterprise License Required"
+    Self-hosting LangGraph Cloud API requires a license key. Please contact sales@langchain.dev for more details.
+
+LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key. Self-hosted deployments are built with Docker and deployed with Helm (on Kubernetes) or with Docker Compose. Ensure that the [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) is installed.
 
 ## Build Image
 
@@ -10,6 +13,13 @@ LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key
 
         langgraph build -t tag_name
 
-## Configure Helm Chart
+## Self-Host on Kubernetes
 
-The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud). Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) for configuring your Helm chart and deploying to Kubernetes.
+The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud).
+
+1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
+2. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure your Helm chart and deploy to Kubernetes.
+
+## Self-Host with Docker
+
+Docker Compose can be used to deploy LangGraph Cloud to the compute infrastructure of your choice (e.g. VM).

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -7,18 +7,22 @@ LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key
 
 ## Build Docker Image
 
-1. Follow the [How-to Guide](setup.md) for setting up a LangGraph application for deployment.
+1. Follow the [How-to Guide](setup.md) for setting up a LangGraph application for deployment. Your LangGraph application will vary from the example in the How-to Guide. However, ensure that the [LangGraph API configuration file](../reference/cli.md#configuration-file) is created.
 1. Install the [LangGraph CLI](../reference/cli.md#installation).
 1. Run the following LangGraph CLI `build` command to build a Docker image. Specify the image tag (`-t`) and other desired [options](../reference/cli.md#build).
 
         langgraph build -t tag_name
 
+!!! info "Build Platform"
+    When building the Docker image, ensure that the image is built for the platform of the target Kubernetes cluster: `langgraph build -t tag_name --platform linux/amd64,linux/arm64`
+
 ## Self-Host on Kubernetes
 
-The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud).
+This section is for self-hosting LangGraph Cloud API on Kubernetes via Helm. A Kubernetes cluster must be provisioned before proceeding with these steps. The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud).
 
-1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
 1. Publish the built Docker image to a repository that can be accessed by the target Kubernetes cluster.
+1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
+1. Make note of all environment variables that are needed for the application to run (e.g. `OPENAI_API_KEY`). These values will need to be set in the Helm `values` YAML configuration.
 1. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure the Helm chart and deploy to Kubernetes.
 
 ## Self-Host with Docker

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -5,7 +5,7 @@
 
 LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key. Self-hosted deployments are built with Docker and deployed with Helm (on Kubernetes) or with Docker Compose. Ensure that the [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) is installed.
 
-## Build Image
+## Build Docker Image
 
 1. Follow the [How-to Guide](setup.md) for setting up a LangGraph application for deployment.
 1. Install the [LangGraph CLI](../reference/cli.md#installation).
@@ -18,7 +18,8 @@ LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key
 The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud).
 
 1. Ensure that the [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) is installed.
-2. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure your Helm chart and deploy to Kubernetes.
+1. Publish the built Docker image to a respository that can be accessed by the target Kubernetes cluster.
+1. Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) to configure the Helm chart and deploy to Kubernetes.
 
 ## Self-Host with Docker
 

--- a/docs/docs/cloud/deployment/self_hosted.md
+++ b/docs/docs/cloud/deployment/self_hosted.md
@@ -1,3 +1,15 @@
 # How to Self-Host LangGraph Cloud API
 
-Coming soon...
+LangGraph Cloud APIs can be self-hosted with a valid LangGraph Cloud license key. Self-hosted deployments are built with Docker and Helm. Ensure that both the [Docker CLI](https://docs.docker.com/engine/reference/commandline/cli/) and [Helm client](https://github.com/helm/helm?tab=readme-ov-file#install) are installed.
+
+## Build Image
+
+1. Follow the [How-to Guide](setup.md) for setting up a LangGraph application for deployment.
+1. Install the [LangGraph CLI](../reference/cli.md#installation).
+1. Run the following LangGraph CLI `build` command to build a Docker image. Specify the image tag (`-t`) and other desired [options](../reference/cli.md#build).
+
+        langgraph build -t tag_name
+
+## Configure Helm Chart
+
+The public Helm chart for LangGraph Cloud is available [here](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud). Follow [these instructions](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-cloud#readme) for configuring your Helm chart and deploying to Kubernetes.

--- a/docs/docs/cloud/deployment/setup.md
+++ b/docs/docs/cloud/deployment/setup.md
@@ -28,6 +28,7 @@ Example `.env` file:
 ```
 MY_ENV_VAR_1=foo
 MY_ENV_VAR_2=bar
+OPENAI_API_KEY=key
 ```
 
 Example file directory:
@@ -77,13 +78,13 @@ Example `langgraph.json` file:
 ```json
 {
     "dependencies": [
-        "./my-app"
+        "."
     ],
     "graphs": {
         "openai_agent": "./openai_agent.py:agent",
         "anthropic_agent": "./anthropic_agent.py:agent"
     },
-    "env": ".env"
+    "env": "./.env"
 }
 ```
 


### PR DESCRIPTION
### Summary
The how-to page for self-hosted LangGraph Cloud mostly refers to the `README` of the public Helm chart. GitHub links are pending...