### PR TITLE
chore(cli): use different container port for debugger

### DIFF
--- a/libs/cli/langgraph_cli/docker.py
+++ b/libs/cli/langgraph_cli/docker.py
@@ -37,7 +37,7 @@ DEBUGGER = """
         image: langchain/langgraph-debugger
         restart: on-failure
         ports:
-            - "{debugger_port}:80"
+            - "{debugger_port}:3968"
         depends_on:
             langgraph-postgres:
                 condition: service_healthy

--- a/libs/cli/tests/unit_tests/test_cli.py
+++ b/libs/cli/tests/unit_tests/test_cli.py
@@ -65,7 +65,7 @@ services:
         image: langchain/langgraph-debugger
         restart: on-failure
         ports:
-            - "{debugger_port}:80"
+            - "{debugger_port}:3968"
         depends_on:
             langgraph-postgres:
                 condition: service_healthy


### PR DESCRIPTION
Will wait until the corresponding LangSmith PR will land