### PR TITLE
[Docs] add langchian_community module in tutorials intro

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -409,7 +409,8 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U tavily-python"
+    "%pip install -U tavily-python\n",
+    "%pip install -U langchain_community"
    ]
   },
   {


### PR DESCRIPTION
## Summary

[Introduction to LangGraph - Part 2: Enhancing the Chatbot with Tools](https://langchain-ai.github.io/langgraph/tutorials/introduction/#part-2-enhancing-the-chatbot-with-tools) Less installation of the langchain_community module
