### PR TITLE
Add missing pip install libraries that are used in the example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ LangGraph is inspired by [Pregel](https://research.google/pubs/pub37252/) and [A
 ## Installation
 
 ```shell
-pip install -U langgraph
+pip install -U langgraph langchain-openai langchain-community langchain-core
 ```
 
 ## Example


### PR DESCRIPTION
Add missing pip install libraries that are used in the example (Python imports).