### PR TITLE
Interupt during tool call

### DIFF
--- a/examples/human-in-the-loop.ipynb
+++ b/examples/human-in-the-loop.ipynb
@@ -631,6 +631,7 @@
     "        message = event[\"messages\"][-1]\n",
     "        if isinstance(message, AIMessage) and message.tool_calls:\n",
     "            tool_call_message = message\n",
+    "            break\n",
     "        else:\n",
     "            message.pretty_print()\n",
     "\n",


### PR DESCRIPTION
There is no break-statement which required to achieve the proposed technique, of asking for the user approval before the tool invocation. The current implementation doesn't stop when the LLM returns a tool_call.