### PR TITLE
fix: typo

### DIFF
--- a/examples/streaming-from-final-node.ipynb
+++ b/examples/streaming-from-final-node.ipynb
@@ -5,7 +5,7 @@
    "id": "15c4bd28",
    "metadata": {},
    "source": [
-    "# How to stream from the final node node"
+    "# How to stream from the final node"
    ]
   },
   {


### PR DESCRIPTION
fix typo `# How to stream from the final node node` -> `# How to stream from the final node`