### PR TITLE
docs: fix typo in langgraph crag tutorial notebook

### DIFF
--- a/examples/rag/langgraph_crag.ipynb
+++ b/examples/rag/langgraph_crag.ipynb
@@ -17,7 +17,7 @@
     "In the paper [here](https://arxiv.org/pdf/2401.15884.pdf), a few steps are taken:\n",
     "\n",
     "* If at least one document exceeds the threshold for relevance, then it proceeds to generation\n",
-    "* Before generation, it performns knowledge refinement\n",
+    "* Before generation, it performs knowledge refinement\n",
     "* This partitions the document into \"knowledge strips\"\n",
     "* It grades each strip, and filters our irrelevant ones\n",
     "* If all documents fall below the relevance threshold or if the grader is unsure, then the framework seeks an additional datasource\n",


### PR DESCRIPTION
small typo in the langgraph_crag tutorial notebook.