### PR TITLE
cli: set verbose flag for pull in langgraph build

### DIFF
--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -2,8 +2,8 @@
 
 This package implements the official CLI for LangGraph API.
 
-## How to Test Locally
-Use the CLI examples to test CLI changes locally.
+## How to Test CLI Changes Locally
+These instructions are for CLI development and testing. Use the CLI examples to test CLI changes locally.
 1. Make changes to the CLI code.
 1. Navigate to the `libs/cli/examples`: `cd libs/cli/examples`
 1. Install CLI examples dependencies: `poetry install`

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -1,3 +1,10 @@
 # langchain-cli
 
 This package implements the official CLI for LangGraph API.
+
+## How to Test Locally
+Use the CLI examples to test CLI changes locally.
+1. Make changes to the CLI code.
+1. Navigate to the `libs/cli/examples`: `cd libs/cli/examples`
+1. Install CLI examples dependencies: `poetry install`
+1. Run/test CLI command (e.g. `langgraph build`).

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -369,6 +369,7 @@ def _build(
                 "docker",
                 "pull",
                 f"{base_image}:{config_json['python_version']}",
+                verbose=True,
             )
         )
     set("Building...")


### PR DESCRIPTION
### Summary
The digest SHA of the base image should be output for debugging purposes when running `langgraph build`.

Example output:
```
(env) andrewnguonly@Andrews-MBP examples % langgraph build -t langgraph-libs-cli-examples:1 
- Pulling...+ docker pull langchain/langgraph-api:3.11
- Pulling...3.11: Pulling from langchain/langgraph-api
\ Pulling...Digest: sha256:5aad40e6635aee3e91a1254bf0ad26bb8b5021b3d65a56e0e0a5720f2555ef46
Status: Downloaded newer image for langchain/langgraph-api:3.11
docker.io/langchain/langgraph-api:3.11

...
```