### PR TITLE
lib: Checkpoint pending writes whenever a node finishes

### DIFF
--- a/libs/langgraph/langgraph/checkpoint/aiosqlite.py
+++ b/libs/langgraph/langgraph/checkpoint/aiosqlite.py
@@ -242,56 +242,58 @@ class AsyncSqliteSaver(BaseCheckpointSaver, AbstractAsyncContextManager):
             Optional[CheckpointTuple]: The retrieved checkpoint tuple, or None if no matching checkpoint was found.
         """
         await self.setup()
-        if config["configurable"].get("thread_ts"):
-            async with self.conn.execute(
-                "SELECT checkpoint, parent_ts, metadata FROM checkpoints WHERE thread_id = ? AND thread_ts = ?",
-                (
-                    str(config["configurable"]["thread_id"]),
-                    str(config["configurable"]["thread_ts"]),
-                ),
-            ) as cursor:
-                if value := await cursor.fetchone():
-                    return CheckpointTuple(
-                        config,
-                        self.serde.loads(value[0]),
-                        self.serde.loads(value[2]) if value[2] is not None else {},
-                        (
-                            {
-                                "configurable": {
-                                    "thread_id": config["configurable"]["thread_id"],
-                                    "thread_ts": value[1],
-                                }
-                            }
-                            if value[1]
-                            else None
-                        ),
-                    )
-        else:
-            async with self.conn.execute(
-                "SELECT thread_id, thread_ts, parent_ts, checkpoint, metadata FROM checkpoints WHERE thread_id = ? ORDER BY thread_ts DESC LIMIT 1",
-                (str(config["configurable"]["thread_id"]),),
-            ) as cursor:
-                if value := await cursor.fetchone():
-                    return CheckpointTuple(
+        async with self.conn.cursor() as cur:
+            # find the latest checkpoint for the thread_id
+            if config["configurable"].get("thread_ts"):
+                await cur.execute(
+                    "SELECT thread_id, thread_ts, parent_ts, checkpoint, metadata FROM checkpoints WHERE thread_id = ? AND thread_ts = ?",
+                    (
+                        str(config["configurable"]["thread_id"]),
+                        str(config["configurable"]["thread_ts"]),
+                    ),
+                )
+            else:
+                await cur.execute(
+                    "SELECT thread_id, thread_ts, parent_ts, checkpoint, metadata FROM checkpoints WHERE thread_id = ? ORDER BY thread_ts DESC LIMIT 1",
+                    (str(config["configurable"]["thread_id"]),),
+                )
+            # if a checkpoint is found, return it
+            if value := await cur.fetchone():
+                if not config["configurable"].get("thread_ts"):
+                    config = {
+                        "configurable": {
+                            "thread_id": value[0],
+                            "thread_ts": value[1],
+                        }
+                    }
+                # find any pending writes
+                await cur.execute(
+                    "SELECT task_id, channel, value FROM writes WHERE thread_id = ? AND thread_ts = ?",
+                    (
+                        str(config["configurable"]["thread_id"]),
+                        str(config["configurable"]["thread_ts"]),
+                    ),
+                )
+                # deserialize the checkpoint and metadata
+                return CheckpointTuple(
+                    config,
+                    self.serde.loads(value[3]),
+                    self.serde.loads(value[4]) if value[4] is not None else {},
+                    (
                         {
                             "configurable": {
                                 "thread_id": value[0],
-                                "thread_ts": value[1],
+                                "thread_ts": value[2],
                             }
-                        },
-                        self.serde.loads(value[3]),
-                        self.serde.loads(value[4]) if value[4] is not None else {},
-                        (
-                            {
-                                "configurable": {
-                                    "thread_id": value[0],
-                                    "thread_ts": value[2],
-                                }
-                            }
-                            if value[2]
-                            else None
-                        ),
-                    )
+                        }
+                        if value[2]
+                        else None
+                    ),
+                    [
+                        (task_id, channel, self.serde.loads(value))
+                        async for task_id, channel, value in cur
+                    ],
+                )
 
     async def alist(
         self,

--- a/libs/langgraph/langgraph/checkpoint/base.py
+++ b/libs/langgraph/langgraph/checkpoint/base.py
@@ -118,7 +118,7 @@ class CheckpointTuple(NamedTuple):
     checkpoint: Checkpoint
     metadata: CheckpointMetadata
     parent_config: Optional[RunnableConfig] = None
-    pending_writes: Optional[List[Tuple[str, Any]]] = None
+    pending_writes: Optional[List[Tuple[str, str, Any]]] = None
 
 
 CheckpointThreadId = ConfigurableFieldSpec(

--- a/libs/langgraph/langgraph/checkpoint/base.py
+++ b/libs/langgraph/langgraph/checkpoint/base.py
@@ -185,7 +185,9 @@ class BaseCheckpointSaver(ABC):
         writes: List[Tuple[str, Any]],
         task_id: str,
     ) -> None:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "This method was added in langgraph 0.1.7. Please update your checkpointer to implement it."
+        )
 
     async def aget(self, config: RunnableConfig) -> Optional[Checkpoint]:
         if value := await self.aget_tuple(config):
@@ -219,7 +221,9 @@ class BaseCheckpointSaver(ABC):
         writes: List[Tuple[str, Any]],
         task_id: str,
     ) -> None:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "This method was added in langgraph 0.1.7. Please update your checkpointer to implement it."
+        )
 
     def get_next_version(self, current: Optional[V], channel: BaseChannel) -> V:
         """Get the next version of a channel. Default is to use int versions, incrementing by 1. If you override, you can use str/int/float versions,

--- a/libs/langgraph/langgraph/checkpoint/base.py
+++ b/libs/langgraph/langgraph/checkpoint/base.py
@@ -10,6 +10,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    Tuple,
     TypedDict,
     TypeVar,
     Union,
@@ -117,6 +118,7 @@ class CheckpointTuple(NamedTuple):
     checkpoint: Checkpoint
     metadata: CheckpointMetadata
     parent_config: Optional[RunnableConfig] = None
+    pending_writes: Optional[List[Tuple[str, Any]]] = None
 
 
 CheckpointThreadId = ConfigurableFieldSpec(
@@ -177,6 +179,14 @@ class BaseCheckpointSaver(ABC):
     ) -> RunnableConfig:
         raise NotImplementedError
 
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Tuple[str, Any]],
+        task_id: str,
+    ) -> None:
+        raise NotImplementedError
+
     async def aget(self, config: RunnableConfig) -> Optional[Checkpoint]:
         if value := await self.aget_tuple(config):
             return value.checkpoint
@@ -201,6 +211,14 @@ class BaseCheckpointSaver(ABC):
         checkpoint: Checkpoint,
         metadata: CheckpointMetadata,
     ) -> RunnableConfig:
+        raise NotImplementedError
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Tuple[str, Any]],
+        task_id: str,
+    ) -> None:
         raise NotImplementedError
 
     def get_next_version(self, current: Optional[V], channel: BaseChannel) -> V:

--- a/libs/langgraph/langgraph/checkpoint/memory.py
+++ b/libs/langgraph/langgraph/checkpoint/memory.py
@@ -78,7 +78,9 @@ class MemorySaver(BaseCheckpointSaver):
                     config=config,
                     checkpoint=self.serde.loads(checkpoint),
                     metadata=self.serde.loads(metadata),
-                    pending_writes=[(c, self.serde.loads(v)) for c, v in writes],
+                    pending_writes=[
+                        (id, c, self.serde.loads(v)) for id, c, v in writes
+                    ],
                 )
         else:
             if checkpoints := self.storage[thread_id]:
@@ -89,7 +91,9 @@ class MemorySaver(BaseCheckpointSaver):
                     config={"configurable": {"thread_id": thread_id, "thread_ts": ts}},
                     checkpoint=self.serde.loads(checkpoint),
                     metadata=self.serde.loads(metadata),
-                    pending_writes=[(c, self.serde.loads(v)) for c, v in writes],
+                    pending_writes=[
+                        (id, c, self.serde.loads(v)) for id, c, v in writes
+                    ],
                 )
 
     def list(
@@ -194,7 +198,7 @@ class MemorySaver(BaseCheckpointSaver):
         thread_id = config["configurable"]["thread_id"]
         ts = config["configurable"]["thread_ts"]
         self.writes[(thread_id, ts)].extend(
-            [(c, self.serde.dumps(v)) for c, v in writes]
+            [(task_id, c, self.serde.dumps(v)) for c, v in writes]
         )
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:

--- a/libs/langgraph/langgraph/checkpoint/memory.py
+++ b/libs/langgraph/langgraph/checkpoint/memory.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections import defaultdict
 from functools import partial
-from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple
 
 from langchain_core.runnables import RunnableConfig
 
@@ -53,6 +53,7 @@ class MemorySaver(BaseCheckpointSaver):
     ) -> None:
         super().__init__(serde=serde)
         self.storage = defaultdict(dict)
+        self.writes = defaultdict(list)
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the in-memory storage.
@@ -72,19 +73,23 @@ class MemorySaver(BaseCheckpointSaver):
         if ts := config["configurable"].get("thread_ts"):
             if saved := self.storage[thread_id].get(ts):
                 checkpoint, metadata = saved
+                writes = self.writes[(thread_id, ts)]
                 return CheckpointTuple(
                     config=config,
                     checkpoint=self.serde.loads(checkpoint),
                     metadata=self.serde.loads(metadata),
+                    pending_writes=[(c, self.serde.loads(v)) for c, v in writes],
                 )
         else:
             if checkpoints := self.storage[thread_id]:
                 ts = max(checkpoints.keys())
                 checkpoint, metadata = checkpoints[ts]
+                writes = self.writes[(thread_id, ts)]
                 return CheckpointTuple(
                     config={"configurable": {"thread_id": thread_id, "thread_ts": ts}},
                     checkpoint=self.serde.loads(checkpoint),
                     metadata=self.serde.loads(metadata),
+                    pending_writes=[(c, self.serde.loads(v)) for c, v in writes],
                 )
 
     def list(
@@ -168,6 +173,30 @@ class MemorySaver(BaseCheckpointSaver):
             }
         }
 
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Tuple[str, Any]],
+        task_id: str,
+    ) -> RunnableConfig:
+        """Save a list of writes to the in-memory storage.
+
+        This method saves a list of writes to the in-memory storage. The writes are associated
+        with the provided config.
+
+        Args:
+            config (RunnableConfig): The config to associate with the writes.
+            writes (list[tuple[str, Any]]): The writes to save.
+
+        Returns:
+            RunnableConfig: The updated config containing the saved writes' timestamp.
+        """
+        thread_id = config["configurable"]["thread_id"]
+        ts = config["configurable"]["thread_ts"]
+        self.writes[(thread_id, ts)].extend(
+            [(c, self.serde.dumps(v)) for c, v in writes]
+        )
+
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Asynchronous version of get_tuple.
 
@@ -223,4 +252,14 @@ class MemorySaver(BaseCheckpointSaver):
     ) -> RunnableConfig:
         return await asyncio.get_running_loop().run_in_executor(
             None, self.put, config, checkpoint, metadata
+        )
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: List[Tuple[str, Any]],
+        task_id: str,
+    ) -> RunnableConfig:
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self.put_writes, config, writes, task_id
         )

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -884,7 +884,7 @@ class Pregel(
                 self.managed_values_dict, config, self
             ) as managed:
 
-                def put_writes(id: str, writes: Sequence[tuple[str, Any]]) -> None:
+                def put_writes(task_id: str, writes: Sequence[tuple[str, Any]]) -> None:
                     if self.checkpointer is not None:
                         bg.append(
                             executor.submit(
@@ -897,7 +897,7 @@ class Pregel(
                                     },
                                 },
                                 writes,
-                                id,
+                                task_id,
                             )
                         )
 
@@ -1265,7 +1265,7 @@ class Pregel(
                 self.managed_values_dict, config, self
             ) as managed:
 
-                def put_writes(id: str, writes: Sequence[tuple[str, Any]]) -> None:
+                def put_writes(task_id: str, writes: Sequence[tuple[str, Any]]) -> None:
                     if self.checkpointer is not None:
                         bg.append(
                             asyncio.create_task(
@@ -1278,7 +1278,7 @@ class Pregel(
                                         },
                                     },
                                     writes,
-                                    id,
+                                    task_id,
                                 )
                             )
                         )

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import json
 import time
 from collections import defaultdict, deque
 from functools import partial
@@ -23,6 +24,7 @@ from typing import (
     get_type_hints,
     overload,
 )
+from uuid import UUID, uuid5
 
 from langchain_core.callbacks.manager import AsyncParentRunManager, ParentRunManager
 from langchain_core.globals import get_debug
@@ -442,7 +444,7 @@ class Pregel(
             and signature(self.checkpointer.list).parameters.get("filter") is None
         ):
             raise ValueError("Checkpointer does not support filtering")
-        for config, checkpoint, metadata, parent_config in self.checkpointer.list(
+        for config, checkpoint, metadata, parent_config, _ in self.checkpointer.list(
             config, before=before, limit=limit, filter=filter
         ):
             with ChannelsManager(
@@ -489,6 +491,7 @@ class Pregel(
             checkpoint,
             metadata,
             parent_config,
+            _,
         ) in self.checkpointer.alist(config, before=before, limit=limit, filter=filter):
             async with AsyncChannelsManager(
                 self.channels, checkpoint, config
@@ -565,6 +568,7 @@ class Pregel(
                 deque(),
                 None,
                 [INTERRUPT],
+                str(uuid5(UUID(checkpoint["id"]), INTERRUPT)),
             )
             # execute task
             task.proc.invoke(
@@ -653,6 +657,7 @@ class Pregel(
                 deque(),
                 None,
                 [INTERRUPT],
+                str(uuid5(UUID(checkpoint["id"]), INTERRUPT)),
             )
             # execute task
             await task.proc.ainvoke(
@@ -879,6 +884,23 @@ class Pregel(
                 self.managed_values_dict, config, self
             ) as managed:
 
+                def put_writes(id: str, writes: Sequence[tuple[str, Any]]) -> None:
+                    if self.checkpointer is not None:
+                        bg.append(
+                            executor.submit(
+                                self.checkpointer.put_writes,
+                                {
+                                    **checkpoint_config,
+                                    "configurable": {
+                                        **checkpoint_config["configurable"],
+                                        "thread_ts": checkpoint["id"],
+                                    },
+                                },
+                                writes,
+                                id,
+                            )
+                        )
+
                 def put_checkpoint(metadata: CheckpointMetadata) -> Iterator[Any]:
                     nonlocal checkpoint, checkpoint_config, channels
 
@@ -1050,6 +1072,9 @@ class Pregel(
                                 # exception will be handled in panic_or_proceed
                                 futures.clear()
                             else:
+                                # save task writes to checkpointer
+                                if self.checkpointer is not None:
+                                    put_writes(task.id, task.writes)
                                 # yield updates output for the finished task
                                 if "updates" in stream_modes:
                                     yield from _with_mode(
@@ -1076,7 +1101,7 @@ class Pregel(
 
                     # combine pending writes from all tasks
                     pending_writes = deque[tuple[str, Any]]()
-                    for _, _, _, writes, _, _ in next_tasks:
+                    for _, _, _, writes, _, _, _ in next_tasks:
                         pending_writes.extend(writes)
 
                     if debug:
@@ -1239,6 +1264,24 @@ class Pregel(
             ) as channels, AsyncManagedValuesManager(
                 self.managed_values_dict, config, self
             ) as managed:
+
+                def put_writes(id: str, writes: Sequence[tuple[str, Any]]) -> None:
+                    if self.checkpointer is not None:
+                        bg.append(
+                            asyncio.create_task(
+                                self.checkpointer.aput_writes(
+                                    {
+                                        **checkpoint_config,
+                                        "configurable": {
+                                            **checkpoint_config["configurable"],
+                                            "thread_ts": checkpoint["id"],
+                                        },
+                                    },
+                                    writes,
+                                    id,
+                                )
+                            )
+                        )
 
                 def put_checkpoint(metadata: CheckpointMetadata) -> Iterator[Any]:
                     nonlocal checkpoint, checkpoint_config, channels
@@ -1406,6 +1449,9 @@ class Pregel(
                                 # exception will be handle in panic_or_proceed
                                 futures.clear()
                             else:
+                                # save task writes to checkpointer
+                                if self.checkpointer is not None:
+                                    put_writes(task.id, task.writes)
                                 # yield updates output for the finished task
                                 if "updates" in stream_modes:
                                     for chunk in _with_mode(
@@ -1434,7 +1480,7 @@ class Pregel(
 
                     # combine pending writes from all tasks
                     pending_writes = deque[tuple[str, Any]]()
-                    for _, _, _, writes, _, _ in next_tasks:
+                    for _, _, _, writes, _, _, _ in next_tasks:
                         pending_writes.extend(writes)
 
                     if debug:
@@ -1671,7 +1717,7 @@ def _should_interrupt(
         # and any triggered node is in interrupt_nodes list
         and any(
             node
-            for node, _, _, _, config, _ in tasks
+            for node, _, _, _, config, _, _ in tasks
             if (
                 (not config or TAG_HIDDEN not in config.get("tags"))
                 if interrupt_nodes == "*"
@@ -1825,6 +1871,14 @@ def _prepare_next_tasks(
             continue
         if for_execution:
             if node := processes[packet.node].get_node():
+                triggers = [TASKS]
+                metadata = {
+                    "langgraph_step": step,
+                    "langgraph_node": packet.node,
+                    "langgraph_triggers": triggers,
+                    "langgraph_task_idx": len(tasks),
+                }
+                task_id = str(uuid5(UUID(checkpoint["id"]), json.dumps(metadata)))
                 writes = deque()
                 tasks.append(
                     PregelExecutableTask(
@@ -1836,14 +1890,7 @@ def _prepare_next_tasks(
                             merge_configs(
                                 config,
                                 processes[packet.node].config,
-                                {
-                                    "metadata": {
-                                        "langgraph_step": step,
-                                        "langgraph_node": packet.node,
-                                        "langgraph_triggers": [TASKS],
-                                        "langgraph_task_idx": len(tasks),
-                                    }
-                                },
+                                {"metadata": metadata},
                             ),
                             run_name=packet.node,
                             callbacks=(
@@ -1861,7 +1908,8 @@ def _prepare_next_tasks(
                                 ),
                             },
                         ),
-                        [TASKS],
+                        triggers,
+                        task_id,
                     )
                 )
         else:
@@ -1879,7 +1927,7 @@ def _prepare_next_tasks(
     for name, proc in processes.items():
         seen = checkpoint["versions_seen"][name]
         # If any of the channels read by this process were updated
-        if triggers := [
+        if triggers := sorted(
             chan
             for chan in proc.triggers
             if not isinstance(
@@ -1887,7 +1935,7 @@ def _prepare_next_tasks(
             )
             and checkpoint["channel_versions"].get(chan, null_version)
             > seen.get(chan, null_version)
-        ]:
+        ):
             channels_to_consume.update(triggers)
             try:
                 val = next(_proc_input(step, name, proc, managed, channels))
@@ -1906,8 +1954,14 @@ def _prepare_next_tasks(
 
             if for_execution:
                 if node := proc.get_node():
+                    metadata = {
+                        "langgraph_step": step,
+                        "langgraph_node": name,
+                        "langgraph_triggers": triggers,
+                        "langgraph_task_idx": len(tasks),
+                    }
+                    task_id = str(uuid5(UUID(checkpoint["id"]), json.dumps(metadata)))
                     writes = deque()
-                    triggers = sorted(triggers)
                     tasks.append(
                         PregelExecutableTask(
                             name,
@@ -1918,14 +1972,7 @@ def _prepare_next_tasks(
                                 merge_configs(
                                     config,
                                     proc.config,
-                                    {
-                                        "metadata": {
-                                            "langgraph_step": step,
-                                            "langgraph_node": name,
-                                            "langgraph_triggers": triggers,
-                                            "langgraph_task_idx": len(tasks),
-                                        }
-                                    },
+                                    {"metadata": metadata},
                                 ),
                                 run_name=name,
                                 callbacks=(
@@ -1948,6 +1995,7 @@ def _prepare_next_tasks(
                                 },
                             ),
                             triggers,
+                            task_id,
                         )
                     )
             else:

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1926,7 +1926,7 @@ def _prepare_next_tasks(
                                     _local_write, writes.extend, processes, channels
                                 ),
                                 CONFIG_KEY_READ: partial(
-                                    _local_read, checkpoint, channels, tasks, config
+                                    _local_read, checkpoint, channels, writes, config
                                 ),
                             },
                         ),

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1083,8 +1083,9 @@ class Pregel(
                                 # exception will be handled in panic_or_proceed
                                 futures.clear()
                             else:
-                                # save task writes to checkpointer
-                                if self.checkpointer is not None:
+                                # save task writes to checkpointer, unless this
+                                # is the single or last task in this step
+                                if futures:
                                     put_writes(task.id, task.writes)
                                 # yield updates output for the finished task
                                 if "updates" in stream_modes:
@@ -1471,8 +1472,9 @@ class Pregel(
                                 # exception will be handle in panic_or_proceed
                                 futures.clear()
                             else:
-                                # save task writes to checkpointer
-                                if self.checkpointer is not None:
+                                # save task writes to checkpointer, unless this
+                                # is the single or last task in this step
+                                if futures:
                                     put_writes(task.id, task.writes)
                                 # yield updates output for the finished task
                                 if "updates" in stream_modes:

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -66,7 +66,7 @@ def map_debug_tasks(
     step: int, tasks: list[PregelExecutableTask]
 ) -> Iterator[DebugOutputTask]:
     ts = datetime.now(timezone.utc).isoformat()
-    for name, input, _, _, config, triggers in tasks:
+    for name, input, _, _, config, triggers, _ in tasks:
         if config is not None and TAG_HIDDEN in config.get("tags", []):
             continue
 
@@ -91,7 +91,7 @@ def map_debug_task_results(
     stream_channels_list: Sequence[str],
 ) -> Iterator[DebugOutputTaskResult]:
     ts = datetime.now(timezone.utc).isoformat()
-    for name, _, _, writes, config, _ in tasks:
+    for name, _, _, writes, config, _, _ in tasks:
         if config is not None and TAG_HIDDEN in config.get("tags", []):
             continue
 
@@ -138,7 +138,7 @@ def print_step_tasks(step: int, next_tasks: list[PregelExecutableTask]) -> None:
         )
         + "\n".join(
             f"- {get_colored_text(name, 'green')} -> {pformat(val)}"
-            for name, val, _, _, _, _ in next_tasks
+            for name, val, _, _, _, _, _ in next_tasks
         )
     )
 

--- a/libs/langgraph/langgraph/pregel/io.py
+++ b/libs/langgraph/langgraph/pregel/io.py
@@ -105,7 +105,7 @@ def map_output_updates(
     if isinstance(output_channels, str):
         if updated := [
             (node, value)
-            for node, _, _, writes, _, _ in output_tasks
+            for node, _, _, writes, _, _, _ in output_tasks
             for chan, value in writes
             if chan == output_channels
         ]:
@@ -122,7 +122,7 @@ def map_output_updates(
                 node,
                 {chan: value for chan, value in writes if chan in output_channels},
             )
-            for node, _, _, writes, _, _ in output_tasks
+            for node, _, _, writes, _, _, _ in output_tasks
             if any(chan in output_channels for chan, _ in writes)
         ]:
             grouped = defaultdict(list)

--- a/libs/langgraph/langgraph/pregel/types.py
+++ b/libs/langgraph/langgraph/pregel/types.py
@@ -18,6 +18,7 @@ class PregelExecutableTask(NamedTuple):
     writes: deque[tuple[str, Any]]
     config: RunnableConfig
     triggers: list[str]
+    id: str
 
 
 class StateSnapshot(NamedTuple):

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1039,6 +1039,7 @@ def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
 
         # resume execution, without exception
         two.rtn = {"value": 3}
+        # both the pending write and the new write were applied, 1 + 2 + 3 = 6
         assert graph.invoke(None, thread1) == {"value": 6}
     finally:
         if getattr(checkpointer, "__exit__", None):

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -999,7 +999,6 @@ def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
         builder.add_edge(START, "two")
         graph = builder.compile(checkpointer=checkpointer)
 
-        # test interrupting astream
         thread1: RunnableConfig = {"configurable": {"thread_id": 1}}
         with pytest.raises(ValueError, match="I'm not good"):
             graph.invoke({"value": 1}, thread1)

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1027,7 +1027,7 @@ def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
         with pytest.raises(ValueError, match="I'm not good"):
             graph.invoke(None, thread1)
 
-        # node "one" succeded previously, so shouldn't be called again
+        # node "one" succeeded previously, so shouldn't be called again
         assert one.calls == 1
         # node "two" should have been called once again
         assert two.calls == 2

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -38,6 +38,7 @@ from langgraph.channels.context import Context
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.checkpoint.base import (
+    BaseCheckpointSaver,
     Checkpoint,
     CheckpointMetadata,
     CheckpointTuple,
@@ -953,6 +954,95 @@ def test_invoke_checkpoint(mocker: MockerFixture) -> None:
     checkpoint = memory.get({"configurable": {"thread_id": "2"}})
     assert checkpoint is not None
     assert checkpoint["channel_values"].get("total") == 5
+
+
+@pytest.mark.parametrize(
+    "checkpointer",
+    [
+        MemorySaverAssertImmutable(),
+        SqliteSaver.from_conn_string(":memory:"),
+    ],
+    ids=[
+        "memory",
+        "sqlite",
+    ],
+)
+def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
+    try:
+
+        class State(TypedDict):
+            value: Annotated[int, operator.add]
+
+        class AwhileMaker:
+            def __init__(self, sleep: float, rtn: Union[Dict, Exception]) -> None:
+                self.sleep = sleep
+                self.rtn = rtn
+                self.reset()
+
+            def __call__(self, input: State) -> Any:
+                self.calls += 1
+                time.sleep(self.sleep)
+                if isinstance(self.rtn, Exception):
+                    raise self.rtn
+                else:
+                    return self.rtn
+
+            def reset(self):
+                self.calls = 0
+
+        one = AwhileMaker(0.2, {"value": 2})
+        two = AwhileMaker(0.6, ValueError("I'm not good"))
+        builder = StateGraph(State)
+        builder.add_node("one", one)
+        builder.add_node("two", two)
+        builder.add_edge(START, "one")
+        builder.add_edge(START, "two")
+        graph = builder.compile(checkpointer=checkpointer)
+
+        # test interrupting astream
+        thread1: RunnableConfig = {"configurable": {"thread_id": 1}}
+        with pytest.raises(ValueError, match="I'm not good"):
+            graph.invoke({"value": 1}, thread1)
+
+        # both nodes should have been called once
+        assert one.calls == 1
+        assert two.calls == 1
+
+        # latest checkpoint should be before nodes "one", "two"
+        state = graph.get_state(thread1)
+        assert state is not None
+        assert state.values == {"value": 1}
+        assert state.next == ("one", "two")
+        assert state.metadata == {"source": "loop", "step": 0, "writes": None}
+        # should contain pending write of "one"
+        checkpoint = checkpointer.get_tuple(thread1)
+        assert checkpoint is not None
+        assert checkpoint.pending_writes == [
+            (AnyStr(), "one", "one"),
+            (AnyStr(), "value", 2),
+        ]
+        # both pending writes come from same task
+        assert checkpoint.pending_writes[0][0] == checkpoint.pending_writes[1][0]
+
+        # resume execution
+        with pytest.raises(ValueError, match="I'm not good"):
+            graph.invoke(None, thread1)
+
+        # node "one" succeded previously, so shouldn't be called again
+        assert one.calls == 1
+        # node "two" should have been called once again
+        assert two.calls == 2
+
+        # confirm no new checkpoints saved
+        state_two = graph.get_state(thread1)
+        assert state_two == state
+
+        # resume execution, without exception
+        two.rtn = {"value": 3}
+        assert graph.invoke(None, thread1) == {"value": 6}
+    finally:
+        if getattr(checkpointer, "__exit__", None):
+            checkpointer.__exit__(None, None, None)
 
 
 def test_invoke_checkpoint_sqlite(mocker: MockerFixture) -> None:

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -1136,7 +1136,7 @@ async def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
         with pytest.raises(ValueError, match="I'm not good"):
             await graph.ainvoke(None, thread1)
 
-        # node "one" succeded previously, so shouldn't be called again
+        # node "one" succeeded previously, so shouldn't be called again
         assert one.calls == 1
         # node "two" should have been called once again
         assert two.calls == 2

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -1108,7 +1108,6 @@ async def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
         builder.add_edge(START, "two")
         graph = builder.compile(checkpointer=checkpointer)
 
-        # test interrupting astream
         thread1: RunnableConfig = {"configurable": {"thread_id": 1}}
         with pytest.raises(ValueError, match="I'm not good"):
             await graph.ainvoke({"value": 1}, thread1)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -1147,6 +1147,7 @@ async def test_pending_writes_resume(checkpointer: BaseCheckpointSaver) -> None:
 
         # resume execution, without exception
         two.rtn = {"value": 3}
+        # both the pending write and the new write were applied, 1 + 2 + 3 = 6
         assert await graph.ainvoke(None, thread1) == {"value": 6}
     finally:
         if getattr(checkpointer, "__aexit__", None):


### PR DESCRIPTION
- Whenever a node finishes, checkpoint pending writes
- [x] Use pending_writes at beginning of stream (where we deal with input writes?)
- [x] Add test for two concurrent nodes, the longer one fails, the shorter one isn't re-run on resume
- [x] in sqlite/aiosqlite savers read pending writes in get_tuple