### PR TITLE
Support multiple interruptions after resuming execution

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1799,7 +1799,7 @@ def _should_interrupt(
     # defaultdicts are mutated on access :( so we need to copy
     seen = checkpoint["versions_seen"].copy()[INTERRUPT]
     return (
-        # interrupt if any of snapshopt_channels has been updated since last interrupt
+        # interrupt if any channel has been updated since last interrupt
         any(
             version > seen.get(chan, null_version)
             for chan, version in checkpoint["channel_versions"].items()

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -987,7 +987,7 @@ class Pregel(
                 else:
                     # no input is taken as signal to proceed past previous interrupt
                     checkpoint = copy_checkpoint(checkpoint)
-                    for k in self.stream_channels_list:
+                    for k in channels:
                         if k in checkpoint["channel_versions"]:
                             version = checkpoint["channel_versions"][k]
                             checkpoint["versions_seen"][INTERRUPT][k] = version
@@ -1444,7 +1444,7 @@ class Pregel(
                 else:
                     # no input is taken as signal to proceed past previous interrupt
                     checkpoint = copy_checkpoint(checkpoint)
-                    for k in self.stream_channels_list:
+                    for k in channels:
                         if k in checkpoint["channel_versions"]:
                             version = checkpoint["channel_versions"][k]
                             checkpoint["versions_seen"][INTERRUPT][k] = version
@@ -1801,9 +1801,8 @@ def _should_interrupt(
     return (
         # interrupt if any of snapshopt_channels has been updated since last interrupt
         any(
-            checkpoint["channel_versions"].get(chan, null_version)
-            >= seen.get(chan, null_version)
-            for chan in snapshot_channels
+            version > seen.get(chan, null_version)
+            for chan, version in checkpoint["channel_versions"].items()
         )
         # and any triggered node is in interrupt_nodes list
         and any(

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1802,7 +1802,7 @@ def _should_interrupt(
         # interrupt if any of snapshopt_channels has been updated since last interrupt
         any(
             checkpoint["channel_versions"].get(chan, null_version)
-            > seen.get(chan, null_version)
+            >= seen.get(chan, null_version)
             for chan in snapshot_channels
         )
         # and any triggered node is in interrupt_nodes list

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -134,7 +134,7 @@ def print_step_tasks(step: int, next_tasks: list[PregelExecutableTask]) -> None:
     print(
         f"{get_colored_text(f'[{step}:tasks]', color='blue')} "
         + get_bolded_text(
-            f"Starting step {step} with {n_tasks} task{'s' if n_tasks > 1 else ''}:\n"
+            f"Starting step {step} with {n_tasks} task{'s' if n_tasks != 1 else ''}:\n"
         )
         + "\n".join(
             f"- {get_colored_text(name, 'green')} -> {pformat(val)}"
@@ -153,7 +153,7 @@ def print_step_writes(
     print(
         f"{get_colored_text(f'[{step}:writes]', color='blue')} "
         + get_bolded_text(
-            f"Finished step {step} with writes to {len(by_channel)} channel{'s' if len(by_channel) > 1 else ''}:\n"
+            f"Finished step {step} with writes to {len(by_channel)} channel{'s' if len(by_channel) != 1 else ''}:\n"
         )
         + "\n".join(
             f"- {get_colored_text(name, 'yellow')} -> {', '.join(pformat(v) for v in vals)}"

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,0 +1,39 @@
+from typing import TypedDict
+from langgraph.graph import StateGraph, START, END
+from langgraph.checkpoint.memory import MemorySaver
+
+
+def test_multiple_interruptions():
+    class State(TypedDict):
+      input: str
+    
+    def step_1(_state):
+       pass
+      
+    def step_2(_state):
+        pass
+
+    def step_3(_state):
+        pass
+      
+    builder = StateGraph(State)
+    builder.add_node("step_1", step_1)
+    builder.add_node("step_2", step_2)
+    builder.add_node("step_3", step_3)
+    builder.add_edge(START, "step_1")
+    builder.add_edge("step_1", "step_2")
+    builder.add_edge("step_2", "step_3")
+    builder.add_edge("step_3", END)
+
+    memory = MemorySaver()
+
+    graph = builder.compile(checkpointer=memory, interrupt_after="*")
+
+    initial_input = {"input": "hello world"}
+    thread = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke(initial_input, thread, stream_mode="values")
+    assert(graph.get_state(thread).next == ("step_2",))
+
+    graph.invoke(None, thread, stream_mode="values")
+    assert(graph.get_state(thread).next == ("step_3",))

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,25 +1,23 @@
 from typing import TypedDict
-from langgraph.graph import StateGraph, START, END
+
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
 
 
-def test_multiple_interruptions():
+def test_interruption_without_state_updates():
+    """Test interruption without state updates. This test confirms that
+    interrupting doesn't require a state key having been updated in the prev step"""
+
     class State(TypedDict):
-      input: str
-    
-    def step_1(_state):
-       pass
-      
-    def step_2(_state):
+        input: str
+
+    def noop(_state):
         pass
 
-    def step_3(_state):
-        pass
-      
     builder = StateGraph(State)
-    builder.add_node("step_1", step_1)
-    builder.add_node("step_2", step_2)
-    builder.add_node("step_3", step_3)
+    builder.add_node("step_1", noop)
+    builder.add_node("step_2", noop)
+    builder.add_node("step_3", noop)
     builder.add_edge(START, "step_1")
     builder.add_edge("step_1", "step_2")
     builder.add_edge("step_2", "step_3")
@@ -32,8 +30,47 @@ def test_multiple_interruptions():
     initial_input = {"input": "hello world"}
     thread = {"configurable": {"thread_id": "1"}}
 
-    graph.invoke(initial_input, thread, stream_mode="values")
-    assert(graph.get_state(thread).next == ("step_2",))
+    graph.invoke(initial_input, thread, debug=True)
+    assert graph.get_state(thread).next == ("step_2",)
 
-    graph.invoke(None, thread, stream_mode="values")
-    assert(graph.get_state(thread).next == ("step_3",))
+    graph.invoke(None, thread, debug=True)
+    assert graph.get_state(thread).next == ("step_3",)
+
+    graph.invoke(None, thread, debug=True)
+    assert graph.get_state(thread).next == ()
+
+
+async def test_interruption_without_state_updates_async():
+    """Test interruption without state updates. This test confirms that
+    interrupting doesn't require a state key having been updated in the prev step"""
+
+    class State(TypedDict):
+        input: str
+
+    async def noop(_state):
+        pass
+
+    builder = StateGraph(State)
+    builder.add_node("step_1", noop)
+    builder.add_node("step_2", noop)
+    builder.add_node("step_3", noop)
+    builder.add_edge(START, "step_1")
+    builder.add_edge("step_1", "step_2")
+    builder.add_edge("step_2", "step_3")
+    builder.add_edge("step_3", END)
+
+    memory = MemorySaver()
+
+    graph = builder.compile(checkpointer=memory, interrupt_after="*")
+
+    initial_input = {"input": "hello world"}
+    thread = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke(initial_input, thread, debug=True)
+    assert (await graph.aget_state(thread)).next == ("step_2",)
+
+    await graph.ainvoke(None, thread, debug=True)
+    assert (await graph.aget_state(thread)).next == ("step_3",)
+
+    await graph.ainvoke(None, thread, debug=True)
+    assert (await graph.aget_state(thread)).next == ()


### PR DESCRIPTION
We noticed that it is currently not possible to interrupt a graph multiple times.

Once the graph resumes execution after an interruption, it just continues executing, ignoring `interrupt_before` and `interrupt_after`.

The reason is that after resuming this condition in `_should_interrupt` seems to always return false:
```
any(
    checkpoint["channel_versions"].get(chan, null_version)
    > seen.get(chan, null_version)
    for chan in snapshot_channels
)
```

In this PR I added a unit test in `test_interruption.py` to spec the desired behavior. I modified the code to pass the unit test, but since I do not understand what this code does it's probably not the right thing.

It would be great to get some guidance on how to fix this properly.
