### PR TITLE
Remove Jupyter cell 'In[<number>]' display column from docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -146,6 +146,9 @@
       display: none !important;
     }
 
+    .jupyter-wrapper .jp-CodeCell .jp-Cell-inputWrapper .jp-InputPrompt.jp-InputArea-prompt {
+      display: none !important;
+    }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
Leaves more space for code.

Before:
<img width="790" alt="Screenshot 2024-07-12 at 12 26 52 PM" src="https://github.com/user-attachments/assets/ecb678c1-6b3e-4a6a-8d72-7737296321b0">


After:
<img width="783" alt="Screenshot 2024-07-12 at 12 26 14 PM" src="https://github.com/user-attachments/assets/54a56dac-35c0-454a-aaee-43702e8ad3fa">
