### PR TITLE
Hide output spacer column in docs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -149,6 +149,10 @@
     .jupyter-wrapper .jp-CodeCell .jp-Cell-inputWrapper .jp-InputPrompt.jp-InputArea-prompt {
       display: none !important;
     }
+
+    .jupyter-wrapper .jp-Notebook .jp-Cell .jp-OutputPrompt {
+      display: none !important;
+    }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
Hide indented output columns as well