### PR TITLE
docs: Add instructions to test locally before deploying to Cloud

### DIFF
--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -2,9 +2,10 @@
 
 LangGraph Cloud is available within <a href="https://www.langchain.com/langsmith" target="_blank">LangSmith</a>. To deploy a LangGraph Cloud API, navigate to the <a href="https://smith.langchain.com/" target="_blank">LangSmith UI</a>.
 
-## Setup GitHub Repository
+## Prerequisites
 
-LangGraph Cloud applications are deployed from GitHub repositories. Configure and upload a LangGraph Cloud application to a GitHub repository in order to deploy it to LangGraph Cloud.
+1. LangGraph Cloud applications are deployed from GitHub repositories. Configure and upload a LangGraph Cloud application to a GitHub repository in order to deploy it to LangGraph Cloud.
+1. [Verify that the LangGraph API runs locally](test_locally.md). If the API does not build and run successfully (i.e. `langgraph up`), deploying to LangGraph Cloud will fail as well.
 
 ## Create New Deployment
 

--- a/docs/docs/cloud/deployment/setup_pyproject.md
+++ b/docs/docs/cloud/deployment/setup_pyproject.md
@@ -102,7 +102,7 @@ agent = graph_workflow.compile()
 ```
 
 !!! warning "Assign `CompiledGraph` to Variable"
-The build process for LangGraph Cloud requires that the `CompiledGraph` object be assigned to a variable at the top-level of a Python module.
+    The build process for LangGraph Cloud requires that the `CompiledGraph` object be assigned to a variable at the top-level of a Python module.
 
 Example file directory:
 
@@ -132,6 +132,9 @@ Example `langgraph.json` file:
 ```
 
 Note that the variable name of the `CompiledGraph` appears at the end of the value of each subkey in the top-level `graphs` key (i.e. `:<variable_name>`).
+
+!!! warning "Configuration Location"
+    The LangGraph API configuration file must be placed in a directory that is at the same level or higher than the Python files that contain compiled graphs and associated dependencies.
 
 Example file directory:
 

--- a/docs/docs/cloud/deployment/test_locally.md
+++ b/docs/docs/cloud/deployment/test_locally.md
@@ -2,6 +2,8 @@
 
 This guide assumes you have a LangGraph app correctly set up with a proper configuration file and a corresponding compiled graph, and that you have a proper LangChain API key.
 
+Testing locally ensures that there are no errors or conflicts with Python dependencies and confirms that the configuration file is specified correctly.
+
 ## Setup
 
 Install the proper packages:


### PR DESCRIPTION
### Summary
There are a lot of build errors in LangGraph Cloud. Typos in package names, dependency conflicts, etc. Adding a note to the docs to suggest building the app locally before deploying to LangGraph Cloud. Hopefully, this reduces some of the build errors in LangGraph Cloud.