### PR TITLE
Don't include lambdas in __eq__ for BinOp

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -56,9 +56,11 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
             pass
 
     def __eq__(self, value: object) -> bool:
-        return (
-            isinstance(value, BinaryOperatorAggregate)
-            and value.operator == self.operator
+        return isinstance(value, BinaryOperatorAggregate) and (
+            value.operator is self.operator
+            if value.operator.__name__ != "<lambda>"
+            and self.operator.__name__ != "<lambda>"
+            else True
         )
 
     @property


### PR DESCRIPTION
When using forward refs, inline lambdas in Annotated are re-evaluated for every subclass, thus making the comparison fail