### PR TITLE
Fix StateGraph.add_edge end_key check

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -358,8 +358,8 @@ class StateGraph(Graph):
                 raise ValueError("END cannot be a start node")
             if start not in self.nodes:
                 raise ValueError(f"Need to add_node `{start}` first")
-        if end_key == END:
-            raise ValueError("END cannot be an end node")
+        if end_key == START:
+            raise ValueError("START cannot be an end node")
         if end_key not in self.nodes:
             raise ValueError(f"Need to add_node `{end_key}` first")
 


### PR DESCRIPTION
It looks like a typo to me: `END` should be `START`.

`END` should be accepted as `end_key` and it is accepted with the `super` call path.