### PR TITLE
Add trace parameter to init method

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/tool_executor.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_executor.py
@@ -94,8 +94,9 @@ class ToolExecutor(RunnableCallable):
         tools: Sequence[Union[BaseTool, Callable]],
         *,
         invalid_tool_msg_template: str = INVALID_TOOL_MSG_TEMPLATE,
+        trace: bool = False,
     ) -> None:
-        super().__init__(self._execute, afunc=self._aexecute, trace=False)
+        super().__init__(self._execute, afunc=self._aexecute, trace=trace)
         tools_ = [
             tool if isinstance(tool, BaseTool) else create_tool(tool) for tool in tools
         ]


### PR DESCRIPTION
Currently, the `trace` parameter in `ToolExecutor` is fixed at False. This means that if a node in the graph uses this, the trace record of that node in LangSmith is always independent of the entire graph. To allow for flexible tracing configuration, I added a trace parameter to the `ToolExecutor.__init__()` method.