### PR TITLE
fix: update the function for node colors

### DIFF
--- a/examples/visualization.ipynb
+++ b/examples/visualization.ipynb
@@ -268,7 +268,7 @@
    ],
    "source": [
     "from IPython.display import Image, display\n",
-    "from langchain_core.runnables.graph import CurveStyle, MermaidDrawMethod, NodeColors\n",
+    "from langchain_core.runnables.graph import CurveStyle, MermaidDrawMethod, NodeStyles\n",
     "\n",
     "display(\n",
     "    Image(\n",
@@ -340,7 +340,7 @@
     "    Image(\n",
     "        app.get_graph().draw_mermaid_png(\n",
     "            curve_style=CurveStyle.LINEAR,\n",
-    "            node_colors=NodeColors(start=\"#ffdfba\", end=\"#baffc9\", other=\"#fad7de\"),\n",
+    "            node_colors=NodeStyles(first=\"#ffdfba\", last=\"#baffc9\", default=\"#fad7de\"),\n",
     "            wrap_label_n_words=9,\n",
     "            output_file_path=None,\n",
     "            draw_method=MermaidDrawMethod.PYPPETEER,\n",


### PR DESCRIPTION
`NodeColors` does not exist anymore in[ Langchain_core ](https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/runnables/graph.py) -> updated to `NodeStyles` and changed the param names. 

Comment:
- Additional point I noticed is that the graph outputs do not match the code. Let me know if it's intentional or you want me to fix it.