### PR TITLE
Support serialization/deserialization of bytes when using a checkpointer

### DIFF
--- a/libs/langgraph/langgraph/serde/jsonplus.py
+++ b/libs/langgraph/langgraph/serde/jsonplus.py
@@ -68,6 +68,10 @@ class JsonPlusSerializer(SerializerProtocol):
             return self._encode_constructor_args(
                 obj.__class__, kwargs={"node": obj.node, "arg": obj.arg}
             )
+        elif isinstance(obj, bytes):
+            return self._encode_constructor_args(
+                obj.__class__, args=[str(obj, encoding="utf-8")], kwargs={"encoding": "utf-8"}
+            )
         else:
             raise TypeError(
                 f"Object of type {obj.__class__.__name__} is not JSON serializable"


### PR DESCRIPTION
If the graph State contains bytes and a checkpointer is being used, the serialization fails with a `TypeError`:

```
from typing_extensions import TypedDict

from typing import Optional

from langgraph.checkpoint.sqlite import SqliteSaver
from langgraph.graph import StateGraph, START, END


class State(TypedDict):
    my_bytes: Optional[bytes]


def my_func(state: State):
    return {"my_bytes": bytes([0, 1])}


graph_builder = StateGraph(State)
graph_builder.add_node("my_func", my_func)
graph_builder.add_edge(START, "my_func")
graph_builder.add_edge("my_func", END)

memory = SqliteSaver.from_conn_string(":memory:")
config = {
    "configurable": {
        "thread_id": "1",
    },
}

graph = graph_builder.compile(checkpointer=memory)

graph.invoke({"my_bytes": None}, config=config)

graph.get_state(config)
```

Fails with:
```
    raise TypeError(
TypeError: Object of type bytes is not JSON serializable
```

This PR fixes the issue by adding a new branch to encode/decode the bytes into a "utf-8" strings for serialization/deserialization.