### PR TITLE
langgraph[patch]: Use _schema instead of BaseModel.schema() for pydantic 2 migration

### DIFF
--- a/libs/langgraph/tests/pydantic_utils.py
+++ b/libs/langgraph/tests/pydantic_utils.py
@@ -1,0 +1,94 @@
+"""Helper utilities for pydantic.
+
+This module includes helper utilities to ease the migration from pydantic v1 to v2.
+
+They're meant to be used in the following way:
+
+1) Use utility code to help (selected) unit tests pass without modifications
+2) Upgrade the unit tests to match pydantic 2
+3) Stop using the utility code
+"""
+
+from typing import Any
+
+
+# Function to replace allOf with $ref
+def _replace_all_of_with_ref(schema: Any) -> None:
+    """Replace allOf with $ref in the schema."""
+    if isinstance(schema, dict):
+        # If the schema has an allOf key with a single item that contains a $ref
+        if (
+            "allOf" in schema
+            and len(schema["allOf"]) == 1
+            and "$ref" in schema["allOf"][0]
+        ):
+            schema["$ref"] = schema["allOf"][0]["$ref"]
+            del schema["allOf"]
+            if "default" in schema and schema["default"] is None:
+                del schema["default"]
+        else:
+            # Recursively process nested schemas
+            for key, value in schema.items():
+                if isinstance(value, (dict, list)):
+                    _replace_all_of_with_ref(value)
+    elif isinstance(schema, list):
+        for item in schema:
+            _replace_all_of_with_ref(item)
+
+
+def _remove_bad_none_defaults(schema: Any) -> None:
+    """Removing all none defaults.
+
+    Pydantic v1 did not generate these, but Pydantic v2 does.
+
+    The None defaults usually represent **NotRequired** fields, and the None value
+    is actually **incorrect** as a value since the fields do not allow a None value.
+
+    See difference between Optional and NotRequired types in python.
+    """
+    if isinstance(schema, dict):
+        for key, value in schema.items():
+            if isinstance(value, dict):
+                if "default" in value and value["default"] is None:
+                    any_of = value.get("anyOf", [])
+                    for type_ in any_of:
+                        if "type" in type_ and type_["type"] == "null":
+                            break  # Null type explicitly defined
+                    else:
+                        del value["default"]
+                _remove_bad_none_defaults(value)
+            elif isinstance(value, list):
+                for item in value:
+                    _remove_bad_none_defaults(item)
+    elif isinstance(schema, list):
+        for item in schema:
+            _remove_bad_none_defaults(item)
+
+
+def _schema(obj: Any) -> dict:
+    """Get the schema of a pydantic model in the pydantic v1 style.
+
+    This will attempt to map the schema as close as possible to the pydantic v1 schema.
+    """
+    # Remap to old style schema
+    if not hasattr(obj, "model_json_schema"):  # V1 model
+        return obj.schema()
+
+    # Then we're using V2 models internally.
+    raise AssertionError(
+        "Hi there! Looks like you're attempting to upgrade to Pydantic v2. If so: \n"
+        "1) remove this exception\n"
+        "2) confirm that the old unit tests pass, and if not look for difference\n"
+        "3) update the unit tests to match the new schema\n"
+        "4) remove this utility function\n"
+    )
+
+    schema_ = obj.model_json_schema(ref_template="#/definitions/{model}")
+    if "$defs" in schema_:
+        schema_["definitions"] = schema_["$defs"]
+        del schema_["$defs"]
+
+    _replace_all_of_with_ref(schema_)
+    _remove_bad_none_defaults(schema_)
+
+    return schema_

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -70,6 +70,7 @@ from tests.memory_assert import (
     NoopSerializer,
 )
 from tests.messages import _AnyIdAIMessage, _AnyIdHumanMessage
+from tests.pydantic_utils import _schema
 
 
 def test_graph_validation() -> None:
@@ -395,11 +396,11 @@ def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
     graph.set_finish_point("add_one")
     gapp = graph.compile()
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {"title": "LangGraphOutput", "type": "integer"}
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {"title": "LangGraphOutput", "type": "integer"}
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # raise warnings as errors
-        assert app.config_schema().schema() == {
+        assert _schema(app.config_schema()) == {
             "properties": {},
             "title": "LangGraphConfig",
             "type": "object",
@@ -444,8 +445,8 @@ def test_invoke_single_process_in_write_kwargs(mocker: MockerFixture) -> None:
         input_channels="input",
     )
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {
@@ -468,8 +469,8 @@ def test_invoke_single_process_in_out_dict(mocker: MockerFixture) -> None:
         output_channels=["output"],
     )
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {"output": {"title": "Output", "type": "integer"}},
@@ -488,12 +489,12 @@ def test_invoke_single_process_in_dict_out_dict(mocker: MockerFixture) -> None:
         output_channels=["output"],
     )
 
-    assert app.input_schema.schema() == {
+    assert _schema(app.input_schema) == {
         "title": "LangGraphInput",
         "type": "object",
         "properties": {"input": {"title": "Input", "type": "integer"}},
     }
-    assert app.output_schema.schema() == {
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {"output": {"title": "Output", "type": "integer"}},
@@ -7253,8 +7254,8 @@ def test_in_one_fan_out_state_graph_waiting_edge_custom_state_class_pydantic1(
     app = workflow.compile()
 
     assert app.get_graph().draw_mermaid(with_styles=False) == snapshot
-    assert app.get_input_schema().schema() == snapshot
-    assert app.get_output_schema().schema() == snapshot
+    assert _schema(app.get_input_schema()) == snapshot
+    assert _schema(app.get_output_schema()) == snapshot
 
     with pytest.raises(ValidationError):
         app.invoke({"query": {}})

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -67,6 +67,7 @@ from tests.memory_assert import (
     MemorySaverAssertImmutable,
 )
 from tests.messages import _AnyIdAIMessage, _AnyIdHumanMessage
+from tests.pydantic_utils import _schema
 
 
 async def test_checkpoint_errors() -> None:
@@ -510,8 +511,8 @@ async def test_invoke_single_process_in_out(mocker: MockerFixture) -> None:
     graph.set_finish_point("add_one")
     gapp = graph.compile()
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {"title": "LangGraphOutput", "type": "integer"}
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {"title": "LangGraphOutput", "type": "integer"}
     assert await app.ainvoke(2) == 3
     assert await app.ainvoke(2, output_keys=["output"]) == {"output": 3}
 
@@ -551,8 +552,8 @@ async def test_invoke_single_process_in_write_kwargs(mocker: MockerFixture) -> N
         input_channels="input",
     )
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {
@@ -575,8 +576,8 @@ async def test_invoke_single_process_in_out_dict(mocker: MockerFixture) -> None:
         output_channels=["output"],
     )
 
-    assert app.input_schema.schema() == {"title": "LangGraphInput", "type": "integer"}
-    assert app.output_schema.schema() == {
+    assert _schema(app.input_schema) == {"title": "LangGraphInput", "type": "integer"}
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {"output": {"title": "Output", "type": "integer"}},
@@ -595,12 +596,12 @@ async def test_invoke_single_process_in_dict_out_dict(mocker: MockerFixture) -> 
         output_channels=["output"],
     )
 
-    assert app.input_schema.schema() == {
+    assert _schema(app.input_schema) == {
         "title": "LangGraphInput",
         "type": "object",
         "properties": {"input": {"title": "Input", "type": "integer"}},
     }
-    assert app.output_schema.schema() == {
+    assert _schema(app.output_schema) == {
         "title": "LangGraphOutput",
         "type": "object",
         "properties": {"output": {"title": "Output", "type": "integer"}},


### PR DESCRIPTION
This PR introduces a module with some helper utilities for the pydantic 1 -> 2 migration.

They're meant to be used in the following way:

1) Use the utility code to get unit tests pass without requiring modification to the unit tests
2) (If desired) upgrade the unit tests to match pydantic 2 output
3) (If desired) stop using the utility code

Currently, this module contains a way to map `schema()` generated by pydantic 2 to (mostly) match the output from pydantic v1.

Mirrors this PR:  https://github.com/langchain-ai/langchain/pull/24930