### PR TITLE
Fix message duplication in GraphState messages

### DIFF
--- a/examples/code_assistant/langgraph_code_assistant_mistral.ipynb
+++ b/examples/code_assistant/langgraph_code_assistant_mistral.ipynb
@@ -33,7 +33,9 @@
    "id": "e501686f-323f-4b87-8f9c-8ba89133078b",
    "metadata": {},
    "outputs": [],
-   "source": ["! pip install -U langchain_community langchain-mistralai langchain langgraph"]
+   "source": [
+    "! pip install -U langchain_community langchain-mistralai langchain langgraph"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -51,7 +53,9 @@
    "id": "982e4609-86e4-4934-828f-e03d89c20393",
    "metadata": {},
    "outputs": [],
-   "source": ["import os\n\nos.environ[\"TOKENIZERS_PARALLELISM\"] = \"true\"\nmistral_api_key = os.getenv(\"MISTRAL_API_KEY\")  # Ensure this is set"]
+   "source": [
+    "import os\n\nos.environ[\"TOKENIZERS_PARALLELISM\"] = \"true\"\nmistral_api_key = os.getenv(\"MISTRAL_API_KEY\")  # Ensure this is set"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -69,7 +73,9 @@
    "id": "37b172d2-3a9d-49a8-898c-22ed0cb45c88",
    "metadata": {},
    "outputs": [],
-   "source": ["os.environ[\"LANGCHAIN_TRACING_V2\"] = \"true\"\nos.environ[\"LANGCHAIN_ENDPOINT\"] = \"https://api.smith.langchain.com\"\nos.environ[\"LANGCHAIN_API_KEY\"] = \"<your-api-key>\"\nos.environ[\"LANGCHAIN_PROJECT\"] = \"Mistral-code-gen-testing\""]
+   "source": [
+    "os.environ[\"LANGCHAIN_TRACING_V2\"] = \"true\"\nos.environ[\"LANGCHAIN_ENDPOINT\"] = \"https://api.smith.langchain.com\"\nos.environ[\"LANGCHAIN_API_KEY\"] = \"<your-api-key>\"\nos.environ[\"LANGCHAIN_PROJECT\"] = \"Mistral-code-gen-testing\""
+   ]
   },
   {
    "cell_type": "markdown",
@@ -87,7 +93,9 @@
    "id": "a188c8ca-c053-4e6d-b7af-38a3b6b371c7",
    "metadata": {},
    "outputs": [],
-   "source": ["# Select LLM\nfrom langchain_core.prompts import ChatPromptTemplate\nfrom langchain_core.pydantic_v1 import BaseModel, Field\nfrom langchain_mistralai import ChatMistralAI\n\nmistral_model = \"mistral-large-latest\"\nllm = ChatMistralAI(model=mistral_model, temperature=0)\n\n# Prompt\ncode_gen_prompt_claude = ChatPromptTemplate.from_messages(\n    [\n        (\n            \"system\",\n            \"\"\"You are a coding assistant. Ensure any code you provide can be executed with all required imports and variables \\n\n            defined. Structure your answer: 1) a prefix describing the code solution, 2) the imports, 3) the functioning code block.\n            \\n Here is the user question:\"\"\",\n        ),\n        (\"placeholder\", \"{messages}\"),\n    ]\n)\n\n\n# Data model\nclass code(BaseModel):\n    \"\"\"Code output\"\"\"\n\n    prefix: str = Field(description=\"Description of the problem and approach\")\n    imports: str = Field(description=\"Code block import statements\")\n    code: str = Field(description=\"Code block not including import statements\")\n    description = \"Schema for code solutions to questions about LCEL.\"\n\n\n# LLM\ncode_gen_chain = llm.with_structured_output(code, include_raw=False)"]
+   "source": [
+    "# Select LLM\nfrom langchain_core.prompts import ChatPromptTemplate\nfrom langchain_core.pydantic_v1 import BaseModel, Field\nfrom langchain_mistralai import ChatMistralAI\n\nmistral_model = \"mistral-large-latest\"\nllm = ChatMistralAI(model=mistral_model, temperature=0)\n\n# Prompt\ncode_gen_prompt_claude = ChatPromptTemplate.from_messages(\n    [\n        (\n            \"system\",\n            \"\"\"You are a coding assistant. Ensure any code you provide can be executed with all required imports and variables \\n\n            defined. Structure your answer: 1) a prefix describing the code solution, 2) the imports, 3) the functioning code block.\n            \\n Here is the user question:\"\"\",\n        ),\n        (\"placeholder\", \"{messages}\"),\n    ]\n)\n\n\n# Data model\nclass code(BaseModel):\n    \"\"\"Code output\"\"\"\n\n    prefix: str = Field(description=\"Description of the problem and approach\")\n    imports: str = Field(description=\"Code block import statements\")\n    code: str = Field(description=\"Code block not including import statements\")\n    description = \"Schema for code solutions to questions about LCEL.\"\n\n\n# LLM\ncode_gen_chain = llm.with_structured_output(code, include_raw=False)"
+   ]
   },
   {
    "cell_type": "code",
@@ -95,7 +103,9 @@
    "id": "9fc0290d-5a04-4514-8664-91f9dbf2da7b",
    "metadata": {},
    "outputs": [],
-   "source": ["question = \"Write a function for fibonacci.\"\nmessages = [(\"user\", question)]"]
+   "source": [
+    "question = \"Write a function for fibonacci.\"\nmessages = [(\"user\", question)]"
+   ]
   },
   {
    "cell_type": "code",
@@ -114,7 +124,9 @@
      "output_type": "execute_result"
     }
    ],
-   "source": ["# Test\nresult = code_gen_chain.invoke(messages)\nresult"]
+   "source": [
+    "# Test\nresult = code_gen_chain.invoke(messages)\nresult"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -130,7 +142,9 @@
    "id": "183d77b8-f180-4815-b39f-8ef507ec0534",
    "metadata": {},
    "outputs": [],
-   "source": ["from typing import Annotated, TypedDict\n\nfrom langgraph.graph.message import AnyMessage, add_messages\n\n\nclass GraphState(TypedDict):\n    \"\"\"\n    Represents the state of our graph.\n\n    Attributes:\n        error : Binary flag for control flow to indicate whether test error was tripped\n        messages : With user question, error messages, reasoning\n        generation : Code solution\n        iterations : Number of tries\n    \"\"\"\n\n    error: str\n    messages: Annotated[list[AnyMessage], add_messages]\n    generation: str\n    iterations: int"]
+   "source": [
+    "from typing import Annotated, TypedDict\n\nfrom langgraph.graph.message import AnyMessage, add_messages\n\n\nclass GraphState(TypedDict):\n    \"\"\"\n    Represents the state of our graph.\n\n    Attributes:\n        error : Binary flag for control flow to indicate whether test error was tripped\n        messages : With user question, error messages, reasoning\n        generation : Code solution\n        iterations : Number of tries\n    \"\"\"\n\n    error: str\n    messages: Annotated[list[AnyMessage], add_messages]\n    generation: str\n    iterations: int"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -146,7 +160,161 @@
    "id": "14bc89d1-3ca6-4847-a048-1803e0e4600e",
    "metadata": {},
    "outputs": [],
-   "source": ["import uuid\n\nfrom langchain_core.pydantic_v1 import BaseModel, Field\n\n### Parameters\nmax_iterations = 3\n\n\n### Nodes\ndef generate(state: GraphState):\n    \"\"\"\n    Generate a code solution\n\n    Args:\n        state (dict): The current graph state\n\n    Returns:\n        state (dict): New key added to state, generation\n    \"\"\"\n\n    print(\"---GENERATING CODE SOLUTION---\")\n\n    # State\n    messages = state[\"messages\"]\n    iterations = state[\"iterations\"]\n\n    # Solution\n    code_solution = code_gen_chain.invoke(messages)\n    messages += [\n        (\n            \"assistant\",\n            f\"Here is my attempt to solve the problem: {code_solution.prefix} \\n Imports: {code_solution.imports} \\n Code: {code_solution.code}\",\n        )\n    ]\n\n    # Increment\n    iterations = iterations + 1\n    return {\"generation\": code_solution, \"messages\": messages, \"iterations\": iterations}\n\n\ndef code_check(state: GraphState):\n    \"\"\"\n    Check code\n\n    Args:\n        state (dict): The current graph state\n\n    Returns:\n        state (dict): New key added to state, error\n    \"\"\"\n\n    print(\"---CHECKING CODE---\")\n\n    # State\n    messages = state[\"messages\"]\n    code_solution = state[\"generation\"]\n    iterations = state[\"iterations\"]\n\n    # Get solution components\n    imports = code_solution.imports\n    code = code_solution.code\n\n    # Check imports\n    try:\n        exec(imports)\n    except Exception as e:\n        print(\"---CODE IMPORT CHECK: FAILED---\")\n        error_message = [\n            (\n                \"user\",\n                f\"Your solution failed the import test. Here is the error: {e}. Reflect on this error and your prior attempt to solve the problem. (1) State what you think went wrong with the prior solution and (2) try to solve this problem again. Return the FULL SOLUTION. Use the code tool to structure the output with a prefix, imports, and code block:\",\n            )\n        ]\n        messages += error_message\n        return {\n            \"generation\": code_solution,\n            \"messages\": messages,\n            \"iterations\": iterations,\n            \"error\": \"yes\",\n        }\n\n    # Check execution\n    try:\n        combined_code = f\"{imports}\\n{code}\"\n        print(f\"CODE TO TEST: {combined_code}\")\n        # Use a shared scope for exec\n        global_scope = {}\n        exec(combined_code, global_scope)\n    except Exception as e:\n        print(\"---CODE BLOCK CHECK: FAILED---\")\n        error_message = [\n            (\n                \"user\",\n                f\"Your solution failed the code execution test: {e}) Reflect on this error and your prior attempt to solve the problem. (1) State what you think went wrong with the prior solution and (2) try to solve this problem again. Return the FULL SOLUTION. Use the code tool to structure the output with a prefix, imports, and code block:\",\n            )\n        ]\n        messages += error_message\n        return {\n            \"generation\": code_solution,\n            \"messages\": messages,\n            \"iterations\": iterations,\n            \"error\": \"yes\",\n        }\n\n    # No errors\n    print(\"---NO CODE TEST FAILURES---\")\n    return {\n        \"generation\": code_solution,\n        \"messages\": messages,\n        \"iterations\": iterations,\n        \"error\": \"no\",\n    }\n\n\n### Conditional edges\n\n\ndef decide_to_finish(state: GraphState):\n    \"\"\"\n    Determines whether to finish.\n\n    Args:\n        state (dict): The current graph state\n\n    Returns:\n        str: Next node to call\n    \"\"\"\n    error = state[\"error\"]\n    iterations = state[\"iterations\"]\n\n    if error == \"no\" or iterations == max_iterations:\n        print(\"---DECISION: FINISH---\")\n        return \"end\"\n    else:\n        print(\"---DECISION: RE-TRY SOLUTION---\")\n        return \"generate\"\n\n\n### Utilities\n\n\ndef _print_event(event: dict, _printed: set, max_length=1500):\n    current_state = event.get(\"dialog_state\")\n    if current_state:\n        print(\"Currently in: \", current_state[-1])\n    message = event.get(\"messages\")\n    if message:\n        if isinstance(message, list):\n            message = message[-1]\n        if message.id not in _printed:\n            msg_repr = message.pretty_repr(html=True)\n            if len(msg_repr) > max_length:\n                msg_repr = msg_repr[:max_length] + \" ... (truncated)\"\n            print(msg_repr)\n            _printed.add(message.id)"]
+   "source": [
+    "import uuid\n",
+    "\n",
+    "from langchain_core.pydantic_v1 import BaseModel, Field\n",
+    "\n",
+    "### Parameters\n",
+    "max_iterations = 3\n",
+    "\n",
+    "\n",
+    "### Nodes\n",
+    "def generate(state: GraphState):\n",
+    "    \"\"\"\n",
+    "    Generate a code solution\n",
+    "\n",
+    "    Args:\n",
+    "        state (dict): The current graph state\n",
+    "\n",
+    "    Returns:\n",
+    "        state (dict): New key added to state, generation\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(\"---GENERATING CODE SOLUTION---\")\n",
+    "\n",
+    "    # State\n",
+    "    messages = state[\"messages\"]\n",
+    "    iterations = state[\"iterations\"]\n",
+    "\n",
+    "    # Solution\n",
+    "    code_solution = code_gen_chain.invoke(messages)\n",
+    "    message = [\n",
+    "        (\n",
+    "            \"assistant\",\n",
+    "            f\"Here is my attempt to solve the problem: {code_solution.prefix} \\n Imports: {code_solution.imports} \\n Code: {code_solution.code}\",\n",
+    "        )\n",
+    "    ]\n",
+    "\n",
+    "    # Increment\n",
+    "    iterations = iterations + 1\n",
+    "    return {\"generation\": code_solution, \"messages\": message, \"iterations\": iterations}\n",
+    "\n",
+    "\n",
+    "def code_check(state: GraphState):\n",
+    "    \"\"\"\n",
+    "    Check code\n",
+    "\n",
+    "    Args:\n",
+    "        state (dict): The current graph state\n",
+    "\n",
+    "    Returns:\n",
+    "        state (dict): New key added to state, error\n",
+    "    \"\"\"\n",
+    "\n",
+    "    print(\"---CHECKING CODE---\")\n",
+    "\n",
+    "    # State\n",
+    "    messages = state[\"messages\"]\n",
+    "    code_solution = state[\"generation\"]\n",
+    "    iterations = state[\"iterations\"]\n",
+    "\n",
+    "    # Get solution components\n",
+    "    imports = code_solution.imports\n",
+    "    code = code_solution.code\n",
+    "\n",
+    "    # Check imports\n",
+    "    try:\n",
+    "        exec(imports)\n",
+    "    except Exception as e:\n",
+    "        print(\"---CODE IMPORT CHECK: FAILED---\")\n",
+    "        error_message = [\n",
+    "            (\n",
+    "                \"user\",\n",
+    "                f\"Your solution failed the import test. Here is the error: {e}. Reflect on this error and your prior attempt to solve the problem. (1) State what you think went wrong with the prior solution and (2) try to solve this problem again. Return the FULL SOLUTION. Use the code tool to structure the output with a prefix, imports, and code block:\",\n",
+    "            )\n",
+    "        ]\n",
+    "        return {\n",
+    "            \"generation\": code_solution,\n",
+    "            \"messages\": error_message,\n",
+    "            \"iterations\": iterations,\n",
+    "            \"error\": \"yes\",\n",
+    "        }\n",
+    "\n",
+    "    # Check execution\n",
+    "    try:\n",
+    "        combined_code = f\"{imports}\\n{code}\"\n",
+    "        print(f\"CODE TO TEST: {combined_code}\")\n",
+    "        # Use a shared scope for exec\n",
+    "        global_scope = {}\n",
+    "        exec(combined_code, global_scope)\n",
+    "    except Exception as e:\n",
+    "        print(\"---CODE BLOCK CHECK: FAILED---\")\n",
+    "        error_message = [\n",
+    "            (\n",
+    "                \"user\",\n",
+    "                f\"Your solution failed the code execution test: {e}) Reflect on this error and your prior attempt to solve the problem. (1) State what you think went wrong with the prior solution and (2) try to solve this problem again. Return the FULL SOLUTION. Use the code tool to structure the output with a prefix, imports, and code block:\",\n",
+    "            )\n",
+    "        ]\n",
+    "        return {\n",
+    "            \"generation\": code_solution,\n",
+    "            \"messages\": error_message,\n",
+    "            \"iterations\": iterations,\n",
+    "            \"error\": \"yes\",\n",
+    "        }\n",
+    "\n",
+    "    # No errors\n",
+    "    print(\"---NO CODE TEST FAILURES---\")\n",
+    "    return {\n",
+    "        \"generation\": code_solution,\n",
+    "        \"messages\": messages,\n",
+    "        \"iterations\": iterations,\n",
+    "        \"error\": \"no\",\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "### Conditional edges\n",
+    "\n",
+    "\n",
+    "def decide_to_finish(state: GraphState):\n",
+    "    \"\"\"\n",
+    "    Determines whether to finish.\n",
+    "\n",
+    "    Args:\n",
+    "        state (dict): The current graph state\n",
+    "\n",
+    "    Returns:\n",
+    "        str: Next node to call\n",
+    "    \"\"\"\n",
+    "    error = state[\"error\"]\n",
+    "    iterations = state[\"iterations\"]\n",
+    "\n",
+    "    if error == \"no\" or iterations == max_iterations:\n",
+    "        print(\"---DECISION: FINISH---\")\n",
+    "        return \"end\"\n",
+    "    else:\n",
+    "        print(\"---DECISION: RE-TRY SOLUTION---\")\n",
+    "        return \"generate\"\n",
+    "\n",
+    "\n",
+    "### Utilities\n",
+    "\n",
+    "\n",
+    "def _print_event(event: dict, _printed: set, max_length=1500):\n",
+    "    current_state = event.get(\"dialog_state\")\n",
+    "    if current_state:\n",
+    "        print(\"Currently in: \", current_state[-1])\n",
+    "    message = event.get(\"messages\")\n",
+    "    if message:\n",
+    "        if isinstance(message, list):\n",
+    "            message = message[-1]\n",
+    "        if message.id not in _printed:\n",
+    "            msg_repr = message.pretty_repr(html=True)\n",
+    "            if len(msg_repr) > max_length:\n",
+    "                msg_repr = msg_repr[:max_length] + \" ... (truncated)\"\n",
+    "            print(msg_repr)\n",
+    "            _printed.add(message.id)"
+   ]
   },
   {
    "cell_type": "code",
@@ -154,7 +322,9 @@
    "id": "2dff2209-44c7-4e2c-b607-ba6675f9e45f",
    "metadata": {},
    "outputs": [],
-   "source": ["from langgraph.checkpoint.memory import MemorySaver\nfrom langgraph.graph import END, StateGraph, START\n\nbuilder = StateGraph(GraphState)\n\n# Define the nodes\nbuilder.add_node(\"generate\", generate)  # generation solution\nbuilder.add_node(\"check_code\", code_check)  # check code\n\n# Build graph\nbuilder.add_edge(START, \"generate\")\nbuilder.add_edge(\"generate\", \"check_code\")\nbuilder.add_conditional_edges(\n    \"check_code\",\n    decide_to_finish,\n    {\n        \"end\": END,\n        \"generate\": \"generate\",\n    },\n)\n\nmemory = MemorySaver()\ngraph = builder.compile(checkpointer=memory)"]
+   "source": [
+    "from langgraph.checkpoint.memory import MemorySaver\nfrom langgraph.graph import END, StateGraph, START\n\nbuilder = StateGraph(GraphState)\n\n# Define the nodes\nbuilder.add_node(\"generate\", generate)  # generation solution\nbuilder.add_node(\"check_code\", code_check)  # check code\n\n# Build graph\nbuilder.add_edge(START, \"generate\")\nbuilder.add_edge(\"generate\", \"check_code\")\nbuilder.add_conditional_edges(\n    \"check_code\",\n    decide_to_finish,\n    {\n        \"end\": END,\n        \"generate\": \"generate\",\n    },\n)\n\nmemory = MemorySaver()\ngraph = builder.compile(checkpointer=memory)"
+   ]
   },
   {
    "cell_type": "code",
@@ -173,7 +343,9 @@
      "output_type": "display_data"
     }
    ],
-   "source": ["from IPython.display import Image, display\n\ntry:\n    display(Image(graph.get_graph(xray=True).draw_mermaid_png()))\nexcept Exception:\n    # This requires some extra dependencies and is optional\n    pass"]
+   "source": [
+    "from IPython.display import Image, display\n\ntry:\n    display(Image(graph.get_graph(xray=True).draw_mermaid_png()))\nexcept Exception:\n    # This requires some extra dependencies and is optional\n    pass"
+   ]
   },
   {
    "cell_type": "code",
@@ -181,7 +353,9 @@
    "id": "242aa2f0-2c31-462f-a958-ff9ae0cf7c62",
    "metadata": {},
    "outputs": [],
-   "source": ["_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"Write a Python program that prints 'Hello, World!' to the console.\"\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"]
+   "source": [
+    "_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"Write a Python program that prints 'Hello, World!' to the console.\"\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -199,7 +373,9 @@
    "id": "390b2768-f395-4aea-8b0e-9d36212a31ac",
    "metadata": {},
    "outputs": [],
-   "source": ["_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Create a Python program that checks if a given string is a palindrome. A palindrome is a word, phrase, number, or other sequence of characters that reads the same forward and backward (ignoring spaces, punctuation, and capitalization).\n\nRequirements:\nThe program should define a function is_palindrome(s) that takes a string s as input.\nThe function should return True if the string is a palindrome and False otherwise.\nIgnore spaces, punctuation, and case differences when checking for palindromes.\n\nGive an example of it working on an example input word.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"]
+   "source": [
+    "_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Create a Python program that checks if a given string is a palindrome. A palindrome is a word, phrase, number, or other sequence of characters that reads the same forward and backward (ignoring spaces, punctuation, and capitalization).\n\nRequirements:\nThe program should define a function is_palindrome(s) that takes a string s as input.\nThe function should return True if the string is a palindrome and False otherwise.\nIgnore spaces, punctuation, and case differences when checking for palindromes.\n\nGive an example of it working on an example input word.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -217,7 +393,9 @@
    "id": "0a3f946b-e2f2-44d9-905b-09f36980cf9f",
    "metadata": {},
    "outputs": [],
-   "source": ["_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Write a program that prints the numbers from 1 to 100. \nBut for multiples of three, print \"Fizz\" instead of the number, and for the multiples of five, print \"Buzz\". \nFor numbers which are multiples of both three and five, print \"FizzBuzz\".\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"]
+   "source": [
+    "_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Write a program that prints the numbers from 1 to 100. \nBut for multiples of three, print \"Fizz\" instead of the number, and for the multiples of five, print \"Buzz\". \nFor numbers which are multiples of both three and five, print \"FizzBuzz\".\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -235,7 +413,9 @@
    "id": "2bb883df-540b-46ab-9415-fe27db68456f",
    "metadata": {},
    "outputs": [],
-   "source": ["import uuid\n\n_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"I want to vectorize a function\n\n        frame = np.zeros((out_h, out_w, 3), dtype=np.uint8)\n        for i, val1 in enumerate(rows):\n            for j, val2 in enumerate(cols):\n                for j, val3 in enumerate(ch):\n                    # Assuming you want to store the pair as tuples in the matrix\n                    frame[i, j, k] = image[val1, val2, val3]\n\n        out.write(np.array(frame))\n\nwith a simple numpy function that does something like this what is it called. Show me a test case with this working.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"]
+   "source": [
+    "import uuid\n\n_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"I want to vectorize a function\n\n        frame = np.zeros((out_h, out_w, 3), dtype=np.uint8)\n        for i, val1 in enumerate(rows):\n            for j, val2 in enumerate(cols):\n                for j, val3 in enumerate(ch):\n                    # Assuming you want to store the pair as tuples in the matrix\n                    frame[i, j, k] = image[val1, val2, val3]\n\n        out.write(np.array(frame))\n\nwith a simple numpy function that does something like this what is it called. Show me a test case with this working.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -253,7 +433,9 @@
    "id": "ee05da1f-c272-405d-8a7b-552cfc3106e1",
    "metadata": {},
    "outputs": [],
-   "source": ["_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Create a Python program that allows two players to play a game of Tic-Tac-Toe. The game should be played on a 3x3 grid. The program should:\n\n- Allow players to take turns to input their moves.\n- Check for invalid moves (e.g., placing a marker on an already occupied space).\n- Determine and announce the winner or if the game ends in a draw.\n\nRequirements:\n- Use a 2D list to represent the Tic-Tac-Toe board.\n- Use functions to modularize the code.\n- Validate player input.\n- Check for win conditions and draw conditions after each move.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"]
+   "source": [
+    "_printed = set()\nthread_id = str(uuid.uuid4())\nconfig = {\n    \"configurable\": {\n        # Checkpoints are accessed by thread_id\n        \"thread_id\": thread_id,\n    }\n}\n\nquestion = \"\"\"Create a Python program that allows two players to play a game of Tic-Tac-Toe. The game should be played on a 3x3 grid. The program should:\n\n- Allow players to take turns to input their moves.\n- Check for invalid moves (e.g., placing a marker on an already occupied space).\n- Determine and announce the winner or if the game ends in a draw.\n\nRequirements:\n- Use a 2D list to represent the Tic-Tac-Toe board.\n- Use functions to modularize the code.\n- Validate player input.\n- Check for win conditions and draw conditions after each move.\"\"\"\n\nevents = graph.stream(\n    {\"messages\": [(\"user\", question)], \"iterations\": 0}, config, stream_mode=\"values\"\n)\nfor event in events:\n    _print_event(event, _printed)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -271,7 +453,9 @@
    "id": "814fc2a4-8e5b-4faa-8f52-3977226bd09a",
    "metadata": {},
    "outputs": [],
-   "source": [""]
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Context:
In the `GraphState` class, the `messages` variable is of type list, annotated with `add_messages`. This ensures that new messages are appended to the list without needing to resend old messages, as they are already present.

### Problem:
In the `generate` and `code_check` methods, the existing list was being extracted and, after appending a new message, sent back to update the `messages` variable. This approach caused duplication since the old messages were already present in the list. The correct behavior should only send back the new message to be appended.

### Solution:
This pull request fixes the issue by ensuring that only the new message is sent from the `generate` and `code_check` methods, preventing duplication.

###  Additional Notes:
- I verified the issue through debugging the GraphState variables.
- The rest of the script remains unchanged.

