### PR TITLE
docs: fix persistence_postgres.ipynb

### DIFF
--- a/examples/persistence_postgres.ipynb
+++ b/examples/persistence_postgres.ipynb
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DB_URI = \"postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable\""
+    "DB_URI = \"postgresql://postgres:postgres@localhost:5441/postgres?sslmode=disable\""
    ]
   },
   {

--- a/examples/persistence_postgres.ipynb
+++ b/examples/persistence_postgres.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "from typing import Literal\n",
-    "from langchain_core.runnables import ConfigurableField\n",
+    "\n",
     "from langchain_core.tools import tool\n",
     "from langchain_openai import ChatOpenAI\n",
     "from langgraph.prebuilt import create_react_agent\n",
@@ -319,8 +319,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from psycopg import Connection\n",
-    "\n",
     "with PostgresSaver.from_conn_string(DB_URI) as checkpointer:\n",
     "    graph = create_react_agent(model, tools=tools, checkpointer=checkpointer)\n",
     "    config = {\"configurable\": {\"thread_id\": \"3\"}}\n",


### PR DESCRIPTION
1. According to the [make start-postgres](https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint-postgres/Makefile#L8) command in the context, execute docker compose, and the configured port is [5441](https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint-postgres/tests/compose-postgres.yml#L5).

1. remove unuse import