### PR TITLE
Fix typo in documentation: corrected 'they agent's' to 'their agent's'

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -1563,7 +1563,7 @@
    "source": [
     "## Part 5: Manually Updating the State\n",
     "\n",
-    "In the previous section, we showed how to interrupt a graph so that a human could inspect its actions. This lets the human `read` the state, but if they want to change they agent's course, they'll need to have `write` access.\n",
+    "In the previous section, we showed how to interrupt a graph so that a human could inspect its actions. This lets the human `read` the state, but if they want to change their agent's course, they'll need to have `write` access.\n",
     "\n",
     "Thankfully, LangGraph lets you **manually update state**! Updating the state lets you control the agent's trajectory by modifying its actions (even modifying the past!). This capability is particularly useful when you want to correct the agent's mistakes, explore alternative paths, or guide the agent towards a specific goal.\n",
     "\n",


### PR DESCRIPTION

**PR Details:**
This PR corrects a minor typo in the documentation, changing "they agent's course" to "their agent's course" for clarity and consistency.

---

**Hi [LangGraph/LangChain Team Member’s Name],**

I’m excited to share that I recently contributed to the LangChain project and am now contributing to the LangGraph Docs. If possible, could you give me a shoutout on LinkedIn? It would mean a lot and might inspire others to contribute as well.

Here’s my LinkedIn profile: [Hassan Memon](https://www.linkedin.com/in/hassan-memon-a109b3257/).

Thank you for your support and for fostering such a great platform for learning and collaboration. I look forward to contributing more in the future!

Best regards,  
Hassan Memon