### PR TITLE
Include exception traceback in run_with_retry logging

### DIFF
--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -3,6 +3,7 @@ import logging
 import random
 import time
 from typing import Optional
+import traceback
 
 from langgraph.pregel.types import PregelExecutableTask, RetryPolicy
 
@@ -49,7 +50,9 @@ def run_with_retry(
             )
             # log the retry
             logger.info(
-                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) after {exc.__class__.__name__} {exc}"
+                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) due to:\n"
+                f"{exc.__class__.__name__}: {exc}\n"
+                f"{traceback.format_exc()}"
             )
 
 

--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -3,7 +3,6 @@ import logging
 import random
 import time
 from typing import Optional
-import traceback
 
 from langgraph.pregel.types import PregelExecutableTask, RetryPolicy
 
@@ -50,9 +49,8 @@ def run_with_retry(
             )
             # log the retry
             logger.info(
-                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) due to:\n"
-                f"{exc.__class__.__name__}: {exc}\n"
-                f"{traceback.format_exc()}"
+                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) after {exc.__class__.__name__} {exc}",
+                exc_info=exc,
             )
 
 
@@ -101,5 +99,6 @@ async def arun_with_retry(
             )
             # log the retry
             logger.info(
-                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) after {exc.__class__.__name__} {exc}"
+                f"Retrying task {task.name} after {interval:.2f} seconds (attempt {attempts}) after {exc.__class__.__name__} {exc}",
+                exc_info=exc,
             )

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1238,7 +1238,6 @@ def test_invoke_checkpoint(mocker: MockerFixture, caplog) -> None:
     assert checkpoint["channel_values"].get("total") == 2
     # total is now 2, so output is 2+3=5
     assert app.invoke(3, {"configurable": {"thread_id": "1"}}) == 5
-    assert 0
     assert errored_once, "errored and retried"
     checkpoint = memory.get({"configurable": {"thread_id": "1"}})
     assert checkpoint is not None

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import operator
 import time
 import warnings
@@ -1191,7 +1192,8 @@ def test_invoke_two_processes_two_in_two_out_valid(mocker: MockerFixture) -> Non
     assert app.invoke(2) == [3, 3]
 
 
-def test_invoke_checkpoint(mocker: MockerFixture) -> None:
+def test_invoke_checkpoint(mocker: MockerFixture, caplog) -> None:
+    caplog.set_level(logging.INFO)
     add_one = mocker.Mock(side_effect=lambda x: x["total"] + x["input"])
     errored_once = False
 
@@ -1236,6 +1238,7 @@ def test_invoke_checkpoint(mocker: MockerFixture) -> None:
     assert checkpoint["channel_values"].get("total") == 2
     # total is now 2, so output is 2+3=5
     assert app.invoke(3, {"configurable": {"thread_id": "1"}}) == 5
+    assert 0
     assert errored_once, "errored and retried"
     checkpoint = memory.get({"configurable": {"thread_id": "1"}})
     assert checkpoint is not None


### PR DESCRIPTION
## About

- LangGraph Studio 0.0.12 (0.0.12)
- langgraph 0.2.3

## Real Example Logs

This is a real example from running my `graph` with a bug in one of the nodes.

### :x: Before - Logs are not useful for locating bug

```python
langgraph-api-1       | Retrying task Generate Data Schema after 0.23 seconds (attempt 2) after AttributeError 'dict' object has no attribute 'project_id'
langgraph-api-1       | Run Error
```

### ✅  After - Logs are useful for locating bug 

```python
langgraph-api-1       | Retrying task Generate Data Schema after 0.23 seconds (attempt 2) due to:
AttributeError: 'dict' object has no attribute 'project_id'
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/langgraph/pregel/retry.py", line 74, in arun_with_retry
    async for _ in task.proc.astream(task.input, task.config):
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 3287, in astream
    async for chunk in self.atransform(input_aiter(), config, **kwargs):
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 3270, in atransform
    async for chunk in self._atransform_stream_with_config(
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 2161, in _atransform_stream_with_config
    chunk: Output = await asyncio.create_task(  # type: ignore[call-arg]
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langchain_core/tracers/event_stream.py", line 181, in tap_output_aiter
    first = await py_anext(output, default=sentinel)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langchain_core/utils/aiter.py", line 78, in anext_impl
    return await __anext__(iterator)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 3240, in _atransform
    async for output in final_pipeline:
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 1314, in atransform
    async for ichunk in input:
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 1332, in atransform
    async for output in self.astream(final, config, **kwargs):
  File "/usr/local/lib/python3.12/site-packages/langchain_core/runnables/base.py", line 875, in astream
    yield await self.ainvoke(input, config, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/REDACTED.py", line 82, in ainvoke
    "project_id": self.prompt.project_id,
                          ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'project_id'

langgraph-api-1       | Run Error
```