### PR TITLE
Checkpoint errors in pending_writes, expose under StateSnapshot.tasks

### DIFF
--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -6,9 +6,11 @@ CONFIG_KEY_READ = "__pregel_read"
 CONFIG_KEY_CHECKPOINTER = "__pregel_checkpointer"
 CONFIG_KEY_RESUMING = "__pregel_resuming"
 INTERRUPT = "__interrupt__"
+ERROR = "__error__"
 TASKS = "__pregel_tasks"
 RESERVED = {
     INTERRUPT,
+    ERROR,
     TASKS,
     CONFIG_KEY_SEND,
     CONFIG_KEY_READ,

--- a/libs/langgraph/langgraph/managed/base.py
+++ b/libs/langgraph/langgraph/managed/base.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, contextmanager
 from inspect import isclass
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Generator,
@@ -16,9 +15,6 @@ from typing import (
 
 from langchain_core.runnables import RunnableConfig
 from typing_extensions import Self, TypeGuard
-
-if TYPE_CHECKING:
-    from langgraph.pregel.types import PregelTaskDescription
 
 V = TypeVar("V")
 
@@ -60,7 +56,7 @@ class ManagedValue(ABC, Generic[V]):
                 pass
 
     @abstractmethod
-    def __call__(self, step: int, task: "PregelTaskDescription") -> V:
+    def __call__(self, step: int) -> V:
         ...
 
 

--- a/libs/langgraph/langgraph/managed/is_last_step.py
+++ b/libs/langgraph/langgraph/managed/is_last_step.py
@@ -1,11 +1,10 @@
 from typing import Annotated
 
 from langgraph.managed.base import ManagedValue
-from langgraph.pregel.types import PregelExecutableTask
 
 
 class IsLastStepManager(ManagedValue[bool]):
-    def __call__(self, step: int, task: PregelExecutableTask) -> bool:
+    def __call__(self, step: int) -> bool:
         return step == self.config["recursion_limit"] - 1
 
 

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -39,7 +39,13 @@ from langgraph.checkpoint.base import (
     create_checkpoint,
     empty_checkpoint,
 )
-from langgraph.constants import CONFIG_KEY_READ, CONFIG_KEY_RESUMING, INPUT, INTERRUPT
+from langgraph.constants import (
+    CONFIG_KEY_READ,
+    CONFIG_KEY_RESUMING,
+    ERROR,
+    INPUT,
+    INTERRUPT,
+)
 from langgraph.errors import EmptyInputError, GraphInterrupt
 from langgraph.managed.base import (
     AsyncManagedValuesManager,
@@ -252,6 +258,8 @@ class PregelLoop:
         # if there are pending writes from a previous loop, apply them
         if self.checkpoint_pending_writes:
             for tid, k, v in self.checkpoint_pending_writes:
+                if k == ERROR:  # TODO same for INTERRUPT
+                    continue
                 if task := next((t for t in self.tasks if t.id == tid), None):
                     task.writes.append((k, v))
 

--- a/libs/langgraph/langgraph/pregel/types.py
+++ b/libs/langgraph/langgraph/pregel/types.py
@@ -56,8 +56,10 @@ class RetryPolicy(NamedTuple):
     """List of exception classes that should trigger a retry, or a callable that returns True for exceptions that should trigger a retry."""
 
 
-class PregelTaskDescription(NamedTuple):
+class PregelTask(NamedTuple):
+    id: str
     name: str
+    error: Optional[Exception] = None
 
 
 class PregelExecutableTask(NamedTuple):
@@ -72,18 +74,22 @@ class PregelExecutableTask(NamedTuple):
 
 
 class StateSnapshot(NamedTuple):
+    """Snapshot of the state of the graph at the beginning of a step."""
+
     values: Union[dict[str, Any], Any]
     """Current values of channels"""
-    next: tuple[str]
-    """Nodes to execute in the next step, if any"""
+    next: tuple[str, ...]
+    """The name of the node to execute in each task for this step."""
     config: RunnableConfig
     """Config used to fetch this snapshot"""
     metadata: Optional[CheckpointMetadata]
     """Metadata associated with this snapshot"""
     created_at: Optional[str]
     """Timestamp of snapshot creation"""
-    parent_config: Optional[RunnableConfig] = None
+    parent_config: Optional[RunnableConfig]
     """Config used to fetch the parent snapshot, if any"""
+    tasks: tuple[PregelTask, ...]
+    """Tasks to execute in this step. If already attempted, may contain an error."""
 
 
 All = Literal["*"]

--- a/libs/langgraph/tests/any_str.py
+++ b/libs/langgraph/tests/any_str.py
@@ -4,3 +4,21 @@ class AnyStr(str):
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, str)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
+
+class ExceptionLike:
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+
+    def __eq__(self, value: object) -> bool:
+        return (
+            isinstance(value, Exception)
+            and self.exc.__class__ == value.__class__
+            and str(self.exc) == str(value)
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.exc.__class__, str(self.exc)))


### PR DESCRIPTION
- Save errors produced by tasks, under pending_writes
- Re-work logic to cancel other tasks when one fails, ready to change for interrupt exception
- Update serializer to handle exceptions
- Update get_state/get_state_history with new return value property "tasks" which contains a richer description of the next tasks, currently with id, name and error (if already ran and errored)