### PR TITLE
Allow passing `ToolNode` as `tools` in `create_react_agent`

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
@@ -139,7 +139,7 @@ def create_react_agent(
     interrupt_before: Optional[Sequence[str]] = None,
     interrupt_after: Optional[Sequence[str]] = None,
     debug: bool = False,
-    handle_tool_errors: Optional[bool] = True
+    handle_tool_errors: Optional[bool] = True,
 ) -> CompiledGraph:
     """Creates a graph that works with a chat model that utilizes tool calling.
 
@@ -476,7 +476,9 @@ def create_react_agent(
 
     # Define the two nodes we will cycle between
     workflow.add_node("agent", RunnableLambda(call_model, acall_model))
-    workflow.add_node("tools", ToolNode(tool_classes, handle_tool_errors=handle_tool_errors))
+    workflow.add_node(
+        "tools", ToolNode(tool_classes, handle_tool_errors=handle_tool_errors)
+    )
 
     # Set the entrypoint as `agent`
     # This means that this node is the first one called

--- a/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
@@ -139,6 +139,7 @@ def create_react_agent(
     interrupt_before: Optional[Sequence[str]] = None,
     interrupt_after: Optional[Sequence[str]] = None,
     debug: bool = False,
+    handle_tool_errors: Optional[bool] = True
 ) -> CompiledGraph:
     """Creates a graph that works with a chat model that utilizes tool calling.
 
@@ -177,6 +178,7 @@ def create_react_agent(
             Should be one of the following: "agent", "tools".
             This is useful if you want to return directly or run additional processing on an output.
         debug: A flag indicating whether to enable debug mode.
+        handle_tool_errors: A flag indicating whether to handle a ToolException thrown
 
     Returns:
         A compiled LangChain runnable that can be used for chat interactions.
@@ -474,7 +476,7 @@ def create_react_agent(
 
     # Define the two nodes we will cycle between
     workflow.add_node("agent", RunnableLambda(call_model, acall_model))
-    workflow.add_node("tools", ToolNode(tool_classes))
+    workflow.add_node("tools", ToolNode(tool_classes, handle_tool_errors=handle_tool_errors))
 
     # Set the entrypoint as `agent`
     # This means that this node is the first one called


### PR DESCRIPTION
In the current version of `create_react_agent`, execution cannot be halted when a tool exception occurs. Instead, exceptions are intercepted and passed to the agent as text in a `ToolMessage`. This differs from the `AgentExecutor`, which does not handle exceptions and leaves tool error handling to the tools themselves.

To address this limitation, `create_react_agent` signature is adjusted to take `ToolNode` in the `tools` argument, which allows modifying how tool errors are handled