### PR TITLE
docs: Add section about authentication to API reference

### DIFF
--- a/docs/docs/cloud/reference/api/api_ref.md
+++ b/docs/docs/cloud/reference/api/api_ref.md
@@ -3,3 +3,20 @@
 The LangGraph Cloud API reference is available with each deployment at the `/docs` URL path (e.g. `http://localhost:8124/docs`).
 
 Click <a href="/langgraph/cloud/reference/api/api_ref.html" target="_blank">here</a> to view the API reference.
+
+## Authentication
+
+For deployments to LangGraph Cloud, authentication is required. Pass the `X-Api-Key` header with each request to the LangGraph Cloud API. The value of the header should be set to a valid LangSmith API key for the organization where the API is deployed.
+
+Example `curl` command:
+```shell
+curl --request POST \
+  --url http://localhost:8124/assistants/search \
+  --header 'Content-Type: application/json' \
+  --header 'X-Api-Key: LANGSMITH_API_KEY' \
+  --data '{
+  "metadata": {},
+  "limit": 10,
+  "offset": 0
+}'  
+```


### PR DESCRIPTION
### Summary
Added a section to the API reference to clarify that calling the API requires the `X-Api-Key` header. I think this is the most appropriate place in the docs to put this information.

### Screenshot
![image](https://github.com/user-attachments/assets/212862f1-5275-4557-a382-4811f08ddfdb)
