### PR TITLE
Removes trailing slashes from apiUrl's to prevent erroneous 404s

### DIFF
--- a/libs/sdk-js/src/client.mts
+++ b/libs/sdk-js/src/client.mts
@@ -47,7 +47,7 @@ class BaseClient {
     });
 
     this.timeoutMs = config?.timeoutMs || 12_000;
-    this.apiUrl = config?.apiUrl || "http://localhost:8123";
+    this.apiUrl = config?.apiUrl?.replace(/\/+$/, "") || "http://localhost:8123";
     this.defaultHeaders = config?.defaultHeaders || {};
     if (config?.apiKey != null) {
       this.defaultHeaders["X-Api-Key"] = config.apiKey;


### PR DESCRIPTION
Hey Langgraph folks, I noticed a little issue when I was putting my base `apiUrl` in for my client in the JS SDK. I left the trailing slash on and was getting 404s. I couldn't figure out why, so I removed the slash locally and it resolved it. I decided to open a PR to fix this minor bug that could save some people's sanity later. 

Example of the regex I used - https://regexr.com/856tn