### PR TITLE
fix: ToolNode output isn't a str and contains non-ASCII characters

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/tool_node.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_node.py
@@ -34,7 +34,7 @@ def str_output(output: Any) -> str:
         return output
     else:
         try:
-            return json.dumps(output)
+            return json.dumps(output, ensure_ascii=False)
         except Exception:
             return str(output)
 


### PR DESCRIPTION
fix: #1504
Solve the issue where non-ASCII characters can't be restored when the tool's output is not a string.

- #1504