### PR TITLE
docs: Fix Replan action failing due to incorrect format

### DIFF
--- a/examples/llm-compiler/LLMCompiler.ipynb
+++ b/examples/llm-compiler/LLMCompiler.ipynb
@@ -646,11 +646,12 @@
     "def _parse_joiner_output(decision: JoinOutputs) -> List[BaseMessage]:\n",
     "    response = [AIMessage(content=f\"Thought: {decision.thought}\")]\n",
     "    if isinstance(decision.action, Replan):\n",
-    "        return response + [\n",
+    "        return {\"messages\": response + [\n",
     "            SystemMessage(\n",
     "                content=f\"Context from last attempt: {decision.action.feedback}\"\n",
     "            )\n",
     "        ]\n",
+    "        }\n",
     "    else:\n",
     "        return {\"messages\": response + [AIMessage(content=decision.action.response)]}\n",
     "\n",
@@ -931,6 +932,46 @@
    "source": [
     "# Final answer\n",
     "print(step['join']['messages'][-1].content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9487866",
+   "metadata": {},
+   "source": [
+    "#### Complex Replanning Example\n",
+    "\n",
+    "This question is likely to prompt the Replan functionality, but it may need to be run multiple times to see this in action."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "391d6931",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'plan_and_schedule': {'messages': [FunctionMessage(content=\"[{'url': 'https://www.timeanddate.com/weather/japan/tokyo', 'content': '88 / 84 °F. 13. 87 / 82 °F. 14. 84 / 80 °F. Detailed forecast for 14 days. Need some help? Current weather in Tokyo and forecast for today, tomorrow, and next 14 days.'}]\", additional_kwargs={'idx': 1, 'args': {'query': 'current temperature in Tokyo'}}, name='tavily_search_results_json', tool_call_id=1), FunctionMessage(content='join', additional_kwargs={'idx': 2, 'args': ()}, name='join', tool_call_id=2)]}}\n",
+      "{'join': {'messages': [AIMessage(content=\"Thought: The search result provides the current temperature in Tokyo but does not explicitly state which temperature (88 / 84 °F) corresponds to the current condition. It seems to be a range, possibly the day's high and low. Without a clear indication of the exact current temperature, it's challenging to provide a precise flashcard summary.\", id='8ef2a131-69db-4180-a76e-fd9d6f4037c1'), SystemMessage(content='Context from last attempt: The information provided does not explicitly state the current temperature in Tokyo; it provides a temperature range without specifying which is the current temperature. Need to find a source that gives the exact current temperature in Tokyo for a precise flashcard summary.', id='f5bd752c-b068-459a-8d9e-bd1f1b5fa4fe')]}}\n",
+      "{'plan_and_schedule': {'messages': [FunctionMessage(content='join', additional_kwargs={'idx': 3, 'args': ()}, name='join', tool_call_id=3)]}}\n",
+      "{'join': {'messages': [AIMessage(content=\"Thought: The search result provides a temperature range for Tokyo but does not specify the current temperature. This makes it challenging to create a precise flashcard without an exact current temperature. The user's request cannot be fully satisfied without this detail.\", id='3cc41891-4f47-4453-8edf-b989926ab25e'), SystemMessage(content='Context from last attempt: The search did not provide an exact current temperature for Tokyo, making it impossible to create a precise flashcard. A source that explicitly states the current temperature is needed for an accurate response.', id='96290b41-a4c4-4ab5-829a-89cc31dfe6c8')]}}\n",
+      "{'plan_and_schedule': {'messages': [FunctionMessage(content='join', additional_kwargs={'idx': 4, 'args': ()}, name='join', tool_call_id=4)]}}\n",
+      "{'join': {'messages': [AIMessage(content=\"Thought: The search result provides a temperature range for Tokyo but does not specify the current temperature. This makes it challenging to create a precise flashcard without an exact current temperature. The user's request cannot be fully satisfied without this detail.\", id='4724b242-ddb8-47e6-b235-de25de54fe45'), AIMessage(content='I was unable to find the exact current temperature in Tokyo. However, the temperature range for today in Tokyo is between 88°F and 84°F. For the most accurate and up-to-date temperature, I recommend checking a reliable weather forecasting website or app.', id='40e29a47-a001-4f65-a18f-65c2931d1ae5')]}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "for step in chain.stream({\"messages\":\n",
+    "    [\n",
+    "        HumanMessage(\n",
+    "            content=\"Find the current temperature in Tokyo, then, respond with a flashcard summarizing this information\"\n",
+    "        )\n",
+    "    ]}\n",
+    "):\n",
+    "    print(step)"
    ]
   },
   {


### PR DESCRIPTION
Reference to https://github.com/langchain-ai/langgraph/issues/1565 ,

Related issues: https://github.com/langchain-ai/langgraph/issues/1513 and https://github.com/langchain-ai/langgraph/issues/1459

This bug fix is an extension of this PR: [1444](https://github.com/langchain-ai/langgraph/pull/1444/files#diff-552f25122adeb48c8f6671a7add98adf73598c57907e9ebfe6c1187c6a0a26e0R656), which fixed the same issue but missed this instance of it.

## Changes:
- The function _parse_joiner_output has been changed to always have a return type of Dict {"messages": ...}, as expected
- An example has been added to show off the Replan functionality