### PR TITLE
Use a lock for all operations on sqlite checkpointer

### DIFF
--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -9784,7 +9784,6 @@ def test_doubly_nested_graph_state(
     ]
 
 
-@pytest.mark.repeat(10)
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_SYNC)
 def test_send_to_nested_graphs(
     request: pytest.FixtureRequest, checkpointer_name: str


### PR DESCRIPTION
- Otherwise when used in multiple subgraphs in parallel separate queries can interfere w each other

Closes #1586