### PR TITLE
Add support for pydantic v1 state to ToolNode

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/tool_node.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_node.py
@@ -244,14 +244,14 @@ class ToolNode(RunnableCallable):
 
 
 def tools_condition(
-    state: Union[list[AnyMessage], dict[str, Any]],
+    state: Union[list[AnyMessage], dict[str, Any], BaseModel],
 ) -> Literal["tools", "__end__"]:
     """Use in the conditional_edge to route to the ToolNode if the last message
 
     has tool calls. Otherwise, route to the end.
 
     Args:
-        state (Union[list[AnyMessage], dict[str, Any]]): The state to check for
+        state (Union[list[AnyMessage], dict[str, Any], BaseModel]): The state to check for
             tool calls. Must have a list of messages (MessageGraph) or have the
             "messages" key (StateGraph).
 
@@ -297,7 +297,9 @@ def tools_condition(
     """
     if isinstance(state, list):
         ai_message = state[-1]
-    elif messages := state.get("messages", []):
+    elif isinstance(state, dict) and (messages := state.get("messages", [])):
+        ai_message = messages[-1]
+    elif isinstance(state, BaseModel) and (messages := getattr(state, "messages", [])):
         ai_message = messages[-1]
     else:
         raise ValueError(f"No messages found in input state to tool_edge: {state}")

--- a/libs/langgraph/langgraph/prebuilt/tool_node.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_node.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -96,7 +95,7 @@ class ToolNode(RunnableCallable):
         input: Union[
             list[AnyMessage],
             dict[str, Any],
-            Type[BaseModel],
+            BaseModel,
         ],
         config: RunnableConfig,
     ) -> Any:
@@ -111,7 +110,7 @@ class ToolNode(RunnableCallable):
         input: Union[
             list[AnyMessage],
             dict[str, Any],
-            Type[BaseModel],
+            BaseModel,
         ],
         config: RunnableConfig,
     ) -> Any:
@@ -161,7 +160,7 @@ class ToolNode(RunnableCallable):
         input: Union[
             list[AnyMessage],
             dict[str, Any],
-            Type[BaseModel],
+            BaseModel,
         ],
     ) -> Tuple[List[ToolCall], Literal["list", "dict", "pydantic"]]:
         if isinstance(input, list):
@@ -203,7 +202,7 @@ class ToolNode(RunnableCallable):
         input: Union[
             list[AnyMessage],
             dict[str, Any],
-            Type[BaseModel],
+            BaseModel,
         ],
     ) -> ToolCall:
         if tool_call["name"] not in self.tools_by_name:

--- a/libs/langgraph/tests/test_prebuilt.py
+++ b/libs/langgraph/tests/test_prebuilt.py
@@ -1,5 +1,15 @@
 import json
-from typing import Annotated, Any, Callable, Dict, List, Optional, Sequence, Type, Union
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+)
 
 import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -463,6 +473,10 @@ def test_tool_node_inject_state() -> None:
         """Tool 1 docstring."""
         return msgs[0].content
 
+    class AgentState(BaseModel):
+        messages: List[AnyMessage]
+        foo: str
+
     node = ToolNode([tool1, tool2, tool3, tool4])
     for tool_name in ("tool1", "tool2", "tool3"):
         tool_call = {
@@ -473,6 +487,12 @@ def test_tool_node_inject_state() -> None:
         }
         msg = AIMessage("hi?", tool_calls=[tool_call])
         result = node.invoke({"messages": [msg], "foo": "bar"})
+        tool_message = result["messages"][-1]
+        assert tool_message.content == "bar"
+
+        # test pydantic v1 state
+        state_v1 = AgentState(messages=[msg], foo="bar")
+        result = node.invoke(state_v1)
         tool_message = result["messages"][-1]
         assert tool_message.content == "bar"
 


### PR DESCRIPTION
This pull request adds support for pydantic v1 state to the ToolNode class. The `ToolNode` class now accepts an additional input type `BaseModel` for the `input` parameter in the `_func` and `_afunc` methods. 