### PR TITLE
Return `before,after` for `__interrupt` metadata if both interrupts are configured for a node

### DIFF
--- a/libs/langgraph/langgraph/graph/graph.py
+++ b/libs/langgraph/langgraph/graph/graph.py
@@ -512,7 +512,9 @@ class CompiledGraph(Pregel):
         for key, n in self.builder.nodes.items():
             node = n.runnable
             metadata = n.metadata or {}
-            if key in self.interrupt_before_nodes:
+            if key in self.interrupt_before_nodes and key in self.interrupt_after_nodes:
+                metadata["__interrupt"] = "before,after"
+            elif key in self.interrupt_before_nodes:
                 metadata["__interrupt"] = "before"
             elif key in self.interrupt_after_nodes:
                 metadata["__interrupt"] = "after"


### PR DESCRIPTION
### Summary
This change will result in the LangGraph API `GET /assistants/<id>/graph` endpoint returning the updated `before,after` (comma separated) value. Clients (e.g. LangGraph Studio) will be able to parse this string and render appropriate UI controls.

Clients that are using the `__interrupt` field will need to migrate to support comma separated value in this field.