### PR TITLE
docs: fix typo `NodeInterupt`

### DIFF
--- a/examples/human_in_the_loop/dynamic_breakpoints.ipynb
+++ b/examples/human_in_the_loop/dynamic_breakpoints.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "In LangGraph you can add breakpoints before / after a node is executed. But oftentimes it may be helpful to **dynamically** interrupt the graph from inside a given node based on some condition. When doing so, it may also be helpful to include information about **why** that interrupt was raised.\n",
     "\n",
-    "This guide shows how you can dynamically interrupt the graph using `NodeInterupt` -- a special exception that can be raised from inside a node. Let's see it in action!\n",
+    "This guide shows how you can dynamically interrupt the graph using `NodeInterrupt` -- a special exception that can be raised from inside a node. Let's see it in action!\n",
     "\n",
     "## Setup\n",
     "\n",


### PR DESCRIPTION
I corrected a typo in the document, changing "NodeInterupt" to "NodeInterrupt".