### PR TITLE
refactor: Type narrowing for ToolNode.name

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/tool_node.py
+++ b/libs/langgraph/langgraph/prebuilt/tool_node.py
@@ -79,6 +79,8 @@ class ToolNode(RunnableCallable):
         - The `AIMessage` MUST have `tool_calls` populated.
     """
 
+    name: str = "ToolNode"
+
     def __init__(
         self,
         tools: Sequence[Union[BaseTool, Callable]],


### PR DESCRIPTION
Avoid type incompatibility when using `add_node` to add a `ToolNode`.