### PR TITLE
Added optional bool to disable parallel tool calling in prebuilt react agent

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
@@ -139,6 +139,7 @@ def create_react_agent(
     interrupt_before: Optional[Sequence[str]] = None,
     interrupt_after: Optional[Sequence[str]] = None,
     debug: bool = False,
+    disable_parallel_tool_calls: bool = False
 ) -> CompiledGraph:
     """Creates a graph that works with a chat model that utilizes tool calling.
 
@@ -426,7 +427,11 @@ def create_react_agent(
     else:
         tool_classes = tools
         tool_node = ToolNode(tool_classes)
-    model = model.bind_tools(tool_classes)
+        
+    if disable_parallel_tool_calls:
+        model = model.bind_tools(tool_classes, parallel_tool_calls=False)
+    else:
+        model = model.bind_tools(tool_classes)
 
     # Define the function that determines whether to continue or not
     def should_continue(state: AgentState):


### PR DESCRIPTION
Hey folks, 

I wanted to way to disable parallel tool calls in the prebuilt react agent so decided to modify this. 
Reason: A lot of times the agent calls the same tool in parallel, leading to increased hallucinations and sub-optimal answers. I want the agent to call one tool at a time, think about the answer, and then call the next tool if necessary. 
Unfortunately, this is not solved entirely through prompting. 

Relevant Discussion: https://github.com/langchain-ai/langgraph/discussions/1461

cc: @vbarda 