### PR TITLE
Stream subgraph output while it executes

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1417,7 +1417,7 @@ class Pregel(Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]]):
                         loop.tasks.values(),
                         timeout=self.step_timeout,
                         retry_policy=self.retry_policy,
-                        extra=lambda: aioloop.create_task(stream.wait()),
+                        get_waiter=lambda: aioloop.create_task(stream.wait()),
                     ):
                         # emit output
                         for o in output():

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -83,6 +83,7 @@ from langgraph.pregel.utils import get_new_channel_versions
 from langgraph.pregel.validate import validate_graph, validate_keys
 from langgraph.pregel.write import ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
+from langgraph.utils.aio import Queue
 from langgraph.utils.config import (
     ensure_config,
     merge_configs,
@@ -1323,11 +1324,14 @@ class Pregel(Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]]):
             ```
         """
 
-        stream = deque()
+        stream = Queue()
 
         def output() -> Iterator:
-            while stream:
-                ns, mode, payload = stream.popleft()
+            while True:
+                try:
+                    ns, mode, payload = stream.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
                 if subgraphs and isinstance(stream_mode, list):
                     yield (ns, mode, payload)
                 elif isinstance(stream_mode, list):
@@ -1337,6 +1341,7 @@ class Pregel(Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]]):
                 else:
                     yield payload
 
+        aioloop = asyncio.get_event_loop()
         config = ensure_config(self.config, config)
         callback_manager = get_async_callback_manager_for_config(config)
         run_manager = await callback_manager.on_chain_start(
@@ -1379,7 +1384,7 @@ class Pregel(Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]]):
             )
             async with AsyncPregelLoop(
                 input,
-                stream=StreamProtocol(stream.append, stream_modes),
+                stream=StreamProtocol(stream.put_nowait, stream_modes),
                 config=config,
                 store=self.store,
                 checkpointer=checkpointer,
@@ -1412,6 +1417,7 @@ class Pregel(Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]]):
                         loop.tasks.values(),
                         timeout=self.step_timeout,
                         retry_policy=self.retry_policy,
+                        extra=lambda: aioloop.create_task(stream.wait()),
                     ):
                         # emit output
                         for o in output():

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -105,6 +105,7 @@ class PregelRunner:
         loop = asyncio.get_event_loop()
         # give control back to the caller
         yield
+        # add extra task if requested
         if extra is not None:
             futures: dict[asyncio.Future, Optional[PregelExecutableTask]] = {
                 extra(): None

--- a/libs/langgraph/langgraph/utils/aio.py
+++ b/libs/langgraph/langgraph/utils/aio.py
@@ -1,0 +1,25 @@
+import asyncio
+
+
+class Queue(asyncio.Queue):
+    async def wait(self):
+        """If queue is empty, wait until an item is available."""
+        while self.empty():
+            getter = self._get_loop().create_future()
+            self._getters.append(getter)
+            try:
+                await getter
+            except:
+                getter.cancel()  # Just in case getter is not done yet.
+                try:
+                    # Clean self._getters from canceled getters.
+                    self._getters.remove(getter)
+                except ValueError:
+                    # The getter could be removed from self._getters by a
+                    # previous put_nowait call.
+                    pass
+                if not self.empty() and not getter.cancelled():
+                    # We were woken up by put_nowait(), but can't take
+                    # the call.  Wake up the next in line.
+                    self._wakeup_next(self._getters)
+                raise

--- a/libs/langgraph/langgraph/utils/aio.py
+++ b/libs/langgraph/langgraph/utils/aio.py
@@ -6,7 +6,11 @@ PY_310 = sys.version_info >= (3, 10)
 
 class Queue(asyncio.Queue):
     async def wait(self):
-        """If queue is empty, wait until an item is available."""
+        """If queue is empty, wait until an item is available.
+
+        Copied from Queue.get(), removing the call to .get_nowait(),
+        ie. this doesn't consume the item, just waits for it.
+        """
         while self.empty():
             if PY_310:
                 getter = self._get_loop().create_future()

--- a/libs/langgraph/langgraph/utils/aio.py
+++ b/libs/langgraph/langgraph/utils/aio.py
@@ -1,11 +1,17 @@
 import asyncio
+import sys
+
+PY_310 = sys.version_info >= (3, 10)
 
 
 class Queue(asyncio.Queue):
     async def wait(self):
         """If queue is empty, wait until an item is available."""
         while self.empty():
-            getter = self._get_loop().create_future()
+            if PY_310:
+                getter = self._get_loop().create_future()
+            else:
+                getter = self._loop.create_future()
             self._getters.append(getter)
             try:
                 await getter

--- a/libs/langgraph/poetry.lock
+++ b/libs/langgraph/poetry.lock
@@ -1238,7 +1238,7 @@ typing-extensions = ">=4.7"
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "1.0.9"
+version = "1.0.10"
 description = "Library with base interfaces for LangGraph checkpoint savers."
 optional = false
 python-versions = "^3.9.0,<4.0"
@@ -1255,7 +1255,7 @@ url = "../checkpoint"
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "1.0.6"
+version = "1.0.7"
 description = "Library with a Postgres implementation of LangGraph checkpoint saver."
 optional = false
 python-versions = "^3.9.0,<4.0"
@@ -3202,4 +3202,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.0,<4.0"
-content-hash = "f72e42e6f957927f9acf19a838ad5331eb2ed11f0e58df3a6d3240eafb3dc057"
+content-hash = "73c2dec0a0e833ad8742ebfca86d8e3d602a8a63671a782d21d8e0079a02d448"

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -28,7 +28,7 @@ pytest-repeat = "^0.9.3"
 langgraph-checkpoint = {path = "../checkpoint", develop = true}
 langgraph-checkpoint-sqlite = {path = "../checkpoint-sqlite", develop = true}
 langgraph-checkpoint-postgres = {path = "../checkpoint-postgres", develop = true}
-psycopg = {extras = ["binary"], version = ">=3.0.0"}
+psycopg = {extras = ["binary"], version = ">=3.0.0", python = ">=3.10"}
 uvloop = "^0.20.0"
 pyperf = "^2.7.0"
 py-spy = "^0.3.14"


### PR DESCRIPTION
- previous behavior was to buffer all output from subgraph until it finished, now subgraph steps are emitted as soon as produced, while the subgraph is still running
- this is slightly slower in benchmark scripts, but worth it as it's much "faster" in real-world latency