### PR TITLE
[Bug Fix] retry_on handling and add support for lists in RetryPolicy

### DIFF
--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import time
-from typing import Optional
+from typing import Optional, Sequence
 
 from langgraph.constants import CONFIG_KEY_RESUMING
 from langgraph.errors import GraphInterrupt
@@ -38,7 +38,7 @@ def run_with_retry(
             # increment attempts
             attempts += 1
             # check if we should retry
-            if isinstance(retry_policy.retry_on, (list, tuple)):
+            if isinstance(retry_policy.retry_on, Sequence):
                 if not isinstance(exc, tuple(retry_policy.retry_on)):
                     raise
             elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):
@@ -102,7 +102,7 @@ async def arun_with_retry(
             # increment attempts
             attempts += 1
             # check if we should retry
-            if isinstance(retry_policy.retry_on, (list, tuple)):
+            if isinstance(retry_policy.retry_on, Sequence):
                 if not isinstance(exc, tuple(retry_policy.retry_on)):
                     raise
             elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):

--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -38,11 +38,19 @@ def run_with_retry(
             # increment attempts
             attempts += 1
             # check if we should retry
-            if callable(retry_policy.retry_on):
+            if isinstance(retry_policy.retry_on, (list, tuple)):
+                if not isinstance(exc, tuple(retry_policy.retry_on)):
+                    raise
+            elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):
+                if not isinstance(exc, retry_policy.retry_on):
+                    raise
+            elif callable(retry_policy.retry_on):
                 if not retry_policy.retry_on(exc):
                     raise
-            elif not isinstance(exc, retry_policy.retry_on):
-                raise
+            else:
+                raise TypeError(
+                    "retry_on must be an Exception class, a list or tuple of Exception classes, or a callable"
+                )
             # check if we should give up
             if attempts >= retry_policy.max_attempts:
                 raise
@@ -94,11 +102,19 @@ async def arun_with_retry(
             # increment attempts
             attempts += 1
             # check if we should retry
-            if callable(retry_policy.retry_on):
+            if isinstance(retry_policy.retry_on, (list, tuple)):
+                if not isinstance(exc, tuple(retry_policy.retry_on)):
+                    raise
+            elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):
+                if not isinstance(exc, retry_policy.retry_on):
+                    raise
+            elif callable(retry_policy.retry_on):
                 if not retry_policy.retry_on(exc):
                     raise
-            elif not isinstance(exc, retry_policy.retry_on):
-                raise
+            else:
+                raise TypeError(
+                    "retry_on must be an Exception class, a list or tuple of Exception classes, or a callable"
+                )
             # check if we should give up
             if attempts >= retry_policy.max_attempts:
                 raise

--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -41,7 +41,9 @@ def run_with_retry(
             if isinstance(retry_policy.retry_on, Sequence):
                 if not isinstance(exc, tuple(retry_policy.retry_on)):
                     raise
-            elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):
+            elif isinstance(retry_policy.retry_on, type) and issubclass(
+                retry_policy.retry_on, Exception
+            ):
                 if not isinstance(exc, retry_policy.retry_on):
                     raise
             elif callable(retry_policy.retry_on):
@@ -105,7 +107,9 @@ async def arun_with_retry(
             if isinstance(retry_policy.retry_on, Sequence):
                 if not isinstance(exc, tuple(retry_policy.retry_on)):
                     raise
-            elif isinstance(retry_policy.retry_on, type) and issubclass(retry_policy.retry_on, Exception):
+            elif isinstance(retry_policy.retry_on, type) and issubclass(
+                retry_policy.retry_on, Exception
+            ):
                 if not isinstance(exc, retry_policy.retry_on):
                     raise
             elif callable(retry_policy.retry_on):

--- a/libs/langgraph/langgraph/pregel/types.py
+++ b/libs/langgraph/langgraph/pregel/types.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Any, Callable, Literal, NamedTuple, Optional, Type, Union, List
+from typing import Any, Callable, Literal, NamedTuple, Optional, Sequence, Type, Union
 
 from langchain_core.runnables import Runnable, RunnableConfig
 
@@ -52,7 +52,7 @@ class RetryPolicy(NamedTuple):
     jitter: bool = True
     """Whether to add random jitter to the interval between retries."""
     retry_on: Union[
-        Type[Exception], List[Type[Exception]], tuple[Type[Exception], ...], Callable[[Exception], bool]
+        Type[Exception], Sequence[Type[Exception]], Callable[[Exception], bool]
     ] = default_retry_on
     """List of exception classes that should trigger a retry, or a callable that returns True for exceptions that should trigger a retry."""
 

--- a/libs/langgraph/langgraph/pregel/types.py
+++ b/libs/langgraph/langgraph/pregel/types.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Any, Callable, Literal, NamedTuple, Optional, Type, Union
+from typing import Any, Callable, Literal, NamedTuple, Optional, Type, Union, List
 
 from langchain_core.runnables import Runnable, RunnableConfig
 
@@ -52,7 +52,7 @@ class RetryPolicy(NamedTuple):
     jitter: bool = True
     """Whether to add random jitter to the interval between retries."""
     retry_on: Union[
-        Type[Exception], tuple[Type[Exception], ...], Callable[[Exception], bool]
+        Type[Exception], List[Type[Exception]], tuple[Type[Exception], ...], Callable[[Exception], bool]
     ] = default_retry_on
     """List of exception classes that should trigger a retry, or a callable that returns True for exceptions that should trigger a retry."""
 


### PR DESCRIPTION
This PR addresses two issues in the run_with_retry function:

* Exception Classes Misidentified as Callables:
    Issue: Exception classes are callable, leading callable(retry_policy.retry_on) to mistakenly treat them as callables for custom retry logic.

* No Support for Lists in retry_on:
    Issue: retry_on accepted only exception classes, tuples, or callables, not lists of exceptions (as defined in the documentation)

Summary of Changes:
* Modified retry_on type annotation to include List[Type[Exception]].
* Updated run_with_retry to handle lists and tuples when checking exceptions.
* Ensured exception classes are not incorrectly treated as callables.
* Added a TypeError if retry_on is of an unsupported type.
