### PR TITLE
docs: Clarify default_retry_on retry behavior for exceptions

### DIFF
--- a/docs/docs/how-tos/node-retries.ipynb
+++ b/docs/docs/how-tos/node-retries.ipynb
@@ -99,7 +99,9 @@
     "*   `ReferenceError`\n",
     "*   `StopIteration`\n",
     "*   `StopAsyncIteration`\n",
-    "*   `OSError`"
+    "*   `OSError`\n",
+    "\n",
+    "In addition, for exceptions from popular http request libraries such as `requests` and `httpx` it only retries on 5xx status codes."
    ]
   },
   {

--- a/docs/docs/how-tos/node-retries.ipynb
+++ b/docs/docs/how-tos/node-retries.ipynb
@@ -86,6 +86,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "By default, the `retry_on` parameter uses the `default_retry_on` function, which retries on any exception except for the following:\n",
+    "\n",
+    "*   `ValueError`\n",
+    "*   `TypeError`\n",
+    "*   `ArithmeticError`\n",
+    "*   `ImportError`\n",
+    "*   `LookupError`\n",
+    "*   `NameError`\n",
+    "*   `SyntaxError`\n",
+    "*   `RuntimeError`\n",
+    "*   `ReferenceError`\n",
+    "*   `StopIteration`\n",
+    "*   `StopAsyncIteration`\n",
+    "*   `OSError`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If you want more information on what each of the parameters does, be sure to read the [reference](https://langchain-ai.github.io/langgraph/reference/graphs/#retrypolicy).\n",
     "\n",
     "## Passing a retry policy to a node\n",


### PR DESCRIPTION
In the tutorial, added a code cell that briefly explains which exceptions the `default_retry_on` function retries on by default.

This information cannot be found in the tutorial or references, and can only be determined by examining the code directly.

This addition clarifies which exceptions will trigger a retry, helping users better understand the default retry behavior.