### PR TITLE
docs: fix quick start example code

### DIFF
--- a/docs/docs/tutorials/introduction.ipynb
+++ b/docs/docs/tutorials/introduction.ipynb
@@ -295,7 +295,7 @@
     "    if user_input.lower() in [\"quit\", \"exit\", \"q\"]:\n",
     "        print(\"Goodbye!\")\n",
     "        break\n",
-    "    for event in graph.stream({\"messages\": (\"user\", user_input)}):\n",
+    "    for event in graph.stream({\"messages\": [(\"user\", user_input)]}):\n",
     "        for value in event.values():\n",
     "            print(\"Assistant:\", value[\"messages\"][-1].content)"
    ]


### PR DESCRIPTION
Encountered following error when running the example:

TypeError: can only concatenate list (not "tuple") to list