### PR TITLE
docs: add guide for entity memory

### DIFF
--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -24,6 +24,7 @@ LangGraph makes it easy to persist state across graph runs. The guide below show
 - [How to manage conversation history](memory/manage-conversation-history.ipynb)
 - [How to delete messages](memory/delete-messages.ipynb)
 - [How to add summary conversation memory](memory/add-summary-conversation-history.ipynb)
+- [How to add memory of structured entities](memory/entity-memory.ipynb)
 - [How to use Postgres checkpointer for persistence](persistence_postgres.ipynb)
 - [How to create a custom checkpointer using MongoDB](persistence_mongodb.ipynb)
 - [How to create a custom checkpointer using Redis](persistence_redis.ipynb)

--- a/docs/docs/how-tos/memory/entity-memory.ipynb
+++ b/docs/docs/how-tos/memory/entity-memory.ipynb
@@ -5,7 +5,7 @@
    "id": "5aed9b90-b9f1-4345-a0bf-389ec8eda39e",
    "metadata": {},
    "source": [
-    "# How to add memory of named entities\n",
+    "# How to add memory of structured entities\n",
     "\n",
     "One strategy for managing long conversation histories is to restrict what information is stored \"long-term\". For example, instead of storing messages verbatim, an application can persist selected facts that it learns during the conversation.\n",
     "\n",

--- a/docs/docs/how-tos/memory/entity-memory.ipynb
+++ b/docs/docs/how-tos/memory/entity-memory.ipynb
@@ -7,85 +7,156 @@
    "source": [
     "# How to add memory of named entities\n",
     "\n",
-    "One strategy for managing long conversation histories is to restrict what information is stored \"long-term\". For example, instead of storing messages verbatim, an application can persist selected facts that it learns during the conversation."
+    "One strategy for managing long conversation histories is to restrict what information is stored \"long-term\". For example, instead of storing messages verbatim, an application can persist selected facts that it learns during the conversation.\n",
+    "\n",
+    "This guide demonstrates how to persist structured information that is scoped to individual users. We demonstrate two methods:\n",
+    "\n",
+    "1. Using LangGraph's built-in [persistence layer](https://langchain-ai.github.io/langgraph/how-tos/persistence/);\n",
+    "2. Using an external knowledge base.\n",
+    "\n",
+    "## Using built-in persistence\n",
+    "\n",
+    "LangGraph supports built-in persistence via a selection of backends, including in-memory, SQLite, and Postgres. See the persistence [documentation](https://langchain-ai.github.io/langgraph/how-tos/persistence/) for details on these. Below we will use a simple in-memory checkpointer.\n",
+    "\n",
+    "Our strategy is to add fields to the state that are shared across threads (e.g., threads belonging to a specific user). We do this by compiling the graph with a [MemoryStore](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.graph.CompiledGraph.store) and annotating a field of the state with `SharedValue`.\n",
+    "\n",
+    "In the example below, we build a simple application that persists facts learned about the user."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b61b5837-0b2d-4da5-9c63-5c8e44688861",
+   "id": "943638d6-f6c3-42b6-a44d-6080cfd665b8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.documents import Document\n",
-    "from langchain_core.runnables.config import ensure_config\n",
-    "from langchain_core.tools import tool\n",
-    "from langchain_core.vectorstores import InMemoryVectorStore\n",
-    "from langchain_openai import ChatOpenAI, OpenAIEmbeddings\n",
-    "from langgraph.prebuilt import create_react_agent\n",
-    "from typing_extensions import TypedDict\n",
+    "from typing import Literal, TypedDict, Annotated\n",
+    "import uuid\n",
+    "\n",
+    "from langgraph.graph.message import MessagesState\n",
+    "from langgraph.graph.state import StateGraph\n",
+    "from langgraph.store.memory import MemoryStore\n",
+    "from langgraph.managed.shared_value import SharedValue\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
     "\n",
     "\n",
-    "class KnowledgeTriple(TypedDict):\n",
-    "    subject: str\n",
-    "    predicate: str\n",
-    "    object_: str\n",
+    "class State(MessagesState):\n",
+    "    # We use an info key to track information\n",
+    "    # This is scoped to a user_id, so it will be information specific to each user\n",
+    "    info: Annotated[dict[str, dict], SharedValue.on(\"user_id\")]\n",
     "\n",
     "\n",
-    "vector_store = InMemoryVectorStore(OpenAIEmbeddings())\n",
+    "# We will give this as a tool to the agent\n",
+    "# This will let the agent call this tool to save a fact\n",
+    "class Info(TypedDict):\n",
+    "    \"\"\"This tool should be called when you want to save a new fact about the user.\n",
     "\n",
-    "@tool\n",
-    "def update_knowledge_store(knowledge_triple: KnowledgeTriple) -> None:\n",
-    "    \"\"\"Add a new knowledge triple to the knowledge store.\"\"\"\n",
-    "    serialized = \" \".join(knowledge_triple.values())\n",
-    "    config_dict = ensure_config()\n",
-    "    user_id = config_dict[\"configurable\"].get(\"user_id\")\n",
-    "    document = Document(\n",
-    "        serialized,\n",
-    "        metadata={\n",
-    "            \"subject\": knowledge_triple[\"subject\"],\n",
-    "            \"user_id\": user_id,\n",
-    "        },\n",
-    "    )\n",
-    "    vector_store.add_documents([document])\n",
+    "    Attributes:\n",
+    "        fact (str): A fact about the user.\n",
+    "        topic (str): The topic related the fact is about, i.e. Food, Location, Movies, etc.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    fact: str\n",
+    "    topic: str\n",
     "\n",
     "\n",
-    "@tool\n",
-    "def fetch_knowledge(query: str) -> str:\n",
-    "    \"\"\"Fetch facts from the knowledge store.\"\"\"\n",
-    "    config_dict = ensure_config()\n",
-    "    user_id = config_dict[\"configurable\"].get(\"user_id\")\n",
-    "    def _filter_function(doc: Document) -> bool:\n",
-    "        return doc.metadata.get(\"user_id\") == user_id\n",
+    "# This is the prompt we give the agent\n",
+    "# We will pass known info into the prompt\n",
+    "# We will tell it to use the Info tool to save more\n",
+    "prompt = \"\"\"You are a helpful assistant that learns about users to provide better assistance.\n",
     "\n",
-    "    documents = vector_store.similarity_search(\n",
-    "        query, k=3, filter=_filter_function\n",
-    "    )\n",
-    "    return \"\\n\\n\".join(document.page_content for document in documents)\n",
+    "Current user information:\n",
+    "\n",
+    "{info}\n",
     "\n",
     "\n",
-    "tools = [update_knowledge_store, fetch_knowledge]\n",
+    "Instructions:\n",
+    "1. Use the `Info` tool to save new information the user shares.\n",
+    "2. Save facts, opinions, preferences, and experiences.\n",
+    "3. Your goal: Improve assistance by building a user profile over time.\n",
     "\n",
-    "llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
-    "\n",
-    "system_message = \"\"\"\n",
-    "You are a friendly assistant. When you are told a fact about a person,\n",
-    "use the `update_knowledge_store` tool to store that fact via a\n",
-    "subject, predicate, object triple.\n",
-    "\n",
-    "Only update the knowledge store if you are told a material fact.\n",
-    "\n",
-    "If you require facts about a person to answer a query, use the\n",
-    "`fetch_knowledge` tool to retrieve relevant facts.\n",
+    "Remember: Every piece of information helps you serve the user better in future interactions.\n",
     "\"\"\"\n",
     "\n",
-    "app = create_react_agent(llm, tools, state_modifier=system_message)"
+    "\n",
+    "# We give the model access to the Info tool\n",
+    "model = ChatOpenAI().bind_tools([Info])\n",
+    "\n",
+    "\n",
+    "def call_model(state: State):\n",
+    "    \"\"\"Call the model.\"\"\"\n",
+    "    # The info value here is scoped to the user_id\n",
+    "    info = \"\\n\".join([d[\"fact\"] for d in state[\"info\"].values()])\n",
+    "    # Format system prompt\n",
+    "    system_msg = prompt.format(info=info)\n",
+    "    # Call model\n",
+    "    response = model.invoke(\n",
+    "        [{\"role\": \"system\", \"content\": system_msg}] + state[\"messages\"]\n",
+    "    )\n",
+    "    return {\"messages\": [response]}\n",
+    "\n",
+    "\n",
+    "# Routing function to decide what to do next\n",
+    "# If no tool calls, then we end\n",
+    "# If tool calls, then we update memory\n",
+    "def route(state) -> Literal[\"__end__\", \"update_memory\"]:\n",
+    "    if len(state[\"messages\"][-1].tool_calls) == 0:\n",
+    "        return \"__end__\"\n",
+    "    else:\n",
+    "        return \"update_memory\"\n",
+    "\n",
+    "\n",
+    "def update_memory(state: State):\n",
+    "    \"\"\"Update the memory.\"\"\"\n",
+    "    tool_calls = []\n",
+    "    memories = {}\n",
+    "    # Each tool call is a new memory to save\n",
+    "    for tc in state[\"messages\"][-1].tool_calls:\n",
+    "        # We append ToolMessages (to pass back to the LLM)\n",
+    "        # This is needed because OpenAI requires each tool call be followed by a ToolMessage\n",
+    "        tool_calls.append(\n",
+    "            {\"role\": \"tool\", \"content\": \"Saved!\", \"tool_call_id\": tc[\"id\"]}\n",
+    "        )\n",
+    "        # We create a new memory from this tool call\n",
+    "        memories[str(uuid.uuid4())] = {\n",
+    "            \"fact\": tc[\"args\"][\"fact\"],\n",
+    "            \"topic\": tc[\"args\"][\"topic\"],\n",
+    "        }\n",
+    "    # Return the messages and memories to update the state with\n",
+    "    return {\"messages\": tool_calls, \"info\": memories}\n",
+    "\n",
+    "\n",
+    "# This is the in memory checkpointer we will use\n",
+    "# We need this because we want to enable threads (conversations)\n",
+    "memory = MemorySaver()\n",
+    "\n",
+    "# This is the in memory Key Value store\n",
+    "# This is needed to save the memories\n",
+    "kv = MemoryStore()\n",
+    "\n",
+    "# Construct this relatively simple graph\n",
+    "graph = StateGraph(State)\n",
+    "graph.add_node(call_model)\n",
+    "graph.add_node(update_memory)\n",
+    "graph.add_edge(\"update_memory\", \"__end__\")\n",
+    "graph.add_edge(\"__start__\", \"call_model\")\n",
+    "graph.add_conditional_edges(\"call_model\", route, [\"__end__\", \"update_memory\"])\n",
+    "graph = graph.compile(checkpointer=memory, store=kv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bf6dc58-e4c5-4e02-a9b0-ec6ce0f277a9",
+   "metadata": {},
+   "source": [
+    "At the start, the application functions like a simple chatbot:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8cee7be4-b99e-404e-9fa0-988365fdcf86",
+   "id": "06ed7f27-111d-40cd-a6cf-bbfc6c087889",
    "metadata": {},
    "outputs": [
     {
@@ -94,26 +165,35 @@
      "text": [
       "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
-      "Hi I'm Alice, how are you?\n",
+      "hi\n",
       "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
       "\n",
-      "Hello Alice! I'm just a program, so I don't have feelings, but I'm here and ready to help you. How can I assist you today?\n"
+      "Hello! How can I assist you today?\n"
      ]
     }
    ],
    "source": [
-    "config = {\"configurable\": {\"thread_id\": \"abc123\", \"user_id\": \"user_1\"}}\n",
-    "query = \"Hi I'm Alice, how are you?\"\n",
+    "config = {\"configurable\": {\"user_id\": \"abc\", \"thread_id\": \"abc1\"}}\n",
     "\n",
-    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "# First let's just say hi to the AI\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}, config, stream_mode=\"values\"\n",
+    "):\n",
     "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35767718-8f7f-465a-a4f9-ec595c2f9290",
+   "metadata": {},
+   "source": [
+    "Given a statement about the user, the LLM can elect to store it for future reference:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d74d0595-1e34-41e8-9fc7-c61190b3a26f",
+   "id": "640a4ec3-7fd2-494f-81d6-57e1707c8b27",
    "metadata": {},
    "outputs": [
     {
@@ -122,25 +202,41 @@
      "text": [
       "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
-      "What's my name?\n",
+      "I like pepperoni pizza\n",
       "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  Info (call_imzMyN5FzHd8LeRWVk8Pic5h)\n",
+      " Call ID: call_imzMyN5FzHd8LeRWVk8Pic5h\n",
+      "  Args:\n",
+      "    fact: likes pepperoni pizza\n",
+      "    topic: Food\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
       "\n",
-      "I don't have your name yet. If you tell me, I can remember it for you!\n"
+      "Saved!\n"
      ]
     }
    ],
    "source": [
-    "query = \"What's my name?\"\n",
-    "\n",
-    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"I like pepperoni pizza\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
     "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df3e67ad-b194-49ec-908f-c0550e9f159a",
+   "metadata": {},
+   "source": [
+    "Note that the application can then reference this statement in a separate thread for the same `user_id` as before:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "05e96141-1293-4d5b-be19-172e3dbb215d",
+   "id": "1032587c-7e0b-4cca-8824-8fb31406d483",
    "metadata": {},
    "outputs": [
     {
@@ -149,127 +245,198 @@
      "text": [
       "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
-      "Bob likes apples.\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "Tool Calls:\n",
-      "  update_knowledge_store (call_nYa8eaRfzsfzQ5p1iBnniprv)\n",
-      " Call ID: call_nYa8eaRfzsfzQ5p1iBnniprv\n",
-      "  Args:\n",
-      "    knowledge_triple: {'subject': 'Bob', 'predicate': 'likes', 'object_': 'apples'}\n",
-      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: update_knowledge_store\n",
-      "\n",
-      "null\n",
+      "What should I have for dinner?\n",
       "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
       "\n",
-      "I've stored the fact that Bob likes apples. If you have more information or questions, feel free to share!\n"
+      "How about trying a delicious pepperoni pizza for dinner? It seems like you enjoy pepperoni pizza. Would you like me to remember that for future suggestions?\n"
      ]
     }
    ],
    "source": [
-    "query = \"Bob likes apples.\"\n",
+    "config = {\"configurable\": {\"user_id\": \"abc\", \"thread_id\": \"abc2\"}}\n",
     "\n",
-    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"What should I have for dinner?\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
     "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80e688c3-60ff-4640-8142-2b49659affa0",
+   "metadata": {},
+   "source": [
+    "Inspecting the `MemoryStore`, we can observe the facts that have been stored so far:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "a2d87d91-36e0-4cea-8432-8f0672cae64e",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "================================\u001b[1m Human Message \u001b[0m=================================\n",
-      "\n",
-      "What does Bob like to eat?\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "Tool Calls:\n",
-      "  fetch_knowledge (call_mxnUxjOw2PVRfi5lVNgWMC8e)\n",
-      " Call ID: call_mxnUxjOw2PVRfi5lVNgWMC8e\n",
-      "  Args:\n",
-      "    query: Bob\n",
-      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: fetch_knowledge\n",
-      "\n",
-      "Bob likes apples\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "\n",
-      "Bob likes apples.\n"
-     ]
-    }
-   ],
-   "source": [
-    "query = \"What does Bob like to eat?\"\n",
-    "\n",
-    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
-    "    event[\"messages\"][-1].pretty_print()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "8d318811-5109-49ed-99ba-cad05af2a455",
+   "id": "d0a686c4-c453-439b-88f3-dc55f173c2cb",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[Document(id='bd7486ee-cb8e-4167-ae2b-ef973aa0bb90', metadata={'subject': 'Bob', 'user_id': 'user_1'}, page_content='Bob likes apples')]"
+       "{'0a48f184-af25-4f9e-adb9-f8fb620641e6': {'fact': 'likes pepperoni pizza',\n",
+       "  'topic': 'Food'}}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "vector_store.similarity_search(\"Bob\")"
+    "user_id = \"abc\"\n",
+    "\n",
+    "kv.data[f\"scoped:user_id:info:{user_id}\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3877fb60-c8e9-4e10-8591-f62f821a64b1",
+   "metadata": {},
+   "source": [
+    "Note that information is scoped to a `user_id`, so runs only reference facts for the given user. Below, the same query from a different user is given an uninformed answer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cb30797d-aaab-4c47-9e77-af20d793616c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What should I have for dinner?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "What type of cuisine are you in the mood for? Do you have any dietary preferences or restrictions?\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = {\"configurable\": {\"user_id\": \"def\", \"thread_id\": \"def1\"}}\n",
+    "\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"What should I have for dinner?\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8487adf-b9ee-4768-bd51-28b59e588a2b",
+   "metadata": {},
+   "source": [
+    "## Using an external knowledge-base\n",
+    "\n",
+    "If desired, we can update our application to instead reference an external knowledge base. Below, we make these changes:\n",
+    "1. We instantiate a knowledge base, here using a simple vector store (though key-value stores and other knowledge bases will work equally well);\n",
+    "2. We use the built-in `MessagesState` (without the new `info` key);\n",
+    "3. We update the `call_model` node to reference a `user_id` from the run-time configuration and pull from the knowledge base;\n",
+    "4. We update the `update_memory` node to similarly persist to the knowledge base.\n",
+    "\n",
+    "We then compile the graph as before, this time without a `MemoryStore`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "967a5ddc-f3fb-4f3e-9432-f833c47cd438",
+   "id": "22608452-39c8-4d81-841f-6f3b9412352a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain_core.messages import BaseMessage, trim_messages\n",
-    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "from langchain_core.documents import Document\n",
+    "from langchain_core.runnables import RunnableConfig\n",
+    "from langchain_core.tools import tool\n",
+    "from langchain_core.vectorstores import InMemoryVectorStore\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
     "\n",
     "\n",
-    "def state_modifier(state) -> list[BaseMessage]:\n",
-    "    \"\"\"Given the agent state, return a list of messages for the chat model.\"\"\"\n",
-    "    return trim_messages(\n",
-    "        state[\"messages\"],\n",
-    "        token_counter=len,  # specifying `len` will count messages\n",
-    "        max_tokens=4,  # retain up to 5 messages.\n",
-    "        strategy=\"last\",\n",
-    "        start_on=(\"human\", \"ai\"),\n",
-    "        include_system=True,\n",
-    "        allow_partial=False,\n",
+    "vector_store = InMemoryVectorStore(OpenAIEmbeddings())\n",
+    "\n",
+    "\n",
+    "def call_model(state: MessagesState, config: RunnableConfig):\n",
+    "    \"\"\"Call the model.\"\"\"\n",
+    "\n",
+    "    # Fetch user info from knowledge base\n",
+    "    user_id = config[\"configurable\"].get(\"user_id\")\n",
+    "    def _filter_function(doc: Document) -> bool:\n",
+    "        return doc.metadata.get(\"user_id\") == user_id\n",
+    "\n",
+    "    documents = vector_store.similarity_search(\n",
+    "        state[\"messages\"][-1].content, k=3, filter=_filter_function\n",
     "    )\n",
+    "    # Serialize info\n",
+    "    info = \"\\n\".join(document.page_content for document in documents)\n",
+    "    # Format system prompt\n",
+    "    system_msg = prompt.format(info=info)\n",
+    "    # Call model\n",
+    "    response = model.invoke(\n",
+    "        [{\"role\": \"system\", \"content\": system_msg}] + state[\"messages\"]\n",
+    "    )\n",
+    "    return {\"messages\": [response]}\n",
     "\n",
     "\n",
-    "checkpointer = MemorySaver()\n",
+    "def update_memory(state: MessagesState, config: RunnableConfig):\n",
+    "    \"\"\"Update the memory.\"\"\"\n",
+    "    tool_calls = []\n",
+    "    memories = {}\n",
+    "    user_id = config[\"configurable\"].get(\"user_id\")\n",
+    "    # Each tool call is a new memory to save\n",
+    "    for tc in state[\"messages\"][-1].tool_calls:\n",
+    "        # We append ToolMessages (to pass back to the LLM)\n",
+    "        # This is needed because OpenAI requires each tool call be followed by a ToolMessage\n",
+    "        tool_calls.append(\n",
+    "            {\"role\": \"tool\", \"content\": \"Saved!\", \"tool_call_id\": tc[\"id\"]}\n",
+    "        )\n",
+    "        # We create a new memory from this tool call\n",
+    "        serialized = str(\n",
+    "            {\n",
+    "                \"fact\": tc[\"args\"][\"fact\"],\n",
+    "                \"topic\": tc[\"args\"][\"topic\"],\n",
+    "            }\n",
+    "        )\n",
+    "        document = Document(serialized, metadata={\"user_id\": user_id})\n",
+    "        vector_store.add_documents([document])\n",
+    "        \n",
+    "    # Return the messages and memories to update the state with\n",
+    "    return {\"messages\": tool_calls}\n",
     "\n",
-    "app = create_react_agent(\n",
-    "    llm,\n",
-    "    tools,\n",
-    "    state_modifier=state_modifier,\n",
-    "    checkpointer=checkpointer,\n",
-    ")"
+    "\n",
+    "memory = MemorySaver()\n",
+    "\n",
+    "graph = StateGraph(state_schema=MessagesState)\n",
+    "graph.add_node(call_model)\n",
+    "graph.add_node(update_memory)\n",
+    "graph.add_edge(\"update_memory\", \"__end__\")\n",
+    "graph.add_edge(\"__start__\", \"call_model\")\n",
+    "graph.add_conditional_edges(\"call_model\", route, [\"__end__\", \"update_memory\"])\n",
+    "graph = graph.compile(checkpointer=memory)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2832dc17-4f2a-4976-98d1-967b1e407646",
+   "metadata": {},
+   "source": [
+    "Repeating the conversation from before, we see that the application can incorporate information scoped to the user in the same way:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e12d032c-c89a-41cb-902e-f26a5f9509e6",
+   "id": "fd3c7d96-c0d7-439e-be7b-d73244f09b1f",
    "metadata": {},
    "outputs": [
     {
@@ -278,47 +445,26 @@
      "text": [
       "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
-      "Bob is my friend.\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "Tool Calls:\n",
-      "  update_knowledge_store (call_75RzxpGDvU53vVovS4aImKUv)\n",
-      " Call ID: call_75RzxpGDvU53vVovS4aImKUv\n",
-      "  Args:\n",
-      "    knowledge_triple: {'subject': 'Bob', 'predicate': 'is a friend of', 'object_': 'User'}\n",
-      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: update_knowledge_store\n",
-      "\n",
-      "null\n",
+      "hi\n",
       "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
       "\n",
-      "I've stored the fact that Bob is your friend. If you have more information about Bob or anyone else, feel free to share!\n"
+      "Hello! How can I assist you today?\n"
      ]
     }
    ],
    "source": [
-    "config = {\"configurable\": {\"thread_id\": \"abc234\", \"user_id\": \"user_1\"}}\n",
+    "config = {\"configurable\": {\"user_id\": \"abc\", \"thread_id\": \"abc1\"}}\n",
     "\n",
-    "prior_messages = [\n",
-    "    {\"role\": \"system\", \"content\": system_message},\n",
-    "    {\"role\": \"user\", \"content\": \"Bob likes apples.\"},\n",
-    "    {\"role\": \"assistant\", \"content\": \"Nice, good to know.\"},\n",
-    "    {\"role\": \"user\", \"content\": \"What is 2+2?\"},\n",
-    "    {\"role\": \"assistant\", \"content\": \"Four.\"},\n",
-    "    {\"role\": \"user\", \"content\": \"Thanks.\"},\n",
-    "    {\"role\": \"assistant\", \"content\": \"You're welcome!\"},\n",
-    "]\n",
-    "\n",
-    "query = \"Bob is my friend.\"\n",
-    "\n",
-    "input_messages = prior_messages + [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}, config, stream_mode=\"values\"\n",
+    "):\n",
     "    event[\"messages\"][-1].pretty_print()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "d336056d-a565-4c49-be4c-eafcdcf10d20",
+   "execution_count": 9,
+   "id": "e22ec002-bd44-46e4-888e-b7ec57cf6ea2",
    "metadata": {},
    "outputs": [
     {
@@ -327,32 +473,137 @@
      "text": [
       "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
-      "What does my friend like to eat? Use the tool.\n",
+      "I like pepperoni pizza\n",
       "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
       "Tool Calls:\n",
-      "  fetch_knowledge (call_tN1mBQgAzJ16lXZ3jQPhHQGk)\n",
-      " Call ID: call_tN1mBQgAzJ16lXZ3jQPhHQGk\n",
+      "  Info (call_FRRoHg5EtNVlKrrD004NYFUn)\n",
+      " Call ID: call_FRRoHg5EtNVlKrrD004NYFUn\n",
       "  Args:\n",
-      "    query: friend likes to eat\n",
+      "    fact: likes pepperoni pizza\n",
+      "    topic: Food\n",
       "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
-      "Name: fetch_knowledge\n",
       "\n",
-      "Bob likes apples\n",
-      "\n",
-      "Bob is a friend of User\n",
-      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
-      "\n",
-      "Your friend Bob likes to eat apples.\n"
+      "Saved!\n"
      ]
     }
    ],
    "source": [
-    "query = \"What does my friend like to eat? Use the tool.\"\n",
-    "\n",
-    "input_messages = prior_messages + [{\"role\": \"user\", \"content\": query}]\n",
-    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"I like pepperoni pizza\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
     "    event[\"messages\"][-1].pretty_print()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2bc3381d-97d1-4c72-aaf4-1634f56962eb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What should I have for dinner?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "How about trying a delicious pepperoni pizza for dinner? It seems like you enjoy pepperoni pizza!\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = {\"configurable\": {\"user_id\": \"abc\", \"thread_id\": \"abc2\"}}\n",
+    "\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"What should I have for dinner?\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fea66d8-347e-4d99-96ea-ff87a24ad09c",
+   "metadata": {},
+   "source": [
+    "We can inspect the contents of the knowledge base, this time via the vector store instead of the application state:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "eb386074-c447-4e61-8b8b-a3eb09aa9101",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'd29293dd-d9f6-49c9-8898-84b42c1ea02d',\n",
+       " 'text': \"{'fact': 'likes pepperoni pizza', 'topic': 'Food'}\",\n",
+       " 'metadata': {'user_id': 'abc'}}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entry = list(vector_store.store.values())[0]\n",
+    "\n",
+    "{k: v for k, v in entry.items() if k != \"vector\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff661944-6e1e-48e5-afc4-d047d855df87",
+   "metadata": {},
+   "source": [
+    "Note that as before, runs only reference information for the user specified in the input configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a012be39-dd12-42a9-9788-1c18b4170b8f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What should I have for dinner?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I can recommend some dinner options based on your preferences. Do you have any specific dietary restrictions or food preferences?\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = {\"configurable\": {\"user_id\": \"def\", \"thread_id\": \"def1\"}}\n",
+    "\n",
+    "for event in graph.stream(\n",
+    "    {\"messages\": [{\"role\": \"user\", \"content\": \"What should I have for dinner?\"}]},\n",
+    "    config,\n",
+    "    stream_mode=\"values\",\n",
+    "):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef7c7ca3-11ba-41ae-aab7-03233e1e73aa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/docs/how-tos/memory/entity-memory.ipynb
+++ b/docs/docs/how-tos/memory/entity-memory.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5aed9b90-b9f1-4345-a0bf-389ec8eda39e",
+   "metadata": {},
+   "source": [
+    "# How to add memory of named entities\n",
+    "\n",
+    "One strategy for managing long conversation histories is to restrict what information is stored \"long-term\". For example, instead of storing messages verbatim, an application can persist selected facts that it learns during the conversation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b61b5837-0b2d-4da5-9c63-5c8e44688861",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.documents import Document\n",
+    "from langchain_core.runnables.config import ensure_config\n",
+    "from langchain_core.tools import tool\n",
+    "from langchain_core.vectorstores import InMemoryVectorStore\n",
+    "from langchain_openai import ChatOpenAI, OpenAIEmbeddings\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "from typing_extensions import TypedDict\n",
+    "\n",
+    "\n",
+    "class KnowledgeTriple(TypedDict):\n",
+    "    subject: str\n",
+    "    predicate: str\n",
+    "    object_: str\n",
+    "\n",
+    "\n",
+    "vector_store = InMemoryVectorStore(OpenAIEmbeddings())\n",
+    "\n",
+    "@tool\n",
+    "def update_knowledge_store(knowledge_triple: KnowledgeTriple) -> None:\n",
+    "    \"\"\"Add a new knowledge triple to the knowledge store.\"\"\"\n",
+    "    serialized = \" \".join(knowledge_triple.values())\n",
+    "    config_dict = ensure_config()\n",
+    "    user_id = config_dict[\"configurable\"].get(\"user_id\")\n",
+    "    document = Document(\n",
+    "        serialized,\n",
+    "        metadata={\n",
+    "            \"subject\": knowledge_triple[\"subject\"],\n",
+    "            \"user_id\": user_id,\n",
+    "        },\n",
+    "    )\n",
+    "    vector_store.add_documents([document])\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def fetch_knowledge(query: str) -> str:\n",
+    "    \"\"\"Fetch facts from the knowledge store.\"\"\"\n",
+    "    config_dict = ensure_config()\n",
+    "    user_id = config_dict[\"configurable\"].get(\"user_id\")\n",
+    "    def _filter_function(doc: Document) -> bool:\n",
+    "        return doc.metadata.get(\"user_id\") == user_id\n",
+    "\n",
+    "    documents = vector_store.similarity_search(\n",
+    "        query, k=3, filter=_filter_function\n",
+    "    )\n",
+    "    return \"\\n\\n\".join(document.page_content for document in documents)\n",
+    "\n",
+    "\n",
+    "tools = [update_knowledge_store, fetch_knowledge]\n",
+    "\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\")\n",
+    "\n",
+    "system_message = \"\"\"\n",
+    "You are a friendly assistant. When you are told a fact about a person,\n",
+    "use the `update_knowledge_store` tool to store that fact via a\n",
+    "subject, predicate, object triple.\n",
+    "\n",
+    "Only update the knowledge store if you are told a material fact.\n",
+    "\n",
+    "If you require facts about a person to answer a query, use the\n",
+    "`fetch_knowledge` tool to retrieve relevant facts.\n",
+    "\"\"\"\n",
+    "\n",
+    "app = create_react_agent(llm, tools, state_modifier=system_message)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8cee7be4-b99e-404e-9fa0-988365fdcf86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi I'm Alice, how are you?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello Alice! I'm just a program, so I don't have feelings, but I'm here and ready to help you. How can I assist you today?\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = {\"configurable\": {\"thread_id\": \"abc123\", \"user_id\": \"user_1\"}}\n",
+    "query = \"Hi I'm Alice, how are you?\"\n",
+    "\n",
+    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d74d0595-1e34-41e8-9fc7-c61190b3a26f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's my name?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I don't have your name yet. If you tell me, I can remember it for you!\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What's my name?\"\n",
+    "\n",
+    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "05e96141-1293-4d5b-be19-172e3dbb215d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Bob likes apples.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  update_knowledge_store (call_nYa8eaRfzsfzQ5p1iBnniprv)\n",
+      " Call ID: call_nYa8eaRfzsfzQ5p1iBnniprv\n",
+      "  Args:\n",
+      "    knowledge_triple: {'subject': 'Bob', 'predicate': 'likes', 'object_': 'apples'}\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: update_knowledge_store\n",
+      "\n",
+      "null\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I've stored the fact that Bob likes apples. If you have more information or questions, feel free to share!\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Bob likes apples.\"\n",
+    "\n",
+    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a2d87d91-36e0-4cea-8432-8f0672cae64e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What does Bob like to eat?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  fetch_knowledge (call_mxnUxjOw2PVRfi5lVNgWMC8e)\n",
+      " Call ID: call_mxnUxjOw2PVRfi5lVNgWMC8e\n",
+      "  Args:\n",
+      "    query: Bob\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: fetch_knowledge\n",
+      "\n",
+      "Bob likes apples\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Bob likes apples.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What does Bob like to eat?\"\n",
+    "\n",
+    "input_messages = [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8d318811-5109-49ed-99ba-cad05af2a455",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Document(id='bd7486ee-cb8e-4167-ae2b-ef973aa0bb90', metadata={'subject': 'Bob', 'user_id': 'user_1'}, page_content='Bob likes apples')]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vector_store.similarity_search(\"Bob\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "967a5ddc-f3fb-4f3e-9432-f833c47cd438",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import BaseMessage, trim_messages\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "\n",
+    "\n",
+    "def state_modifier(state) -> list[BaseMessage]:\n",
+    "    \"\"\"Given the agent state, return a list of messages for the chat model.\"\"\"\n",
+    "    return trim_messages(\n",
+    "        state[\"messages\"],\n",
+    "        token_counter=len,  # specifying `len` will count messages\n",
+    "        max_tokens=4,  # retain up to 5 messages.\n",
+    "        strategy=\"last\",\n",
+    "        start_on=(\"human\", \"ai\"),\n",
+    "        include_system=True,\n",
+    "        allow_partial=False,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "checkpointer = MemorySaver()\n",
+    "\n",
+    "app = create_react_agent(\n",
+    "    llm,\n",
+    "    tools,\n",
+    "    state_modifier=state_modifier,\n",
+    "    checkpointer=checkpointer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e12d032c-c89a-41cb-902e-f26a5f9509e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Bob is my friend.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  update_knowledge_store (call_75RzxpGDvU53vVovS4aImKUv)\n",
+      " Call ID: call_75RzxpGDvU53vVovS4aImKUv\n",
+      "  Args:\n",
+      "    knowledge_triple: {'subject': 'Bob', 'predicate': 'is a friend of', 'object_': 'User'}\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: update_knowledge_store\n",
+      "\n",
+      "null\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I've stored the fact that Bob is your friend. If you have more information about Bob or anyone else, feel free to share!\n"
+     ]
+    }
+   ],
+   "source": [
+    "config = {\"configurable\": {\"thread_id\": \"abc234\", \"user_id\": \"user_1\"}}\n",
+    "\n",
+    "prior_messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_message},\n",
+    "    {\"role\": \"user\", \"content\": \"Bob likes apples.\"},\n",
+    "    {\"role\": \"assistant\", \"content\": \"Nice, good to know.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"What is 2+2?\"},\n",
+    "    {\"role\": \"assistant\", \"content\": \"Four.\"},\n",
+    "    {\"role\": \"user\", \"content\": \"Thanks.\"},\n",
+    "    {\"role\": \"assistant\", \"content\": \"You're welcome!\"},\n",
+    "]\n",
+    "\n",
+    "query = \"Bob is my friend.\"\n",
+    "\n",
+    "input_messages = prior_messages + [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d336056d-a565-4c49-be4c-eafcdcf10d20",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What does my friend like to eat? Use the tool.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  fetch_knowledge (call_tN1mBQgAzJ16lXZ3jQPhHQGk)\n",
+      " Call ID: call_tN1mBQgAzJ16lXZ3jQPhHQGk\n",
+      "  Args:\n",
+      "    query: friend likes to eat\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: fetch_knowledge\n",
+      "\n",
+      "Bob likes apples\n",
+      "\n",
+      "Bob is a friend of User\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Your friend Bob likes to eat apples.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What does my friend like to eat? Use the tool.\"\n",
+    "\n",
+    "input_messages = prior_messages + [{\"role\": \"user\", \"content\": query}]\n",
+    "for event in app.stream({\"messages\": input_messages}, config, stream_mode=\"values\"):\n",
+    "    event[\"messages\"][-1].pretty_print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
           - Manage conversation history: how-tos/memory/manage-conversation-history.ipynb
           - Delete messages: how-tos/memory/delete-messages.ipynb
           - Add summary of the conversation history: how-tos/memory/add-summary-conversation-history.ipynb
+          - Add memory of structured entities: how-tos/memory/entity-memory.ipynb
           - Use Postgres checkpointer for persistence: how-tos/persistence_postgres.ipynb
           - Create custom checkpointer using MongoDB: how-tos/persistence_mongodb.ipynb
           - Create custom checkpointer using Redis: how-tos/persistence_redis.ipynb


### PR DESCRIPTION
This guide is intended to help users transition from a class of legacy memory abstractions. See guides in v0.1 LangChain docs here:
- https://python.langchain.com/v0.1/docs/modules/memory/types/entity_summary_memory/
- https://python.langchain.com/v0.1/docs/modules/memory/types/kg/

Note: the existing [shared state](https://langchain-ai.github.io/langgraph/how-tos/memory/shared-state/) guide already demonstrates this functionality. Here we add a guide focusing on the "conversation memory" problem that:

1. Covers the same solution;
2. Adds a section showing how to use an external knowledge base, instead of the LangGraph persistence layer, if desired.

If we'd rather not maintain such similar content in two places, we can also direct users to the existing shared state guide.