### PR TITLE
Add rollback to postgres saver setup

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -94,6 +94,7 @@ class PostgresSaver(BasePostgresSaver):
                     version = row["v"]
             except UndefinedTable:
                 version = -1
+                cur.connection.rollback()
             for v, migration in zip(
                 range(version + 1, len(self.MIGRATIONS)),
                 self.MIGRATIONS[version + 1 :],

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -102,6 +102,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     version = row["v"]
             except UndefinedTable:
                 version = -1
+                cur.connection.rollback()
             for v, migration in zip(
                 range(version + 1, len(self.MIGRATIONS)),
                 self.MIGRATIONS[version + 1 :],


### PR DESCRIPTION
When I try to use the `PostgresSaver` I'm getting the following error:

```
  File "/<redacted>/.venv/lib/python3.12/site-packages/langgraph/checkpoint/postgres/__init__.py", line 106, in setup
    cur.execute(migration)
  File "/<redacted>/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block
```

Adding the rollbacks in the `except UndefinedTable` clause seems to fix it and the tables get created successfully.

I consistently hit this error and the change consistently fixes it. I'm not sure how others have avoided this issue. But it doesn't seem like it should cause an issue for anyone as doing an extra rollback shouldn't hurt when the only thing before it is a select query.

Let me know if you'd like me to contribute a unit test or file a separate issue, it just seemed like a small change.