### PR TITLE
docs: Add linting check as part of docs deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -41,6 +41,10 @@ jobs:
           poetry install --with docs
           poetry run pip install -U pytest pytest-check-links langsmith langchain GitPython
 
+      - name: Lint Docs
+        # This step lints the docs using the existing linting set up.
+        # It should be very fast and should not require any external services.
+        run: make lint-docs
       - name: Build site
         run: make build-docs
         env:


### PR DESCRIPTION
We'll need to add the same thing as part of CI testing, but a second check
during deployment wont hurt in case CI is by passed for whatever reason.
