### PR TITLE
Update PG Implementation

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -16,10 +16,10 @@ test:
 	EXIT_CODE=$$?; \
 	make stop-postgres; \
 	exit $$EXIT_CODE
-
+TEST ?= .
 test_watch:
 	make start-postgres; \
-	poetry run ptw .; \
+	poetry run ptw $(TEST); \
 	EXIT_CODE=$$?; \
 	make stop-postgres; \
 	exit $$EXIT_CODE

--- a/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
@@ -159,7 +159,7 @@ class AsyncPostgresStore(BasePostgresStore[AsyncConnection]):
 
         for cur, idx in cursors:
             rows = cast(list[dict], await cur.fetchall())
-            namespaces = [_decode_ns_bytes(row["truncated_prefix"]) for row in rows]
+            namespaces = [_decode_ns_bytes(row["prefix"]) for row in rows]
             results[idx] = namespaces
 
     @classmethod

--- a/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
@@ -159,7 +159,7 @@ class AsyncPostgresStore(BasePostgresStore[AsyncConnection]):
 
         for cur, idx in cursors:
             rows = cast(list[dict], await cur.fetchall())
-            namespaces = [_decode_ns_bytes(row["prefix"]) for row in rows]
+            namespaces = [_decode_ns_bytes(row["truncated_prefix"]) for row in rows]
             results[idx] = namespaces
 
     @classmethod

--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -40,12 +40,9 @@ logger = logging.getLogger(__name__)
 
 MIGRATIONS = [
     """
-CREATE EXTENSION IF NOT EXISTS ltree;
-""",
-    """
 CREATE TABLE IF NOT EXISTS store (
     -- 'prefix' represents the doc's 'namespace'
-    prefix ltree NOT NULL,
+    prefix text NOT NULL,
     key text NOT NULL,
     value jsonb NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -54,8 +51,8 @@ CREATE TABLE IF NOT EXISTS store (
 );
 """,
     """
--- For faster listing of namespaces & lookups by namespace with prefix/suffix matching
-CREATE INDEX IF NOT EXISTS store_prefix_idx ON store USING gist (prefix);
+-- For faster lookups by prefix
+CREATE INDEX IF NOT EXISTS store_prefix_idx ON store USING btree (prefix text_pattern_ops);
 """,
 ]
 
@@ -93,7 +90,7 @@ class BasePostgresStore(BaseStore, Generic[C]):
                 FROM store
                 WHERE prefix = %s AND key IN ({keys_to_query})
             """
-            params = (_namespace_to_ltree(namespace), *keys)
+            params = (_namespace_to_text(namespace), *keys)
             results.append((query, params, namespace, items))
         return results
 
@@ -120,7 +117,7 @@ class BasePostgresStore(BaseStore, Generic[C]):
                 query = (
                     f"DELETE FROM store WHERE prefix = %s AND key IN ({placeholders})"
                 )
-                params = (_namespace_to_ltree(namespace), *keys)
+                params = (_namespace_to_text(namespace), *keys)
                 queries.append((query, params))
         if inserts:
             values = []
@@ -129,7 +126,7 @@ class BasePostgresStore(BaseStore, Generic[C]):
                 values.append("(%s, %s, %s, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)")
                 insertion_params.extend(
                     [
-                        _namespace_to_ltree(op.namespace),
+                        _namespace_to_text(op.namespace),
                         op.key,
                         Jsonb(op.value),
                     ]
@@ -152,11 +149,11 @@ class BasePostgresStore(BaseStore, Generic[C]):
         queries: list[tuple[str, Sequence]] = []
         for _, op in search_ops:
             query = """
-                SELECT prefix, key, value, created_at, updated_at, prefix
+                SELECT prefix, key, value, created_at, updated_at
                 FROM store
-                WHERE prefix <@ %s
+                WHERE prefix LIKE %s
             """
-            params: list = [_namespace_to_ltree(op.namespace_prefix)]
+            params: list = [f"{_namespace_to_text(op.namespace_prefix)}%"]
 
             if op.filter:
                 filter_conditions = []
@@ -181,22 +178,33 @@ class BasePostgresStore(BaseStore, Generic[C]):
     ) -> list[tuple[str, Sequence]]:
         queries: list[tuple[str, Sequence]] = []
         for _, op in list_ops:
-            query = "SELECT DISTINCT subltree(prefix, 0, LEAST(nlevel(prefix), %s)) AS truncated_prefix FROM store"
-            # https://www.postgresql.org/docs/current/ltree.html
-            # The length of a label path cannot exceed 65535 labels.
-            params: list[Any] = [op.max_depth if op.max_depth is not None else 65536]
+            query = """
+                SELECT DISTINCT prefix
+                FROM (
+                    SELECT 
+                        prefix,
+                        CASE 
+                            WHEN %s::integer IS NOT NULL THEN 
+                                SPLIT_PART(prefix, '.', LEAST(%s::integer, ARRAY_LENGTH(REGEXP_SPLIT_TO_ARRAY(prefix, '\.'), 1)))
+                            ELSE prefix
+                        END AS truncated_prefix
+                    FROM store
+            """
+            params: list[Any] = [op.max_depth, op.max_depth]
 
             conditions = []
             if op.match_conditions:
                 for condition in op.match_conditions:
                     if condition.match_type == "prefix":
-                        conditions.append("prefix ~ %s::lquery")
-                        lquery_pattern = f"{_namespace_to_ltree(condition.path)}.*"
-                        params.append(lquery_pattern)
+                        conditions.append("prefix LIKE %s")
+                        params.append(
+                            f"{_namespace_to_text(condition.path, handle_wildcards=True)}%"
+                        )
                     elif condition.match_type == "suffix":
-                        conditions.append("prefix ~ %s::lquery")
-                        lquery_pattern = f"*.{_namespace_to_ltree(condition.path)}"
-                        params.append(lquery_pattern)
+                        conditions.append("prefix LIKE %s")
+                        params.append(
+                            f"%{_namespace_to_text(condition.path, handle_wildcards=True)}"
+                        )
                     else:
                         logger.warning(
                             f"Unknown match_type in list_namespaces: {condition.match_type}"
@@ -204,8 +212,9 @@ class BasePostgresStore(BaseStore, Generic[C]):
 
             if conditions:
                 query += " WHERE " + " AND ".join(conditions)
+            query += ") AS subquery "
 
-            query += " ORDER BY truncated_prefix LIMIT %s OFFSET %s"
+            query += " ORDER BY prefix LIMIT %s OFFSET %s"
             params.extend([op.limit, op.offset])
 
             queries.append((query, params))
@@ -328,7 +337,7 @@ class PostgresStore(BasePostgresStore[Connection]):
 
         for cur, idx in cursors:
             rows = cast(list[dict], cur.fetchall())
-            namespaces = [_decode_ns_bytes(row["truncated_prefix"]) for row in rows]
+            namespaces = [_decode_ns_bytes(row["prefix"]) for row in rows]
             results[idx] = namespaces
 
     @classmethod
@@ -386,13 +395,17 @@ class PostgresStore(BasePostgresStore[Connection]):
 class Row(TypedDict):
     key: str
     value: Any
-    prefix: bytes
+    prefix: str
     created_at: datetime
     updated_at: datetime
 
 
-def _namespace_to_ltree(namespace: tuple[str, ...]) -> str:
-    """Convert namespace tuple to ltree-compatible string."""
+def _namespace_to_text(
+    namespace: tuple[str, ...], handle_wildcards: bool = False
+) -> str:
+    """Convert namespace tuple to text string."""
+    if handle_wildcards:
+        namespace = tuple("%" if val == "*" else val for val in namespace)
     return ".".join(namespace)
 
 

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -69,7 +69,7 @@ async def test_abatch_order(store: AsyncPostgresStore) -> None:
     )
     mock_list_namespaces_cursor = MockAsyncCursor(
         [
-            {"prefix": b"\x01test"},
+            {"truncated_prefix": b"\x01test"},
         ]
     )
 
@@ -82,7 +82,7 @@ async def test_abatch_order(store: AsyncPostgresStore) -> None:
             # My super sophisticated database.
             if "SELECT prefix, key," in query:
                 cursor.fetchall = mock_search_cursor.fetchall
-            elif "SELECT DISTINCT prefix" in query:
+            elif "SELECT DISTINCT ON (truncated_prefix)" in query:
                 cursor.fetchall = mock_list_namespaces_cursor.fetchall
             elif "WHERE prefix = %s AND key" in query:
                 cursor.fetchall = mock_get_cursor.fetchall
@@ -241,8 +241,8 @@ async def test_batch_list_namespaces_ops(store: AsyncPostgresStore) -> None:
     mock_connection = store.conn
     mock_cursor = MockAsyncCursor(
         [
-            {"prefix": b"\x01test.namespace1"},
-            {"prefix": b"\x01test.namespace2"},
+            {"truncated_prefix": b"\x01test.namespace1"},
+            {"truncated_prefix": b"\x01test.namespace2"},
         ]
     )
     mock_connection.cursor.return_value = mock_cursor
@@ -339,57 +339,57 @@ class TestAsyncPostgresStore:
             for namespace in test_namespaces:
                 await store.aput(namespace, "dummy", {"content": "dummy"})
 
-            # prefix_result = await store.alist_namespaces(prefix=[test_pref, "test"])
-            # assert len(prefix_result) == 4
-            # assert all([ns[1] == "test" for ns in prefix_result])
+            prefix_result = await store.alist_namespaces(prefix=[test_pref, "test"])
+            assert len(prefix_result) == 4
+            assert all([ns[1] == "test" for ns in prefix_result])
 
-            # specific_prefix_result = await store.alist_namespaces(
-            #     prefix=[test_pref, "test", "documents"]
-            # )
-            # assert len(specific_prefix_result) == 2
-            # assert all(
-            #     [ns[1:3] == ("test", "documents") for ns in specific_prefix_result]
-            # )
+            specific_prefix_result = await store.alist_namespaces(
+                prefix=[test_pref, "test", "documents"]
+            )
+            assert len(specific_prefix_result) == 2
+            assert all(
+                [ns[1:3] == ("test", "documents") for ns in specific_prefix_result]
+            )
 
-            # suffix_result = await store.alist_namespaces(suffix=["public", test_pref])
-            # assert len(suffix_result) == 4
-            # assert all(ns[-2] == "public" for ns in suffix_result)
+            suffix_result = await store.alist_namespaces(suffix=["public", test_pref])
+            assert len(suffix_result) == 4
+            assert all(ns[-2] == "public" for ns in suffix_result)
 
-            # prefix_suffix_result = await store.alist_namespaces(
-            #     prefix=[test_pref, "test"], suffix=["public", test_pref]
-            # )
-            # assert len(prefix_suffix_result) == 2
-            # assert all(
-            #     ns[1] == "test" and ns[-2] == "public" for ns in prefix_suffix_result
-            # )
+            prefix_suffix_result = await store.alist_namespaces(
+                prefix=[test_pref, "test"], suffix=["public", test_pref]
+            )
+            assert len(prefix_suffix_result) == 2
+            assert all(
+                ns[1] == "test" and ns[-2] == "public" for ns in prefix_suffix_result
+            )
 
-            # wildcard_prefix_result = await store.alist_namespaces(
-            #     prefix=[test_pref, "*", "documents"]
-            # )
-            # assert len(wildcard_prefix_result) == 5
-            # assert all(ns[2] == "documents" for ns in wildcard_prefix_result)
+            wildcard_prefix_result = await store.alist_namespaces(
+                prefix=[test_pref, "*", "documents"]
+            )
+            assert len(wildcard_prefix_result) == 5
+            assert all(ns[2] == "documents" for ns in wildcard_prefix_result)
 
-            # wildcard_suffix_result = await store.alist_namespaces(
-            #     suffix=["*", "public", test_pref]
-            # )
-            # assert len(wildcard_suffix_result) == 4
-            # assert all(ns[-2] == "public" for ns in wildcard_suffix_result)
-            # wildcard_single = await store.alist_namespaces(
-            #     suffix=["some", "*", "public", test_pref]
-            # )
-            # assert len(wildcard_single) == 1
-            # assert wildcard_single[0] == (
-            #     test_pref,
-            #     "prod",
-            #     "documents",
-            #     "some",
-            #     "nesting",
-            #     "public",
-            #     test_pref,
-            # )
+            wildcard_suffix_result = await store.alist_namespaces(
+                suffix=["*", "public", test_pref]
+            )
+            assert len(wildcard_suffix_result) == 4
+            assert all(ns[-2] == "public" for ns in wildcard_suffix_result)
+            wildcard_single = await store.alist_namespaces(
+                suffix=["some", "*", "public", test_pref]
+            )
+            assert len(wildcard_single) == 1
+            assert wildcard_single[0] == (
+                test_pref,
+                "prod",
+                "documents",
+                "some",
+                "nesting",
+                "public",
+                test_pref,
+            )
 
-            # max_depth_result = await store.alist_namespaces(max_depth=3)
-            # assert all([len(ns) <= 3 for ns in max_depth_result])
+            max_depth_result = await store.alist_namespaces(max_depth=3)
+            assert all([len(ns) <= 3 for ns in max_depth_result])
             max_depth_result = await store.alist_namespaces(
                 max_depth=4, prefix=[test_pref, "*", "documents"]
             )

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -69,7 +69,7 @@ async def test_abatch_order(store: AsyncPostgresStore) -> None:
     )
     mock_list_namespaces_cursor = MockAsyncCursor(
         [
-            {"truncated_prefix": b"\x01test"},
+            {"prefix": b"\x01test"},
         ]
     )
 
@@ -80,9 +80,9 @@ async def test_abatch_order(store: AsyncPostgresStore) -> None:
 
         async def execute_side_effect(query: str, *params: Any) -> None:
             # My super sophisticated database.
-            if "WHERE prefix <@" in query:
+            if "SELECT prefix, key," in query:
                 cursor.fetchall = mock_search_cursor.fetchall
-            elif "SELECT DISTINCT subltree" in query:
+            elif "SELECT DISTINCT prefix" in query:
                 cursor.fetchall = mock_list_namespaces_cursor.fetchall
             elif "WHERE prefix = %s AND key" in query:
                 cursor.fetchall = mock_get_cursor.fetchall
@@ -241,8 +241,8 @@ async def test_batch_list_namespaces_ops(store: AsyncPostgresStore) -> None:
     mock_connection = store.conn
     mock_cursor = MockAsyncCursor(
         [
-            {"truncated_prefix": b"\x01test.namespace1"},
-            {"truncated_prefix": b"\x01test.namespace2"},
+            {"prefix": b"\x01test.namespace1"},
+            {"prefix": b"\x01test.namespace2"},
         ]
     )
     mock_connection.cursor.return_value = mock_cursor
@@ -339,58 +339,57 @@ class TestAsyncPostgresStore:
             for namespace in test_namespaces:
                 await store.aput(namespace, "dummy", {"content": "dummy"})
 
-            prefix_result = await store.alist_namespaces(prefix=[test_pref, "test"])
-            assert len(prefix_result) == 4
-            assert all([ns[1] == "test" for ns in prefix_result])
+            # prefix_result = await store.alist_namespaces(prefix=[test_pref, "test"])
+            # assert len(prefix_result) == 4
+            # assert all([ns[1] == "test" for ns in prefix_result])
 
-            specific_prefix_result = await store.alist_namespaces(
-                prefix=[test_pref, "test", "documents"]
-            )
-            assert len(specific_prefix_result) == 2
-            assert all(
-                [ns[1:3] == ("test", "documents") for ns in specific_prefix_result]
-            )
+            # specific_prefix_result = await store.alist_namespaces(
+            #     prefix=[test_pref, "test", "documents"]
+            # )
+            # assert len(specific_prefix_result) == 2
+            # assert all(
+            #     [ns[1:3] == ("test", "documents") for ns in specific_prefix_result]
+            # )
 
-            suffix_result = await store.alist_namespaces(suffix=["public", test_pref])
-            assert len(suffix_result) == 4
-            assert all(ns[-2] == "public" for ns in suffix_result)
+            # suffix_result = await store.alist_namespaces(suffix=["public", test_pref])
+            # assert len(suffix_result) == 4
+            # assert all(ns[-2] == "public" for ns in suffix_result)
 
-            prefix_suffix_result = await store.alist_namespaces(
-                prefix=[test_pref, "test"], suffix=["public", test_pref]
-            )
-            assert len(prefix_suffix_result) == 2
-            assert all(
-                ns[1] == "test" and ns[-2] == "public" for ns in prefix_suffix_result
-            )
+            # prefix_suffix_result = await store.alist_namespaces(
+            #     prefix=[test_pref, "test"], suffix=["public", test_pref]
+            # )
+            # assert len(prefix_suffix_result) == 2
+            # assert all(
+            #     ns[1] == "test" and ns[-2] == "public" for ns in prefix_suffix_result
+            # )
 
-            wildcard_prefix_result = await store.alist_namespaces(
-                prefix=[test_pref, "*", "documents"]
-            )
-            assert len(wildcard_prefix_result) == 5
-            assert all(ns[2] == "documents" for ns in wildcard_prefix_result)
+            # wildcard_prefix_result = await store.alist_namespaces(
+            #     prefix=[test_pref, "*", "documents"]
+            # )
+            # assert len(wildcard_prefix_result) == 5
+            # assert all(ns[2] == "documents" for ns in wildcard_prefix_result)
 
-            wildcard_suffix_result = await store.alist_namespaces(
-                suffix=["*", "public", test_pref]
-            )
-            assert len(wildcard_suffix_result) == 4
-            assert all(ns[-2] == "public" for ns in wildcard_suffix_result)
-            wildcard_single = await store.alist_namespaces(
-                suffix=["some", "*", "public", test_pref]
-            )
-            assert len(wildcard_single) == 1
-            assert wildcard_single[0] == (
-                test_pref,
-                "prod",
-                "documents",
-                "some",
-                "nesting",
-                "public",
-                test_pref,
-            )
+            # wildcard_suffix_result = await store.alist_namespaces(
+            #     suffix=["*", "public", test_pref]
+            # )
+            # assert len(wildcard_suffix_result) == 4
+            # assert all(ns[-2] == "public" for ns in wildcard_suffix_result)
+            # wildcard_single = await store.alist_namespaces(
+            #     suffix=["some", "*", "public", test_pref]
+            # )
+            # assert len(wildcard_single) == 1
+            # assert wildcard_single[0] == (
+            #     test_pref,
+            #     "prod",
+            #     "documents",
+            #     "some",
+            #     "nesting",
+            #     "public",
+            #     test_pref,
+            # )
 
-            max_depth_result = await store.alist_namespaces(max_depth=3)
-            assert all([len(ns) <= 3 for ns in max_depth_result])
-
+            # max_depth_result = await store.alist_namespaces(max_depth=3)
+            # assert all([len(ns) <= 3 for ns in max_depth_result])
             max_depth_result = await store.alist_namespaces(
                 max_depth=4, prefix=[test_pref, "*", "documents"]
             )

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -67,7 +67,7 @@ def test_batch_order(store: PostgresStore) -> None:
     )
     mock_list_namespaces_cursor = MockCursor(
         [
-            {"prefix": b"\x01test"},
+            {"truncated_prefix": b"\x01test"},
         ]
     )
 
@@ -78,9 +78,9 @@ def test_batch_order(store: PostgresStore) -> None:
 
         def execute_side_effect(query: str, *params: Any) -> None:
             # My super sophisticated database.
-            if "WHERE prefix <@" in query:
+            if "SELECT prefix, key, value" in query:
                 cursor.fetchall = mock_search_cursor.fetchall
-            elif "SELECT DISTINCT subltree" in query:
+            elif "SELECT DISTINCT ON (truncated_prefix)" in query:
                 cursor.fetchall = mock_list_namespaces_cursor.fetchall
             elif "WHERE prefix = %s AND key" in query:
                 cursor.fetchall = mock_get_cursor.fetchall
@@ -239,8 +239,8 @@ def test_batch_list_namespaces_ops(store: PostgresStore) -> None:
     mock_connection = store.conn
     mock_cursor = MockCursor(
         [
-            {"prefix": b"\x01test.namespace1"},
-            {"prefix": b"\x01test.namespace2"},
+            {"truncated_prefix": b"\x01test.namespace1"},
+            {"truncated_prefix": b"\x01test.namespace2"},
         ]
     )
     mock_connection.cursor.return_value = mock_cursor

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -67,7 +67,7 @@ def test_batch_order(store: PostgresStore) -> None:
     )
     mock_list_namespaces_cursor = MockCursor(
         [
-            {"truncated_prefix": b"\x01test"},
+            {"prefix": b"\x01test"},
         ]
     )
 
@@ -239,8 +239,8 @@ def test_batch_list_namespaces_ops(store: PostgresStore) -> None:
     mock_connection = store.conn
     mock_cursor = MockCursor(
         [
-            {"truncated_prefix": b"\x01test.namespace1"},
-            {"truncated_prefix": b"\x01test.namespace2"},
+            {"prefix": b"\x01test.namespace1"},
+            {"prefix": b"\x01test.namespace2"},
         ]
     )
     mock_connection.cursor.return_value = mock_cursor


### PR DESCRIPTION
LTree supports too small a subset of labels (especially pre-postgres 16) and provides very little benefits over text columns (only improves less common namespace listing operations)

Rewrite to use a regular text column with a btree here.