### PR TITLE
checkpoint: set CheckpointNS `ConfigurableFieldSpec` model default to empty string

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -178,7 +178,7 @@ CheckpointNS = ConfigurableFieldSpec(
     annotation=str,
     name="Checkpoint NS",
     description='Checkpoint namespace. Denotes the path to the subgraph node the checkpoint originates from, separated by `|` character, e.g. `"child|grandchild"`. Defaults to "" (root graph).',
-    default=None,
+    default='',
     is_shared=True,
 )
 

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -178,7 +178,7 @@ CheckpointNS = ConfigurableFieldSpec(
     annotation=str,
     name="Checkpoint NS",
     description='Checkpoint namespace. Denotes the path to the subgraph node the checkpoint originates from, separated by `|` character, e.g. `"child|grandchild"`. Defaults to "" (root graph).',
-    default='',
+    default="",
     is_shared=True,
 )
 


### PR DESCRIPTION
In the Checkpointer Base schema definitions, the default value for the CheckpointNS column is an empty string: [link](https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py#L40). 

However, in the ConfigurableFieldSpec, the default is None, which then makes model validation of configs hard, since the default is set to None which gets converted to NULL in postgres, and causes errors when trying to `aput` checkpoints into the database.

Specifically, like doing `model(**config).model_dump()` will turn `{'configurable': {'thread_id': '9517384e-1307-49bc-9456-158b8b8a003c'}` into like ` {'configurable': {'checkpoint_id': None, 'checkpoint_ns': None, 'thread_id': '9517384e-1307-49bc-9456-158b8b8a003c'}`)

This change fixes that by bringing the field spec in line with the db schema.

