### PR TITLE
Handle pandas DataFrame conversion to JSON-friendly format

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -3,6 +3,7 @@ import decimal
 import importlib
 import json
 import pathlib
+import pandas as pd
 import re
 from collections import deque
 from datetime import date, datetime, time, timedelta, timezone
@@ -128,6 +129,8 @@ class JsonPlusSerializer(SerializerProtocol):
             )
         elif isinstance(obj, BaseException):
             return repr(obj)
+        elif isinstance(obj, pd.DataFrame):
+            return self._encode_constructor_args(pd.DataFrame, method="from_dict", args=[obj.to_dict()])
         else:
             raise TypeError(
                 f"Object of type {obj.__class__.__name__} is not JSON serializable"


### PR DESCRIPTION
This pull request enhances the `JsonPlusSerializer` class to handle the serialization and deserialization of `pandas.DataFrame` objects. Previously, the class could not serialize `pandas.DataFrame` objects. 

This update improves support for data science workflows where `pandas.DataFrame` objects need to be serialized or passed between different components.