### PR TITLE
sdk-py: Add `Sequence[dict]` type to `values` param type for `update_state()`

### DIFF
--- a/libs/sdk-py/langgraph_sdk/client.py
+++ b/libs/sdk-py/langgraph_sdk/client.py
@@ -1056,7 +1056,7 @@ class ThreadsClient:
     async def update_state(
         self,
         thread_id: str,
-        values: dict,
+        values: Optional[Union[dict, Sequence[dict]]],
         *,
         as_node: Optional[str] = None,
         checkpoint: Optional[Checkpoint] = None,
@@ -3117,7 +3117,7 @@ class SyncThreadsClient:
     def update_state(
         self,
         thread_id: str,
-        values: dict,
+        values: Optional[Union[dict, Sequence[dict]]],
         *,
         as_node: Optional[str] = None,
         checkpoint: Optional[Checkpoint] = None,


### PR DESCRIPTION
### Summary
The LangGraph API supports a list of `dict` for the `values` field for the `POST /threads/<thread_id>/state` endpoint.

Reference: https://github.com/langchain-ai/langgraph-api/blob/main/api/openapi.json#L3005-L3021