### PR TITLE
fix(sdk-js): pass checkpoint when creating run

### DIFF
--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -664,6 +664,12 @@ export class RunsClient extends BaseClient {
     event: StreamEvent;
     data: any;
   }> {
+    if (!!payload?.checkpointId && !!payload?.checkpoint) {
+      throw new Error(
+        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
+      );
+    }
+
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,
@@ -674,6 +680,7 @@ export class RunsClient extends BaseClient {
       assistant_id: assistantId,
       interrupt_before: payload?.interruptBefore,
       interrupt_after: payload?.interruptAfter,
+      checkpoint: payload?.checkpoint,
       checkpoint_id: payload?.checkpointId,
       webhook: payload?.webhook,
       multitask_strategy: payload?.multitaskStrategy,
@@ -748,6 +755,12 @@ export class RunsClient extends BaseClient {
     assistantId: string,
     payload?: RunsCreatePayload,
   ): Promise<Run> {
+    if (!!payload?.checkpointId && !!payload?.checkpoint) {
+      throw new Error(
+        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
+      );
+    }
+
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,
@@ -756,6 +769,7 @@ export class RunsClient extends BaseClient {
       interrupt_before: payload?.interruptBefore,
       interrupt_after: payload?.interruptAfter,
       webhook: payload?.webhook,
+      checkpoint: payload?.checkpoint,
       checkpoint_id: payload?.checkpointId,
       multitask_strategy: payload?.multitaskStrategy,
       after_seconds: payload?.afterSeconds,
@@ -815,6 +829,12 @@ export class RunsClient extends BaseClient {
     assistantId: string,
     payload?: RunsWaitPayload,
   ): Promise<ThreadState["values"]> {
+    if (!!payload?.checkpointId && !!payload?.checkpoint) {
+      throw new Error(
+        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
+      );
+    }
+
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,
@@ -822,6 +842,7 @@ export class RunsClient extends BaseClient {
       assistant_id: assistantId,
       interrupt_before: payload?.interruptBefore,
       interrupt_after: payload?.interruptAfter,
+      checkpoint: payload?.checkpoint,
       checkpoint_id: payload?.checkpointId,
       webhook: payload?.webhook,
       multitask_strategy: payload?.multitaskStrategy,

--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -664,12 +664,6 @@ export class RunsClient extends BaseClient {
     event: StreamEvent;
     data: any;
   }> {
-    if (!!payload?.checkpointId && !!payload?.checkpoint) {
-      throw new Error(
-        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
-      );
-    }
-
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,
@@ -755,12 +749,6 @@ export class RunsClient extends BaseClient {
     assistantId: string,
     payload?: RunsCreatePayload,
   ): Promise<Run> {
-    if (!!payload?.checkpointId && !!payload?.checkpoint) {
-      throw new Error(
-        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
-      );
-    }
-
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,
@@ -829,12 +817,6 @@ export class RunsClient extends BaseClient {
     assistantId: string,
     payload?: RunsWaitPayload,
   ): Promise<ThreadState["values"]> {
-    if (!!payload?.checkpointId && !!payload?.checkpoint) {
-      throw new Error(
-        "Cannot specify both a checkpoint and a checkpoint ID in the payload.",
-      );
-    }
-
     const json: Record<string, any> = {
       input: payload?.input,
       config: payload?.config,

--- a/libs/sdk-js/src/types.ts
+++ b/libs/sdk-js/src/types.ts
@@ -34,7 +34,6 @@ interface RunsInvokePayload {
 
   /**
    * Checkpoint ID for when creating a new run.
-   * @deprecated Use `checkpoint` instead.
    */
   checkpointId?: string;
 

--- a/libs/sdk-js/src/types.ts
+++ b/libs/sdk-js/src/types.ts
@@ -1,4 +1,4 @@
-import { Config, Metadata } from "./schema.js";
+import { Checkpoint, Config, Metadata } from "./schema.js";
 
 export type StreamMode = "values" | "messages" | "updates" | "events" | "debug";
 export type MultitaskStrategy = "reject" | "interrupt" | "rollback" | "enqueue";
@@ -34,8 +34,14 @@ interface RunsInvokePayload {
 
   /**
    * Checkpoint ID for when creating a new run.
+   * @deprecated Use `checkpoint` instead.
    */
   checkpointId?: string;
+
+  /**
+   * Checkpoint for when creating a new run.
+   */
+  checkpoint?: Omit<Checkpoint, "thread_id">;
 
   /**
    * Interrupt execution before entering these nodes.


### PR DESCRIPTION
- **fix(sdk-js): allow passing `checkpoint` when creating a run**
- **Remove error warning**
- **Remove deprecated message**
