### PR TITLE
Fix(docs): InMemoryStore example error

### DIFF
--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -185,7 +185,7 @@ application_context = "chitchat"
 namespace = (user_id, application_context)
 store.put(namespace, "a-memory", {"rules": ["User likes short, direct language", "User only speaks English & python"], "my-key": "my-value"})
 # get the "memory" by ID
-item = store.get(namespace, key="a-memory")
+item = store.get(namespace, "a-memory")
 # list "memories" within this namespace, filtering on content equivalence
 items = store.search(namespace, filter={"my-key": "my-value"})
 ```

--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -183,7 +183,7 @@ store = InMemoryStore()
 user_id = "my-user"
 application_context = "chitchat"
 namespace = (user_id, application_context)
-store.put(namespace, key="a-memory", value={"rules": ["User likes short, direct language", "User only speaks English & python"], "my-key": "my-value"})
+store.put(namespace, "a-memory", {"rules": ["User likes short, direct language", "User only speaks English & python"], "my-key": "my-value"})
 # get the "memory" by ID
 item = store.get(namespace, key="a-memory")
 # list "memories" within this namespace, filtering on content equivalence

--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -183,9 +183,9 @@ store = InMemoryStore()
 user_id = "my-user"
 application_context = "chitchat"
 namespace = (user_id, application_context)
-store.put(namespace, key="a-memory", {"rules": ["User likes short, direct language", "User only speaks English & python"], "my-key": "my-value"})
+store.put(namespace, key="a-memory", value={"rules": ["User likes short, direct language", "User only speaks English & python"], "my-key": "my-value"})
 # get the "memory" by ID
-item = store.get(namespace)
+item = store.get(namespace, key="a-memory")
 # list "memories" within this namespace, filtering on content equivalence
 items = store.search(namespace, filter={"my-key": "my-value"})
 ```


### PR DESCRIPTION
When executing the code in the document about InMemoryStore, the following two errors occurred, so I fixed them.

> SyntaxError: positional argument follows keyword argument

> TypeError: BaseStore.get() missing 1 required positional argument: 'key'
