### PR TITLE
docs: remove Literal as it is not being used

### DIFF
--- a/docs/docs/tutorials/introduction.ipynb
+++ b/docs/docs/tutorials/introduction.ipynb
@@ -564,9 +564,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Literal\n",
-    "\n",
-    "\n",
     "def route_tools(\n",
     "    state: State,\n",
     "):\n",

--- a/docs/docs/tutorials/introduction.ipynb
+++ b/docs/docs/tutorials/introduction.ipynb
@@ -2661,7 +2661,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Annotated, Literal\n",
+    "from typing import Annotated\n",
     "\n",
     "from langchain_anthropic import ChatAnthropic\n",
     "from langchain_community.tools.tavily_search import TavilySearchResults\n",


### PR DESCRIPTION
This PR removes the use of `from typing import Literal` since it is not being used in the code implementation