### PR TITLE
ci: update deploy docs workflow to check external links on langchain.com

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -82,7 +82,6 @@ jobs:
               --check-links-ignore "https://github\.com/.*" \
               --check-links-ignore "/.*\.(ipynb|html)$" \
               --check-links-ignore "https://python\.langchain\.com/.*" \
-              --check-links-ignore "https://www.langchain\.com/.*" \
               --check-links-ignore "https://openai.com/index/memory-and-new-controls-for-chatgpt/" \
               --check-links $(find docs/site -name "index.html" | grep -v 'storm/index.html') 
               
@@ -97,7 +96,6 @@ jobs:
               poetry run pytest -v \
                 --check-links-ignore "https://(api|web|docs)\.smith\.langchain\.com/.*" \
                 --check-links-ignore "https://x.com/.*" \
-                --check-links-ignore "https://www\.langchain\.com/.*" \
                 --check-links-ignore "https://github\.com/.*" \
                 --check-links-ignore "/.*\.(ipynb|html)$" \
                 --check-links ${CHANGED_FILES} \


### PR DESCRIPTION
Reverts temporary change that was made yesterday to accommodate a link that was only available on the staging version of langchain.com