### PR TITLE
lib: In calls to get_state apply pending writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -511,7 +511,7 @@ class Pregel(PregelProtocol):
             # apply pending writes
             if apply_pending_writes and saved.pending_writes:
                 for tid, *t in saved.pending_writes:
-                    next_tasks[tid].writes.append(t)
+                    next_tasks[tid].writes.append(t)  # type: ignore[arg-type]
                 if tasks := [t for t in next_tasks.values() if t.writes]:
                     apply_writes(saved.checkpoint, channels, tasks, None)
             # assemble the state snapshot
@@ -609,7 +609,7 @@ class Pregel(PregelProtocol):
             # apply pending writes
             if apply_pending_writes and saved.pending_writes:
                 for tid, *t in saved.pending_writes:
-                    next_tasks[tid].writes.append(t)
+                    next_tasks[tid].writes.append(t)  # type: ignore[arg-type]
                 if tasks := [t for t in next_tasks.values() if t.writes]:
                     apply_writes(saved.checkpoint, channels, tasks, None)
             # assemble the state snapshot

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1513,9 +1513,10 @@ def test_pending_writes_resume(
     assert two.calls == 2  # two attempts
 
     # latest checkpoint should be before nodes "one", "two"
+    # but we should have applied the write from "one"
     state = graph.get_state(thread1)
     assert state is not None
-    assert state.values == {"value": 1}
+    assert state.values == {"value": 3}
     assert state.next == ("one", "two")
     assert state.tasks == (
         PregelTask(AnyStr(), "one", (PULL, "one"), result={"value": 2}),
@@ -1528,6 +1529,10 @@ def test_pending_writes_resume(
         "writes": None,
         "thread_id": "1",
     }
+    # get_state with checkpoint_id should not apply any pending writes
+    state = graph.get_state(state.config)
+    assert state is not None
+    assert state.values == {"value": 1}
     # should contain pending write of "one"
     checkpoint = checkpointer.get_tuple(thread1)
     assert checkpoint is not None

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -2123,6 +2123,8 @@ async def test_max_concurrency(checkpointer_name: str) -> None:
         thread1 = {"max_concurrency": 10, "configurable": {"thread_id": "1"}}
 
         assert await graph.ainvoke(["0"], thread1) == ["0", "1"]
+        state = await graph.aget_state(thread1)
+        assert state.values == ["0", "1"]
         assert await graph.ainvoke(None, thread1) == ["0", "1", *range(100), "3"]
 
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -482,10 +482,11 @@ async def test_cancel_graph_astream(checkpointer_name: str) -> None:
         assert awhile.started is False
 
         # checkpoint with output of "alittlewhile" should not be saved
+        # but we should have applied pending writes
         if checkpointer is not None:
             state = await graph.aget_state(thread1)
             assert state is not None
-            assert state.values == {"value": 1}
+            assert state.values == {"value": 3}  # 1 + 2
             assert state.next == (
                 "aparallelwhile",
                 "alittlewhile",
@@ -1722,9 +1723,10 @@ async def test_pending_writes_resume(
         assert two.calls == 2
 
         # latest checkpoint should be before nodes "one", "two"
+        # but we should have applied pending writes from "one"
         state = await graph.aget_state(thread1)
         assert state is not None
-        assert state.values == {"value": 1}
+        assert state.values == {"value": 3}
         assert state.next == ("one", "two")
         assert state.tasks == (
             PregelTask(AnyStr(), "one", (PULL, "one"), result={"value": 2}),
@@ -1742,6 +1744,10 @@ async def test_pending_writes_resume(
             "writes": None,
             "thread_id": "1",
         }
+        # get_state with checkpoint_id should not apply any pending writes
+        state = await graph.aget_state(state.config)
+        assert state is not None
+        assert state.values == {"value": 1}
         # should contain pending write of "one"
         checkpoint = await checkpointer.aget_tuple(thread1)
         assert checkpoint is not None


### PR DESCRIPTION
- When calling get_state without a checkpoint id (ie to get the latest state) apply any pending writes for current checkpoint