### PR TITLE
lib: Enforce write application order in apply_writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -877,6 +877,7 @@ class Pregel(PregelProtocol):
                 # tasks for this checkpoint
                 next_tasks = prepare_next_tasks(
                     checkpoint,
+                    saved.pending_writes or [],
                     self.nodes,
                     channels,
                     managed,
@@ -941,7 +942,7 @@ class Pregel(PregelProtocol):
             if not writers:
                 raise InvalidUpdateError(f"Node {as_node} has no writers")
             writes: deque[tuple[str, Any]] = deque()
-            task = PregelTaskWrites(as_node, writes, [INTERRUPT])
+            task = PregelTaskWrites((), as_node, writes, [INTERRUPT])
             task_id = str(uuid5(UUID(checkpoint["id"]), INTERRUPT))
             run = RunnableSequence(*writers) if len(writers) > 1 else writers[0]
             # execute task
@@ -1060,6 +1061,7 @@ class Pregel(PregelProtocol):
                 # tasks for this checkpoint
                 next_tasks = prepare_next_tasks(
                     checkpoint,
+                    saved.pending_writes or [],
                     self.nodes,
                     channels,
                     managed,
@@ -1121,7 +1123,7 @@ class Pregel(PregelProtocol):
             if not writers:
                 raise InvalidUpdateError(f"Node {as_node} has no writers")
             writes: deque[tuple[str, Any]] = deque()
-            task = PregelTaskWrites(as_node, writes, [INTERRUPT])
+            task = PregelTaskWrites((), as_node, writes, [INTERRUPT])
             task_id = str(uuid5(UUID(checkpoint["id"]), INTERRUPT))
             run = RunnableSequence(*writers) if len(writers) > 1 else writers[0]
             # execute task

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -477,7 +477,10 @@ class PregelLoop(LoopProtocol):
             mv_writes = apply_writes(
                 self.checkpoint,
                 self.channels,
-                [*discard_tasks.values(), PregelTaskWrites(INPUT, input_writes, [])],
+                [
+                    *discard_tasks.values(),
+                    PregelTaskWrites((), INPUT, input_writes, []),
+                ],
                 self.checkpointer_get_next_version,
             )
             assert not mv_writes, "Can't write to SharedValues in graph input"

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1787,11 +1787,11 @@ def test_concurrent_emit_sends() -> None:
         "0",
         "1",
         "1.1",
+        "3.1",
         "2|1",
         "2|2",
         "2|3",
         "2|4",
-        "3.1",
         "3",
     ]
 
@@ -1836,12 +1836,12 @@ def test_send_sequences() -> None:
     assert graph.invoke(["0"]) == [
         "0",
         "1",
+        "3.1",
         "2|Control(send=Send(node='2', arg=3))",
         "2|Control(send=Send(node='2', arg=4))",
-        "3.1",
+        "3",
         "2|3",
         "2|4",
-        "3",
         "3",
     ]
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -2004,11 +2004,11 @@ async def test_concurrent_emit_sends() -> None:
         "0",
         "1",
         "1.1",
+        "3.1",
         "2|1",
         "2|2",
         "2|3",
         "2|4",
-        "3.1",
         "3",
     ]
 
@@ -2053,12 +2053,12 @@ async def test_send_sequences() -> None:
     assert await graph.ainvoke(["0"]) == [
         "0",
         "1",
+        "3.1",
         "2|Control(send=Send(node='2', arg=3))",
         "2|Control(send=Send(node='2', arg=4))",
-        "3.1",
+        "3",
         "2|3",
         "2|4",
-        "3",
         "3",
     ]
 


### PR DESCRIPTION
- Previously order was enforced in prepare_next_tasks, but that's not a good fit for future features
- This changes order between PULL and PUSH tasks, updates from PUSH tasks will now be applied after updates from PULL tasks