### PR TITLE
lib: Add interrupt() function

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -25,6 +25,7 @@ from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import (
     ERROR,
     INTERRUPT,
+    RESUME,
     SCHEDULED,
     ChannelProtocol,
     SendProtocol,
@@ -450,4 +451,4 @@ Special writes (e.g. errors) map to negative indices, to avoid those writes from
 conflicting with regular writes.
 Each Checkpointer implementation should use this mapping in put_writes.
 """
-WRITES_IDX_MAP = {ERROR: -1, SCHEDULED: -2, INTERRUPT: -3}
+WRITES_IDX_MAP = {ERROR: -1, SCHEDULED: -2, INTERRUPT: -3, RESUME: -4}

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -25,7 +25,7 @@ from langchain_core.load.serializable import Serializable
 from zoneinfo import ZoneInfo
 
 from langgraph.checkpoint.serde.base import SerializerProtocol
-from langgraph.checkpoint.serde.types import CommandProtocol, SendProtocol
+from langgraph.checkpoint.serde.types import SendProtocol
 from langgraph.store.base import Item
 
 LC_REVIVER = Reviver()
@@ -121,11 +121,6 @@ class JsonPlusSerializer(SerializerProtocol):
         elif isinstance(obj, SendProtocol):
             return self._encode_constructor_args(
                 obj.__class__, kwargs={"node": obj.node, "arg": obj.arg}
-            )
-        elif isinstance(obj, CommandProtocol):
-            return self._encode_constructor_args(
-                obj.__class__,
-                kwargs={k: getattr(obj, k) for k in obj.__all_slots__},
             )
         elif isinstance(obj, (bytes, bytearray)):
             return self._encode_constructor_args(
@@ -405,17 +400,6 @@ def _msgpack_default(obj: Any) -> Union[str, msgpack.ExtType]:
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, (obj.node, obj.arg)),
-            ),
-        )
-    elif isinstance(obj, CommandProtocol):
-        return msgpack.ExtType(
-            EXT_CONSTRUCTOR_KW_ARGS,
-            _msgpack_enc(
-                (
-                    obj.__class__.__module__,
-                    obj.__class__.__name__,
-                    {k: getattr(obj, k) for k in obj.__all_slots__},
-                ),
             ),
         )
     elif dataclasses.is_dataclass(obj):

--- a/libs/checkpoint/langgraph/checkpoint/serde/types.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/types.py
@@ -4,7 +4,6 @@ from typing import (
     Protocol,
     Sequence,
     TypeVar,
-    Union,
     runtime_checkable,
 )
 
@@ -51,11 +50,3 @@ class SendProtocol(Protocol):
     def __repr__(self) -> str: ...
 
     def __eq__(self, value: object) -> bool: ...
-
-
-@runtime_checkable
-class CommandProtocol(Protocol):
-    # Mirrors langgraph.types.Command
-    update: Optional[dict[str, Any]]
-    send: Union[Any, Sequence[Any]]
-    __all_slots__: set[str]

--- a/libs/checkpoint/langgraph/checkpoint/serde/types.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/types.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 ERROR = "__error__"
 SCHEDULED = "__scheduled__"
 INTERRUPT = "__interrupt__"
+RESUME = "__resume__"
 TASKS = "__pregel_tasks"
 
 Value = TypeVar("Value", covariant=True)

--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -11,6 +11,7 @@ from langgraph.types import Interrupt, Send  # noqa: F401
 # --- Empty read-only containers ---
 EMPTY_MAP: Mapping[str, Any] = MappingProxyType({})
 EMPTY_SEQ: tuple[str, ...] = tuple()
+MISSING = object()
 
 # --- Public constants ---
 TAG_NOSTREAM = sys.intern("langsmith:nostream")
@@ -29,6 +30,8 @@ INPUT = sys.intern("__input__")
 # for values passed as input to the graph
 INTERRUPT = sys.intern("__interrupt__")
 # for dynamic interrupts raised by nodes
+RESUME = sys.intern("__resume__")
+# for values passed to resume a node after an interrupt
 ERROR = sys.intern("__error__")
 # for errors raised by nodes
 NO_WRITES = sys.intern("__no_writes__")
@@ -70,6 +73,8 @@ CONFIG_KEY_CHECKPOINT_NS = sys.intern("checkpoint_ns")
 # holds the current checkpoint_ns, "" for root graph
 CONFIG_KEY_NODE_FINISHED = sys.intern("__pregel_node_finished")
 # callback to be called when a node is finished
+CONFIG_KEY_RESUME_VALUE = sys.intern("__pregel_resume_value")
+# holds the value that "answers" an interrupt() call
 
 # --- Other constants ---
 PUSH = sys.intern("__pregel_push")
@@ -84,12 +89,15 @@ CONF = cast(Literal["configurable"], sys.intern("configurable"))
 # key for the configurable dict in RunnableConfig
 FF_SEND_V2 = getenv("LANGGRAPH_FF_SEND_V2", "false").lower() == "true"
 # temporary flag to enable new Send semantics
+NULL_TASK_ID = sys.intern("00000000-0000-0000-0000-000000000000")
+# the task_id to use for writes that are not associated with a task
 
 RESERVED = {
     TAG_HIDDEN,
     # reserved write keys
     INPUT,
     INTERRUPT,
+    RESUME,
     ERROR,
     NO_WRITES,
     SCHEDULED,

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -70,7 +70,7 @@ class NodeInterrupt(GraphInterrupt):
     """Raised by a node to interrupt execution."""
 
     def __init__(self, value: Any) -> None:
-        super().__init__([Interrupt(value)])
+        super().__init__([Interrupt(value=value)])
 
 
 class GraphDelegate(Exception):

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -92,8 +92,9 @@ class GraphCommand(Command, Generic[N]):
         update: Optional[dict[str, Any]] = None,
         goto: Union[str, Sequence[str]] = (),
         send: Union[Send, Sequence[Send]] = (),
+        resume: Optional[Union[Any, dict[str, Any]]] = None,
     ) -> None:
-        super().__init__(update=update, send=send)
+        super().__init__(update=update, send=send, resume=resume)
         self.goto = goto
 
 

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 import logging
 import typing
@@ -49,7 +50,7 @@ from langgraph.managed.base import (
 from langgraph.pregel.read import ChannelRead, PregelNode
 from langgraph.pregel.write import SKIP_WRITE, ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
-from langgraph.types import All, Checkpointer, Command, N, RetryPolicy
+from langgraph.types import _DC_KWARGS, All, Checkpointer, Command, N, RetryPolicy
 from langgraph.utils.fields import get_field_default
 from langgraph.utils.pydantic import create_model
 from langgraph.utils.runnable import RunnableCallable, coerce_to_runnable
@@ -78,21 +79,20 @@ def _get_node_name(node: RunnableLike) -> str:
         raise TypeError(f"Unsupported node type: {type(node)}")
 
 
+@dataclasses.dataclass(**_DC_KWARGS)
 class GraphCommand(Generic[N], Command[N]):
     """One or more commands to update a StateGraph's state and go to, or send messages to nodes."""
 
-    __slots__ = ("goto",)
+    goto: Union[str, Sequence[str]] = ()
 
-    def __init__(
-        self,
-        *,
-        update: Optional[dict[str, Any]] = None,
-        send: Union[Send, Sequence[Send]] = (),
-        resume: Optional[Union[Any, dict[str, Any]]] = None,
-        goto: Union[str, Sequence[str]] = (),
-    ) -> None:
-        super().__init__(update=update, send=send, resume=resume)
-        self.goto = goto
+    def __repr__(self) -> str:
+        # get all non-None values
+        contents = ", ".join(
+            f"{key}={value!r}"
+            for key, value in dataclasses.asdict(self).items()
+            if value
+        )
+        return f"Command({contents})"
 
 
 class StateNodeSpec(NamedTuple):

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -14,7 +14,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TypeVar,
     Union,
     cast,
     get_args,
@@ -50,14 +49,12 @@ from langgraph.managed.base import (
 from langgraph.pregel.read import ChannelRead, PregelNode
 from langgraph.pregel.write import SKIP_WRITE, ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
-from langgraph.types import All, Checkpointer, Command, RetryPolicy
+from langgraph.types import All, Checkpointer, Command, N, RetryPolicy
 from langgraph.utils.fields import get_field_default
 from langgraph.utils.pydantic import create_model
 from langgraph.utils.runnable import RunnableCallable, coerce_to_runnable
 
 logger = logging.getLogger(__name__)
-
-N = TypeVar("N")
 
 
 def _warn_invalid_state_schema(schema: Union[Type[Any], Any]) -> None:
@@ -81,7 +78,7 @@ def _get_node_name(node: RunnableLike) -> str:
         raise TypeError(f"Unsupported node type: {type(node)}")
 
 
-class GraphCommand(Command, Generic[N]):
+class GraphCommand(Generic[N], Command[N]):
     """One or more commands to update a StateGraph's state and go to, or send messages to nodes."""
 
     __slots__ = ("goto",)
@@ -90,9 +87,9 @@ class GraphCommand(Command, Generic[N]):
         self,
         *,
         update: Optional[dict[str, Any]] = None,
-        goto: Union[str, Sequence[str]] = (),
         send: Union[Send, Sequence[Send]] = (),
         resume: Optional[Union[Any, dict[str, Any]]] = None,
+        goto: Union[str, Sequence[str]] = (),
     ) -> None:
         super().__init__(update=update, send=send, resume=resume)
         self.goto = goto
@@ -390,7 +387,7 @@ class StateGraph(Graph):
                             input = input_hint
                 if (
                     (rtn := hints.get("return"))
-                    and get_origin(rtn) is GraphCommand
+                    and get_origin(rtn) in (Command, GraphCommand)
                     and (rargs := get_args(rtn))
                     and get_origin(rargs[0]) is Literal
                     and (vals := get_args(rargs[0]))

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -66,9 +66,11 @@ from langgraph.constants import (
     CONFIG_KEY_STREAM_WRITER,
     CONFIG_KEY_TASK_ID,
     ERROR,
+    INPUT,
     INTERRUPT,
     NS_END,
     NS_SEP,
+    NULL_TASK_ID,
     PUSH,
     SCHEDULED,
 )
@@ -519,6 +521,15 @@ class Pregel(PregelProtocol):
                         config, subgraphs=True
                     )
             # apply pending writes
+            if null_writes := [
+                w[1:] for w in saved.pending_writes or [] if w[0] == NULL_TASK_ID
+            ]:
+                apply_writes(
+                    saved.checkpoint,
+                    channels,
+                    [PregelTaskWrites((), INPUT, null_writes, [])],
+                    None,
+                )
             if apply_pending_writes and saved.pending_writes:
                 for tid, k, v in saved.pending_writes:
                     if k in (ERROR, INTERRUPT, SCHEDULED):
@@ -622,6 +633,15 @@ class Pregel(PregelProtocol):
                         config, subgraphs=True
                     )
             # apply pending writes
+            if null_writes := [
+                w[1:] for w in saved.pending_writes or [] if w[0] == NULL_TASK_ID
+            ]:
+                apply_writes(
+                    saved.checkpoint,
+                    channels,
+                    [PregelTaskWrites((), INPUT, null_writes, [])],
+                    None,
+                )
             if apply_pending_writes and saved.pending_writes:
                 for tid, k, v in saved.pending_writes:
                     if k in (ERROR, INTERRUPT, SCHEDULED):
@@ -898,6 +918,18 @@ class Pregel(PregelProtocol):
                         checkpointer=self.checkpointer or None,
                         manager=None,
                     )
+                    # apply null writes
+                    if null_writes := [
+                        w[1:]
+                        for w in saved.pending_writes or []
+                        if w[0] == NULL_TASK_ID
+                    ]:
+                        apply_writes(
+                            saved.checkpoint,
+                            channels,
+                            [PregelTaskWrites((), INPUT, null_writes, [])],
+                            None,
+                        )
                     # apply writes from tasks that already ran
                     for tid, k, v in saved.pending_writes or []:
                         if k in (ERROR, INTERRUPT, SCHEDULED):
@@ -943,6 +975,16 @@ class Pregel(PregelProtocol):
                     checkpointer=self.checkpointer or None,
                     manager=None,
                 )
+                # apply null writes
+                if null_writes := [
+                    w[1:] for w in saved.pending_writes or [] if w[0] == NULL_TASK_ID
+                ]:
+                    apply_writes(
+                        saved.checkpoint,
+                        channels,
+                        [PregelTaskWrites((), INPUT, null_writes, [])],
+                        None,
+                    )
                 # apply writes
                 for tid, k, v in saved.pending_writes:
                     if k in (ERROR, INTERRUPT, SCHEDULED):
@@ -1118,6 +1160,18 @@ class Pregel(PregelProtocol):
                         checkpointer=self.checkpointer or None,
                         manager=None,
                     )
+                    # apply null writes
+                    if null_writes := [
+                        w[1:]
+                        for w in saved.pending_writes or []
+                        if w[0] == NULL_TASK_ID
+                    ]:
+                        apply_writes(
+                            saved.checkpoint,
+                            channels,
+                            [PregelTaskWrites((), INPUT, null_writes, [])],
+                            None,
+                        )
                     # apply writes from tasks that already ran
                     for tid, k, v in saved.pending_writes or []:
                         if k in (ERROR, INTERRUPT, SCHEDULED):
@@ -1163,6 +1217,16 @@ class Pregel(PregelProtocol):
                     checkpointer=self.checkpointer or None,
                     manager=None,
                 )
+                # apply null writes
+                if null_writes := [
+                    w[1:] for w in saved.pending_writes or [] if w[0] == NULL_TASK_ID
+                ]:
+                    apply_writes(
+                        saved.checkpoint,
+                        channels,
+                        [PregelTaskWrites((), INPUT, null_writes, [])],
+                        None,
+                    )
                 for tid, k, v in saved.pending_writes:
                     if k in (ERROR, INTERRUPT, SCHEDULED):
                         continue

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -500,7 +500,6 @@ def prepare_single_task(
                 return
             packet = writes_for_path[task_path_t[2]][2]
             if not isinstance(packet, Send):
-                print("packet", task_path_t, writes_for_path)
                 logger.warning(
                     f"Ignoring invalid packet type {type(packet)} in pending writes"
                 )
@@ -613,19 +612,6 @@ def prepare_single_task(
         if name not in processes:
             return
         proc = processes[name]
-        print(
-            "preparing task",
-            task_path,
-            pending_writes,
-            sorted(
-                (chan, read_channel(channels, chan, return_exception=True))
-                for chan in proc.triggers
-                # if not isinstance(
-                #     read_channel(channels, chan, return_exception=True),
-                #     EmptyChannelError,
-                # )
-            ),
-        )
         version_type = type(next(iter(checkpoint["channel_versions"].values()), None))
         null_version = version_type()  # type: ignore[misc]
         if null_version is None:
@@ -666,7 +652,6 @@ def prepare_single_task(
                 "langgraph_path": task_path,
                 "langgraph_checkpoint_ns": task_checkpoint_ns,
             }
-            print("preparing task", task_id, task_path, pending_writes)
             if task_id_checksum is not None:
                 assert task_id == task_id_checksum
             if for_execution:

--- a/libs/langgraph/langgraph/pregel/io.py
+++ b/libs/langgraph/langgraph/pregel/io.py
@@ -22,8 +22,7 @@ from langgraph.types import Command, PregelExecutableTask, Send
 def is_task_id(task_id: str) -> bool:
     """Check if a string is a valid task id."""
     try:
-        u = UUID(task_id)
-        print(u.version)
+        UUID(task_id)
     except ValueError:
         return False
     return True

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -417,7 +417,6 @@ class PregelLoop(LoopProtocol):
             )
             for key, values in mv_writes.items():
                 self._update_mv(key, values)
-            print("applied null writes", null_writes)
         # prepare next tasks
         self.tasks = prepare_next_tasks(
             self.checkpoint,
@@ -544,7 +543,6 @@ class PregelLoop(LoopProtocol):
             # save writes
             for tid, ws in writes.items():
                 self.put_writes(tid, ws)
-            print("applied cmd", writes)
         # map inputs to channel updates
         elif input_writes := deque(map_input(input_keys, self.input)):
             # TODO shouldn't these writes be passed to put_writes too?
@@ -559,22 +557,19 @@ class PregelLoop(LoopProtocol):
                     }
                 )
             # discard any unfinished tasks from previous checkpoint
-            if not isinstance(self.input, Command):
-                discard_tasks = prepare_next_tasks(
-                    self.checkpoint,
-                    self.checkpoint_pending_writes,
-                    self.nodes,
-                    self.channels,
-                    self.managed,
-                    self.config,
-                    self.step,
-                    for_execution=True,
-                    store=None,
-                    checkpointer=None,
-                    manager=None,
-                )
-            else:
-                discard_tasks = {}
+            discard_tasks = prepare_next_tasks(
+                self.checkpoint,
+                self.checkpoint_pending_writes,
+                self.nodes,
+                self.channels,
+                self.managed,
+                self.config,
+                self.step,
+                for_execution=True,
+                store=None,
+                checkpointer=None,
+                manager=None,
+            )
             # apply input writes
             mv_writes = apply_writes(
                 self.checkpoint,

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -317,7 +317,6 @@ def interrupt(value: Any) -> Any:
     from langgraph.utils.config import get_configurable
 
     conf = get_configurable()
-    print("interrupt", conf.get(CONFIG_KEY_RESUME_VALUE))
     if (resume := conf.get(CONFIG_KEY_RESUME_VALUE, MISSING)) and resume is not MISSING:
         return resume
     else:

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -1,5 +1,6 @@
+import dataclasses
+import sys
 from collections import deque
-from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,6 +47,11 @@ StreamWriter = Callable[[Any], None]
 """Callable that accepts a single argument and writes it to the output stream.
 Always injected into nodes if requested as a keyword argument, but it's a no-op
 when not using stream_mode="custom"."""
+
+if sys.version_info >= (3, 10):
+    _DC_KWARGS = {"kw_only": True, "slots": True, "frozen": True}
+else:
+    _DC_KWARGS = {"frozen": True}
 
 
 def default_retry_on(exc: Exception) -> bool:
@@ -104,9 +110,11 @@ class CachePolicy(NamedTuple):
     pass
 
 
-@dataclass
+@dataclasses.dataclass(**_DC_KWARGS)
 class Interrupt:
     value: Any
+    resumable: bool = False
+    ns: Optional[Sequence[str]] = None
     when: Literal["during"] = "during"
 
 
@@ -227,52 +235,22 @@ class Send:
 N = TypeVar("N", bound=Hashable)
 
 
+@dataclasses.dataclass(**_DC_KWARGS)
 class Command(Generic[N]):
     """One or more commands to update the graph's state and send messages to nodes."""
 
-    __slots__ = ("update", "send", "resume")
-
-    def __init__(
-        self,
-        *,
-        update: Optional[dict[str, Any]] = None,
-        send: Union[Send, Sequence[Send]] = (),
-        resume: Optional[Union[Any, dict[str, Any]]] = None,
-    ) -> None:
-        self.update = update
-        self.send = send
-        self.resume = resume
-
-    @property
-    def __all_slots__(self) -> set[str]:
-        # get all slots from mro
-        slots = set()
-        for cls in type(self).__mro__:
-            if ss := getattr(cls, "__slots__", ()):
-                if isinstance(ss, str):
-                    slots.add(ss)
-                else:
-                    slots.update(ss)
-        return slots
+    update: Optional[dict[str, Any]] = None
+    send: Union[Send, Sequence[Send]] = ()
+    resume: Optional[Union[Any, dict[str, Any]]] = None
 
     def __repr__(self) -> str:
         # get all non-None values
         contents = ", ".join(
             f"{key}={value!r}"
-            for key in self.__all_slots__
-            if (value := getattr(self, key))
+            for key, value in dataclasses.asdict(self).items()
+            if value
         )
         return f"Command({contents})"
-
-    def __eq__(self, value: Any) -> bool:
-        return type(value) is type(self) and all(
-            getattr(self, key) == getattr(value, key) for key in self.__all_slots__
-        )
-
-    def copy(self, **kwargs: Any) -> Self:
-        for slot in self.__all_slots__:
-            kwargs.setdefault(slot, getattr(self, slot))
-        return self.__class__(**kwargs)
 
 
 StreamChunk = tuple[tuple[str, ...], str, Any]
@@ -318,12 +296,25 @@ class LoopProtocol:
 
 
 def interrupt(value: Any) -> Any:
-    from langgraph.constants import CONFIG_KEY_RESUME_VALUE, MISSING
-    from langgraph.errors import NodeInterrupt
+    from langgraph.constants import (
+        CONFIG_KEY_CHECKPOINT_NS,
+        CONFIG_KEY_RESUME_VALUE,
+        MISSING,
+        NS_SEP,
+    )
+    from langgraph.errors import GraphInterrupt
     from langgraph.utils.config import get_configurable
 
     conf = get_configurable()
     if (resume := conf.get(CONFIG_KEY_RESUME_VALUE, MISSING)) and resume is not MISSING:
         return resume
     else:
-        raise NodeInterrupt(value)
+        raise GraphInterrupt(
+            (
+                Interrupt(
+                    value=value,
+                    resumable=True,
+                    ns=cast(str, conf[CONFIG_KEY_CHECKPOINT_NS]).split(NS_SEP),
+                ),
+            )
+        )

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -4,11 +4,14 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
+    Hashable,
     Literal,
     NamedTuple,
     Optional,
     Sequence,
     Type,
+    TypeVar,
     Union,
     cast,
 )
@@ -221,7 +224,10 @@ class Send:
         )
 
 
-class Command:
+N = TypeVar("N", bound=Hashable)
+
+
+class Command(Generic[N]):
     """One or more commands to update the graph's state and send messages to nodes."""
 
     __slots__ = ("update", "send", "resume")

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -224,16 +224,18 @@ class Send:
 class Command:
     """One or more commands to update the graph's state and send messages to nodes."""
 
-    __slots__ = ("update", "send")
+    __slots__ = ("update", "send", "resume")
 
     def __init__(
         self,
         *,
         update: Optional[dict[str, Any]] = None,
         send: Union[Send, Sequence[Send]] = (),
+        resume: Optional[Union[Any, dict[str, Any]]] = None,
     ) -> None:
         self.update = update
         self.send = send
+        self.resume = resume
 
     @property
     def __all_slots__(self) -> set[str]:
@@ -307,3 +309,16 @@ class LoopProtocol:
         self.store = store
         self.step = step
         self.stop = stop
+
+
+def interrupt(value: Any) -> Any:
+    from langgraph.constants import CONFIG_KEY_RESUME_VALUE, MISSING
+    from langgraph.errors import NodeInterrupt
+    from langgraph.utils.config import get_configurable
+
+    conf = get_configurable()
+    print("interrupt", conf.get(CONFIG_KEY_RESUME_VALUE))
+    if (resume := conf.get(CONFIG_KEY_RESUME_VALUE, MISSING)) and resume is not MISSING:
+        return resume
+    else:
+        raise NodeInterrupt(value)

--- a/libs/langgraph/langgraph/utils/config.py
+++ b/libs/langgraph/langgraph/utils/config.py
@@ -290,3 +290,10 @@ def ensure_config(*configs: Optional[RunnableConfig]) -> RunnableConfig:
         ):
             empty["metadata"][key] = value
     return empty
+
+
+def get_configurable() -> dict[str, Any]:
+    if var_config := var_child_runnable_config.get():
+        return var_config[CONF]
+    else:
+        raise RuntimeError("Called get_configurable outside of a runnable context")

--- a/libs/langgraph/langgraph/utils/config.py
+++ b/libs/langgraph/langgraph/utils/config.py
@@ -1,3 +1,5 @@
+import asyncio
+import sys
 from collections import ChainMap
 from typing import Any, Optional, Sequence
 
@@ -293,6 +295,14 @@ def ensure_config(*configs: Optional[RunnableConfig]) -> RunnableConfig:
 
 
 def get_configurable() -> dict[str, Any]:
+    if sys.version_info < (3, 11):
+        try:
+            if asyncio.current_task():
+                raise RuntimeError(
+                    "Python 3.11 or later required to use this in an async context"
+                )
+        except RuntimeError:
+            pass
     if var_config := var_child_runnable_config.get():
         return var_config[CONF]
     else:

--- a/libs/langgraph/tests/__snapshots__/test_pregel.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel.ambr
@@ -5108,6 +5108,81 @@
   
   '''
 # ---
+# name: test_send_react_interrupt_control[memory]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres_pipe]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres_pool]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[sqlite]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_simple_multi_edge
   '''
   graph TD;

--- a/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
@@ -1334,18 +1334,14 @@
   	__start__([<p>__start__</p>]):::first
   	router_node(router_node)
   	normal_llm_node(normal_llm_node)
-  	weather_graph_model_node(model_node)
-  	weather_graph_weather_node(weather_node<hr/><small><em>__interrupt = before</em></small>)
+  	weather_graph(weather_graph)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> router_node;
   	normal_llm_node --> __end__;
-  	weather_graph_weather_node --> __end__;
+  	weather_graph --> __end__;
   	router_node -.-> normal_llm_node;
-  	router_node -.-> weather_graph_model_node;
+  	router_node -.-> weather_graph;
   	router_node -.-> __end__;
-  	subgraph weather_graph
-  	weather_graph_model_node --> weather_graph_weather_node;
-  	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
@@ -1302,6 +1302,81 @@
    +---------+   
   '''
 # ---
+# name: test_send_react_interrupt_control[memory]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres_aio]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres_aio_pipe]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[postgres_aio_pool]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_send_react_interrupt_control[sqlite_aio]
+  '''
+  %%{init: {'flowchart': {'curve': 'linear'}}}%%
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	agent(agent)
+  	foo([foo]):::last
+  	__start__ --> agent;
+  	agent -.-> foo;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_weather_subgraph[duckdb_aio]
   '''
   %%{init: {'flowchart': {'curve': 'linear'}}}%%

--- a/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel_async.ambr
@@ -1334,14 +1334,18 @@
   	__start__([<p>__start__</p>]):::first
   	router_node(router_node)
   	normal_llm_node(normal_llm_node)
-  	weather_graph(weather_graph)
+  	weather_graph_model_node(model_node)
+  	weather_graph_weather_node(weather_node<hr/><small><em>__interrupt = before</em></small>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> router_node;
   	normal_llm_node --> __end__;
-  	weather_graph --> __end__;
+  	weather_graph_weather_node --> __end__;
   	router_node -.-> normal_llm_node;
-  	router_node -.-> weather_graph;
+  	router_node -.-> weather_graph_model_node;
   	router_node -.-> __end__;
+  	subgraph weather_graph
+  	weather_graph_model_node --> weather_graph_weather_node;
+  	end
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -2691,7 +2691,7 @@ def test_send_react_interrupt(
 
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_SYNC)
 def test_send_react_interrupt_control(
-    request: pytest.FixtureRequest, checkpointer_name: str
+    request: pytest.FixtureRequest, checkpointer_name: str, snapshot: SnapshotAssertion
 ) -> None:
     from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
 
@@ -2721,6 +2721,7 @@ def test_send_react_interrupt_control(
     builder.add_node(foo)
     builder.add_edge(START, "agent")
     graph = builder.compile()
+    assert graph.get_graph().draw_mermaid() == snapshot
 
     assert graph.invoke({"messages": [HumanMessage("hello")]}) == {
         "messages": [

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8,6 +8,7 @@ import warnings
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import replace
 from random import randrange
 from typing import (
     Annotated,
@@ -1834,9 +1835,8 @@ def test_send_sequences() -> None:
                 if isinstance(state, list)
                 else ["|".join((self.name, str(state)))]
             )
-            if isinstance(state, GraphCommand):
-                state.update = update
-                return state
+            if isinstance(state, Command):
+                return replace(state, update=update)
             else:
                 return update
 
@@ -1918,7 +1918,7 @@ def test_send_dedupe_on_resume(
                 else ["|".join((self.name, str(state)))]
             )
             if isinstance(state, GraphCommand):
-                return state.copy(update=update)
+                return replace(state, update=update)
             else:
                 return update
 
@@ -8409,7 +8409,15 @@ def test_dynamic_interrupt(
     assert [
         c for c in tool_two.stream({"my_key": "value ⛰️", "market": "DE"}, thread2)
     ] == [
-        {"__interrupt__": [Interrupt(value="Just because...", when="during")]},
+        {
+            "__interrupt__": (
+                Interrupt(
+                    value="Just because...",
+                    resumable=True,
+                    ns=[AnyStr("tool_two:")],
+                ),
+            )
+        },
     ]
     # resume with answer
     assert [c for c in tool_two.stream(Command(resume=" my answer"), thread2)] == [
@@ -8447,7 +8455,13 @@ def test_dynamic_interrupt(
                 AnyStr(),
                 "tool_two",
                 (PULL, "tool_two"),
-                interrupts=(Interrupt("Just because..."),),
+                interrupts=(
+                    Interrupt(
+                        value="Just because...",
+                        resumable=True,
+                        ns=[AnyStr("tool_two:")],
+                    ),
+                ),
             ),
         ),
         config=tool_two.checkpointer.get_tuple(thread1).config,

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -257,6 +257,10 @@ async def test_node_cancellation_on_other_node_exception_two() -> None:
         await graph.ainvoke(1)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="Python 3.11+ is required for async contextvars support",
+)
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
 async def test_dynamic_interrupt(checkpointer_name: str) -> None:
     class State(TypedDict):
@@ -399,6 +403,10 @@ async def test_dynamic_interrupt(checkpointer_name: str) -> None:
         )
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="Python 3.11+ is required for async contextvars support",
+)
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
 async def test_node_not_cancelled_on_other_node_interrupted(
     checkpointer_name: str,

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from collections import Counter
 from contextlib import asynccontextmanager, contextmanager
+from dataclasses import replace
 from time import perf_counter
 from typing import (
     Annotated,
@@ -318,7 +319,15 @@ async def test_dynamic_interrupt(checkpointer_name: str) -> None:
                 {"my_key": "value ⛰️", "market": "DE"}, thread2
             )
         ] == [
-            {"__interrupt__": [Interrupt(value="Just because...", when="during")]},
+            {
+                "__interrupt__": (
+                    Interrupt(
+                        value="Just because...",
+                        resumable=True,
+                        ns=[AnyStr("tool_two:")],
+                    ),
+                )
+            },
         ]
         # resume with answer
         assert [
@@ -336,7 +345,15 @@ async def test_dynamic_interrupt(checkpointer_name: str) -> None:
                 {"my_key": "value ⛰️", "market": "DE"}, thread1
             )
         ] == [
-            {"__interrupt__": [Interrupt(value="Just because...", when="during")]},
+            {
+                "__interrupt__": (
+                    Interrupt(
+                        value="Just because...",
+                        resumable=True,
+                        ns=[AnyStr("tool_two:")],
+                    ),
+                )
+            },
         ]
         assert [c.metadata async for c in tool_two.checkpointer.alist(thread1)] == [
             {
@@ -363,7 +380,13 @@ async def test_dynamic_interrupt(checkpointer_name: str) -> None:
                     AnyStr(),
                     "tool_two",
                     (PULL, "tool_two"),
-                    interrupts=(Interrupt("Just because..."),),
+                    interrupts=(
+                        Interrupt(
+                            value="Just because...",
+                            resumable=True,
+                            ns=[AnyStr("tool_two:")],
+                        ),
+                    ),
                 ),
             ),
             config=tup.config,
@@ -2111,7 +2134,7 @@ async def test_send_sequences(checkpointer_name: str) -> None:
                 else ["|".join((self.name, str(state)))]
             )
             if isinstance(state, GraphCommand):
-                return state.copy(update=update)
+                return replace(state, update=update)
             else:
                 return update
 
@@ -2215,7 +2238,7 @@ async def test_send_dedupe_on_resume(checkpointer_name: str) -> None:
                 else ["|".join((self.name, str(state)))]
             )
             if isinstance(state, GraphCommand):
-                return state.copy(update=update)
+                return replace(state, update=update)
             else:
                 return update
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -2973,7 +2973,9 @@ async def test_send_react_interrupt(checkpointer_name: str) -> None:
 
 
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
-async def test_send_react_interrupt_control(checkpointer_name: str) -> None:
+async def test_send_react_interrupt_control(
+    checkpointer_name: str, snapshot: SnapshotAssertion
+) -> None:
     from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
 
     ai_message = AIMessage(
@@ -2982,7 +2984,7 @@ async def test_send_react_interrupt_control(checkpointer_name: str) -> None:
         tool_calls=[ToolCall(name="foo", args={"hi": [1, 2, 3]}, id=AnyStr())],
     )
 
-    async def agent(state) -> GraphCommand[Literal["foo"]]:
+    async def agent(state) -> Command[Literal["foo"]]:
         return GraphCommand(
             update={"messages": ai_message},
             send=[Send(call["name"], call) for call in ai_message.tool_calls],
@@ -3000,6 +3002,7 @@ async def test_send_react_interrupt_control(checkpointer_name: str) -> None:
     builder.add_node(foo)
     builder.add_edge(START, "agent")
     graph = builder.compile()
+    assert graph.get_graph().draw_mermaid() == snapshot
 
     assert await graph.ainvoke({"messages": [HumanMessage("hello")]}) == {
         "messages": [

--- a/libs/scheduler-kafka/tests/test_subgraph.py
+++ b/libs/scheduler-kafka/tests/test_subgraph.py
@@ -194,8 +194,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -258,8 +259,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -352,8 +354,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -456,8 +459,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -515,8 +519,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -630,8 +635,9 @@ async def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]

--- a/libs/scheduler-kafka/tests/test_subgraph_sync.py
+++ b/libs/scheduler-kafka/tests/test_subgraph_sync.py
@@ -193,8 +193,9 @@ def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -255,10 +256,11 @@ def test_subgraph_w_interrupt(
                             "__pregel_read": None,
                             "__pregel_send": None,
                             "__pregel_ensure_latest": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -350,9 +352,10 @@ def test_subgraph_w_interrupt(
                             "__pregel_send": None,
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_resuming": False,
                             "__pregel_task_id": history[0].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -453,9 +456,10 @@ def test_subgraph_w_interrupt(
                             "__pregel_send": None,
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_resuming": True,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -512,9 +516,10 @@ def test_subgraph_w_interrupt(
                             "__pregel_send": None,
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_resuming": True,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -628,8 +633,9 @@ def test_subgraph_w_interrupt(
                             "__pregel_ensure_latest": True,
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": True,
-                            '__pregel_store': None,
+                            "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
+                            "__pregel_resume_value": None,
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]


### PR DESCRIPTION
- This works similarly to the input() function from stdlib
- calling it in a node interrupts execution
- invoking the graph with Command(resume=...) will set ... as the return value of interrupt() so that the node can access the "answer" to the "question"
- This PR also starts the work to control the graph on invoke/stream with Command() input, to be continued in a future PR

```py
    class State(TypedDict):
        my_key: Annotated[str, operator.add]
        market: str

    async def tool_two_node(s: State) -> State:
        if s["market"] == "DE":
            answer = interrupt("Just because...")
        else:
            answer = " all good"
        return {"my_key": answer}

    tool_two_graph = StateGraph(State)
    tool_two_graph.add_node("tool_two", tool_two_node)
    tool_two_graph.add_edge(START, "tool_two")
    tool_two = tool_two_graph.compile()

        tool_two = tool_two_graph.compile(checkpointer=checkpointer)

        # flow: interrupt -> resume with answer
        thread2 = {"configurable": {"thread_id": "2"}}
        # stop when about to enter node
        assert [
            c
            async for c in tool_two.astream(
                {"my_key": "value ⛰️", "market": "DE"}, thread2
            )
        ] == [
            {"__interrupt__": [Interrupt(value="Just because...", when="during")]},
        ]
        # resume with answer
        assert [
            c async for c in tool_two.astream(Command(resume=" my answer"), thread2)
        ] == [
            {"tool_two": {"my_key": " my answer"}},
        ]
```