### PR TITLE
lib: Restore prev behavior for update_state(None)

### DIFF
--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -14034,7 +14034,6 @@ def test_debug_retry():
     update_config = graph.update_state(target_config, values=None)
 
     events = [*graph.stream(None, config=update_config, stream_mode="debug")]
-    assert events == []
 
     checkpoint_events = list(
         reversed([e["payload"] for e in events if e["type"] == "checkpoint"])


### PR DESCRIPTION
- update_state(None) copies checkpoint and keeps current (PUSH) tasks, eg for replay
- update_state(None, as_node=END) clears all tasks (PUSH or PULL)