### PR TITLE
lib: find_subgraph doesn't need to look in both func and afunc

### DIFF
--- a/libs/langgraph/langgraph/pregel/utils.py
+++ b/libs/langgraph/langgraph/pregel/utils.py
@@ -48,7 +48,7 @@ def find_subgraph_pregel(candidate: Runnable) -> Optional[Runnable]:
                     nl.__self__ if hasattr(nl, "__self__") else nl
                     for nl in get_function_nonlocals(c.func)
                 )
-            if c.afunc is not None:
+            elif c.afunc is not None:
                 candidates.extend(
                     nl.__self__ if hasattr(nl, "__self__") else nl
                     for nl in get_function_nonlocals(c.afunc)


### PR DESCRIPTION
- if they both exist they're expected to share the same implementation, so looking in both is redundant