### PR TITLE
docs: fix typo

### DIFF
--- a/docs/docs/tutorials/langgraph-platform/local-server.md
+++ b/docs/docs/tutorials/langgraph-platform/local-server.md
@@ -9,7 +9,7 @@ This is a quick start guide to help you get a LangGraph app up and running local
 ## Install the LangGraph CLI
 
 ```bash
-pip install "langgraph-cli[inmem]==0.1.58" python-dot-env
+pip install "langgraph-cli[inmem]==0.1.58" python-dotenv
 ```
 
 ## 🌱 Create a LangGraph App


### PR DESCRIPTION
`python-dotenv` not `python-dot-env`