### PR TITLE
fix: Replace hardcoded PostgresSaver with cls in factory method

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -73,9 +73,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield PostgresSaver(conn, pipe)
+                    yield cls(conn, pipe)
             else:
-                yield PostgresSaver(conn)
+                yield cls(conn)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
Replace hardcoded `PostgresSaver` with `cls` in the `from_conn_string` factory method to improve subclassing support.

## Changes
- Modified `from_conn_string` to use `cls` instead of `PostgresSaver` when instantiating new instances
- This change allows subclasses to properly inherit and override the factory method

## Why
This refactor makes the `PostgresSaver` class more extensible by following Python's convention of using `cls` in class methods. This enables proper inheritance patterns where subclasses can reuse the factory method without modification.

## Testing
The change is backward compatible and doesn't alter existing functionality. All existing tests should continue to pass.