### PR TITLE
Correct annotation for file_name in read_document function

### DIFF
--- a/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
+++ b/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
@@ -190,7 +190,7 @@
     "\n",
     "@tool\n",
     "def read_document(\n",
-    "    file_name: Annotated[str, \"File path to save the document.\"],\n",
+    "    file_name: Annotated[str, \"File path to read the document.\"],\n",
     "    start: Annotated[Optional[int], \"The start line. Default is 0\"] = None,\n",
     "    end: Annotated[Optional[int], \"The end line. Default is None\"] = None,\n",
     ") -> str:\n",


### PR DESCRIPTION
The current annotation states "File path to save the document." which implies that the function saves data to the file. However, read_document is only used to read the contents of the file, not save to it. This PR changes the annotation to "File path to read the document." to more accurately describe the parameter’s purpose.