### PR TITLE
Fix Return Type for create_team_supervisor Function to Reflect Correc…

### DIFF
--- a/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
+++ b/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
@@ -310,7 +310,7 @@
     "    }\n",
     "\n",
     "\n",
-    "def create_team_supervisor(llm: ChatOpenAI, system_prompt, members) -> str:\n",
+    "def create_team_supervisor(llm: ChatOpenAI, system_prompt, members) -> Any:\n",
     "    \"\"\"An LLM-based router.\"\"\"\n",
     "    options = [\"FINISH\"] + members\n",
     "    function_def = {\n",


### PR DESCRIPTION
…t Output Structure

I noticed that the return type of the create_team_supervisor function was incorrectly defined as -> str, but the function does not simply return a string. Instead, it returns a complex object involving a series of chained operations, including function bindings and JSON parsing. To reflect this behavior accurately, I updated the return type to -> Any, which is more appropriate for the dynamic nature of the return value.