### PR TITLE
fix(js): Adds fallback for fetching environment variables

### DIFF
--- a/libs/sdk-js/package.json
+++ b/libs/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-sdk",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Client library for interacting with the LangGraph API",
   "type": "module",
   "packageManager": "yarn@1.22.19",

--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -33,6 +33,7 @@ import {
   OnConflictBehavior,
 } from "./types.js";
 import { mergeSignals } from "./utils/signals.js";
+import { getEnvironmentVariable } from "./utils/env.js";
 
 /**
  * Get the API key from the environment.
@@ -53,7 +54,7 @@ export function getApiKey(apiKey?: string): string | undefined {
   const prefixes = ["LANGGRAPH", "LANGSMITH", "LANGCHAIN"];
 
   for (const prefix of prefixes) {
-    const envKey = process.env[`${prefix}_API_KEY`];
+    const envKey = getEnvironmentVariable(`${prefix}_API_KEY`);
     if (envKey) {
       // Remove surrounding quotes
       return envKey.trim().replace(/^["']|["']$/g, "");

--- a/libs/sdk-js/src/utils/env.ts
+++ b/libs/sdk-js/src/utils/env.ts
@@ -1,0 +1,11 @@
+export function getEnvironmentVariable(name: string): string | undefined {
+  // Certain setups (Deno, frontend) will throw an error if you try to access environment variables
+  try {
+    return typeof process !== "undefined"
+      ? // eslint-disable-next-line no-process-env
+        process.env?.[name]
+      : undefined;
+  } catch (e) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Client can be used in non-Node environments, so we cannot assume `process.env` will succeed.