### PR TITLE
langgraph: relax graph validation to handle nodes without return typehints

### DIFF
--- a/libs/langgraph/langgraph/graph/graph.py
+++ b/libs/langgraph/langgraph/graph/graph.py
@@ -374,6 +374,11 @@ class Graph:
             if source not in self.nodes and source != START:
                 raise ValueError(f"Found edge starting at unknown node '{source}'")
 
+        if START not in all_sources:
+            raise ValueError(
+                "Graph must have an entrypoint: add at least one edge from START to another node"
+            )
+
         # assemble targets
         all_targets = {end for _, end in self._all_edges}
         for start, branches in self.branches.items():
@@ -392,13 +397,10 @@ class Graph:
                     for node in self.nodes:
                         if node != start and node != branch.then:
                             all_targets.add(node)
+
         for name, spec in self.nodes.items():
             if spec.ends:
                 all_targets.update(spec.ends)
-        # validate targets
-        for node in self.nodes:
-            if node not in all_targets:
-                raise ValueError(f"Node `{node}` is not reachable")
         for target in all_targets:
             if target not in self.nodes and target != END:
                 raise ValueError(f"Found edge ending at unknown node `{target}`")

--- a/libs/langgraph/langgraph/graph/graph.py
+++ b/libs/langgraph/langgraph/graph/graph.py
@@ -397,7 +397,6 @@ class Graph:
                     for node in self.nodes:
                         if node != start and node != branch.then:
                             all_targets.add(node)
-
         for name, spec in self.nodes.items():
             if spec.ends:
                 all_targets.update(spec.ends)


### PR DESCRIPTION
This allows building `StateGraph` where nodes are runnables returning `GraphCommand` (but don't have a notion of a return type hint), for example `ToolNode`