### PR TITLE
docs: Use edit mode as default to install template

### DIFF
--- a/docs/docs/tutorials/langgraph-platform/local-server.md
+++ b/docs/docs/tutorials/langgraph-platform/local-server.md
@@ -35,10 +35,10 @@ Create a new app from the `react-agent` template. This template is a simple agen
 
 ## Install Dependencies
 
-In the root of your new LangGraph app, install the dependencies:
+In the root of your new LangGraph app, install the dependencies with `edit` mode (You can see the effect immediately when you change the template code) :
 
 ```shell
-pip install .
+pip install -e .
 ```
 
 ## Create a `.env` file

--- a/docs/docs/tutorials/langgraph-platform/local-server.md
+++ b/docs/docs/tutorials/langgraph-platform/local-server.md
@@ -35,7 +35,7 @@ Create a new app from the `react-agent` template. This template is a simple agen
 
 ## Install Dependencies
 
-In the root of your new LangGraph app, install the dependencies with `edit` mode (You can see the effect immediately when you change the template code) :
+In the root of your new LangGraph app, install the dependencies in `edit` mode so your local changes are used by the server:
 
 ```shell
 pip install -e .


### PR DESCRIPTION
Small change to install the dependencies with `edit` mode so that users or freshman can see the effect immediately when they change the template code. As below,
`pip install -e .`

It's very good to evaluate how agent works and easy to test & re-develop!