### PR TITLE
Fixed the code snippet in the Update State From Tools tutorial

### DIFF
--- a/docs/docs/how-tos/update-state-from-tools.ipynb
+++ b/docs/docs/how-tos/update-state-from-tools.ipynb
@@ -43,7 +43,7 @@
     "    ```python\n",
     "    def call_tools(state):\n",
     "        ...\n",
-    "        commands = [tools_by_name[call[\"name\"].invoke(call, config={\"coerce_tool_content\": False}) for tool_call in tool_calls]\n",
+    "        commands = [tools_by_name[tool_call[\"name\"].invoke(tool_call, config={\"coerce_tool_content\": False}) for tool_call in tool_calls]\n",
     "        return commands\n",
     "    ```\n",
     "\n",

--- a/docs/docs/how-tos/update-state-from-tools.ipynb
+++ b/docs/docs/how-tos/update-state-from-tools.ipynb
@@ -43,7 +43,7 @@
     "    ```python\n",
     "    def call_tools(state):\n",
     "        ...\n",
-    "        commands = [tools_by_name[tool_call[\"name\"].invoke(tool_call, config={\"coerce_tool_content\": False}) for tool_call in tool_calls]\n",
+    "        commands = [tools_by_name[tool_call[\"name\"]].invoke(tool_call, config={\"coerce_tool_content\": False}) for tool_call in tool_calls]\n",
     "        return commands\n",
     "    ```\n",
     "\n",

--- a/docs/docs/how-tos/update-state-from-tools.ipynb
+++ b/docs/docs/how-tos/update-state-from-tools.ipynb
@@ -43,7 +43,7 @@
     "    ```python\n",
     "    def call_tools(state):\n",
     "        ...\n",
-    "        commands = [tools_by_name[tool_call[\"name\"]].invoke(tool_call, config={\"coerce_tool_content\": False}) for tool_call in tool_calls]\n",
+    "        commands = [tools_by_name[tool_call[\"name\"]].invoke(tool_call) for tool_call in tool_calls]\n",
     "        return commands\n",
     "    ```\n",
     "\n",


### PR DESCRIPTION
Hi,

While reading the [update state from tools](https://langchain-ai.github.io/langgraph/how-tos/update-state-from-tools/) tutorial. I noticed that this code snippet contains a syntax error:

```python
def call_tools(state):
    ...
    commands = [tools_by_name[call["name"].invoke(call, config={"coerce_tool_content": False}) for tool_call in tool_calls]
    return commands
```

There is a missing closing bracket `]` in the list comprehension. Additionally, the variable `call` inside the list comprehension is undefined, it should be `tool_call`.

Here is a corrected version of the code:

```python
def call_tools(state):
    ...
    commands = [tools_by_name[tool_call["name"]].invoke(tool_call, config={"coerce_tool_content": False}) for tool_call in tool_calls]
    return commands
```