### PR TITLE
docs: Update correct ID for initial ToolNode hyperlink

### DIFF
--- a/docs/docs/how-tos/tool-calling.ipynb
+++ b/docs/docs/how-tos/tool-calling.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# How to call tools using ToolNode\n",
     "\n",
-    "This guide covers how to use LangGraph's prebuilt [`ToolNode`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#toolnode) for tool calling.\n",
+    "This guide covers how to use LangGraph's prebuilt [`ToolNode`](https://langchain-ai.github.io/langgraph/reference/prebuilt/#langgraph.prebuilt.tool_node.ToolNode) for tool calling.\n",
     "\n",
     "`ToolNode` is a LangChain Runnable that takes graph state (with a list of messages) as input and outputs state update with the result of tool calls. It is designed to work well out-of-box with LangGraph's prebuilt [ReAct agent](https://langchain-ai.github.io/langgraph/how-tos/create-react-agent/), but can also work with any `StateGraph` as long as its state has a `messages` key with an appropriate reducer (see [`MessagesState`](https://github.com/langchain-ai/langgraph/blob/e3ef9adac7395e5c0943c22bbc8a4a856b103aa3/libs/langgraph/langgraph/graph/message.py#L150))."
    ]


### PR DESCRIPTION
Automatically leads to the correct `ToolNode` section instead of the top