### PR TITLE
Add node write cache support and implement for Postgres checkpointer

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -180,16 +180,18 @@ class PostgresSaver(BasePostgresSaver):
                     self._load_writes(value["pending_writes"]),
                 )
 
-    def get_writes(self, task_id, ttl=None) -> List[Any]:
-        # MKTODO: add documentation
-        # Only getting results for task_id pending writes in 1 arbitrary checkpoint now
-
-        # query = """
-        #         SELECT
-        #             array_agg(array[task_id::text::bytea, channel::bytea, type::bytea, blob] order by task_id, idx) as pending_writes
-        #         FROM checkpoint_writes
-        #         WHERE task_id = %s
-        #         """
+    def get_writes(self, task_id: str, ttl: int = None) -> List[Any]:
+        """Retrieve pending writes given a task_id and optionally a ttl (in seconds). Used for retrieving pending writes for cached nodes.
+        If ttl is specified, only retrieves pending writes such that the timestamp of the corresponding checkpoint is within ttl seconds 
+        of the query.
+        
+        Args:
+            task_id: a task identifier, usually generated from a cache key for a task deriving from a cached node
+            ttl: the time to live of the cached writes in seconds
+            
+        Returns:
+            a list decoded pending writes for the specified task id, optionally recorded within ttl seconds of this query being made
+        """
 
         query = ""
         

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -181,21 +181,20 @@ class PostgresSaver(BasePostgresSaver):
                 )
 
     def get_writes(self, task_id) -> List[Any]:
-        #MKTODO: add documentation
-        #Only getting results for task_id pending writes in 1 arbitrary checkpoint now
+        # MKTODO: add documentation
+        # Only getting results for task_id pending writes in 1 arbitrary checkpoint now
 
-        results = []
-        with self._cursor() as cur:
-            cur.execute(
-                """
+        query = """
                 SELECT
                     array_agg(array[task_id::text::bytea, channel::bytea, type::bytea, blob] order by task_id, idx) as pending_writes
                 FROM checkpoint_writes
                 WHERE task_id = %s
-                """,
-                (task_id,),
-                binary=True
-            )
+                """
+        args = (task_id,)
+
+        results = []
+        with self._cursor() as cur:
+            cur.execute(query, args, binary=True)
 
             for row in cur:
                 results.extend(

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -190,7 +190,7 @@ class PostgresSaver(BasePostgresSaver):
             ttl: the time to live of the cached writes in seconds
             
         Returns:
-            a list decoded pending writes for the specified task id, optionally recorded within ttl seconds of this query being made
+            a list of decoded pending writes for the specified task id, optionally recorded within ttl seconds of this query being made
         """
 
         query = ""

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -238,6 +238,7 @@ class BaseCheckpointSaver(Generic[V]):
         """
         if value := self.get_tuple(config):
             return value.checkpoint
+        
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Fetch a checkpoint tuple using the given configuration.
@@ -251,6 +252,18 @@ class BaseCheckpointSaver(Generic[V]):
         Raises:
             NotImplementedError: Implement this method in your custom checkpoint saver.
         """
+        raise NotImplementedError
+    
+    def get_writes(self, task_id: str) -> Optional[List[Any]]:
+        """Fetch pending writes from a checkpoint determined by the `task_id`.
+        The `task_id` should be the identifier of a `PregelTask` corresponding to a cached node.
+        
+        Args:
+            task_id (str): The identifer of the `PregelTask` corresponding to a cached node.
+            
+        Returns:
+            List[Any]: A list of checkpoint pending writes"""
+        
         raise NotImplementedError
 
     def list(

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -254,15 +254,17 @@ class BaseCheckpointSaver(Generic[V]):
         """
         raise NotImplementedError
     
-    def get_writes(self, task_id: str) -> Optional[List[Any]]:
-        """Fetch pending writes from a checkpoint determined by the `task_id`.
-        The `task_id` should be the identifier of a `PregelTask` corresponding to a cached node.
+    def get_writes(self, task_id: str, ttl: int = None) -> Optional[List[Any]]:
+        """"Retrieve pending writes given a task_id and optionally a ttl (in seconds). Used for retrieving pending writes for cached nodes.
+        If ttl is specified, only retrieves pending writes such that the timestamp of the corresponding checkpoint is within ttl seconds 
+        of the query.
         
         Args:
-            task_id (str): The identifer of the `PregelTask` corresponding to a cached node.
+            task_id: a task identifier, usually generated from a cache key for a task deriving from a cached node
+            ttl: the time to live of the cached writes in seconds
             
         Returns:
-            List[Any]: A list of checkpoint pending writes"""
+            a list of decoded pending writes for the specified task id, optionally recorded within ttl seconds of this query being made"""
         
         raise NotImplementedError
 

--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, ExitStack
 from functools import partial
 from types import TracebackType
-from typing import Any, AsyncIterator, Dict, Iterator, Optional, Sequence, Tuple, Type
+from typing import Any, AsyncIterator, Dict, Iterator, Optional, Sequence, Tuple, Type, List
 
 from langchain_core.runnables import RunnableConfig
 
@@ -105,6 +105,9 @@ class MemorySaver(
         __traceback: Optional[TracebackType],
     ) -> Optional[bool]:
         return self.stack.__exit__(__exc_type, __exc_value, __traceback)
+    
+    def get_writes(self, task_id: str) -> Optional[List[Any]]:
+        pass
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the in-memory storage.

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -242,6 +242,7 @@ class StateGraph(Graph):
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
         retry: Optional[RetryPolicy] = None,
+        cache: Optional[CachePolicy] = None,
     ) -> Self:
         """Adds a new node to the state graph.
         Will take the name of the function/runnable as the node name.
@@ -704,6 +705,7 @@ class CompiledStateGraph(CompiledGraph):
                 ],
                 metadata=node.metadata,
                 retry_policy=node.retry_policy,
+                cache_policy=node.cache_policy,
                 bound=node.runnable,
             )
         else:

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -100,6 +100,7 @@ class StateNodeSpec(NamedTuple):
     metadata: Optional[dict[str, Any]]
     input: Type[Any]
     retry_policy: Optional[RetryPolicy]
+    cache_policy: Optional[CachePolicy]
     ends: Optional[tuple[str, ...]] = EMPTY_SEQ
 
 
@@ -404,8 +405,8 @@ class StateGraph(Graph):
             metadata,
             input=input or self.schema,
             retry_policy=retry,
+            cache_policy=cache,
             ends=ends,
-            cache=cache,
         )
         return self
 

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -50,7 +50,7 @@ from langgraph.managed.base import (
 from langgraph.pregel.read import ChannelRead, PregelNode
 from langgraph.pregel.write import SKIP_WRITE, ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
-from langgraph.types import _DC_KWARGS, All, Checkpointer, Command, N, RetryPolicy
+from langgraph.types import _DC_KWARGS, All, Checkpointer, Command, N, RetryPolicy, CachePolicy
 from langgraph.utils.fields import get_field_default
 from langgraph.utils.pydantic import create_model
 from langgraph.utils.runnable import RunnableCallable, coerce_to_runnable
@@ -265,6 +265,7 @@ class StateGraph(Graph):
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
         retry: Optional[RetryPolicy] = None,
+        cache: Optional[CachePolicy] = None,
     ) -> Self:
         """Adds a new node to the state graph.
 
@@ -288,6 +289,7 @@ class StateGraph(Graph):
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
         retry: Optional[RetryPolicy] = None,
+        cache: Optional[CachePolicy] = None,
     ) -> Self:
         """Adds a new node to the state graph.
 
@@ -403,6 +405,7 @@ class StateGraph(Graph):
             input=input or self.schema,
             retry_policy=retry,
             ends=ends,
+            cache=cache,
         )
         return self
 

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -489,7 +489,7 @@ def prepare_single_task(
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
-                    cache_key
+                    cache_key,
                 )
             else:
                 task_id = _uuid5_str(
@@ -534,7 +534,7 @@ def prepare_single_task(
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
-                    cache_key
+                    cache_key,
                 )
             else:
                 task_id = _uuid5_str(
@@ -666,7 +666,7 @@ def prepare_single_task(
                 task_id = _uuid5_str(
                     b"",
                     name,
-                    cache_key
+                    cache_key,
                 )
             else:
                 task_id = _uuid5_str(

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -17,6 +17,8 @@ from typing import (
     overload,
 )
 from uuid import UUID
+import time
+import inspect
 
 from langchain_core.callbacks.manager import AsyncParentRunManager, ParentRunManager
 from langchain_core.runnables.config import RunnableConfig
@@ -485,12 +487,27 @@ def prepare_single_task(
             proc = processes[packet.node]
             
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(packet.arg, config)
-                task_id = _uuid5_str(
-                    b"",
-                    packet.node,
-                    cache_key,
-                )
+                # cache policy fn can take state and config or just state
+                cache_key_fn = proc.cache_policy.cache_key
+                if len(inspect.signature(cache_key_fn).parameters) == 2:
+                    cache_key = proc.cache_policy.cache_key(packet.arg, config)
+                else:
+                    cache_key = proc.cache_policy.cache_key(packet.arg)
+                
+                if ttl := proc.cache_policy.ttl:
+                    ttl_str = str(time.time() // ttl)
+                    task_id = _uuid5_str(
+                        b"",
+                        packet.node,
+                        cache_key,
+                        ttl_str
+                    )
+                else:
+                    task_id = _uuid5_str(
+                        b"",
+                        packet.node,
+                        cache_key,
+                    )
             else:
                 task_id = _uuid5_str(
                     checkpoint_id,
@@ -530,12 +547,27 @@ def prepare_single_task(
             )
             proc = processes[packet.node]
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(packet.arg, config)
-                task_id = _uuid5_str(
-                    b"",
-                    packet.node,
-                    cache_key,
-                )
+                # cache policy fn can take state and config or just state
+                cache_key_fn = proc.cache_policy.cache_key
+                if len(inspect.signature(cache_key_fn).parameters) == 2:
+                    cache_key = proc.cache_policy.cache_key(packet.arg, config)
+                else:
+                    cache_key = proc.cache_policy.cache_key(packet.arg)
+
+                if ttl := proc.cache_policy.ttl:
+                    ttl_str = str(time.time() // ttl)
+                    task_id = _uuid5_str(
+                        b"",
+                        packet.node,
+                        cache_key,
+                        ttl_str
+                    )
+                else:
+                    task_id = _uuid5_str(
+                        b"",
+                        packet.node,
+                        cache_key,
+                    )
             else:
                 task_id = _uuid5_str(
                     checkpoint_id,
@@ -662,12 +694,27 @@ def prepare_single_task(
             checkpoint_ns = f"{parent_ns}{NS_SEP}{name}" if parent_ns else name
   
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(val, config)
-                task_id = _uuid5_str(
-                    b"",
-                    name,
-                    cache_key,
-                )
+                # cache policy fn can take state and config or just state
+                cache_key_fn = proc.cache_policy.cache_key
+                if len(inspect.signature(cache_key_fn).parameters) == 2:
+                    cache_key = proc.cache_policy.cache_key(val, config)
+                else:
+                    cache_key = proc.cache_policy.cache_key(val)
+
+                if ttl := proc.cache_policy.ttl:
+                    ttl_str = str(time.time() // ttl)
+                    task_id = _uuid5_str(
+                        b"",
+                        name,
+                        cache_key,
+                        ttl_str
+                    )
+                else:
+                    task_id = _uuid5_str(
+                        b"",
+                        name,
+                        cache_key,
+                    )
             else:
                 task_id = _uuid5_str(
                     checkpoint_id,

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -458,6 +458,7 @@ def prepare_single_task(
     parent_ns = configurable.get(CONFIG_KEY_CHECKPOINT_NS, "")
 
     if task_path[0] == PUSH:
+        #MKTODO: Does caching differ from push vs pull?
         if len(task_path) == 2:  # TODO: remove branch in 1.0
             # legacy SEND tasks, executed in superstep n+1
             # (PUSH, idx of pending send)
@@ -484,7 +485,7 @@ def prepare_single_task(
             )
             proc = processes[packet.node]
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key,
+                cache_key = proc.cache_policy.cache_key(packet.arg)
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
@@ -529,7 +530,7 @@ def prepare_single_task(
             )
             proc = processes[packet.node]
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key,
+                cache_key = proc.cache_policy.cache_key(packet.arg)
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
@@ -661,7 +662,7 @@ def prepare_single_task(
             checkpoint_ns = f"{parent_ns}{NS_SEP}{name}" if parent_ns else name
   
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key,
+                cache_key = proc.cache_policy.cache_key(val)
                 task_id = _uuid5_str(
                     b"",
                     name,

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -458,7 +458,6 @@ def prepare_single_task(
     parent_ns = configurable.get(CONFIG_KEY_CHECKPOINT_NS, "")
 
     if task_path[0] == PUSH:
-        #MKTODO: Does caching differ from push vs pull?
         if len(task_path) == 2:  # TODO: remove branch in 1.0
             # legacy SEND tasks, executed in superstep n+1
             # (PUSH, idx of pending send)
@@ -484,8 +483,9 @@ def prepare_single_task(
                 f"{parent_ns}{NS_SEP}{packet.node}" if parent_ns else packet.node
             )
             proc = processes[packet.node]
+            
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(packet.arg)
+                cache_key = proc.cache_policy.cache_key(packet.arg, config)
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
@@ -530,7 +530,7 @@ def prepare_single_task(
             )
             proc = processes[packet.node]
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(packet.arg)
+                cache_key = proc.cache_policy.cache_key(packet.arg, config)
                 task_id = _uuid5_str(
                     b"",
                     packet.node,
@@ -662,7 +662,7 @@ def prepare_single_task(
             checkpoint_ns = f"{parent_ns}{NS_SEP}{name}" if parent_ns else name
   
             if proc.cache_policy:
-                cache_key = proc.cache_policy.cache_key(val)
+                cache_key = proc.cache_policy.cache_key(val, config)
                 task_id = _uuid5_str(
                     b"",
                     name,

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -472,16 +472,12 @@ class PregelLoop(LoopProtocol):
         if self.exists_cached_node and self.checkpointer:
             for tid, task in self.tasks.items():
                 if task.cache_policy:
-                    cached_writes = self.checkpointer.get_writes(tid)
+                    cached_writes = self.checkpointer.get_writes(tid, task.cache_policy.ttl)
                     if cached_writes:
-                        print("Cache Hit: ", cached_writes)
-                        print()
-
                         task = self.tasks[tid]
                         task.writes.extend(
                             [(channel, value) for _, channel, value in cached_writes]
                         )
-
                         self._output_writes(tid, task.writes, cached=True)
 
         # if there are pending writes from a previous loop, apply them

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -26,6 +26,7 @@ from langgraph.pregel.retry import RetryPolicy
 from langgraph.pregel.write import ChannelWrite
 from langgraph.utils.config import merge_configs
 from langgraph.utils.runnable import RunnableCallable, RunnableSeq
+from langgraph.pregel.types import CachePolicy
 
 READ_TYPE = Callable[[Union[str, Sequence[str]], bool], Union[Any, dict[str, Any]]]
 
@@ -139,6 +140,11 @@ class PregelNode(Runnable):
     retry_policy: Optional[RetryPolicy]
     """The retry policy to use when invoking the node."""
 
+    cache_policy: Optional[CachePolicy]
+    """The cache policy to use when invoking the node. Determines `task_id` and 
+    whether a node that has already been invoked will be invoked again, under
+    specified constraints"""
+
     tags: Optional[Sequence[str]]
     """Tags to attach to the node for tracing."""
 
@@ -156,6 +162,7 @@ class PregelNode(Runnable):
         metadata: Optional[Mapping[str, Any]] = None,
         bound: Optional[Runnable[Any, Any]] = None,
         retry_policy: Optional[RetryPolicy] = None,
+        cache_policy: Optional[CachePolicy] = None,
     ) -> None:
         self.channels = channels
         self.triggers = list(triggers)
@@ -165,6 +172,7 @@ class PregelNode(Runnable):
         self.retry_policy = retry_policy
         self.tags = tags
         self.metadata = metadata
+        self.cache_policy: cache_policy
 
     def copy(self, update: dict[str, Any]) -> PregelNode:
         attrs = {**self.__dict__, **update}

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -172,7 +172,7 @@ class PregelNode(Runnable):
         self.retry_policy = retry_policy
         self.tags = tags
         self.metadata = metadata
-        self.cache_policy: cache_policy
+        self.cache_policy = cache_policy
 
     def copy(self, update: dict[str, Any]) -> PregelNode:
         attrs = {**self.__dict__, **update}

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -108,7 +108,7 @@ class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
     cache_key: Optional[Callable[[Any], str]]
     """A function that generates a hash from a subset of the input of a task, defining cached writes for a task. If not provided, all writes are cached."""
-    ttl: Optional[int]
+    ttl: Optional[int] = None
     """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
 
 

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -106,8 +106,9 @@ class RetryPolicy(NamedTuple):
 
 class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
-    cache_key: Optional[Callable[[Any], str]]
-    """A function that generates a hash from a subset of the input of a task, defining cached writes for a task. If not provided, all writes are cached."""
+
+    cache_key: Callable[[str], str]
+    """A function that generates a hash from a subset of the input of a task at runtime, defining cached writes for a task."""
     ttl: Optional[int] = None
     """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
 

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -109,12 +109,11 @@ class CachePolicy(NamedTuple):
 
     cache_key: Callable[[str, Optional[RunnableConfig]], str]
     """A function that generates a hash from a subset of the input of a task at runtime, defining cached writes for a task. 
-    It must take in 2 arguments: 
-        (1) the state of the graph
-        (2) the config of the graph invocation
+    It must take in the state of the graph as the first argument. It can optionally be defined with the config of the graph invocation
+    as the second invocation.
     """
     ttl: Optional[int] = None
-    """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
+    """Maximum time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever."""
 
 
 @dataclasses.dataclass(**_DC_KWARGS)

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -107,8 +107,12 @@ class RetryPolicy(NamedTuple):
 class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
 
-    cache_key: Callable[[str], str]
-    """A function that generates a hash from a subset of the input of a task at runtime, defining cached writes for a task."""
+    cache_key: Callable[[str, Optional[RunnableConfig]], str]
+    """A function that generates a hash from a subset of the input of a task at runtime, defining cached writes for a task. 
+    It must take in 2 arguments: 
+        (1) the state of the graph
+        (2) the config of the graph invocation
+    """
     ttl: Optional[int] = None
     """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
 

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -106,10 +106,10 @@ class RetryPolicy(NamedTuple):
 
 class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
-    cache_key: Callable[[Any], str]
-    """a function that generates a hash from a subset of the input of a task"""
+    cache_key: Optional[Callable[[Any], str]]
+    """A function that generates a hash from a subset of the input of a task, defining cached writes for a task. If not provided, all writes are cached."""
     ttl: Optional[float]
-    """Time to live (sec) for the cached write corresponding to a task. Default is forever."""
+    """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
 
 
 @dataclasses.dataclass(**_DC_KWARGS)

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -106,8 +106,10 @@ class RetryPolicy(NamedTuple):
 
 class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
-
-    pass
+    cache_key: Callable[[Any], str]
+    """a function that generates a hash from a subset of the input of a task"""
+    ttl: Optional[float]
+    """Time to live (sec) for the cached write corresponding to a task. Default is forever."""
 
 
 @dataclasses.dataclass(**_DC_KWARGS)

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -108,7 +108,7 @@ class CachePolicy(NamedTuple):
     """Configuration for caching nodes."""
     cache_key: Optional[Callable[[Any], str]]
     """A function that generates a hash from a subset of the input of a task, defining cached writes for a task. If not provided, all writes are cached."""
-    ttl: Optional[float]
+    ttl: Optional[int]
     """Time to live (sec) for the cached write corresponding to a task. If not provided, writes are cached forever"""
 
 

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -1,0 +1,20 @@
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import StateGraph, END
+from langgraph.types import CachePolicy
+from typing import TypedDict
+
+
+
+    
+def test_basic_cache():
+    cache = CachePolicy(cache_key=lambda x: "hi")
+    builder = StateGraph(int)
+    builder.add_node("add_two", lambda x: x + 2, cache=cache)
+    builder.add_node("subtract_one", lambda x: x-1)
+    builder.add_edge("add_two", "subtract_one")
+    builder.add_conditional_edges("subtract_one", lambda x: END if x >= 10 else "add_two")
+    builder.set_entry_point("add_two")
+    config = {"configurable": {"thread_id": "thread-1"}}
+    memory = MemorySaver()
+    graph = builder.compile(checkpointer=memory)
+    graph.invoke(1, config, debug=True)

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -5,129 +5,233 @@ from typing import TypedDict
 import pytest
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import BaseCheckpointSaver
-
-
-
-
-    
-def test_basic_cache():
-    cache = CachePolicy(cache_key=lambda x: "hi")
-    builder = StateGraph(int)
-    builder.add_node("add_two", lambda x: x + 2, cache=cache)
-    builder.add_node("subtract_one", lambda x: x-1)
-    builder.add_edge("add_two", "subtract_one")
-    builder.add_conditional_edges("subtract_one", lambda x: END if x >= 10 else "add_two")
-    builder.set_entry_point("add_two")
-    config = {"configurable": {"thread_id": "thread-1"}}
-    memory = MemorySaver()
-    graph = builder.compile(checkpointer=memory)
-    graph.invoke(1, config)
-
-def test_dict_cache():
-
-    class State(TypedDict):
-        foo: int
-        bar: int
-
-    def cache_key(inputs: State):
-        return str(inputs["bar"])
-
-    cache = CachePolicy(cache_key=cache_key)
-    builder = StateGraph(State)
-    builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
-    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
-    builder.add_edge("add_two", "subtract_one")
-    builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
-    builder.set_entry_point("add_two")
-    config = {"configurable": {"thread_id": "thread-1"}}
-    memory = MemorySaver()
-    graph = builder.compile(checkpointer=memory)
-    graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
+import time
+import random
+import hashlib
 
 @pytest.mark.parametrize("checkpointer_name", ["postgres"])
-def test_postgres(request: pytest.FixtureRequest, checkpointer_name: str):
+def test_cached_node_executes_once(request: pytest.FixtureRequest, checkpointer_name: str):
+    """Test that an indefinitely cached node will not be executed more than once"""
+
     checkpointer: PostgresSaver = request.getfixturevalue(
         f"checkpointer_{checkpointer_name}"
     )
 
-    # config = {"configurable": {"thread_id": "thread-1"}}
-
-    # class State(TypedDict):
-    #     foo: int
-    #     bar: int
-
-    # def cache_key(inputs: State, config: RunnableConfig = None):
-    #     return str(inputs["bar"])
-
-    # cache = CachePolicy(cache_key=cache_key)
-    # builder = StateGraph(State)
-    # builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
-    # builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
-    # builder.add_edge("add_two", "subtract_one")
-    # builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
-    # builder.set_entry_point("add_two")
-    
-    # graph = builder.compile(checkpointer=checkpointer)
-    # graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
-
-    # SEcOND TEST
-
-    config = {"configurable": {"thread_id": "thread-1"}}
-
+    call_count = 0
     class State(TypedDict):
-        foo: int
-        bar: int
-        ra: int
+        stop_condition: int
 
-    def cache_key(inputs: State):
-        return str(inputs["ra"])
+    def cached_node(input: State):
+        nonlocal call_count
+        call_count += 1
+        pass
 
+    def cache_key(input: State):
+        return ""
+
+    def dummy_node(input: State):
+        return {"stop_condition": input["stop_condition"] + 1}
+    
+    config = {"configurable": {"thread_id": "thread-1"}}
     cache = CachePolicy(cache_key=cache_key)
     builder = StateGraph(State)
-    builder.add_node("add_two", lambda x: {"ra": x["ra"] + 1}, cache=cache)
-    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] + 2, "ra": x["ra"] + 2})
-    builder.add_edge("add_two", "subtract_one")
-    builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
-    builder.set_entry_point("add_two")
-    
-    graph = builder.compile(checkpointer=checkpointer)
-    graph.invoke({"foo": 1, "bar": 1, "ra": 1}, config, debug=True)
+    builder.add_node("cached_node", cached_node, cache=cache)
+    builder.add_node("dummy_node", dummy_node)
+    builder.add_edge("cached_node", "dummy_node")
+    builder.add_conditional_edges("dummy_node", lambda x: END if x["stop_condition"] >= 10 else "cached_node")
+    builder.set_entry_point("cached_node")
 
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.invoke({"stop_condition": 0}, config)
+
+    assert call_count == 1
+    
 @pytest.mark.parametrize("checkpointer_name", ["postgres"])
-def test_call_count(request: pytest.FixtureRequest, checkpointer_name: str):
+def test_cache_key_single_field(request: pytest.FixtureRequest, checkpointer_name: str):
+    """Test that a cached node with a cache key specifying a single field of the input will 
+    be executed only when a value of the field has not been seen before"""
+
     checkpointer: PostgresSaver = request.getfixturevalue(
         f"checkpointer_{checkpointer_name}"
     )
 
-    node_call_count = 0
-
-    config = {"configurable": {"thread_id": "thread-1"}}
+    call_count = 0
+    target_call_count = random.randint(1, 10)
 
     class State(TypedDict):
-        foo: int
-        bar: int
-        ra: int
+        dependent_field: int
+        stop_condition: int
 
-    def add_two(state: State):
-        nonlocal node_call_count 
-        node_call_count += 1
-        return {"ra": state["ra"] + 1}
+    def cached_node(input: State):
+        nonlocal call_count
+        call_count += 1
+        pass
 
-    def cache_key(inputs: State):
-        return "" #str(inputs["ra"])
+    def cache_key(input: State):
+        s = str(input["dependent_field"])
+        return hashlib.md5(s.encode()).hexdigest()
 
+    def dummy_node(input: State):
+        return {
+            "stop_condition": input["stop_condition"] + 1, 
+            "dependent_field": (input["dependent_field"] + 1) % target_call_count}
+    
+    config = {"configurable": {"thread_id": "thread-1"}}
     cache = CachePolicy(cache_key=cache_key)
     builder = StateGraph(State)
-    builder.add_node("add_two", add_two, cache=cache)
-    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] + 2, "ra": x["ra"] + 2})
-    builder.add_edge("add_two", "subtract_one")
-    builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
-    builder.set_entry_point("add_two")
-    
+    builder.add_node("cached_node", cached_node, cache=cache)
+    builder.add_node("dummy_node", dummy_node)
+    builder.add_edge("cached_node", "dummy_node")
+    builder.add_conditional_edges("dummy_node", lambda x: END if x["stop_condition"] >= 10 else "cached_node")
+    builder.set_entry_point("cached_node")
+
     graph = builder.compile(checkpointer=checkpointer)
-    graph.invoke({"foo": 1, "bar": 1, "ra": 1}, config, debug=True)
+    graph.invoke({"stop_condition": 0, "dependent_field": 0}, config)
 
-    print("NODE CALL COUNT: ", node_call_count)
+    print(call_count)
+    assert call_count == target_call_count
 
+@pytest.mark.parametrize("checkpointer_name", ["postgres"])
+def test_cache_key_multiple_fields(request: pytest.FixtureRequest, checkpointer_name: str):
+    """Test that a cached node with a cache key specifying a subset of input fields  will 
+    be executed only when a value of the fields has not been seen before"""
 
+    checkpointer: PostgresSaver = request.getfixturevalue(
+        f"checkpointer_{checkpointer_name}"
+    )
+    call_count = 0
 
+    class State(TypedDict):
+        dependent_field_1: int
+        dependent_field_2: int
+        stop_condition: int
+
+    def cached_node(input: State):
+        nonlocal call_count
+        call_count += 1
+        pass
+
+    def cache_key(input: State):
+        fields = ["dependent_field_1", "dependent_field_2"]
+        s = "".join([f"{field}{val}" for field, val in input.items() if field in fields])
+        return hashlib.md5(s.encode()).hexdigest()
+
+    def dummy_node(input: State):
+        return {
+            "stop_condition": input["stop_condition"] + 1, 
+            "dependent_field_1": (input["dependent_field_1"] + 1) % 2,
+            "dependent_field_2": (input["dependent_field_2"] + 1) % 3,
+            }
+    
+    config = {"configurable": {"thread_id": "thread-1"}}
+    cache = CachePolicy(cache_key=cache_key)
+    builder = StateGraph(State)
+    builder.add_node("cached_node", cached_node, cache=cache)
+    builder.add_node("dummy_node", dummy_node)
+    builder.add_edge("cached_node", "dummy_node")
+    builder.add_conditional_edges("dummy_node", lambda x: END if x["stop_condition"] >= 10 else "cached_node")
+    builder.set_entry_point("cached_node")
+
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.invoke({"stop_condition": 0, "dependent_field_1": 0, "dependent_field_2": 0}, config)
+
+    assert call_count == 3
+
+@pytest.mark.parametrize("checkpointer_name", ["postgres"])
+def test_multiple_cached_nodes(request: pytest.FixtureRequest, checkpointer_name: str):
+    """Test that multiple cached nodes with different cache keys and ttls behave appropriately TODO update and redo with diff shape graph"""
+
+    checkpointer: PostgresSaver = request.getfixturevalue(
+        f"checkpointer_{checkpointer_name}"
+    )
+
+    call_count_1 = 0
+    call_count_2 = 0
+
+    class State(TypedDict):
+        dependent_field_1: int
+        dependent_field_2: int
+        stop_condition: int
+
+    def cached_node_1(input: State):
+        nonlocal call_count_1
+        call_count_1 += 1
+        pass
+
+    def cached_node_2(input: State):
+        nonlocal call_count_2
+        call_count_2 += 1
+        pass
+
+    def cache_key_1(input: State):
+        s = "key_1" if input["dependent_field_1"] // 2 == 0 else "key_2"
+        return hashlib.md5(s.encode()).hexdigest()
+    
+    def cache_key_2(input: State):
+        s = "key_3" if input["dependent_field_2"] // 3 == 0 else "key_4"
+        return hashlib.md5(s.encode()).hexdigest()
+
+    def dummy_node(input: State):
+        return {
+            "stop_condition": input["stop_condition"] + 1, 
+            "dependent_field_1": input["dependent_field_1"] + 1,
+            "dependent_field_2": input["dependent_field_2"] + 1
+            }
+    
+    config: RunnableConfig = {"configurable": {"thread_id": "thread-1"}, "recursion_limit": 31}
+
+    builder = StateGraph(State)
+    builder.add_node("cached_node_1", cached_node_1, cache=CachePolicy(cache_key=cache_key_1))
+    builder.add_node("cached_node_2", cached_node_2, cache=CachePolicy(cache_key=cache_key_2))
+    builder.add_node("dummy_node", dummy_node)
+    builder.add_edge("cached_node_1", "cached_node_2")
+    builder.add_edge("cached_node_2", "dummy_node")
+    builder.add_conditional_edges("dummy_node", lambda x: END if x["stop_condition"] >= 10 else "cached_node_1")
+    builder.set_entry_point("cached_node_1")
+
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.invoke({"stop_condition": 0, "dependent_field_1": 0, "dependent_field_2": 0}, config, debug=True)
+
+    assert call_count_2 == call_count_1 == 2
+
+@pytest.mark.parametrize("checkpointer_name", ["postgres"])
+def test_cache_ttl(request: pytest.FixtureRequest, checkpointer_name: str):
+    """Test that a cached node defined with ttl does not retrieve cached writes after they've 
+    expired"""
+
+    checkpointer: PostgresSaver = request.getfixturevalue(
+        f"checkpointer_{checkpointer_name}"
+    )
+    call_count = 0
+
+    class State(TypedDict):
+        stop_condition: int
+
+    def cached_node(input: State):
+        nonlocal call_count
+        call_count += 1
+        pass
+
+    def cache_key(input: State):
+        return ""
+
+    # node sleeps for half of the ttl
+    def dummy_node(input: State):
+        time.sleep(0.5)
+        return {
+            "stop_condition": input["stop_condition"] + 1}
+    
+    config = {"configurable": {"thread_id": "thread-1"}}
+    cache = CachePolicy(cache_key=cache_key, ttl=1)
+    builder = StateGraph(State)
+    builder.add_node("cached_node", cached_node, cache=cache)
+    builder.add_node("dummy_node", dummy_node)
+    builder.add_edge("cached_node", "dummy_node")
+    builder.add_conditional_edges("dummy_node", lambda x: END if x["stop_condition"] >= 4 else "cached_node")
+    builder.set_entry_point("cached_node")
+
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.invoke({"stop_condition": 0}, config)
+
+    # node should execute half of the time since cache only lives for 2 cycles of the graph
+    assert call_count == 2

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -74,7 +74,8 @@ def test_cache_key_single_field(request: pytest.FixtureRequest, checkpointer_nam
     def dummy_node(input: State):
         return {
             "stop_condition": input["stop_condition"] + 1, 
-            "dependent_field": (input["dependent_field"] + 1) % target_call_count}
+            "dependent_field": (input["dependent_field"] + 1) % target_call_count
+        }
     
     config = {"configurable": {"thread_id": "thread-1"}}
     cache = CachePolicy(cache_key=cache_key)
@@ -122,7 +123,7 @@ def test_cache_key_multiple_fields(request: pytest.FixtureRequest, checkpointer_
             "stop_condition": input["stop_condition"] + 1, 
             "dependent_field_1": (input["dependent_field_1"] + 1) % 2,
             "dependent_field_2": (input["dependent_field_2"] + 1) % 4,
-            }
+        }
     
     config = {"configurable": {"thread_id": "thread-1"}}
     cache = CachePolicy(cache_key=cache_key)
@@ -185,7 +186,7 @@ def test_multiple_cached_nodes(request: pytest.FixtureRequest, checkpointer_name
             "stop_condition": input["stop_condition"] + 1, 
             "dependent_field_1": input["dependent_field_1"] + 1,
             "dependent_field_2": input["dependent_field_2"] + 1
-            }
+        }
     
     config: RunnableConfig = {"configurable": {"thread_id": "thread-1"}, "recursion_limit": 31}
 
@@ -229,8 +230,7 @@ def test_cache_ttl(request: pytest.FixtureRequest, checkpointer_name: str):
     # node sleeps for half of the ttl
     def dummy_node(input: State):
         time.sleep(0.5)
-        return {
-            "stop_condition": input["stop_condition"] + 1}
+        return {"stop_condition": input["stop_condition"] + 1}
     
     config = {"configurable": {"thread_id": "thread-1"}}
     cache = CachePolicy(cache_key=cache_key, ttl=1)

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -17,4 +17,33 @@ def test_basic_cache():
     config = {"configurable": {"thread_id": "thread-1"}}
     memory = MemorySaver()
     graph = builder.compile(checkpointer=memory)
-    graph.invoke(1, config, debug=True)
+    graph.invoke(1, config) #, debug=True)
+
+    # for elt in list(memory.list(None)):
+    #     print(elt)
+    #     print()
+
+def test_dict_cache():
+
+    class State(TypedDict):
+        foo: int
+        bar: int
+
+    def cache_key(inputs: State):
+        return str(inputs["bar"])
+
+    cache = CachePolicy(cache_key=cache_key)
+    builder = StateGraph(State)
+    builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
+    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
+    builder.add_edge("add_two", "subtract_one")
+    builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
+    builder.set_entry_point("add_two")
+    config = {"configurable": {"thread_id": "thread-1"}}
+    memory = MemorySaver()
+    graph = builder.compile(checkpointer=memory)
+    graph.invoke({"foo": 1, "bar": 1}, config) #, debug=True)
+
+    for elt in list(memory.list(None)):
+        print(elt)
+        print()

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -1,7 +1,10 @@
-from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.postgres import PostgresSaver
 from langgraph.graph import StateGraph, END
 from langgraph.types import CachePolicy
 from typing import TypedDict
+import pytest
+from langchain_core.runnables import RunnableConfig
+
 
 
 
@@ -17,11 +20,7 @@ def test_basic_cache():
     config = {"configurable": {"thread_id": "thread-1"}}
     memory = MemorySaver()
     graph = builder.compile(checkpointer=memory)
-    graph.invoke(1, config) #, debug=True)
-
-    # for elt in list(memory.list(None)):
-    #     print(elt)
-    #     print()
+    graph.invoke(1, config)
 
 def test_dict_cache():
 
@@ -42,8 +41,37 @@ def test_dict_cache():
     config = {"configurable": {"thread_id": "thread-1"}}
     memory = MemorySaver()
     graph = builder.compile(checkpointer=memory)
-    graph.invoke({"foo": 1, "bar": 1}, config) #, debug=True)
+    graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
 
-    for elt in list(memory.list(None)):
-        print(elt)
-        print()
+from langgraph.checkpoint.base import BaseCheckpointSaver
+
+@pytest.mark.parametrize("checkpointer_name", ["postgres"])
+def test_postgres(request: pytest.FixtureRequest, checkpointer_name: str):
+    checkpointer: PostgresSaver = request.getfixturevalue(
+        f"checkpointer_{checkpointer_name}"
+    )
+
+    config = {"configurable": {"thread_id": "thread-1"}}
+
+    class State(TypedDict):
+        foo: int
+        bar: int
+
+    def cache_key(inputs: State, config: RunnableConfig = None):
+        return str(inputs["bar"])
+
+    cache = CachePolicy(cache_key=cache_key)
+    builder = StateGraph(State)
+    builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
+    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
+    builder.add_edge("add_two", "subtract_one")
+    builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
+    builder.set_entry_point("add_two")
+    
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
+
+    print(checkpointer.get_writes("e5eff38b-2ef4-90a3-f2b2-9ecb227146bb"))
+
+    
+

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -134,7 +134,7 @@ def test_cache_key_multiple_fields(request: pytest.FixtureRequest, checkpointer_
     builder.set_entry_point("cached_node")
 
     graph = builder.compile(checkpointer=checkpointer)
-    graph.invoke({"stop_condition": 0, "dependent_field_1": 0, "dependent_field_2": 0}, config, debug=True)
+    graph.invoke({"stop_condition": 0, "dependent_field_1": 0, "dependent_field_2": 0}, config)
 
     assert call_count == 4
 

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -51,27 +51,47 @@ def test_postgres(request: pytest.FixtureRequest, checkpointer_name: str):
         f"checkpointer_{checkpointer_name}"
     )
 
+    # config = {"configurable": {"thread_id": "thread-1"}}
+
+    # class State(TypedDict):
+    #     foo: int
+    #     bar: int
+
+    # def cache_key(inputs: State, config: RunnableConfig = None):
+    #     return str(inputs["bar"])
+
+    # cache = CachePolicy(cache_key=cache_key)
+    # builder = StateGraph(State)
+    # builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
+    # builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
+    # builder.add_edge("add_two", "subtract_one")
+    # builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
+    # builder.set_entry_point("add_two")
+    
+    # graph = builder.compile(checkpointer=checkpointer)
+    # graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
+
+    # SEcOND TEST
+
     config = {"configurable": {"thread_id": "thread-1"}}
 
     class State(TypedDict):
         foo: int
         bar: int
+        ra: int
 
     def cache_key(inputs: State, config: RunnableConfig = None):
         return str(inputs["bar"])
 
     cache = CachePolicy(cache_key=cache_key)
     builder = StateGraph(State)
-    builder.add_node("add_two", lambda x: {"foo": x["foo"] + 2}, cache=cache)
-    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] - 1, "bar": (x["bar"] + 1) % 2})
+    builder.add_node("add_two", lambda x: {"ra": x["ra"] + 1}, cache=cache)
+    builder.add_node("subtract_one", lambda x: {"foo": x["foo"] + 2, "ra": x["ra"] + 2})
     builder.add_edge("add_two", "subtract_one")
     builder.add_conditional_edges("subtract_one", lambda x: END if x["foo"] >= 10 else "add_two")
     builder.set_entry_point("add_two")
     
     graph = builder.compile(checkpointer=checkpointer)
-    graph.invoke({"foo": 1, "bar": 1}, config, debug=True)
-
-    print(checkpointer.get_writes("e5eff38b-2ef4-90a3-f2b2-9ecb227146bb"))
-
+    graph.invoke({"foo": 1, "bar": 1, "ra": 1}, config, debug=True)
     
 


### PR DESCRIPTION
### Summary:
Added caching support for individual nodes, and implemented in Postgres. Added tests for caching.

### Details:
- Added `cache` parameter to `add_node` method in `langgraph/graph/state.py`. Takes a `CachePolicy` object.
- Implemented `CachePolicy` type in `langgraph/types.py` with two parameters: required `cache_key` and optional `ttl` (in seconds). `cache_key` is a function that generates a hash based on (1) the current state of the graph during runtime and (2) the config.
- Implemented `task_id` based on the `cache_key` function for nodes that have a defined `CachePolicy`, in `langgraph/pregel/algo.py`. `cache_key` will generate a hash based on the current input and config. 
- Implemented pending writes retrieval for nodes that have a defined `CachePolicy` in `langgraph/pregel/loop.py`. 
- Added `get_writes(task_id, ttl)` method to base checkpointer in `checkpoint/langgraph/checkpoint/base/__init__.py`. 
- Implemented `get_writes()` method for Postgres checkpointer in `checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py`.
- Added basic tests in `langgraph/tests/test_cache.py`.