### PR TITLE
docs: removed redundant import from the example

### DIFF
--- a/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
+++ b/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
@@ -140,7 +140,6 @@
     "\n",
     "from langchain_openai import ChatOpenAI\n",
     "from langchain_core.messages import AnyMessage\n",
-    "from langchain_openai import ChatOpenAI\n",
     "from langgraph.graph import MessagesState, StateGraph, START, END\n",
     "from langgraph.types import Command, interrupt\n",
     "from langgraph.checkpoint.memory import MemorySaver\n",


### PR DESCRIPTION
there were two "from langchain_openai import ChatOpenAI"