### PR TITLE
docs: removed redundant import from the example

### DIFF
--- a/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
+++ b/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
@@ -140,7 +140,6 @@
     "\n",
     "from langchain_openai import ChatOpenAI\n",
     "from langchain_core.messages import AnyMessage\n",
-    "from langchain_openai import ChatOpenAI\n",
     "from langgraph.graph import MessagesState, StateGraph, START, END\n",
     "from langgraph.types import Command, interrupt\n",
     "from langgraph.checkpoint.memory import MemorySaver\n",

--- a/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
+++ b/docs/docs/how-tos/multi-agent-multi-turn-convo.ipynb
@@ -40,7 +40,7 @@
     "                \"content\": user_input,\n",
     "            }]\n",
     "        },\n",
-    "        goto=active_agent,\n",
+    "        goto=active_agent,)\n",
     "\n",
     "def agent(state) -> Command[Literal[\"agent\", \"another_agent\", \"human\"]]:\n",
     "    # The condition for routing/halting can be anything, e.g. LLM tool call / structured output, etc.\n",


### PR DESCRIPTION
there were two same import
"from langchain_openai import ChatOpenAI"