### PR TITLE
docs: readme nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ⚡ Building language agents as graphs ⚡
 
 > [!NOTE]
-> Looking for the JS version? Click [here](https://github.com/langchain-ai/langgraphjs) ([JS docs](https://langchain-ai.github.io/langgraphjs/)).
+> Looking for the JS version? See the [JS repo](https://github.com/langchain-ai/langgraphjs) and the [JS docs](https://langchain-ai.github.io/langgraphjs/).
 
 ## Overview
 

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -8,7 +8,7 @@
 ⚡ Building language agents as graphs ⚡
 
 > [!NOTE]
-> Looking for the JS version? Click [here](https://github.com/langchain-ai/langgraphjs) ([JS docs](https://langchain-ai.github.io/langgraphjs/)).
+> Looking for the JS version? See the [JS repo](https://github.com/langchain-ai/langgraphjs) and the [JS docs](https://langchain-ai.github.io/langgraphjs/).
 
 ## Overview
 


### PR DESCRIPTION
When looking at [docs](https://langchain-ai.github.io/langgraph/) this sentence is confusing, not clear there's two separate links or why one of them would lead to repo