### PR TITLE
docs: Add docs for `LANGCHAIN_ENDPOINT` for self-hosted deployments

### DIFF
--- a/docs/docs/how-tos/deploy-self-hosted.md
+++ b/docs/docs/how-tos/deploy-self-hosted.md
@@ -29,6 +29,7 @@ You will eventually need to pass in the following environment variables to the L
 - `DATABASE_URI`: Postgres connection details. Postgres will be used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics.
 - `LANGSMITH_API_KEY`: (If using [Self-Hosted Lite](../concepts/deployment_options.md#self-hosted-lite)) LangSmith API key. This will be used to authenticate ONCE at server start up.
 - `LANGGRAPH_CLOUD_LICENSE_KEY`: (If using [Self-Hosted Enterprise](../concepts/deployment_options.md#self-hosted-enterprise)) LangGraph Platform license key. This will be used to authenticate ONCE at server start up.
+- `LANGCHAIN_ENDPOINT`: To send traces to a [self-hosted LangSmith](https://docs.smith.langchain.com/self_hosting) instance, set `LANGCHAIN_ENDPOINT` to the hostname of the self-hosted LangSmith instance.
 
 
 ## Build the Docker Image


### PR DESCRIPTION
@langchain-infra, is this correct? Is this needed or is it redundant/unnecessary?