### PR TITLE
docs: Add note about LangGraph Platform UI not available for self-hosted deployments

### DIFF
--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -28,6 +28,10 @@ The guide below will explain the differences between the deployment options.
 
     The Self-Hosted Enterprise version is only available for the **Enterprise** plan.
 
+!!! warning "Note"
+
+    The LangGraph Platform UI (within LangSmith) is not available for Self-Hosted Enterprise deployments.
+
 With a Self-Hosted Enterprise deployment, you are responsible for managing the infrastructure, including setting up and maintaining required databases and Redis instances.
 
 You’ll build a Docker image using the [LangGraph CLI](./langgraph_cli.md), which can then be deployed on your own infrastructure.
@@ -42,6 +46,10 @@ For more information, please see:
 !!! important
 
     The Self-Hosted Lite version is available for all plans.
+
+!!! warning "Note"
+
+    The LangGraph Platform UI (within LangSmith) is not available for Self-Hosted Lite deployments.
 
 The Self-Hosted Lite deployment option is a free (up to 1 million nodes executed), limited version of LangGraph Platform that you can run locally or in a self-hosted manner.
 
@@ -61,12 +69,11 @@ For more information, please see:
 
     The Cloud SaaS version of LangGraph Platform is only available for **Plus** and **Enterprise** plans.
 
-
 The [Cloud SaaS](./langgraph_cloud.md) version of LangGraph Platform is hosted as part of [LangSmith](https://smith.langchain.com/).
 
 The Cloud SaaS version of LangGraph Platform provides a simple way to deploy and manage your LangGraph applications.
 
-This deployment option provides an integration with GitHub, allowing you to deploy code from any of your repositories on GitHub.
+This deployment option provides access to the LangGraph Platform UI (within LangSmith) and an integration with GitHub, allowing you to deploy code from any of your repositories on GitHub.
 
 For more information, please see:
 
@@ -81,7 +88,7 @@ For more information, please see:
     The Bring Your Own Cloud version of LangGraph Platform is only available for **Enterprise** plans.
 
 
-This combines the best of both worlds for Cloud and Self-Hosted. We manage the infrastructure, so you don't have to, but the infrastructure all runs within your cloud. This is currently only available on AWS.
+This combines the best of both worlds for Cloud and Self-Hosted. Create your deployments through the LangGraph Platform UI (within LangSmith) and we manage the infrastructure so you don't have to. The infrastructure all runs within your cloud. This is currently only available on AWS.
 
 For more information please see:
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -30,7 +30,7 @@ The guide below will explain the differences between the deployment options.
 
 !!! warning "Note"
 
-    The LangGraph Platform UI (within LangSmith) is not available for Self-Hosted Enterprise deployments.
+    The LangGraph Platform Deployments view (within LangSmith SaaS and self-hosted LangSmith) is not available for Self-Hosted Enterprise LangGraph deployments. Self-hosted LangGraph deployments are managed externally from LangSmith (e.g. there is no UI to manage these deployments).
 
 With a Self-Hosted Enterprise deployment, you are responsible for managing the infrastructure, including setting up and maintaining required databases and Redis instances.
 
@@ -49,7 +49,7 @@ For more information, please see:
 
 !!! warning "Note"
 
-    The LangGraph Platform UI (within LangSmith) is not available for Self-Hosted Lite deployments.
+    The LangGraph Platform Deployments view (within LangSmith SaaS and self-hosted LangSmith) is not available for Self-Hosted Lite LangGraph deployments. Self-hosted LangGraph deployments are managed externally from LangSmith (e.g. there is no UI to manage these deployments).
 
 The Self-Hosted Lite deployment option is a free (up to 1 million nodes executed), limited version of LangGraph Platform that you can run locally or in a self-hosted manner.
 

--- a/docs/docs/concepts/self_hosted.md
+++ b/docs/docs/concepts/self_hosted.md
@@ -32,6 +32,10 @@ To use the Self-Hosted Enterprise version, you must acquire a license key that y
 - Build the docker image for [LangGraph Server](./langgraph_server.md) using the [LangGraph CLI](./langgraph_cli.md).
 - Deploy a web server that will run the docker image and pass in the necessary environment variables.
 
+!!! warning "Note"
+
+    The LangGraph Platform Deployments view (within LangSmith SaaS and self-hosted LangSmith) is not available for Self-Hosted Lite or Self-Hosted Enterprise LangGraph deployments. Self-hosted LangGraph deployments are managed externally from LangSmith (e.g. there is no UI to manage these deployments).
+
 For step-by-step instructions, see [How to set up a self-hosted deployment of LangGraph](../how-tos/deploy-self-hosted.md).
 
 ## Helm Chart


### PR DESCRIPTION
Example screenshot:
![image](https://github.com/user-attachments/assets/8304b08d-bc9b-4cd3-8ff4-ed2471d3d6c7)
