### PR TITLE
Fix unexpected re-use of null resume value by subgraphs

### DIFF
--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -75,9 +75,7 @@ CONFIG_KEY_CHECKPOINT_ID = sys.intern("checkpoint_id")
 CONFIG_KEY_CHECKPOINT_NS = sys.intern("checkpoint_ns")
 # holds the current checkpoint_ns, "" for root graph
 CONFIG_KEY_NODE_FINISHED = sys.intern("__pregel_node_finished")
-# holds the value that "answers" an interrupt() call
-CONFIG_KEY_WRITES = sys.intern("__pregel_writes")
-# read-only list of existing task writes
+# holds a callback to be called when a node is finished
 CONFIG_KEY_SCRATCHPAD = sys.intern("__pregel_scratchpad")
 # holds a mutable dict for temporary storage scoped to the current task
 

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -42,10 +42,10 @@ from langgraph.constants import (
     CONFIG_KEY_SEND,
     CONFIG_KEY_STORE,
     CONFIG_KEY_TASK_ID,
-    CONFIG_KEY_WRITES,
     EMPTY_SEQ,
     ERROR,
     INTERRUPT,
+    MISSING,
     NO_WRITES,
     NS_END,
     NS_SEP,
@@ -71,6 +71,7 @@ from langgraph.types import (
     All,
     LoopProtocol,
     PregelExecutableTask,
+    PregelScratchpad,
     PregelTask,
     RetryPolicy,
 )
@@ -502,13 +503,10 @@ def prepare_single_task(
                         },
                         CONFIG_KEY_CHECKPOINT_ID: None,
                         CONFIG_KEY_CHECKPOINT_NS: task_checkpoint_ns,
-                        CONFIG_KEY_WRITES: [
-                            w
-                            for w in pending_writes
-                            + configurable.get(CONFIG_KEY_WRITES, [])
-                            if w[0] in (NULL_TASK_ID, task_id)
-                        ],
-                        CONFIG_KEY_SCRATCHPAD: {},
+                        CONFIG_KEY_SCRATCHPAD: _scratchpad(
+                            pending_writes,
+                            task_id,
+                        ),
                     },
                 ),
                 triggers,
@@ -614,13 +612,10 @@ def prepare_single_task(
                             },
                             CONFIG_KEY_CHECKPOINT_ID: None,
                             CONFIG_KEY_CHECKPOINT_NS: task_checkpoint_ns,
-                            CONFIG_KEY_WRITES: [
-                                w
-                                for w in pending_writes
-                                + configurable.get(CONFIG_KEY_WRITES, [])
-                                if w[0] in (NULL_TASK_ID, task_id)
-                            ],
-                            CONFIG_KEY_SCRATCHPAD: {},
+                            CONFIG_KEY_SCRATCHPAD: _scratchpad(
+                                pending_writes,
+                                task_id,
+                            ),
                         },
                     ),
                     triggers,
@@ -738,13 +733,10 @@ def prepare_single_task(
                                 },
                                 CONFIG_KEY_CHECKPOINT_ID: None,
                                 CONFIG_KEY_CHECKPOINT_NS: task_checkpoint_ns,
-                                CONFIG_KEY_WRITES: [
-                                    w
-                                    for w in pending_writes
-                                    + configurable.get(CONFIG_KEY_WRITES, [])
-                                    if w[0] in (NULL_TASK_ID, task_id)
-                                ],
-                                CONFIG_KEY_SCRATCHPAD: {},
+                                CONFIG_KEY_SCRATCHPAD: _scratchpad(
+                                    pending_writes,
+                                    task_id,
+                                ),
                             },
                         ),
                         triggers,
@@ -756,6 +748,25 @@ def prepare_single_task(
                     )
             else:
                 return PregelTask(task_id, name, task_path[:3])
+
+
+def _scratchpad(
+    pending_writes: Sequence[PendingWrite],
+    task_id: str,
+) -> PregelScratchpad:
+    return PregelScratchpad(
+        # call
+        call_counter=0,
+        # interrupt
+        interrupt_counter=-1,
+        resume=next(
+            (w[2] for w in pending_writes if w[0] == task_id and w[1] == RESUME), []
+        ),
+        null_resume=next(
+            (w[2] for w in pending_writes if w[0] == NULL_TASK_ID and w[1] == RESUME),
+            MISSING,
+        ),
+    )
 
 
 def _proc_input(

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -107,12 +107,11 @@ class PregelRunner:
                     elif next_task.writes:
                         # if it already ran, return the result
                         fut = concurrent.futures.Future()
-                        if (
-                            val := next(
-                                (v for c, v in next_task.writes if c == RETURN), MISSING
-                            )
-                        ) and val is not MISSING:
-                            fut.set_result(val)
+                        ret = next(
+                            (v for c, v in next_task.writes if c == RETURN), MISSING
+                        )
+                        if ret is not MISSING:
+                            fut.set_result(ret)
                         elif exc := next(
                             (v for c, v in next_task.writes if c == ERROR), None
                         ):
@@ -295,12 +294,11 @@ class PregelRunner:
                     elif next_task.writes:
                         # if it already ran, return the result
                         fut = asyncio.Future()
-                        if (
-                            val := next(
-                                (v for c, v in next_task.writes if c == RETURN), MISSING
-                            )
-                        ) and val is not MISSING:
-                            fut.set_result(val)
+                        ret = next(
+                            (v for c, v in next_task.writes if c == RETURN), MISSING
+                        )
+                        if ret is not MISSING:
+                            fut.set_result(ret)
                         elif exc := next(
                             (v for c, v in next_task.writes if c == ERROR), None
                         ):

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -455,7 +455,6 @@ def interrupt(value: Any) -> Any:
     conf = get_config()["configurable"]
     # track interrupt index
     scratchpad: PregelScratchpad = conf[CONFIG_KEY_SCRATCHPAD]
-    print("interrupt", scratchpad)
     scratchpad["interrupt_counter"] += 1
     idx = scratchpad["interrupt_counter"]
     # find previous resume values

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -21,11 +21,7 @@ from typing import (
 from langchain_core.runnables import Runnable, RunnableConfig
 from typing_extensions import Self, TypedDict
 
-from langgraph.checkpoint.base import (
-    BaseCheckpointSaver,
-    CheckpointMetadata,
-    PendingWrite,
-)
+from langgraph.checkpoint.base import BaseCheckpointSaver, CheckpointMetadata
 
 if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
@@ -341,13 +337,13 @@ class LoopProtocol:
         self.stop = stop
 
 
-class PregelScratchpad(TypedDict, total=False):
-    # interrupt
-    interrupt_counter: int
-    used_null_resume: bool
-    resume: list[Any]
+class PregelScratchpad(TypedDict):
     # call
     call_counter: int
+    # interrupt
+    interrupt_counter: int
+    resume: list[Any]
+    null_resume: Any
 
 
 def interrupt(value: Any) -> Any:
@@ -449,10 +445,8 @@ def interrupt(value: Any) -> Any:
         CONFIG_KEY_CHECKPOINT_NS,
         CONFIG_KEY_SCRATCHPAD,
         CONFIG_KEY_SEND,
-        CONFIG_KEY_TASK_ID,
-        CONFIG_KEY_WRITES,
+        MISSING,
         NS_SEP,
-        NULL_TASK_ID,
         RESUME,
     )
     from langgraph.errors import GraphInterrupt
@@ -461,29 +455,21 @@ def interrupt(value: Any) -> Any:
     conf = get_config()["configurable"]
     # track interrupt index
     scratchpad: PregelScratchpad = conf[CONFIG_KEY_SCRATCHPAD]
-    if "interrupt_counter" not in scratchpad:
-        scratchpad["interrupt_counter"] = 0
-    else:
-        scratchpad["interrupt_counter"] += 1
+    print("interrupt", scratchpad)
+    scratchpad["interrupt_counter"] += 1
     idx = scratchpad["interrupt_counter"]
     # find previous resume values
-    task_id = conf[CONFIG_KEY_TASK_ID]
-    writes: list[PendingWrite] = conf[CONFIG_KEY_WRITES]
-    scratchpad.setdefault(
-        "resume", next((w[2] for w in writes if w[0] == task_id and w[1] == RESUME), [])
-    )
     if scratchpad["resume"]:
         if idx < len(scratchpad["resume"]):
             return scratchpad["resume"][idx]
     # find current resume value
-    if not scratchpad.get("used_null_resume"):
-        scratchpad["used_null_resume"] = True
-        for tid, c, v in sorted(writes, key=lambda x: x[0], reverse=True):
-            if tid == NULL_TASK_ID and c == RESUME:
-                assert len(scratchpad["resume"]) == idx, (scratchpad["resume"], idx)
-                scratchpad["resume"].append(v)
-                conf[CONFIG_KEY_SEND]([(RESUME, scratchpad["resume"])])
-                return v
+    if scratchpad["null_resume"] is not MISSING:
+        assert len(scratchpad["resume"]) == idx, (scratchpad["resume"], idx)
+        v = scratchpad["null_resume"]
+        scratchpad["null_resume"] = MISSING
+        scratchpad["resume"].append(v)
+        conf[CONFIG_KEY_SEND]([(RESUME, scratchpad["resume"])])
+        return v
     # no resume value found
     raise GraphInterrupt(
         (

--- a/libs/scheduler-kafka/tests/test_subgraph.py
+++ b/libs/scheduler-kafka/tests/test_subgraph.py
@@ -203,7 +203,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -275,7 +274,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -377,7 +375,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -489,7 +486,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -556,7 +552,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -679,7 +674,6 @@ async def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]

--- a/libs/scheduler-kafka/tests/test_subgraph.py
+++ b/libs/scheduler-kafka/tests/test_subgraph.py
@@ -15,7 +15,7 @@ from langgraph.graph.state import StateGraph
 from langgraph.pregel import Pregel
 from langgraph.scheduler.kafka import serde
 from langgraph.scheduler.kafka.types import MessageToOrchestrator, Topics
-from tests.any import AnyDict, AnyList
+from tests.any import AnyDict
 from tests.drain import drain_topics_async
 from tests.messages import _AnyIdAIMessage, _AnyIdHumanMessage
 

--- a/libs/scheduler-kafka/tests/test_subgraph.py
+++ b/libs/scheduler-kafka/tests/test_subgraph.py
@@ -197,7 +197,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": False,
                             "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
@@ -264,7 +269,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": False,
                             "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -361,7 +371,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": False,
                             "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -468,7 +483,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": True,
                             "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
@@ -530,7 +550,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": True,
                             "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -648,7 +673,12 @@ async def test_subgraph_w_interrupt(
                             "__pregel_resuming": True,
                             "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {

--- a/libs/scheduler-kafka/tests/test_subgraph_sync.py
+++ b/libs/scheduler-kafka/tests/test_subgraph_sync.py
@@ -15,7 +15,7 @@ from langgraph.pregel import Pregel
 from langgraph.scheduler.kafka import serde
 from langgraph.scheduler.kafka.default_sync import DefaultProducer
 from langgraph.scheduler.kafka.types import MessageToOrchestrator, Topics
-from tests.any import AnyDict, AnyList
+from tests.any import AnyDict
 from tests.drain import drain_topics
 from tests.messages import _AnyIdAIMessage, _AnyIdHumanMessage
 

--- a/libs/scheduler-kafka/tests/test_subgraph_sync.py
+++ b/libs/scheduler-kafka/tests/test_subgraph_sync.py
@@ -196,7 +196,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_resuming": False,
                             "__pregel_store": None,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
@@ -263,7 +268,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_dedupe_tasks": True,
                             "__pregel_resuming": False,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -360,7 +370,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_store": None,
                             "__pregel_resuming": False,
                             "__pregel_task_id": history[0].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -466,7 +481,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_store": None,
                             "__pregel_resuming": True,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
@@ -528,7 +548,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_store": None,
                             "__pregel_resuming": True,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
@@ -646,7 +671,12 @@ def test_subgraph_w_interrupt(
                             "__pregel_resuming": True,
                             "__pregel_store": None,
                             "__pregel_task_id": history[1].tasks[0].id,
-                            "__pregel_scratchpad": {},
+                            "__pregel_scratchpad": {
+                                "call_counter": 0,
+                                "interrupt_counter": -1,
+                                "null_resume": None,
+                                "resume": [],
+                            },
                             "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {

--- a/libs/scheduler-kafka/tests/test_subgraph_sync.py
+++ b/libs/scheduler-kafka/tests/test_subgraph_sync.py
@@ -202,7 +202,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -274,7 +273,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -376,7 +374,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[0].config["configurable"]["checkpoint_id"]
@@ -487,7 +484,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": None,
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -554,7 +550,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]
@@ -677,7 +672,6 @@ def test_subgraph_w_interrupt(
                                 "null_resume": None,
                                 "resume": [],
                             },
-                            "__pregel_writes": AnyList(),
                             "checkpoint_id": c.config["configurable"]["checkpoint_id"],
                             "checkpoint_map": {
                                 "": history[1].config["configurable"]["checkpoint_id"]


### PR DESCRIPTION
- Also stop exposing writes in config, in favor of scratchpad