### PR TITLE
docs[patch]: enable navigation back to index pages from child pages via sidebar

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
     - content.action.edit
     - content.tooltips
     - header.autohide
+    - navigation.indexes
     - navigation.expand
     - navigation.footer
     - navigation.instant


### PR DESCRIPTION
Currently, if you're viewing a how-to guide and you click "How-to Guides" in the sidebar, you aren't navigated back to the index page (it will work if you click on a different guides section). To get back to the index page, you need to scroll up and click the breadcrumbs.

After this change, clicking the link in the sidebar should navigate you to the index page regardless of the page you are viewing.

Only side-effect from what I can tell is that "Home > Introduction" just becomes "**Home**", which I think is fine (maybe preferable).

Before:
![Screenshot 2025-01-16 at 11 16 26 AM](https://github.com/user-attachments/assets/e4bdedfc-ed52-4a66-b0b2-194383ce2043)

After:
![Screenshot 2025-01-16 at 11 16 00 AM](https://github.com/user-attachments/assets/4d1d935b-5b11-43ac-8b63-c5aaff871188)
