### PR TITLE
docs: expose functional api reference

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -369,6 +369,7 @@ nav:
       - Errors: reference/errors.md
       - Types: reference/types.md
       - Constants: reference/constants.md
+      - Functional API: reference/func.md
     - LangGraph Platform:
       - Server API: "cloud/reference/api/api_ref.md"
       - CLI: "cloud/reference/cli.md"


### PR DESCRIPTION
The API reference is marked as experimental right now, so this is OK to expose to make it easier to share w/ beta users.