### PR TITLE
DOCS: Incorrect reference to JS/TS SDK as Python SDK

### DIFF
--- a/docs/docs/tutorials/langgraph-platform/local-server.md
+++ b/docs/docs/tutorials/langgraph-platform/local-server.md
@@ -250,4 +250,4 @@ Access detailed documentation for development and API usage:
 
 - **[LangGraph Server API Reference](../../cloud/reference/api/api_ref.html)**: Explore the LangGraph Server API documentation.  
 - **[Python SDK Reference](../../cloud/reference/sdk/python_sdk_ref.md)**: Explore the Python SDK API Reference.
-- **[JS/TS SDK Reference](../../cloud/reference/sdk/js_ts_sdk_ref.md)**: Explore the Python SDK API Reference.
+- **[JS/TS SDK Reference](../../cloud/reference/sdk/js_ts_sdk_ref.md)**: Explore the JS/TS SDK API Reference.


### PR DESCRIPTION
Small typo in the Local Server page: https://langchain-ai.github.io/langgraph/tutorials/langgraph-platform/local-server/