### PR TITLE
Re-enable support for running sync tasks from async entrypoints

### DIFF
--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -407,8 +407,7 @@ class PregelRunner:
             # return a chained future to ensure commit() callback is called
             # before the returned future is resolved, to ensure stream order etc
             try:
-                asyncio.current_task()
-                in_async = True
+                in_async = asyncio.current_task() is not None
             except RuntimeError:
                 in_async = False
             # if in async context return an async future

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -415,7 +415,9 @@ class PregelRunner:
             # otherwise return a chained sync future
             if in_async:
                 if isinstance(fut, asyncio.Task):
-                    sfut = asyncio.Future(loop=loop)
+                    sfut: Union[asyncio.Future[Any], concurrent.futures.Future[Any]] = (
+                        asyncio.Future(loop=loop)
+                    )
                     loop.call_soon_threadsafe(chain_future, fut, sfut)
                     return sfut
                 else:

--- a/libs/langgraph/langgraph/utils/future.py
+++ b/libs/langgraph/langgraph/utils/future.py
@@ -153,7 +153,7 @@ def _ensure_future(
         else:
             raise TypeError(
                 "An asyncio.Future, a coroutine or an awaitable is required."
-                f" Got {type(future).__name__} instead."
+                f" Got {type(coro_or_future).__name__} instead."
             )
 
     try:

--- a/libs/langgraph/langgraph/utils/future.py
+++ b/libs/langgraph/langgraph/utils/future.py
@@ -152,7 +152,8 @@ def _ensure_future(
             called_wrap_awaitable = True
         else:
             raise TypeError(
-                "An asyncio.Future, a coroutine or an awaitable is required"
+                "An asyncio.Future, a coroutine or an awaitable is required."
+                f" Got {type(future).__name__} instead."
             )
 
     try:

--- a/libs/langgraph/langgraph/utils/future.py
+++ b/libs/langgraph/langgraph/utils/future.py
@@ -1,8 +1,15 @@
 import asyncio
 import concurrent.futures
-from typing import Union
+import contextvars
+import inspect
+import sys
+import types
+from typing import Coroutine, Optional, TypeVar, Union
 
+T = TypeVar("T")
 AnyFuture = Union[asyncio.Future, concurrent.futures.Future]
+
+CONTEXT_NOT_SUPPORTED = sys.version_info < (3, 11)
 
 
 def _get_loop(fut: asyncio.Future) -> asyncio.AbstractEventLoop:
@@ -52,10 +59,11 @@ def _copy_future_state(source: AnyFuture, dest: asyncio.Future) -> None:
 
     The other Future may be a concurrent.futures.Future.
     """
+    if dest.done():
+        return
     assert source.done()
     if dest.cancelled():
         return
-    assert not dest.done()
     if source.cancelled():
         dest.cancel()
     else:
@@ -112,10 +120,11 @@ def _chain_future(source: AnyFuture, destination: AnyFuture) -> None:
     source.add_done_callback(_call_set_state)
 
 
-def chain_future(source: AnyFuture, destination: AnyFuture) -> None:
+def chain_future(source: AnyFuture, destination: AnyFuture) -> AnyFuture:
     # adapted from asyncio.run_coroutine_threadsafe
     try:
         _chain_future(source, destination)
+        return destination
     except (SystemExit, KeyboardInterrupt):
         raise
     except BaseException as exc:
@@ -125,3 +134,68 @@ def chain_future(source: AnyFuture, destination: AnyFuture) -> None:
         else:
             destination.set_exception(exc)
         raise
+
+
+def _ensure_future(
+    coro_or_future: Coroutine[None, None, T],
+    *,
+    loop: asyncio.AbstractEventLoop,
+    name: Optional[str] = None,
+    context: Optional[contextvars.Context] = None,
+) -> asyncio.Task[T]:
+    called_wrap_awaitable = False
+    if not asyncio.iscoroutine(coro_or_future):
+        if inspect.isawaitable(coro_or_future):
+            coro_or_future = _wrap_awaitable(coro_or_future)
+            called_wrap_awaitable = True
+        else:
+            raise TypeError(
+                "An asyncio.Future, a coroutine or an awaitable is required"
+            )
+
+    try:
+        if CONTEXT_NOT_SUPPORTED:
+            return loop.create_task(coro_or_future, name=name)
+        else:
+            return loop.create_task(coro_or_future, name=name, context=context)
+    except RuntimeError:
+        if not called_wrap_awaitable:
+            coro_or_future.close()
+        raise
+
+
+@types.coroutine
+def _wrap_awaitable(awaitable):
+    """Helper for asyncio.ensure_future().
+
+    Wraps awaitable (an object with __await__) into a coroutine
+    that will later be wrapped in a Task by ensure_future().
+    """
+    return (yield from awaitable.__await__())
+
+
+def run_coroutine_threadsafe(
+    coro: Coroutine[None, None, T],
+    loop: asyncio.AbstractEventLoop,
+    name: Optional[str] = None,
+    context: Optional[contextvars.Context] = None,
+) -> asyncio.Future[T]:
+    """Submit a coroutine object to a given event loop.
+
+    Return a asyncio.Future to access the result.
+    """
+    future = asyncio.Future(loop=loop)
+
+    def callback():
+        try:
+            chain_future(
+                _ensure_future(coro, loop=loop, name=name, context=context), future
+            )
+        except (SystemExit, KeyboardInterrupt):
+            raise
+        except BaseException as exc:
+            future.set_exception(exc)
+            raise
+
+    loop.call_soon_threadsafe(callback, context=context)
+    return future

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -1158,7 +1158,7 @@ async def test_step_timeout_on_stream_hang(stream_hang_s: float) -> None:
     with pytest.raises(asyncio.TimeoutError):
         async for chunk in graph.astream(1, stream_mode="updates"):
             assert chunk == {"alittlewhile": {"alittlewhile": "1"}}
-            await asyncio.sleep(0.6)
+            await asyncio.sleep(stream_hang_s)
 
     assert inner_task_cancelled
 
@@ -2486,6 +2486,71 @@ async def test_imp_task(checkpointer_name: str) -> None:
 
 @NEEDS_CONTEXTVARS
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
+async def test_imp_nested(checkpointer_name: str) -> None:
+    async def mynode(input: list[str]) -> list[str]:
+        return [it + "a" for it in input]
+
+    builder = StateGraph(list[str])
+    builder.add_node(mynode)
+    builder.add_edge(START, "mynode")
+    add_a = builder.compile()
+
+    @task
+    def submapper(input: int) -> str:
+        return str(input)
+
+    @task
+    async def mapper(input: int) -> str:
+        await asyncio.sleep(input / 100)
+        return await submapper(input) * 2
+
+    async with awith_checkpointer(checkpointer_name) as checkpointer:
+
+        @entrypoint(checkpointer=checkpointer)
+        async def graph(input: list[int]) -> list[str]:
+            futures = [mapper(i) for i in input]
+            mapped = await asyncio.gather(*futures)
+            answer = interrupt("question")
+            final = [m + answer for m in mapped]
+            return await add_a.ainvoke(final)
+
+        assert graph.get_input_jsonschema() == {
+            "type": "array",
+            "items": {"type": "integer"},
+            "title": "LangGraphInput",
+        }
+        assert graph.get_output_jsonschema() == {
+            "type": "array",
+            "items": {"type": "string"},
+            "title": "LangGraphOutput",
+        }
+
+        thread1 = {"configurable": {"thread_id": "1"}}
+        assert [c async for c in graph.astream([0, 1], thread1)] == [
+            {"submapper": "0"},
+            {"mapper": "00"},
+            {"submapper": "1"},
+            {"mapper": "11"},
+            {
+                "__interrupt__": (
+                    Interrupt(
+                        value="question",
+                        resumable=True,
+                        ns=[AnyStr("graph:")],
+                        when="during",
+                    ),
+                )
+            },
+        ]
+
+        assert await graph.ainvoke(Command(resume="answer"), thread1) == [
+            "00answera",
+            "11answera",
+        ]
+
+
+@NEEDS_CONTEXTVARS
+@pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
 async def test_imp_task_cancel(checkpointer_name: str) -> None:
     async with awith_checkpointer(checkpointer_name) as checkpointer:
         mapper_calls = 0
@@ -2535,7 +2600,6 @@ async def test_imp_task_cancel(checkpointer_name: str) -> None:
         assert mapper_cancels == 2
 
 
-@pytest.mark.skip("TODO: re-enable")
 @NEEDS_CONTEXTVARS
 @pytest.mark.parametrize("checkpointer_name", ALL_CHECKPOINTERS_ASYNC)
 async def test_imp_sync_from_async(checkpointer_name: str) -> None:


### PR DESCRIPTION
- When using an async entrypoint you can now freely mix and match sync and async tasks with a uniform api (ie all tasks return a sync or async future depending on context)
- Fix issues with scheduling deeply nested tasks (use threadsafe methods to schedule coroutines and create futures)