### PR TITLE
python[patch]: call create_react_agent model node without is_last_step

### DIFF
--- a/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/langgraph/langgraph/prebuilt/chat_agent_executor.py
@@ -635,7 +635,7 @@ def create_react_agent(
         if (
             (
                 "remaining_steps" not in state
-                and state["is_last_step"]
+                and state.get("is_last_step", False)
                 and has_tool_calls
             )
             or (
@@ -672,7 +672,7 @@ def create_react_agent(
         if (
             (
                 "remaining_steps" not in state
-                and state["is_last_step"]
+                and state.get("is_last_step", False)
                 and has_tool_calls
             )
             or (

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langgraph"
-version = "0.2.64"
+version = "0.2.65"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 license = "MIT"


### PR DESCRIPTION
So that you can call agent.nodes['agent'].invoke({'messages': []}) without needing to specify is_last_step. very helpful for evaluating just the model node of the agent