### PR TITLE
Update persistence_postgres.ipynb to remove typo in markdown cell.

### DIFF
--- a/docs/docs/how-tos/persistence_postgres.ipynb
+++ b/docs/docs/how-tos/persistence_postgres.ipynb
@@ -44,7 +44,8 @@
     "...\n",
     "```\n",
     "\n",
-    "!!! info \"Setup\n",
+    "!!! info \"Setup\"",
+    "\n",
     "    You need to run `.setup()` once on your checkpointer to initialize the database before you can use it."
    ]
   },


### PR DESCRIPTION
Fixed a typo that was interrupting the markdown.