### PR TITLE
docs: set graph entry/finish point

### DIFF
--- a/docs/docs/tutorials/introduction.ipynb
+++ b/docs/docs/tutorials/introduction.ipynb
@@ -175,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph_builder.add_edge(START, \"chatbot\")"
+    "graph_builder.set_entry_point(\"chatbot\")"
    ]
   },
   {
@@ -193,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph_builder.add_edge(\"chatbot\", END)"
+    "graph_builder.set_finish_point(\"chatbot\")"
    ]
   },
   {


### PR DESCRIPTION
When setting the entry point and finish point, the code snippet in the tutorial should be consistent with the **Full Code** provided below it, although calling `set_entry_point(key)`/`set_finish_point(key)` is equivalent to calling `add_edge(START, key)`/`add_edge(key, END)`.