### PR TITLE
Fix: Broken link to multi-agent-collaboration notebook in agent_supervisor.ipynb

### DIFF
--- a/docs/docs/tutorials/multi_agent/agent_supervisor.ipynb
+++ b/docs/docs/tutorials/multi_agent/agent_supervisor.ipynb
@@ -12,7 +12,7 @@
    "source": [
     "# Multi-agent supervisor\n",
     "\n",
-    "The [previous example](../multi-agent-collaboration) routed messages automatically based on the output of the initial researcher agent.\n",
+    "The [previous example](./multi_agent/multi-agent-collaboration.ipynb) routed messages automatically based on the output of the initial researcher agent.\n",
     "\n",
     "We can also choose to use an [LLM to orchestrate](https://langchain-ai.github.io/langgraph/concepts/multi_agent/#supervisor) the different agents.\n",
     "\n",


### PR DESCRIPTION
This pull request fixes a broken link in the `agent_supervisor.ipynb` notebook.

The link to the "previous example" (the multi-agent-collaboration notebook) is currently incorrect. It points to:

```
https://github.com/langchain-ai/langgraph/blob/44840aa23f05edb9758eb63d5cbbef89438b26f7/docs/docs/tutorials/multi-agent-collaboration
```

This URL results in a 404 error because:

1. It's missing the `multi_agent` subdirectory in the path.
2. It's missing the `.ipynb` file extension.
3. It's pointing to a specific commit hash (`44840aa23f05edb9758eb63d5cbbef89438b26f7`) instead of the `main` branch, making it fragile and prone to breaking in the future as the repository evolves.

**Solution:**

This PR updates the link in `agent_supervisor.ipynb` to:

```
./multi_agent/multi-agent-collaboration.ipynb
```

This corrected link:

1. Uses a relative path to navigate to the correct subdirectory (`multi_agent`).
2. Includes the `.ipynb` file extension.
3. Ensures that the link points to the file on the `main` branch (by using a relative path within the same directory structure).
