### PR TITLE
Improve typings for task, it now returns a mixed sync/async future protocol

### DIFF
--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -22,7 +22,13 @@ from langgraph.channels.last_value import LastValue
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.constants import END, PREVIOUS, START, TAG_HIDDEN
 from langgraph.pregel import Pregel
-from langgraph.pregel.call import P, T, call, get_runnable_for_entrypoint
+from langgraph.pregel.call import (
+    P,
+    SyncAsyncFuture,
+    T,
+    call,
+    get_runnable_for_entrypoint,
+)
 from langgraph.pregel.read import PregelNode
 from langgraph.pregel.write import ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
@@ -32,25 +38,13 @@ from langgraph.types import _DC_KWARGS, RetryPolicy, StreamMode, StreamWriter
 @overload
 def task(
     *, retry: Optional[RetryPolicy] = None
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, asyncio.Future[T]]]: ...
-
-
-@overload
-def task(  # type: ignore[overload-cannot-match]
-    *, retry: Optional[RetryPolicy] = None
-) -> Callable[[Callable[P, T]], Callable[P, concurrent.futures.Future[T]]]: ...
+) -> Callable[[Callable[P, T]], Callable[P, SyncAsyncFuture[T]]]: ...
 
 
 @overload
 def task(
     __func_or_none__: Callable[P, T],
-) -> Callable[P, concurrent.futures.Future[T]]: ...
-
-
-@overload
-def task(
-    __func_or_none__: Callable[P, Awaitable[T]],
-) -> Callable[P, asyncio.Future[T]]: ...
+) -> Callable[P, SyncAsyncFuture[T]]: ...
 
 
 def task(
@@ -58,10 +52,8 @@ def task(
     *,
     retry: Optional[RetryPolicy] = None,
 ) -> Union[
-    Callable[[Callable[P, Awaitable[T]]], Callable[P, asyncio.Future[T]]],
-    Callable[[Callable[P, T]], Callable[P, concurrent.futures.Future[T]]],
-    Callable[P, asyncio.Future[T]],
-    Callable[P, concurrent.futures.Future[T]],
+    Callable[[Callable[P, T]], Callable[P, SyncAsyncFuture[T]]],
+    Callable[P, SyncAsyncFuture[T]],
 ]:
     """Define a LangGraph task using the `task` decorator.
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -3,7 +3,6 @@ import logging
 import operator
 import random
 import sys
-import time
 import uuid
 from collections import Counter, deque
 from contextlib import asynccontextmanager, contextmanager
@@ -2537,40 +2536,6 @@ async def test_imp_nested(checkpointer_name: str) -> None:
             {"mapper": "00"},
             {"submapper": "1"},
             {"mapper": "11"},
-            {
-                "__interrupt__": (
-                    Interrupt(
-                        value="question",
-                        resumable=True,
-                        ns=[AnyStr("graph:")],
-                        when="during",
-                    ),
-                )
-            },
-        ]
-
-        assert await graph.ainvoke(Command(resume="answer"), thread1) == [
-            "00answera",
-            "11answera",
-        ]
-
-        def syncmapper(input: int) -> str:
-            time.sleep(input / 100)
-            return submapper(input).result() * 2
-
-        @entrypoint(checkpointer=checkpointer)
-        async def graph(input: list[int]) -> list[str]:
-            mapped = [syncmapper(i) for i in input]
-            answer = interrupt("question")
-            final = [m + answer for m in mapped]
-            return await add_a.ainvoke(final)
-
-        thread1 = {"configurable": {"thread_id": "1"}}
-        assert [c async for c in graph.astream([0, 1], thread1)] == [
-            {"submapper": "0"},
-            {"syncmapper": "00"},
-            {"submapper": "1"},
-            {"syncmapper": "11"},
             {
                 "__interrupt__": (
                     Interrupt(

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -3,6 +3,7 @@ import logging
 import operator
 import random
 import sys
+import time
 import uuid
 from collections import Counter, deque
 from contextlib import asynccontextmanager, contextmanager
@@ -2536,6 +2537,40 @@ async def test_imp_nested(checkpointer_name: str) -> None:
             {"mapper": "00"},
             {"submapper": "1"},
             {"mapper": "11"},
+            {
+                "__interrupt__": (
+                    Interrupt(
+                        value="question",
+                        resumable=True,
+                        ns=[AnyStr("graph:")],
+                        when="during",
+                    ),
+                )
+            },
+        ]
+
+        assert await graph.ainvoke(Command(resume="answer"), thread1) == [
+            "00answera",
+            "11answera",
+        ]
+
+        def syncmapper(input: int) -> str:
+            time.sleep(input / 100)
+            return submapper(input).result() * 2
+
+        @entrypoint(checkpointer=checkpointer)
+        async def graph(input: list[int]) -> list[str]:
+            mapped = [syncmapper(i) for i in input]
+            answer = interrupt("question")
+            final = [m + answer for m in mapped]
+            return await add_a.ainvoke(final)
+
+        thread1 = {"configurable": {"thread_id": "1"}}
+        assert [c async for c in graph.astream([0, 1], thread1)] == [
+            {"submapper": "0"},
+            {"syncmapper": "00"},
+            {"submapper": "1"},
+            {"syncmapper": "11"},
             {
                 "__interrupt__": (
                     Interrupt(


### PR DESCRIPTION


- note this type is never instantiated, it is only used for typing (we cannot make it a protocol as it inherits from concurrent.futures.Future)