### PR TITLE
Update type annotations in errors.py and types.py in langgraph

### DIFF
--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 from langgraph.checkpoint.base import EmptyChannelError  # noqa: F401
 from langgraph.types import Command, Interrupt
@@ -8,11 +8,11 @@ from langgraph.types import Command, Interrupt
 
 
 class ErrorCode(Enum):
-    GRAPH_RECURSION_LIMIT = "GRAPH_RECURSION_LIMIT"
-    INVALID_CONCURRENT_GRAPH_UPDATE = "INVALID_CONCURRENT_GRAPH_UPDATE"
-    INVALID_GRAPH_NODE_RETURN_VALUE = "INVALID_GRAPH_NODE_RETURN_VALUE"
-    MULTIPLE_SUBGRAPHS = "MULTIPLE_SUBGRAPHS"
-    INVALID_CHAT_HISTORY = "INVALID_CHAT_HISTORY"
+    GRAPH_RECURSION_LIMIT: Literal["GRAPH_RECURSION_LIMIT"] = "GRAPH_RECURSION_LIMIT"
+    INVALID_CONCURRENT_GRAPH_UPDATE: Literal["INVALID_CONCURRENT_GRAPH_UPDATE"] = "INVALID_CONCURRENT_GRAPH_UPDATE"
+    INVALID_GRAPH_NODE_RETURN_VALUE: Literal["INVALID_GRAPH_NODE_RETURN_VALUE"] = "INVALID_GRAPH_NODE_RETURN_VALUE"
+    MULTIPLE_SUBGRAPHS: Literal["MULTIPLE_SUBGRAPHS"] = "MULTIPLE_SUBGRAPHS"
+    INVALID_CHAT_HISTORY: Literal["INVALID_CHAT_HISTORY"] = "INVALID_CHAT_HISTORY"
 
 
 def create_error_message(*, message: str, error_code: ErrorCode) -> str:

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -12,6 +12,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -216,7 +217,7 @@ class Send:
         {'subjects': ['cats', 'dogs'], 'jokes': ['Joke about cats', 'Joke about dogs']}
     """
 
-    __slots__ = ("node", "arg")
+    __slots__: Tuple[str, ...] = ("node", "arg")
 
     node: str
     arg: Any
@@ -304,7 +305,7 @@ StreamChunk = tuple[tuple[str, ...], str, Any]
 
 
 class StreamProtocol:
-    __slots__ = ("modes", "__call__")
+    __slots__: Tuple[str, ...] = ("modes", "__call__")
 
     modes: set[StreamMode]
 


### PR DESCRIPTION
Update type annotations in `errors.py` for __slots__  and in `types.py` for Error Codes.