### PR TITLE
Update Corrective RAG demo with small fixes

### DIFF
--- a/docs/docs/tutorials/rag/langgraph_crag.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_crag.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install langchain_community tiktoken langchain-openai langchainhub chromadb langchain langgraph tavily-python"
+    "! pip install langchain_community tiktoken langchain-openai langchainhub chromadb langchain langgraph tavily-python load_dotenv"
    ]
   },
   {
@@ -74,6 +74,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bcf5621a-ae71-4ee7-824a-7e64324e2a07",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3adde047",
    "metadata": {},
@@ -83,7 +106,16 @@
     "    <p style=\"padding-top: 5px;\">\n",
     "        Sign up for LangSmith to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph — read more about how to get started <a href=\"https://docs.smith.langchain.com\">here</a>. \n",
     "    </p>\n",
-    "</div>"
+    "</div>\n",
+    "\n",
+    "For a quick reference, you can just include `.env` file with the following *keys* that can be retrieved from [LangSmith site](https://smith.langchain.com/):\n",
+    "\n",
+    "```JSON\n",
+    "LANGSMITH_TRACING=true\n",
+    "LANGSMITH_ENDPOINT=\"https://api.smith.langchain.com\"\n",
+    "LANGSMITH_API_KEY=\"<your-api-key\"\n",
+    "LANGSMITH_PROJECT=\"<your-project-name\"\n",
+    "```"
    ]
   },
   {
@@ -98,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "3a566a30-cf0e-4330-ad4d-9bf994bdfa86",
    "metadata": {},
    "outputs": [],
@@ -118,7 +150,7 @@
     "docs_list = [item for sublist in docs for item in sublist]\n",
     "\n",
     "text_splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(\n",
-    "    chunk_size=250, chunk_overlap=0\n",
+    "    chunk_size=250, chunk_overlap=25\n",
     ")\n",
     "doc_splits = text_splitter.split_documents(docs_list)\n",
     "\n",
@@ -162,7 +194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "binary_score='yes'\n"
+      "binary_score='no'\n"
      ]
     }
    ],
@@ -185,7 +217,7 @@
     "\n",
     "\n",
     "# LLM with function call\n",
-    "llm = ChatOpenAI(model=\"gpt-3.5-turbo-0125\", temperature=0)\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)\n",
     "structured_llm_grader = llm.with_structured_output(GradeDocuments)\n",
     "\n",
     "# Prompt\n",
@@ -216,7 +248,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The design of generative agents combines LLM with memory, planning, and reflection mechanisms to enable agents to behave conditioned on past experience. Memory stream is a long-term memory module that records a comprehensive list of agents' experience in natural language. Short-term memory is utilized for in-context learning, while long-term memory allows agents to retain and recall information over extended periods.\n"
+      "Agent memory in LLM-powered autonomous systems consists of short-term and long-term memory. Short-term memory utilizes in-context learning for immediate tasks, while long-term memory allows agents to retain and recall information over extended periods, often using external storage for efficient retrieval. This memory structure enables agents to learn from past experiences and improve their performance in future tasks.\n"
      ]
     }
    ],
@@ -230,7 +262,7 @@
     "prompt = hub.pull(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
-    "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",
+    "llm = ChatOpenAI(model_name=\"gpt-4o-mini\", temperature=0)\n",
     "\n",
     "\n",
     "# Post-processing\n",
@@ -255,7 +287,7 @@
     {
      "data": {
       "text/plain": [
-       "'What is the role of memory in artificial intelligence agents?'"
+       "'What is agent memory and how does it function in artificial intelligence?'"
       ]
      },
      "execution_count": 7,
@@ -267,7 +299,7 @@
     "### Question Re-writer\n",
     "\n",
     "# LLM\n",
-    "llm = ChatOpenAI(model=\"gpt-3.5-turbo-0125\", temperature=0)\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)\n",
     "\n",
     "# Prompt\n",
     "system = \"\"\"You a question re-writer that converts an input question to a better version that is optimized \\n \n",
@@ -296,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 8,
    "id": "46d51b53-54a9-4e0a-9f14-e39998f5b340",
    "metadata": {},
    "outputs": [],
@@ -322,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 9,
    "id": "94b3945f-ef0f-458d-a443-f763903550b0",
    "metadata": {},
    "outputs": [],
@@ -351,13 +383,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 10,
    "id": "efd639c5-82e2-45e6-a94a-6a4039646ef5",
    "metadata": {},
    "outputs": [],
    "source": [
     "from langchain.schema import Document\n",
     "\n",
+    "\n",
+    "### Nodes\n",
     "\n",
     "def retrieve(state):\n",
     "    \"\"\"\n",
@@ -377,25 +411,6 @@
     "    return {\"documents\": documents, \"question\": question}\n",
     "\n",
     "\n",
-    "def generate(state):\n",
-    "    \"\"\"\n",
-    "    Generate answer\n",
-    "\n",
-    "    Args:\n",
-    "        state (dict): The current graph state\n",
-    "\n",
-    "    Returns:\n",
-    "        state (dict): New key added to state, generation, that contains LLM generation\n",
-    "    \"\"\"\n",
-    "    print(\"---GENERATE---\")\n",
-    "    question = state[\"question\"]\n",
-    "    documents = state[\"documents\"]\n",
-    "\n",
-    "    # RAG generation\n",
-    "    generation = rag_chain.invoke({\"context\": documents, \"question\": question})\n",
-    "    return {\"documents\": documents, \"question\": question, \"generation\": generation}\n",
-    "\n",
-    "\n",
     "def grade_documents(state):\n",
     "    \"\"\"\n",
     "    Determines whether the retrieved documents are relevant to the question.\n",
@@ -407,7 +422,7 @@
     "        state (dict): Updates documents key with only filtered relevant documents\n",
     "    \"\"\"\n",
     "\n",
-    "    print(\"---CHECK DOCUMENT RELEVANCE TO QUESTION---\")\n",
+    "    print(\"---CHECK PER DOCUMENT RELEVANCE TO QUESTION---\")\n",
     "    question = state[\"question\"]\n",
     "    documents = state[\"documents\"]\n",
     "\n",
@@ -427,6 +442,25 @@
     "            web_search = \"Yes\"\n",
     "            continue\n",
     "    return {\"documents\": filtered_docs, \"question\": question, \"web_search\": web_search}\n",
+    "\n",
+    "\n",
+    "def generate(state):\n",
+    "    \"\"\"\n",
+    "    Generate answer\n",
+    "\n",
+    "    Args:\n",
+    "        state (dict): The current graph state\n",
+    "\n",
+    "    Returns:\n",
+    "        state (dict): New key added to state, generation, that contains LLM generation\n",
+    "    \"\"\"\n",
+    "    print(\"---GENERATE---\")\n",
+    "    question = state[\"question\"]\n",
+    "    documents = state[\"documents\"]\n",
+    "\n",
+    "    # RAG generation\n",
+    "    generation = rag_chain.invoke({\"context\": documents, \"question\": question})\n",
+    "    return {\"documents\": documents, \"question\": question, \"generation\": generation}\n",
     "\n",
     "\n",
     "def transform_query(state):\n",
@@ -475,7 +509,6 @@
     "\n",
     "### Edges\n",
     "\n",
-    "\n",
     "def decide_to_generate(state):\n",
     "    \"\"\"\n",
     "    Determines whether to generate an answer, or re-generate a question.\n",
@@ -487,7 +520,7 @@
     "        str: Binary decision for next node to call\n",
     "    \"\"\"\n",
     "\n",
-    "    print(\"---ASSESS GRADED DOCUMENTS---\")\n",
+    "    print(\"\\n---ASSESS GRADED DOCUMENTS---\")\n",
     "    state[\"question\"]\n",
     "    web_search = state[\"web_search\"]\n",
     "    state[\"documents\"]\n",
@@ -496,12 +529,12 @@
     "        # All documents have been filtered check_relevance\n",
     "        # We will re-generate a new query\n",
     "        print(\n",
-    "            \"---DECISION: ALL DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY---\"\n",
+    "            \"---DECISION: SOME DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY AND PERFORM WEB SEARCH---\"\n",
     "        )\n",
     "        return \"transform_query\"\n",
     "    else:\n",
     "        # We have relevant documents, so generate answer\n",
-    "        print(\"---DECISION: GENERATE---\")\n",
+    "        print(\"---DECISION: ALL DOCUMENTS ARE RELEVANT, GENERATE THE FINAL ANSWER---\")\n",
     "        return \"generate\""
    ]
   },
@@ -517,7 +550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 11,
    "id": "dedae17a-98c6-474d-90a7-9234b7c8cea0",
    "metadata": {},
    "outputs": [],
@@ -562,7 +595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 12,
    "id": "f5b7c2fe-1fc7-4b76-bf93-ba701a40aa6b",
    "metadata": {},
    "outputs": [
@@ -571,33 +604,48 @@
      "output_type": "stream",
      "text": [
       "---RETRIEVE---\n",
-      "\"Node 'retrieve':\"\n",
-      "'\\n---\\n'\n",
-      "---CHECK DOCUMENT RELEVANCE TO QUESTION---\n",
-      "---GRADE: DOCUMENT NOT RELEVANT---\n",
+      "\n",
+      "Node 'retrieve':\n",
+      "\n",
+      "---\n",
+      "\n",
+      "---CHECK PER DOCUMENT RELEVANCE TO QUESTION---\n",
       "---GRADE: DOCUMENT NOT RELEVANT---\n",
       "---GRADE: DOCUMENT RELEVANT---\n",
       "---GRADE: DOCUMENT RELEVANT---\n",
-      "\"Node 'grade_documents':\"\n",
-      "'\\n---\\n'\n",
+      "---GRADE: DOCUMENT RELEVANT---\n",
+      "\n",
       "---ASSESS GRADED DOCUMENTS---\n",
-      "---DECISION: ALL DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY---\n",
+      "---DECISION: SOME DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY AND PERFORM WEB SEARCH---\n",
+      "\n",
+      "Node 'grade_documents':\n",
+      "\n",
+      "---\n",
+      "\n",
       "---TRANSFORM QUERY---\n",
-      "\"Node 'transform_query':\"\n",
-      "'\\n---\\n'\n",
+      "\n",
+      "Node 'transform_query':\n",
+      "\n",
+      "---\n",
+      "\n",
       "---WEB SEARCH---\n",
-      "\"Node 'web_search_node':\"\n",
-      "'\\n---\\n'\n",
+      "\n",
+      "Node 'web_search_node':\n",
+      "\n",
+      "---\n",
+      "\n",
       "---GENERATE---\n",
-      "\"Node 'generate':\"\n",
-      "'\\n---\\n'\n",
-      "\"Node '__end__':\"\n",
-      "'\\n---\\n'\n",
-      "('Agents possess short-term memory, which is utilized for in-context learning, '\n",
-      " 'and long-term memory, allowing them to retain and recall vast amounts of '\n",
-      " 'information over extended periods. Some experts also classify working memory '\n",
-      " 'as a distinct type, although it can be considered a part of short-term '\n",
-      " 'memory in many cases.')\n"
+      "\n",
+      "Node 'generate':\n",
+      "\n",
+      "---\n",
+      "\n",
+      "('The different types of agent memory in artificial intelligence include '\n",
+      " 'short-term memory and long-term memory. Short-term memory is utilized for '\n",
+      " 'in-context learning, while long-term memory allows agents to retain and '\n",
+      " 'recall information over extended periods, often using external storage for '\n",
+      " 'fast retrieval. Additionally, sensory memory can be considered as learning '\n",
+      " 'embedding representations for raw inputs.')\n"
      ]
     }
    ],
@@ -609,10 +657,10 @@
     "for output in app.stream(inputs):\n",
     "    for key, value in output.items():\n",
     "        # Node\n",
-    "        pprint(f\"Node '{key}':\")\n",
+    "        print(f\"\\nNode '{key}':\")\n",
     "        # Optional: print full state at each node\n",
-    "        # pprint.pprint(value[\"keys\"], indent=2, width=80, depth=None)\n",
-    "    pprint(\"\\n---\\n\")\n",
+    "        # pprint(value, indent=2, width=80, depth=None)\n",
+    "    print(\"\\n---\\n\")\n",
     "\n",
     "# Final generation\n",
     "pprint(value[\"generation\"])"
@@ -620,7 +668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 13,
    "id": "41ea1108-f385-4774-962d-db157922e231",
    "metadata": {},
    "outputs": [
@@ -630,34 +678,43 @@
      "text": [
       "---RETRIEVE---\n",
       "\"Node 'retrieve':\"\n",
-      "'\\n---\\n'\n",
-      "---CHECK DOCUMENT RELEVANCE TO QUESTION---\n",
+      "\n",
+      "---\n",
+      "\n",
+      "---CHECK PER DOCUMENT RELEVANCE TO QUESTION---\n",
       "---GRADE: DOCUMENT NOT RELEVANT---\n",
       "---GRADE: DOCUMENT NOT RELEVANT---\n",
       "---GRADE: DOCUMENT NOT RELEVANT---\n",
-      "---GRADE: DOCUMENT RELEVANT---\n",
-      "\"Node 'grade_documents':\"\n",
-      "'\\n---\\n'\n",
+      "---GRADE: DOCUMENT NOT RELEVANT---\n",
+      "\n",
       "---ASSESS GRADED DOCUMENTS---\n",
-      "---DECISION: ALL DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY---\n",
+      "---DECISION: SOME DOCUMENTS ARE NOT RELEVANT TO QUESTION, TRANSFORM QUERY AND PERFORM WEB SEARCH---\n",
+      "\"Node 'grade_documents':\"\n",
+      "\n",
+      "---\n",
+      "\n",
       "---TRANSFORM QUERY---\n",
       "\"Node 'transform_query':\"\n",
-      "'\\n---\\n'\n",
+      "\n",
+      "---\n",
+      "\n",
       "---WEB SEARCH---\n",
       "\"Node 'web_search_node':\"\n",
-      "'\\n---\\n'\n",
+      "\n",
+      "---\n",
+      "\n",
       "---GENERATE---\n",
       "\"Node 'generate':\"\n",
-      "'\\n---\\n'\n",
-      "\"Node '__end__':\"\n",
-      "'\\n---\\n'\n",
-      "('The AlphaCodium paper functions by proposing a code-oriented iterative flow '\n",
-      " 'that involves repeatedly running and fixing generated code against '\n",
-      " 'input-output tests. Its key mechanisms include generating additional data '\n",
-      " 'like problem reflection and test reasoning to aid the iterative process, as '\n",
-      " 'well as enriching the code generation process. AlphaCodium aims to improve '\n",
-      " 'the performance of Large Language Models on code problems by following a '\n",
-      " 'test-based, multi-stage approach.')\n"
+      "\n",
+      "---\n",
+      "\n",
+      "('The AlphaCodium research paper introduces a test-based, multi-stage, '\n",
+      " 'code-oriented iterative flow aimed at enhancing the performance of large '\n",
+      " 'language models (LLMs) in code generation tasks. It emphasizes the '\n",
+      " 'importance of matching syntax, identifying edge cases, and addressing '\n",
+      " 'code-specific requirements, particularly in competitive programming contexts '\n",
+      " 'like CodeContests. The approach is designed to improve the overall '\n",
+      " 'effectiveness of LLMs in solving complex coding challenges.')\n"
      ]
     }
    ],
@@ -672,7 +729,7 @@
     "        pprint(f\"Node '{key}':\")\n",
     "        # Optional: print full state at each node\n",
     "        # pprint.pprint(value[\"keys\"], indent=2, width=80, depth=None)\n",
-    "    pprint(\"\\n---\\n\")\n",
+    "    print(\"\\n---\\n\")\n",
     "\n",
     "# Final generation\n",
     "pprint(value[\"generation\"])"
@@ -685,9 +742,9 @@
    "source": [
     "LangSmith Traces - \n",
     " \n",
-    "* https://smith.langchain.com/public/f6b1716c-e842-4282-9112-1026b93e246b/r\n",
+    "* https://smith.langchain.com/public/5eaf4647-720a-480a-829a-185755da96b7/r\n",
     "\n",
-    "* https://smith.langchain.com/public/497c8ed9-d9e2-429e-8ada-e64de3ec26c9/r"
+    "* https://smith.langchain.com/public/9a03a964-7356-49d7-bea2-1b1b9c183ef6/r"
    ]
   }
  ],
@@ -707,7 +764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I have been playing with Corrective RAG demo in LangGraph repository and gave found some small issues and typos.
Here is the list of them:

- OpenAI model GPT-4o-mini is cheaper and supports [structured output](https://platform.openai.com/docs/guides/structured-outputs) as opposite to gpt-3.5-turbo used along the script 
- Added a small section to load `dotenv` and quick-setup for LangSmith
- Some prints at the end of the script were broken or not showing the expected output
- Typo: "ALL DOCUMENTS ARE NOT RELATED TO THE QUESTION..."; actually this is triggered if at least 1 of them is not relevant, so the message is wrong.