### PR TITLE
Guard and cache calls to find_subgraph_pregel

### DIFF
--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -630,6 +630,7 @@ def prepare_single_task(
                     task_id,
                     task_path[:3],
                     writers=proc.flat_writers,
+                    subgraphs=proc.subgraphs,
                 )
         else:
             return PregelTask(task_id, packet.node, task_path[:3])
@@ -754,6 +755,7 @@ def prepare_single_task(
                         task_id,
                         task_path[:3],
                         writers=proc.flat_writers,
+                        subgraphs=proc.subgraphs,
                     )
             else:
                 return PregelTask(task_id, name, task_path[:3])

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -30,7 +30,6 @@ from langgraph.constants import (
     TAG_HIDDEN,
 )
 from langgraph.pregel.io import read_channels
-from langgraph.pregel.utils import find_subgraph_pregel
 from langgraph.types import PregelExecutableTask, PregelTask, StateSnapshot
 from langgraph.utils.config import patch_checkpoint_map
 
@@ -157,7 +156,7 @@ def map_debug_checkpoint(
     task_states: dict[str, Union[RunnableConfig, StateSnapshot]] = {}
 
     for task in tasks:
-        if not find_subgraph_pregel(task.proc):
+        if not task.subgraphs:
             continue
 
         # assemble checkpoint_ns for this task

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -22,7 +22,9 @@ from langchain_core.runnables.base import Input, Other, coerce_to_runnable
 from langchain_core.runnables.utils import ConfigurableFieldSpec
 
 from langgraph.constants import CONF, CONFIG_KEY_READ
+from langgraph.pregel.protocol import PregelProtocol
 from langgraph.pregel.retry import RetryPolicy
+from langgraph.pregel.utils import find_subgraph_pregel
 from langgraph.pregel.write import ChannelWrite
 from langgraph.utils.config import merge_configs
 from langgraph.utils.runnable import RunnableCallable, RunnableSeq
@@ -145,6 +147,9 @@ class PregelNode(Runnable):
     metadata: Optional[Mapping[str, Any]]
     """Metadata to attach to the node for tracing."""
 
+    subgraphs: Sequence[PregelProtocol]
+    """Subgraphs used by the node."""
+
     def __init__(
         self,
         *,
@@ -165,9 +170,21 @@ class PregelNode(Runnable):
         self.retry_policy = retry_policy
         self.tags = tags
         self.metadata = metadata
+        if self.bound is not DEFAULT_BOUND:
+            try:
+                subgraph = find_subgraph_pregel(self.bound)
+            except Exception:
+                subgraph = None
+            if subgraph:
+                self.subgraphs = [subgraph]
+            else:
+                self.subgraphs = []
+        else:
+            self.subgraphs = []
 
     def copy(self, update: dict[str, Any]) -> PregelNode:
         attrs = {**self.__dict__, **update}
+        attrs.pop("subgraphs")
         return PregelNode(**attrs)
 
     @cached_property
@@ -205,12 +222,12 @@ class PregelNode(Runnable):
             return self.bound
 
     def join(self, channels: Sequence[str]) -> PregelNode:
-        assert isinstance(channels, list) or isinstance(
-            channels, tuple
-        ), "channels must be a list or tuple"
-        assert isinstance(
-            self.channels, dict
-        ), "all channels must be named when using .join()"
+        assert isinstance(channels, list) or isinstance(channels, tuple), (
+            "channels must be a list or tuple"
+        )
+        assert isinstance(self.channels, dict), (
+            "all channels must be named when using .join()"
+        )
         return self.copy(
             update=dict(
                 channels={

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -222,12 +222,12 @@ class PregelNode(Runnable):
             return self.bound
 
     def join(self, channels: Sequence[str]) -> PregelNode:
-        assert isinstance(channels, list) or isinstance(channels, tuple), (
-            "channels must be a list or tuple"
-        )
-        assert isinstance(self.channels, dict), (
-            "all channels must be named when using .join()"
-        )
+        assert isinstance(channels, list) or isinstance(
+            channels, tuple
+        ), "channels must be a list or tuple"
+        assert isinstance(
+            self.channels, dict
+        ), "all channels must be named when using .join()"
         return self.copy(
             update=dict(
                 channels={

--- a/libs/langgraph/langgraph/pregel/utils.py
+++ b/libs/langgraph/langgraph/pregel/utils.py
@@ -26,7 +26,7 @@ def get_new_channel_versions(
     return new_versions
 
 
-def find_subgraph_pregel(candidate: Runnable) -> Optional[Runnable]:
+def find_subgraph_pregel(candidate: Runnable) -> Optional[PregelProtocol]:
     from langgraph.pregel import Pregel
 
     candidates: list[Runnable] = [candidate]

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 from langgraph.checkpoint.base import BaseCheckpointSaver, CheckpointMetadata
 
 if TYPE_CHECKING:
+    from langgraph.pregel.protocol import PregelProtocol
     from langgraph.store.base import BaseStore
 
 
@@ -155,6 +156,7 @@ class PregelExecutableTask(NamedTuple):
     path: tuple[Union[str, int, tuple], ...]
     scheduled: bool = False
     writers: Sequence[Runnable] = ()
+    subgraphs: Sequence["PregelProtocol"] = ()
 
 
 class StateSnapshot(NamedTuple):

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -6256,6 +6256,8 @@ def test_merging_updates_command_parent():
         ),
         ((), {"node_3": {"bar": ["node_3"]}}),
     ]
+
+
 def test_entrypoint_output_schema_with_return_and_save() -> None:
     """Test output schema inference with entrypoint.final."""
 


### PR DESCRIPTION
- The result of these doesnt change once a node is created, and it's fairly expensive to run, so great thing to cache
- There's a variety of errors that can come from inspecting the source code of a function (part of what this does) so adding a catch-all try-except block as this should be best-effort, not crash your graph