### PR TITLE
Fix typo in cloud/quick_start docs

### DIFF
--- a/docs/docs/cloud/quick_start.md
+++ b/docs/docs/cloud/quick_start.md
@@ -90,7 +90,7 @@ For this guide, we'll use the pre-built Python [**ReAct Agent**](https://github.
     </figure>
 
 
-## Lagraph Studio Web UI
+## LangGraph Studio Web UI
 
 Once your application is deployed, you can test it in **LangGraph Studio**. 
 


### PR DESCRIPTION
Hi,

just fixing a typo which I saw in the cloud quick_start docs.