### PR TITLE
docs: convert to executable markdown

### DIFF
--- a/docs/_scripts/notebook_convert.py
+++ b/docs/_scripts/notebook_convert.py
@@ -38,6 +38,11 @@ class EscapePreprocessor(Preprocessor):
             )
 
         elif cell.cell_type == "code":
+            # Determine if the cell has bash or cell magic
+            if cell.source.startswith("%") or cell.source.startswith("!"):
+                # update metadata to denote that it's not a python cell
+                cell.metadata["language_info"] = {"name": "unknown"}
+
             # Remove noqa comments
             cell.source = re.sub(r"#\s*noqa.*$", "", cell.source, flags=re.MULTILINE)
             # escape ``` in code

--- a/docs/_scripts/notebook_convert.py
+++ b/docs/_scripts/notebook_convert.py
@@ -186,7 +186,7 @@ def _convert_notebooks(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert notebooks to markdown")
     parser.add_argument(
-        "--output_dir", default=None, help="Directory to output markdown files"
+        "--output_dir", default=None, help="Directory to output markdown files",
     )
     parser.add_argument(
         "--replace",
@@ -194,4 +194,4 @@ if __name__ == "__main__":
         help="Replace original notebooks with markdown files",
     )
     args = parser.parse_args()
-    _convert_notebooks(args.replace, args.output_dir)
+    _convert_notebooks(replace=args.replace, output_dir=args.output_dir)

--- a/docs/_scripts/notebook_convert_templates/md_executable/conf.json
+++ b/docs/_scripts/notebook_convert_templates/md_executable/conf.json
@@ -1,0 +1,5 @@
+{
+  "mimetypes": {
+    "text/markdown": true
+  }
+}

--- a/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
+++ b/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
@@ -7,11 +7,7 @@
 {%- if 'magics_language' in cell.metadata  -%}
     {{ cell.metadata.magics_language}}
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
-    {%- if nb.metadata.get('mode') == 'exec' -%}
     {{ nb.metadata.language_info.name }} exec="1" source="below" result="ini"
-    {%- else -%}
-    {{ nb.metadata.language_info.name }}
-    {%- endif %}
 {%- endif %}
 {{ cell.source}}
 ```
@@ -19,21 +15,12 @@
 {% endblock input %}
 
 {%- block traceback_line -%}
-```output
-{{ line.rstrip() | strip_ansi }}
-```
 {%- endblock traceback_line -%}
 
 {%- block stream -%}
-```output
-{{ output.text.rstrip() }}
-```
 {%- endblock stream -%}
 
 {%- block data_text scoped -%}
-```output
-{{ output.data['text/plain'].rstrip() }}
-```
 {%- endblock data_text -%}
 
 {%- block data_html scoped -%}

--- a/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
+++ b/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
@@ -6,6 +6,10 @@
 ```
 {%- if 'magics_language' in cell.metadata  -%}
     {{ cell.metadata.magics_language}}
+{%- elif 'name' in cell.metadata.get('language_info', {}) -%}
+    {%- if cell.metadata['language_info']['name'] == "python" -%}
+        {{ cell.metadata.language_info.name }} exec="1" source="below" result="ini"
+    {%- endif -%}
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
     {{ nb.metadata.language_info.name }} exec="1" source="below" result="ini"
 {%- endif %}

--- a/docs/_scripts/notebook_convert_templates/mdoutput/index.md.j2
+++ b/docs/_scripts/notebook_convert_templates/mdoutput/index.md.j2
@@ -1,4 +1,23 @@
+{#https://github.com/rdbisme/nbconvert/blob/master/share/jupyter/nbconvert/templates/markdown/index.md.j2#}
 {% extends 'markdown/index.md.j2' %}
+
+{% block input %}
+
+{{ nb.metadata.target }}
+```
+{%- if 'magics_language' in cell.metadata  -%}
+    {{ cell.metadata.magics_language}}
+{%- elif 'name' in nb.metadata.get('language_info', {}) -%}
+    {%- if nb.metadata.get('mode') == 'exec' -%}
+    {{ nb.metadata.language_info.name }} exec="1" source="below" result="ini"
+    {%- else -%}
+    {{ nb.metadata.language_info.name }}
+    {%- endif %}
+{%- endif %}
+{{ cell.source}}
+```
+
+{% endblock input %}
 
 {%- block traceback_line -%}
 ```output

--- a/docs/_scripts/notebook_convert_templates/mdoutput/index.md.j2
+++ b/docs/_scripts/notebook_convert_templates/mdoutput/index.md.j2
@@ -1,22 +1,4 @@
-{#https://github.com/rdbisme/nbconvert/blob/master/share/jupyter/nbconvert/templates/markdown/index.md.j2#}
 {% extends 'markdown/index.md.j2' %}
-
-{% block input %}
-
-```
-{%- if 'magics_language' in cell.metadata  -%}
-    {{ cell.metadata.magics_language}}
-{%- elif 'name' in nb.metadata.get('language_info', {}) -%}
-    {%- if nb.metadata.get('mode') == 'exec' -%}
-    {{ nb.metadata.language_info.name }} exec="1" source="below" result="ini"
-    {%- else -%}
-    {{ nb.metadata.language_info.name }}
-    {%- endif %}
-{%- endif %}
-{{ cell.source}}
-```
-
-{% endblock input %}
 
 {%- block traceback_line -%}
 ```output

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
   - search:
       separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - autorefs
+  - markdown-exec
   - mkdocstrings:
       handlers:
         python:

--- a/docs/tests/test_notebook_convert.py
+++ b/docs/tests/test_notebook_convert.py
@@ -1,0 +1,39 @@
+import nbformat
+
+from _scripts.notebook_convert import exporter
+
+
+def _remove_consecutive_new_lines(s) -> str:
+    """Remove consecutive new lines from a string."""
+    return "\n".join([line for line in s.split("\n") if line.strip()])
+
+
+def test_convert_notebook():
+    # Test the convert_notebook function
+    # Create a new, minimal notebook programmatically
+    nb = nbformat.v4.new_notebook()
+    nb.metadata.kernelspec = {
+        "name": "python3",
+        "language": "python",
+        "display_name": "Python 3",
+    }
+    nb.metadata.language_info = {
+        "name": "python",
+        "mimetype": "text/x-python",
+        "codemirror_mode": {
+            "name": "ipython",
+            "version": 3,
+        },
+    }
+
+    # Add a markdown cell with a link to an .ipynb file
+    md_cell_source = "This is a [link](example_notebook.ipynb) in markdown."
+    nb.cells.append(nbformat.v4.new_markdown_cell(md_cell_source))
+
+    # Add a code cell with a noqa comment
+    code_cell_source = "print('hello')  # noqa: F401"
+    nb.cells.append(nbformat.v4.new_code_cell(code_cell_source))
+    nb.metadata.mode = "exec"
+
+    body, _ = exporter.from_notebook_node(nb)
+    assert body == """"""

--- a/docs/tests/test_notebook_convert.py
+++ b/docs/tests/test_notebook_convert.py
@@ -31,9 +31,16 @@ def test_convert_notebook():
     nb.cells.append(nbformat.v4.new_markdown_cell(md_cell_source))
 
     # Add a code cell with a noqa comment
-    code_cell_source = "print('hello')  # noqa: F401"
+    code_cell_source = "print('hello')"
     nb.cells.append(nbformat.v4.new_code_cell(code_cell_source))
     nb.metadata.mode = "exec"
 
     body, _ = exporter.from_notebook_node(nb)
-    assert body == """"""
+    assert (
+        _remove_consecutive_new_lines(body)
+        == """\
+This is a [link](example_notebook.ipynb) in markdown.
+```python exec="1" source="below" result="ini"
+print('hello')
+```"""
+    )


### PR DESCRIPTION
```
python notebook_convert.py --replace 
```

will replace ipython notebooks w/ markdown

- [ ] set up cassetts or some sort of caching otherwise editing is very annoying (slow)
- [ ] handle outputs that are images (e.g., graph display)