### PR TITLE
docs: fix grammatical error for navigating node to parent section

### DIFF
--- a/docs/docs/concepts/low_level.md
+++ b/docs/docs/concepts/low_level.md
@@ -357,7 +357,7 @@ Use [conditional edges](#conditional-edges) to route between nodes conditionally
 
 ### Navigating to a node in a parent graph
 
-If you are using [subgraphs](#subgraphs), you might want to navigate from a node a subgraph to a different subgraph (i.e. a different node in the parent graph). To do so, you can specify `graph=Command.PARENT` in `Command`:
+If you are using [subgraphs](#subgraphs), you might want to navigate from a node within a subgraph to a different subgraph (i.e. a different node in the parent graph). To do so, you can specify `graph=Command.PARENT` in `Command`:
 
 ```python
 def my_node(state: State) -> Command[Literal["my_other_node"]]:


### PR DESCRIPTION
Add within to better explain moving from one subgraph to another