### PR TITLE
fix(sdk-js): use `type` instead of `interface` to avoid TS errors

### DIFF
--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -649,7 +649,7 @@ export class ThreadsClient extends BaseClient {
     let threadId: string;
 
     if (typeof threadIdOrConfig !== "string") {
-      if (typeof threadIdOrConfig.configurable.thread_id !== "string") {
+      if (typeof threadIdOrConfig.configurable?.thread_id !== "string") {
         throw new Error(
           "Thread ID is required when updating state with a config.",
         );

--- a/libs/sdk-js/src/schema.ts
+++ b/libs/sdk-js/src/schema.ts
@@ -16,7 +16,7 @@ type MultitaskStrategy = "reject" | "interrupt" | "rollback" | "enqueue";
 
 export type CancelAction = "interrupt" | "rollback";
 
-export interface Config {
+export type Config = {
   /**
    * Tags for this call and any sub-calls (eg. a Chain calling an LLM).
    * You can use these to filter calls.
@@ -32,19 +32,20 @@ export interface Config {
   /**
    * Runtime values for attributes previously made configurable on this Runnable.
    */
-  configurable: {
+  configurable?: {
     /**
      * ID of the thread
      */
-    thread_id?: string;
+    thread_id?: Optional<string>;
 
     /**
      * Timestamp of the state checkpoint
      */
-    checkpoint_id?: string;
+    checkpoint_id?: Optional<string>;
+
     [key: string]: unknown;
   };
-}
+};
 
 export interface GraphSchema {
   /**
@@ -254,12 +255,12 @@ export interface Run {
   multitask_strategy: Optional<MultitaskStrategy>;
 }
 
-export interface Checkpoint {
+export type Checkpoint = {
   thread_id: string;
   checkpoint_ns: string;
   checkpoint_id: Optional<string>;
   checkpoint_map: Optional<Record<string, unknown>>;
-}
+};
 
 export interface ListNamespaceResponse {
   namespaces: string[][];


### PR DESCRIPTION
Allow assigning `threadState?.checkpoint` to the `configurable` object without TSC throwing "Index signature for type 'string' is missing in type".
