### PR TITLE
docs: add check code output for result="ansi"

### DIFF
--- a/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
+++ b/docs/_scripts/notebook_convert_templates/md_executable/index.md.j2
@@ -8,8 +8,7 @@
 {%- elif cell.metadata.get('language') == "shell" -%}
     shell
 {%- elif 'name' in nb.metadata.get('language_info', {}) -%}
-    {{ nb.metadata.language_info.name }}{% if cell.metadata.exec|default(false) %} exec="on" source="above" session="1"{% if cell.metadata.has_output|default(false) %} result="ansi"{% endif %}
-{% endif %}
+    {{ nb.metadata.language_info.name }}{% if cell.metadata.exec|default(false) %} exec="on" source="above" session="1"{% if cell.metadata.has_output|default(false) %} result="ansi"{% endif %}{% endif %}
 {%- endif %}
 {{ cell.source}}
 ```

--- a/docs/tests/unit_tests/test_notebook_conversion.py
+++ b/docs/tests/unit_tests/test_notebook_conversion.py
@@ -1,9 +1,11 @@
 import nbformat
-
-from _scripts.notebook_convert import md_executable, _convert_links_in_markdown
 import pytest
-from _scripts.notebook_convert import md_executable, _has_output
 
+from _scripts.notebook_convert import (
+    _convert_links_in_markdown,
+    md_executable,
+    _has_output,
+)
 
 EXPECTED_OUTPUT = """\
 ```python exec="on" source="above" session="1" result="ansi"
@@ -60,14 +62,8 @@ def test_convert_input_cell() -> None:
     assert markdown == STDIN_OUTPUT
 
 
-NO_STDOUT = """\
-```python
-display(x)
-```
-"""
-
 NO_STDOUT_EXPECTED = """\
-```python
+```python exec="on" source="above" session="1"
 display(x)
 ```
 """
@@ -76,7 +72,7 @@ display(x)
 def test_convert_block_without_output() -> None:
     notebook = nbformat.v4.new_notebook()
     notebook.metadata.language_info = {"name": "python", "version": "3.11"}
-    notebook.cells.append(nbformat.v4.new_code_cell(NO_STDOUT))
+    notebook.cells.append(nbformat.v4.new_code_cell("display(x)"))
     markdown, _ = md_executable.from_notebook_node(notebook)
     assert markdown == NO_STDOUT_EXPECTED
 

--- a/docs/tests/unit_tests/test_notebook_conversion.py
+++ b/docs/tests/unit_tests/test_notebook_conversion.py
@@ -1,6 +1,6 @@
 import nbformat
 
-from _scripts.notebook_convert import md_executable
+from _scripts.notebook_convert import md_executable, _has_output
 
 
 EXPECTED_OUTPUT = """\
@@ -56,3 +56,14 @@ def test_convert_input_cell() -> None:
     notebook.cells.append(nbformat.v4.new_code_cell(STDIN_INPUT))
     markdown, _ = md_executable.from_notebook_node(notebook)
     assert markdown == STDIN_OUTPUT
+
+
+def test_has_output() -> None:
+    """Test if a given code block is expected to have output."""
+    assert _has_output("print('Hello, world!')") is True
+    assert _has_output("print_stream(some_iterable)") is True
+    assert _has_output("foo.y") is True
+    assert _has_output("display(x)") is False
+    assert _has_output("assert 1 == 1") is False
+    assert _has_output("def foo(): pass") is False
+    assert _has_output("import foobar") is False


### PR DESCRIPTION
* Add ast parsing to determine whether we should include result="ansi". It's not meant to be perfect, but will hopefully catch the most common cases. Still requires manual review.
* Ideally we could suppress output in markdown-exec in the future.