### PR TITLE
Ensure remote respects recursion_limit param if it's passed

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -323,7 +323,6 @@ class RemoteGraph(PregelProtocol):
             if k not in reserved_configurable_keys and not k.startswith("__pregel_")
         }
 
-        # Preserve top-level keys like recursion_limit.
         sanitized = {
             "tags": config.get("tags") or [],
             "metadata": config.get("metadata") or {},

--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -323,11 +323,16 @@ class RemoteGraph(PregelProtocol):
             if k not in reserved_configurable_keys and not k.startswith("__pregel_")
         }
 
-        return {
+        # Preserve top-level keys like recursion_limit.
+        sanitized = {
             "tags": config.get("tags") or [],
             "metadata": config.get("metadata") or {},
             "configurable": new_configurable,
         }
+        if "recursion_limit" in config:
+            sanitized["recursion_limit"] = config["recursion_limit"]
+
+        return sanitized
 
     def get_state(
         self, config: RunnableConfig, *, subgraphs: bool = False

--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -323,7 +323,7 @@ class RemoteGraph(PregelProtocol):
             if k not in reserved_configurable_keys and not k.startswith("__pregel_")
         }
 
-        sanitized = {
+        sanitized: RunnableConfig = {
             "tags": config.get("tags") or [],
             "metadata": config.get("metadata") or {},
             "configurable": new_configurable,


### PR DESCRIPTION
Currently when using RemoteGraph the recursion_limit cannot be set, due to the sanitize_config.