### PR TITLE
reference: remove incorrect example from pregel class

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -249,25 +249,6 @@ class Pregel(PregelProtocol):
 
     Repeat until no chains are planned for execution, or a maximum number of steps
     is reached.
-
-    Example:
-        ```python
-        from langgraph import Channel, Pregel
-
-        grow_value = (
-            Channel.subscribe_to("value")
-            | (lambda x: x + x)
-            | Channel.write_to(value=lambda x: x if len(x) < 10 else None)
-        )
-
-        app = Pregel(
-            chains={"grow_value": grow_value},
-            input="value",
-            output="value",
-        )
-
-        assert app.invoke("a") == "aaaaaaaa"
-        ```
     """
 
     nodes: dict[str, PregelNode]


### PR DESCRIPTION
Remove incorrect example from Pregel class. Will follow later this week with better docs