### PR TITLE
docs: Add Pydantic usage examples and runtime coercion documentation

### DIFF
--- a/docs/docs/how-tos/state-model.ipynb
+++ b/docs/docs/how-tos/state-model.ipynb
@@ -71,9 +71,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "id": "af4ce0ba-7596-4e5f-8bf8-0b0bd6e62833",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:20.617675Z",
+     "start_time": "2025-02-25T13:54:19.634983Z"
+    }
+   },
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
@@ -82,9 +87,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "01456d57-4064-4ccb-baf9-98df39c6b8e0",
-   "metadata": {},
    "outputs": [],
    "source": [
     "import getpass\n",
@@ -97,7 +99,16 @@
     "\n",
     "\n",
     "_set_env(\"OPENAI_API_KEY\")"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:21.063763Z",
+     "start_time": "2025-02-25T13:54:21.059961Z"
+    }
+   },
+   "id": "94568d1c0649fdf5",
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -122,17 +133,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 9,
    "id": "efc46b36-425c-49c3-9f9e-d9785c70b034",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:22.645247Z",
+     "start_time": "2025-02-25T13:54:22.633583Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "{'a': 'goodbye'}"
-      ]
+      "text/plain": "{'a': 'goodbye'}"
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,9 +188,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "id": "05d7d43b-0b71-4e25-af6f-61d1560a46cb",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:23.781159Z",
+     "start_time": "2025-02-25T13:54:23.767703Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -186,7 +205,7 @@
       "1 validation error for OverallState\n",
       "a\n",
       "  Input should be a valid string [type=string_type, input_value=123, input_type=int]\n",
-      "    For further information visit https://errors.pydantic.dev/2.9/v/string_type\n"
+      "    For further information visit https://errors.pydantic.dev/2.10/v/string_type\n"
      ]
     }
    ],
@@ -212,9 +231,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "25336b0d-2fe6-45c8-8204-f962c3995df7",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:25.711465Z",
+     "start_time": "2025-02-25T13:54:25.704527Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -224,7 +248,7 @@
       "1 validation error for OverallState\n",
       "a\n",
       "  Input should be a valid string [type=string_type, input_value=123, input_type=int]\n",
-      "    For further information visit https://errors.pydantic.dev/2.9/v/string_type\n"
+      "    For further information visit https://errors.pydantic.dev/2.10/v/string_type\n"
      ]
     }
    ],
@@ -266,6 +290,230 @@
     "    print(\"An exception was raised because bad_node sets `a` to an integer.\")\n",
     "    print(e)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "advanced-pydantic-usage",
+   "metadata": {},
+   "source": [
+    "## Advanced Pydantic Model Usage\n",
+    "\n",
+    "This section covers more advanced topics when using Pydantic models with LangGraph.\n",
+    "\n",
+    "### Serialization Behavior\n",
+    "\n",
+    "When using Pydantic models as state schemas, it's important to understand how serialization works, especially when:\n",
+    "- Passing Pydantic objects as inputs\n",
+    "- Receiving outputs from the graph\n",
+    "- Working with nested Pydantic models\n",
+    "\n",
+    "Let's see these behaviors in action:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "pydantic-serialization",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:43.726617Z",
+     "start_time": "2025-02-25T13:54:43.704541Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input object type: <class '__main__.ComplexState'>\n",
+      "Input state type: <class '__main__.ComplexState'>\n",
+      "Nested type: <class '__main__.NestedModel'>\n",
+      "Output type: <class 'langgraph.pregel.io.AddableValuesDict'>\n",
+      "Output content: {'text': 'hello processed', 'count': 1, 'nested': NestedModel(value='test')}\n",
+      "Converted back to Pydantic: <class '__main__.ComplexState'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "class NestedModel(BaseModel):\n",
+    "    value: str\n",
+    "\n",
+    "class ComplexState(BaseModel):\n",
+    "    text: str\n",
+    "    count: int\n",
+    "    nested: NestedModel\n",
+    "\n",
+    "def process_node(state: ComplexState):\n",
+    "    # Node receives a validated Pydantic object\n",
+    "    print(f\"Input state type: {type(state)}\")\n",
+    "    print(f\"Nested type: {type(state.nested)}\")\n",
+    "    \n",
+    "    # Return a dictionary update\n",
+    "    return {\"text\": state.text + \" processed\", \"count\": state.count + 1}\n",
+    "\n",
+    "# Build the graph\n",
+    "builder = StateGraph(ComplexState)\n",
+    "builder.add_node(\"process\", process_node)\n",
+    "builder.add_edge(START, \"process\")\n",
+    "builder.add_edge(\"process\", END)\n",
+    "graph = builder.compile()\n",
+    "\n",
+    "# Create a Pydantic instance for input\n",
+    "input_state = ComplexState(text=\"hello\", count=0, nested=NestedModel(value=\"test\"))\n",
+    "print(f\"Input object type: {type(input_state)}\")\n",
+    "\n",
+    "# Invoke graph with a Pydantic instance\n",
+    "result = graph.invoke(input_state)\n",
+    "print(f\"Output type: {type(result)}\")\n",
+    "print(f\"Output content: {result}\")\n",
+    "\n",
+    "# Convert back to Pydantic model if needed\n",
+    "output_model = ComplexState(**result)\n",
+    "print(f\"Converted back to Pydantic: {type(output_model)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "runtime-coercion",
+   "metadata": {},
+   "source": [
+    "### Runtime Type Coercion\n",
+    "\n",
+    "Pydantic performs runtime type coercion for certain data types. This can be helpful but also lead to unexpected behavior if you're not aware of it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "coercion-example",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T13:54:52.676641Z",
+     "start_time": "2025-02-25T13:54:52.668675Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number: 42 (type: <class 'int'>)\n",
+      "flag: True (type: <class 'bool'>)\n",
+      "\n",
+      "Expected validation error: 1 validation error for CoercionExample\n",
+      "number\n",
+      "  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='not-a-number', input_type=str]\n",
+      "    For further information visit https://errors.pydantic.dev/2.10/v/int_parsing\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "class CoercionExample(BaseModel):\n",
+    "    # Pydantic will coerce string numbers to integers\n",
+    "    number: int\n",
+    "    # Pydantic will parse string booleans to bool\n",
+    "    flag: bool\n",
+    "\n",
+    "def inspect_node(state: CoercionExample):\n",
+    "    print(f\"number: {state.number} (type: {type(state.number)})\")\n",
+    "    print(f\"flag: {state.flag} (type: {type(state.flag)})\")\n",
+    "    return {}\n",
+    "\n",
+    "builder = StateGraph(CoercionExample)\n",
+    "builder.add_node(\"inspect\", inspect_node)\n",
+    "builder.add_edge(START, \"inspect\")\n",
+    "builder.add_edge(\"inspect\", END)\n",
+    "graph = builder.compile()\n",
+    "\n",
+    "# Demonstrate coercion with string inputs that will be converted\n",
+    "result = graph.invoke({\"number\": \"42\", \"flag\": \"true\"})\n",
+    "\n",
+    "# This would fail with a validation error\n",
+    "try:\n",
+    "    graph.invoke({\"number\": \"not-a-number\", \"flag\": \"true\"})\n",
+    "except Exception as e:\n",
+    "    print(f\"\\nExpected validation error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "messaging-models",
+   "metadata": {},
+   "source": [
+    "### Working with Message Models\n",
+    "\n",
+    "When working with LangChain message types in your state schema, there are important considerations for serialization. You should use `AnyMessage` (rather than `BaseMessage`) for proper serialization/deserialization when using message objects over the wire:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "message-example",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-02-25T22:22:13.252377Z",
+     "start_time": "2025-02-25T22:22:13.244167Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Output: {'messages': [HumanMessage(content='Hi', additional_kwargs={}, response_metadata={}), AIMessage(content='Hello there!', additional_kwargs={}, response_metadata={})], 'context': 'Customer support chat'}\n",
+      "Message 0: HumanMessage - Hi\n",
+      "Message 1: AIMessage - Hello there!\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langgraph.graph import StateGraph, START, END\n",
+    "from pydantic import BaseModel\n",
+    "from langchain_core.messages import HumanMessage, AIMessage, BaseMessage\n",
+    "from typing import List\n",
+    "\n",
+    "class ChatState(BaseModel):\n",
+    "    messages: List[BaseMessage]  \n",
+    "    context: str\n",
+    "\n",
+    "def add_message(state: ChatState):\n",
+    "    return {\"messages\": state.messages + [AIMessage(content=\"Hello there!\")]}\n",
+    "\n",
+    "builder = StateGraph(ChatState)\n",
+    "builder.add_node(\"add_message\", add_message)\n",
+    "builder.add_edge(START, \"add_message\")\n",
+    "builder.add_edge(\"add_message\", END)\n",
+    "graph = builder.compile()\n",
+    "\n",
+    "# Create input with a message\n",
+    "initial_state = ChatState(\n",
+    "    messages=[HumanMessage(content=\"Hi\")],\n",
+    "    context=\"Customer support chat\"\n",
+    ")\n",
+    "\n",
+    "result = graph.invoke(initial_state)\n",
+    "print(f\"Output: {result}\")\n",
+    "\n",
+    "# Convert back to Pydantic model to see message types\n",
+    "output_model = ChatState(**result)\n",
+    "for i, msg in enumerate(output_model.messages):\n",
+    "    print(f\"Message {i}: {type(msg).__name__} - {msg.content}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "3ee47119e50be052"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description
This PR enhances the state-model documentation by adding comprehensive examples for advanced Pydantic usage in LangGraph. It addresses issue #2745 regarding the need for better documentation of Pydantic schema behavior.

### Changes
- Added new section on Advanced Pydantic Model Usage
- Added examples for serialization behavior with nested models
- Added section on runtime type coercion with examples
- Added documentation for proper message type handling (BaseMessage vs AnyMessage)
- Updated Pydantic error URLs to latest version

### Related Issues
Closes #2745

### Testing
- All notebook cells have been executed and outputs verified
- Examples demonstrate proper usage patterns
- Error cases are properly documented

### Documentation
The changes are documentation-focused and include:
- New examples for complex Pydantic models
- Runtime coercion behavior examples
- Message type handling best practices