### PR TITLE
Refactor deprecated copy method

### DIFF
--- a/libs/langgraph/bench/react_agent.py
+++ b/libs/langgraph/bench/react_agent.py
@@ -26,7 +26,7 @@ def react_agent(n_tools: int, checkpointer: Optional[BaseCheckpointSaver]) -> Pr
             run_manager: Optional[CallbackManagerForLLMRun] = None,
             **kwargs: Any,
         ) -> ChatResult:
-            response = self.responses[self.i].copy()
+            response = self.responses[self.i].model_copy()
             if self.i < len(self.responses) - 1:
                 self.i += 1
             else:

--- a/libs/langgraph/tests/fake_chat.py
+++ b/libs/langgraph/tests/fake_chat.py
@@ -33,10 +33,7 @@ class FakeChatModel(GenericFakeChatModel):
         if isinstance(message, str):
             message_ = AIMessage(content=message)
         else:
-            if hasattr(message, "model_copy"):
-                message_ = message.model_copy()
-            else:
-                message_ = message.copy()
+            message_ = message.model_copy()
         generation = ChatGeneration(message=message_)
         return ChatResult(generations=[generation])
 

--- a/libs/langgraph/tests/fake_tracer.py
+++ b/libs/langgraph/tests/fake_tracer.py
@@ -55,7 +55,7 @@ class FakeTracer(BaseTracer):
             new_dotted_order = ".".join(processed_levels)
         else:
             new_dotted_order = None
-        return run.copy(
+        return run.model_copy(
             update={
                 "id": self._replace_uuid(run.id),
                 "parent_run_id": (


### PR DESCRIPTION
When I installed langgraph 0.3.5, it was depending on pydantic 2.10.6. 
The BaseModel class in pydantic.main has a copy() method, but it is currently deprecated and recommends using the model_copy() method. I've changed the code that uses BaseModel accordingly. 
Please check it out. Thank you. 


<img width="1338" alt="image" src="https://github.com/user-attachments/assets/aa997b6b-45af-4e0c-8a9b-0cfc917130c1" />
