### PR TITLE
Item `updated_at` not being correctly initialized with the correct attribute.

### DIFF
--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -59,7 +59,7 @@ class Item:
             else created_at
         )
         self.updated_at = (
-            datetime.fromisoformat(cast(str, created_at))
+            datetime.fromisoformat(cast(str, updated_at))
             if isinstance(updated_at, str)
             else updated_at
         )


### PR DESCRIPTION
Issue fixed in  #3748.