### PR TITLE
docs: Fix version badge by linking it to PyPi instead of shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🦜🕸️LangGraph
 
-![Version](https://img.shields.io/pypi/v/langgraph)
+[![Version](https://img.shields.io/pypi/v/langgraph.svg)](https://pypi.org/project/langgraph/)
 [![Downloads](https://static.pepy.tech/badge/langgraph/month)](https://pepy.tech/project/langgraph)
 [![Open Issues](https://img.shields.io/github/issues-raw/langchain-ai/langgraph)](https://github.com/langchain-ai/langgraph/issues)
 [![Docs](https://img.shields.io/badge/docs-latest-blue)](https://langchain-ai.github.io/langgraph/)

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -1,6 +1,6 @@
 # 🦜🕸️LangGraph
 
-![Version](https://img.shields.io/pypi/v/langgraph)
+[![Version](https://img.shields.io/pypi/v/langgraph.svg)](https://pypi.org/project/langgraph/)
 [![Downloads](https://static.pepy.tech/badge/langgraph/month)](https://pepy.tech/project/langgraph)
 [![Open Issues](https://img.shields.io/github/issues-raw/langchain-ai/langgraph)](https://github.com/langchain-ai/langgraph/issues)
 [![Docs](https://img.shields.io/badge/docs-latest-blue)](https://langchain-ai.github.io/langgraph/)


### PR DESCRIPTION
Currently the version badge showing langgraph version as PyPi shield image is linking to the shield image. It would be more intuitive to link it to PyPi.