### PR TITLE
Print only messages without all the metadata

### DIFF
--- a/docs/docs/tutorials/chatbot-simulation-evaluation/agent-simulation-evaluation.ipynb
+++ b/docs/docs/tutorials/chatbot-simulation-evaluation/agent-simulation-evaluation.ipynb
@@ -410,7 +410,10 @@
     "for chunk in simulation.stream({\"messages\": []}):\n",
     "    # Print out all events aside from the final end chunk\n",
     "    if END not in chunk:\n",
-    "        print(chunk)\n",
+    "        # Extract and print only the message content"
+    "        for node, data in chunk.items():"
+    "            for message in data["messages"]:"
+    "                print(f"{node}: {message.content}")"
     "        print(\"----\")"
    ]
   }


### PR DESCRIPTION
With the existing code, I was getting the whole object with metadata which was just cluttering the output and different from the example shown.