### PR TITLE
Update recursion-limit.ipynb

### DIFF
--- a/docs/docs/how-tos/recursion-limit.ipynb
+++ b/docs/docs/how-tos/recursion-limit.ipynb
@@ -54,7 +54,7 @@
     "    if termination_condition(state):\n",
     "        return END\n",
     "    else:\n",
-    "        return \"a\"\n",
+    "        return \"b\"\n",
     "\n",
     "builder.add_edge(START, \"a\")\n",
     "builder.add_conditional_edges(\"a\", route)\n",


### PR DESCRIPTION
There was a typo of returning 'a' when the fn def clearly states that: def route(state: State) -> Literal["b", END]: