### PR TITLE
docs: fix state type in Persistence documentation

### DIFF
--- a/docs/docs/concepts/persistence.md
+++ b/docs/docs/concepts/persistence.md
@@ -32,7 +32,7 @@ from typing_extensions import TypedDict
 from operator import add
 
 class State(TypedDict):
-    foo: int
+    foo: str
     bar: Annotated[list[str], add]
 
 def node_a(state: State):


### PR DESCRIPTION
This PR fixes the type of `foo` in the `State` class in Persistence documentation. The type was previously defined as `int`, but the code uses it as a `str`.

Updated the type of `foo` in the documentation to `str` to match its actual usage in the code.

No changes to the functionality or codebase, only a documentation fix.
