### PR TITLE
Add Support for Pandas DataFrame Serialization

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -443,7 +443,6 @@ def _msgpack_default(obj: Any) -> Union[str, msgpack.ExtType]:
                 ),
             ),
         )
-
     else:
         raise TypeError(f"Object of type {obj.__class__.__name__} is not serializable")
 

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 import re
 from collections import deque
+from pandas import DataFrame
 from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
@@ -429,9 +430,20 @@ def _msgpack_default(obj: Any) -> Union[str, msgpack.ExtType]:
                 ),
             ),
         )
-
     elif isinstance(obj, BaseException):
         return repr(obj)
+    elif isinstance(obj, DataFrame):
+        return msgpack.ExtType(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.to_dict(),),
+                ),
+            ),
+        )
+
     else:
         raise TypeError(f"Object of type {obj.__class__.__name__} is not serializable")
 


### PR DESCRIPTION
**Description**:
This pull request introduces support for serializing a pandas DataFrame objects within the JsonPlus serializer. The changes include:

- Extending the msgpack default serialization function to check if an object is a pandas DataFrame. If so, the DataFrame is converted to a dictionary using its to_dict() method, then wrapped in a msgpack ExtType with a unique extension code.

- Leveraging the existing deserialization logic (EXT_CONSTRUCTOR_POS_ARGS) to reconstruct the DataFrame from the serialized dictionary.

- Enabling modules like MemorySaver to store DataFrame objects directly using the new serialization support, allowing for seamless saving and retrieval of DataFrames without additional modifications.