### PR TITLE
doc: remove Python max version limit from example pyproject.toml

### DIFF
--- a/docs/docs/cloud/deployment/setup_pyproject.md
+++ b/docs/docs/cloud/deployment/setup_pyproject.md
@@ -64,7 +64,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9.0,<3.13"
+python = ">=3.9"
 langgraph = "^0.2.0"
 langchain-fireworks = "^0.1.3"
 


### PR DESCRIPTION
LangGraph officially supported Python 3.13 back in October 2024: 
https://changelog.langchain.com/announcements/langgraph-is-now-compatible-with-python-3-13

But why suggest restricting the version of Python at all? The app/agent owner will be in control of the runtime version anyway, so don't add unnecessary restrictions.

Note this example from Poetry: https://python-poetry.org/docs/pyproject/#requires-python

I did not refactor pyproject.toml to the newer Poetry 2 / uv format, but I can do that in a future PR if it will help... please don't let that block approval+merging this PR.