### PR TITLE
docs: make sentence relating to how to navigate between sub graphs clearer in the docs

### DIFF
--- a/docs/docs/how-tos/command.ipynb
+++ b/docs/docs/how-tos/command.ipynb
@@ -33,7 +33,7 @@
     "    )\n",
     "```\n",
     "\n",
-    "If you are using [subgraphs](#subgraphs), you might want to navigate from a node a subgraph to a different subgraph (i.e. a different node in the parent graph). To do so, you can specify `graph=Command.PARENT` in `Command`:\n",
+    "If you are using [subgraphs](#subgraphs), you might want to navigate from a node within a subgraph to a different subgraph (i.e. a different node in the parent graph). To do so, you can specify `graph=Command.PARENT` in `Command`:\n",
     "\n",
     "```python\n",
     "def my_node(state: State) -> Command[Literal[\"my_other_node\"]]:\n",


### PR DESCRIPTION
- fix typo / add missing word
- make sentence relating to how to navigate between sub graphs clearer in the docs