### PR TITLE
fix(docs): Update deprecated methods and add validator

### DIFF
--- a/docs/docs/tutorials/storm/storm.ipynb
+++ b/docs/docs/tutorials/storm/storm.ipynb
@@ -642,7 +642,7 @@
     "    ]\n",
     ")\n",
     "gen_queries_chain = gen_queries_prompt | fast_llm.with_structured_output(\n",
-    "    Queries, include_raw=True, method='function_calling'\n",
+    "    Queries, include_raw=True, method=\"function_calling\"\n",
     ")"
    ]
   },

--- a/docs/docs/tutorials/storm/storm.ipynb
+++ b/docs/docs/tutorials/storm/storm.ipynb
@@ -153,7 +153,7 @@
     "\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
     "\n",
-    "from pydantic import BaseModel, Field\n",
+    "from pydantic import BaseModel, Field, field_validator\n",
     "\n",
     "direct_gen_outline_prompt = ChatPromptTemplate.from_messages(\n",
     "    [\n",
@@ -336,6 +336,10 @@
     "        description=\"Description of the editor's focus, concerns, and motives.\",\n",
     "    )\n",
     "\n",
+    "    @field_validator(\"name\", mode=\"before\")\n",
+    "    def sanitize_name(cls, value: str) -> str:\n",
+    "        return value.replace(\" \", \"\").replace(\".\", \"\")\n",
+    "\n",
     "    @property\n",
     "    def persona(self) -> str:\n",
     "        return f\"Name: {self.name}\\nRole: {self.role}\\nAffiliation: {self.affiliation}\\nDescription: {self.description}\\n\"\n",
@@ -362,9 +366,9 @@
     "    ]\n",
     ")\n",
     "\n",
-    "gen_perspectives_chain = gen_perspectives_prompt | ChatOpenAI(\n",
-    "    model=\"gpt-3.5-turbo\"\n",
-    ").with_structured_output(Perspectives)"
+    "gen_perspectives_chain = gen_perspectives_prompt | fast_llm.with_structured_output(\n",
+    "    Perspectives, method=\"function_calling\"\n",
+    ")"
    ]
   },
   {
@@ -451,7 +455,7 @@
     }
    ],
    "source": [
-    "perspectives.dict()"
+    "perspectives.model_dump()"
    ]
   },
   {
@@ -559,7 +563,7 @@
     "    converted = []\n",
     "    for message in state[\"messages\"]:\n",
     "        if isinstance(message, AIMessage) and message.name != name:\n",
-    "            message = HumanMessage(**message.dict(exclude={\"type\"}))\n",
+    "            message = HumanMessage(**message.model_dump(exclude={\"type\"}))\n",
     "        converted.append(message)\n",
     "    return {\"messages\": converted}\n",
     "\n",
@@ -637,9 +641,9 @@
     "        MessagesPlaceholder(variable_name=\"messages\", optional=True),\n",
     "    ]\n",
     ")\n",
-    "gen_queries_chain = gen_queries_prompt | ChatOpenAI(\n",
-    "    model=\"gpt-3.5-turbo\"\n",
-    ").with_structured_output(Queries, include_raw=True)"
+    "gen_queries_chain = gen_queries_prompt | fast_llm.with_structured_output(\n",
+    "    Queries, include_raw=True, method='function_calling'\n",
+    ")"
    ]
   },
   {
@@ -1695,6 +1699,13 @@
     "# We will down-header the sections to create less confusion in this notebook\n",
     "Markdown(article.replace(\"\\n#\", \"\\n##\"))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Added a validator to sanitize 'name' fields and prevent string_pattern_mismatch errors.
- Replaced deprecated `dict` method with `model_dump` in line with Pydantic v2.0 migration guidelines.
- Updated gen_perspectives_chain and gen_queries_chain to ensure compatibility with structured output and include raw data where needed. This allows use of fast_llm across the notebook.