### PR TITLE
Small perf improvements

### DIFF
--- a/libs/langgraph/langgraph/graph/branch.py
+++ b/libs/langgraph/langgraph/graph/branch.py
@@ -138,6 +138,7 @@ class Branch(NamedTuple):
                 reader=reader,
                 name=None,
                 trace=False,
+                func_accepts_config=True,
             )
         )
 

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -323,8 +323,8 @@ def apply_writes(
     # Channels that weren't updated in this step are notified of a new step
     if bump_step:
         for chan in channels:
-            if chan not in updated_channels:
-                if channels[chan].update([]) and get_next_version is not None:
+            if channels[chan].is_available() and chan not in updated_channels:
+                if channels[chan].update(EMPTY_SEQ) and get_next_version is not None:
                     checkpoint["channel_versions"][chan] = get_next_version(
                         max_version,
                         channels[chan],

--- a/libs/langgraph/langgraph/pregel/write.py
+++ b/libs/langgraph/langgraph/pregel/write.py
@@ -57,7 +57,13 @@ class ChannelWrite(RunnableCallable):
         tags: Optional[Sequence[str]] = None,
         require_at_least_one_of: Optional[Sequence[str]] = None,  # ignored
     ):
-        super().__init__(func=self._write, afunc=self._awrite, name=None, tags=tags)
+        super().__init__(
+            func=self._write,
+            afunc=self._awrite,
+            name=None,
+            tags=tags,
+            func_accepts_config=True,
+        )
         self.writes = cast(
             list[Union[ChannelWriteEntry, ChannelWriteTupleEntry, Send]], writes
         )

--- a/libs/langgraph/poetry.lock
+++ b/libs/langgraph/poetry.lock
@@ -1324,14 +1324,14 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.44"
+version = "0.3.46"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "langchain_core-0.3.44-py3-none-any.whl", hash = "sha256:d989ce8bd62f1d07765acd575e6ec1254aec0cf7775aaea39fe4af8102377459"},
-    {file = "langchain_core-0.3.44.tar.gz", hash = "sha256:7c0a01e78360f007cbca448178fe7e032404068e6431dbe8ce905f84febbdfa5"},
+    {file = "langchain_core-0.3.46-py3-none-any.whl", hash = "sha256:28b5689fc347975ea520b5364ab4aee5567e661553bbee5e97cabf4596c28ce0"},
+    {file = "langchain_core-0.3.46.tar.gz", hash = "sha256:5fca010eeb0a427be5aa8a8525e2112995dde790c584cef165be7c5e0ee1c2b5"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
- RunnableCallable: Skip signature checks for internal callables where we know the signatures ahead of time
- PregelNode: Avoid redoing subgraphs serarch when copying it
- CompiledStateGraph: Avoid copying PregelNode when attaching writers