### PR TITLE
Bugfix: proper link to multi-agent-collaboration.ipynb

### DIFF
--- a/docs/docs/tutorials/multi_agent/agent_supervisor.ipynb
+++ b/docs/docs/tutorials/multi_agent/agent_supervisor.ipynb
@@ -12,7 +12,7 @@
    "source": [
     "# Multi-agent supervisor\n",
     "\n",
-    "The [previous example](../multi-agent-collaboration) routed messages automatically based on the output of the initial researcher agent.\n",
+    "The [previous example](./multi-agent-collaboration.ipynb) routed messages automatically based on the output of the initial researcher agent.\n",
     "\n",
     "We can also choose to use an [LLM to orchestrate](https://langchain-ai.github.io/langgraph/concepts/multi_agent/#supervisor) the different agents.\n",
     "\n",


### PR DESCRIPTION
There is a mistake in agent_supervisor.ipynb.
Current "previous example" link leads to 404 - page not found
This is fix for that.