### PR TITLE
docs(pregel): One-line markdown formatting quick-fix

### DIFF
--- a/docs/docs/concepts/pregel.md
+++ b/docs/docs/concepts/pregel.md
@@ -284,7 +284,7 @@ LangGraph provides two high-level APIs for creating a Pregel application: the [S
     {'__start__': <langgraph.pregel.read.PregelNode at 0x7d05e3ba1810>,
      'write_essay': <langgraph.pregel.read.PregelNode at 0x7d05e3ba14d0>,
      'score_essay': <langgraph.pregel.read.PregelNode at 0x7d05e3ba1710>}
-     ```
+    ```
 
     ```python
     print(graph.channels)


### PR DESCRIPTION
## Description

I noticed a very minor issue in the formatting of the Concepts > Pregel doc: (https://langchain-ai.github.io/langgraph/concepts/pregel/#high-level-api) (https://github.com/langchain-ai/langgraph/blob/main/docs/docs/concepts/pregel.md)

You can see in the image below that there is a python codeblock, then a pycon block, and inside that block there is an extra triple-backtick/code fence, and then text at the bottom, which it appears like it is supposed to be a separate python block, like the one above it. I.e., clearly:

```
```python
print(graph.channels)
```

is intended to be:

```python
print(graph.channels)
```

I'm pretty sure this is due to an extra whitespace character before the preceding closing code fence, which is throwing off the formatting.


![image](https://github.com/user-attachments/assets/616d72d6-652b-4599-be3e-55c47766861d)

My VS-Code/extensions can't really render the Markdown the way it appears on the Website, I think because of the tabs (Graph API vs. Functional API), but I noticed that if I remove the extra whitespace, the highlighting on the python codeblock is corrected:

BEFORE:
<img width="605" alt="Screenshot 2025-03-25 at 5 02 41 PM" src="https://github.com/user-attachments/assets/8474f103-c5ab-4c02-b22f-3d54b3363331" />

AFTER:
<img width="277" alt="Screenshot 2025-03-25 at 5 02 50 PM" src="https://github.com/user-attachments/assets/a311b87b-859c-4aba-a4d8-6b063a155d90" />


## Fix
* Remove one whitespace character that was throwing off markdown rendering