### PR TITLE
patch: fix return type of Topic.update

### DIFF
--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -62,7 +62,7 @@ class Topic(
                 empty.values = checkpoint
         return empty
 
-    def update(self, values: Sequence[Union[Value, list[Value]]]) -> None:
+    def update(self, values: Sequence[Union[Value, list[Value]]]) -> bool:
         current = list(self.values)
         if not self.accumulate:
             self.values = list[Value]()


### PR DESCRIPTION
This PR fixes the return type annotation of the `update` method from `None` to `bool`, as the method returns a boolean value indicating whether self.values has changed