### PR TITLE
Reduce perf impact of pregel scratchpad creation

### DIFF
--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -369,7 +369,7 @@ class LoopProtocol:
         self.stop = stop
 
 
-@dataclasses.dataclass(**{**_DC_KWARGS, "frozen": False})
+@dataclasses.dataclass(**_DC_KWARGS)
 class PregelScratchpad:
     # call
     call_counter: Callable[[], int]


### PR DESCRIPTION
- make scratchpad class frozen now that its members are never reassigned
- replace next(gen expr) with for-loop to avoid allocating generator objects