### PR TITLE
Maintain checkpoint LATEST_VERSION constant in langgraph lib

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -30,6 +30,7 @@ from langgraph.checkpoint.serde.types import (
 
 V = TypeVar("V", int, float, str)
 PendingWrite = Tuple[str, str, Any]
+# Kept for backwards compat, newer versions of LangGraph no longer use this.
 LATEST_VERSION = 2
 
 
@@ -100,6 +101,7 @@ class Checkpoint(TypedDict):
     Cleared by the next checkpoint."""
 
 
+# Kept for backwards compat, newer versions of LangGraph no longer use this.
 def empty_checkpoint() -> Checkpoint:
     return Checkpoint(
         v=LATEST_VERSION,

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -50,7 +50,6 @@ from langgraph.checkpoint.base import (
     BaseCheckpointSaver,
     CheckpointTuple,
     copy_checkpoint,
-    empty_checkpoint,
 )
 from langgraph.constants import (
     CONF,
@@ -90,7 +89,7 @@ from langgraph.pregel.algo import (
     local_write,
     prepare_next_tasks,
 )
-from langgraph.pregel.checkpoint import create_checkpoint
+from langgraph.pregel.checkpoint import create_checkpoint, empty_checkpoint
 from langgraph.pregel.debug import tasks_w_writes
 from langgraph.pregel.io import map_input, read_channels
 from langgraph.pregel.loop import AsyncPregelLoop, StreamProtocol, SyncPregelLoop

--- a/libs/langgraph/langgraph/pregel/checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/checkpoint.py
@@ -2,9 +2,23 @@ from datetime import datetime, timezone
 from typing import Mapping, Optional
 
 from langgraph.channels.base import BaseChannel
-from langgraph.checkpoint.base import LATEST_VERSION, Checkpoint
+from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.base.id import uuid6
 from langgraph.constants import MISSING
+
+LATEST_VERSION = 2
+
+
+def empty_checkpoint() -> Checkpoint:
+    return Checkpoint(
+        v=LATEST_VERSION,
+        id=str(uuid6(clock_seq=-2)),
+        ts=datetime.now(timezone.utc).isoformat(),
+        channel_values={},
+        channel_versions={},
+        versions_seen={},
+        pending_sends=[],
+    )
 
 
 def create_checkpoint(

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -38,7 +38,6 @@ from langgraph.checkpoint.base import (
     CheckpointTuple,
     PendingWrite,
     copy_checkpoint,
-    empty_checkpoint,
 )
 from langgraph.constants import (
     CONF,
@@ -87,7 +86,7 @@ from langgraph.pregel.algo import (
     should_interrupt,
     task_path_str,
 )
-from langgraph.pregel.checkpoint import create_checkpoint
+from langgraph.pregel.checkpoint import create_checkpoint, empty_checkpoint
 from langgraph.pregel.debug import (
     map_debug_checkpoint,
     map_debug_task_results,


### PR DESCRIPTION
- This should be controlled by the langgraph version, not the version of langgraph-checkpoint installed