### PR TITLE
docs: add missing MemorySaver import for unexpanded example

### DIFF
--- a/docs/docs/concepts/functional_api.md
+++ b/docs/docs/concepts/functional_api.md
@@ -26,6 +26,8 @@ Below we demonstrate a simple application that writes an essay and [interrupts](
 from langgraph.func import entrypoint, task
 from langgraph.types import interrupt
 from langgraph.checkpoint.memory import MemorySaver
+
+
 @task
 def write_essay(topic: str) -> str:
     """Write an essay about the given topic."""

--- a/docs/docs/concepts/functional_api.md
+++ b/docs/docs/concepts/functional_api.md
@@ -25,7 +25,6 @@ Below we demonstrate a simple application that writes an essay and [interrupts](
 ```python
 from langgraph.func import entrypoint, task
 from langgraph.types import interrupt
-from langgraph.checkpoint.memory import MemorySaver
 
 
 @task

--- a/docs/docs/concepts/functional_api.md
+++ b/docs/docs/concepts/functional_api.md
@@ -25,7 +25,7 @@ Below we demonstrate a simple application that writes an essay and [interrupts](
 ```python
 from langgraph.func import entrypoint, task
 from langgraph.types import interrupt
-
+from langgraph.checkpoint.memory import MemorySaver
 @task
 def write_essay(topic: str) -> str:
     """Write an essay about the given topic."""

--- a/docs/docs/concepts/functional_api.md
+++ b/docs/docs/concepts/functional_api.md
@@ -23,6 +23,7 @@ This provides a minimal abstraction for building workflows with state management
 Below we demonstrate a simple application that writes an essay and [interrupts](human_in_the_loop.md) to request human review.
 
 ```python
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.func import entrypoint, task
 from langgraph.types import interrupt
 


### PR DESCRIPTION
Import `MemorySaver` for the code to run without expanding the example