### PR TITLE
feat(langgraph): Add UI messages API

### DIFF
--- a/docs/docs/cloud/how-tos/generative_ui_react.md
+++ b/docs/docs/cloud/how-tos/generative_ui_react.md
@@ -80,12 +80,12 @@ CSS and Tailwind 4.x is also supported out of the box, so you can freely use Tai
     from langchain_openai import ChatOpenAI
     from langgraph.graph import StateGraph
     from langgraph.graph.message import add_messages
-    from langgraph.graph.ui import AnyUIMessage, add_ui_messages, push_ui_message
+    from langgraph.graph.ui import AnyUIMessage, ui_message_reducer, push_ui_message
 
 
     class AgentState(TypedDict):  # noqa: D101
         messages: Annotated[Sequence[BaseMessage], add_messages]
-        ui: Annotated[Sequence[AnyUIMessage], add_ui_messages]
+        ui: Annotated[Sequence[AnyUIMessage], ui_message_reducer]
 
 
     async def weather(state: AgentState):
@@ -342,13 +342,13 @@ Similar to how messages can be removed from the state by appending a RemoveMessa
 === "Python"
 
     ```python
-    from langgraph.graph.ui import push_ui_message, remove_ui_message
+    from langgraph.graph.ui import push_ui_message, delete_ui_message
 
     # push message
     message = push_ui_message("weather", {"city": "London"})
 
     # remove said message
-    remove_ui_message(message["id"])
+    delete_ui_message(message["id"])
     ```
 
 === "JS"

--- a/libs/langgraph/langgraph/graph/ui.py
+++ b/libs/langgraph/langgraph/graph/ui.py
@@ -115,7 +115,7 @@ def push_ui_message(
     return evt
 
 
-def remove_ui_message(id: str, *, state_key: str = "ui") -> RemoveUIMessage:
+def delete_ui_message(id: str, *, state_key: str = "ui") -> RemoveUIMessage:
     """Delete a UI message by ID from the UI state.
 
     This function creates and sends a message to remove a UI component from the current state.
@@ -132,7 +132,7 @@ def remove_ui_message(id: str, *, state_key: str = "ui") -> RemoveUIMessage:
 
     .. code-block:: python
 
-        remove_ui_message("message-123")
+        delete_ui_message("message-123")
 
     """
     writer = get_stream_writer()
@@ -146,14 +146,14 @@ def remove_ui_message(id: str, *, state_key: str = "ui") -> RemoveUIMessage:
     return evt
 
 
-def add_ui_messages(
+def ui_message_reducer(
     left: Union[list[AnyUIMessage], AnyUIMessage],
     right: Union[list[AnyUIMessage], AnyUIMessage],
 ) -> list[AnyUIMessage]:
     """Merge two lists of UI messages, supporting removing UI messages.
 
     This function combines two lists of UI messages, handling both regular UI messages
-    and remove-ui messages. When a remove-ui message is encountered, it removes any
+    and `remove-ui` messages. When a `remove-ui` message is encountered, it removes any
     UI message with the matching ID from the current state.
 
     Args:
@@ -167,7 +167,7 @@ def add_ui_messages(
 
     .. code-block:: python
 
-        messages = reduce_ui_messages(
+        messages = ui_message_reducer(
             [{"type": "ui", "id": "1", "name": "Chat", "props": {}}],
             {"type": "remove-ui", "id": "1"}
         )


### PR DESCRIPTION
Sample usage:

```python
from typing import Annotated, Sequence, TypedDict

from langchain_core.messages import BaseMessage
from langchain_openai import ChatOpenAI
from langgraph.graph import StateGraph
from langgraph.graph.message import add_messages

from langgraph.graph.ui import AnyUIMessage, ui_message_reducer, push_ui_message


class AgentState(TypedDict):  # noqa: D101
    messages: Annotated[Sequence[BaseMessage], add_messages]
    ui: Annotated[Sequence[AnyUIMessage], ui_message_reducer]


async def agent(state: AgentState):  # noqa: D103
    message = await ChatOpenAI(model="gpt-4o-mini", temperature=0).ainvoke(
        state["messages"]
    )

    # Also directly writes the message to `ui`
    push_ui_message("simple", {"hello": "123"}, message=message, state_key="ui")

    return {"messages": [message]}

```