### PR TITLE
docs: add CopilotKit integration guide

### DIFF
--- a/docs/docs/cloud/how-tos/generative_ui_using_copilotkit_react.md
+++ b/docs/docs/cloud/how-tos/generative_ui_using_copilotkit_react.md
@@ -1,0 +1,157 @@
+---
+title: Using CopilotKit with LangGraph
+description: Turn your LangGraph agent into an agent-native application in minutes
+---
+
+# How to Use CopilotKit with LangGraph
+
+CopilotKit is an open-source framework for building AI copilots in web applications. This guide will show you how to connect your LangGraph agent to a React application using CopilotKit.
+
+## Prerequisites
+
+- An existing LangGraph agent (running locally with LangGraph Studio)
+- LangSmith API key (optional)
+
+## Installation
+
+### Frontend
+
+```bash
+npm install @copilotkit/react-ui @copilotkit/react-core
+```
+
+### Backend
+
+```bash
+npm install @copilotkit/runtime
+```
+
+## Setup
+
+### 1. Start your LangGraph agent
+
+Run your LangGraph agent locally using LangGraph Studio:
+
+```bash
+langgraph dev
+```
+
+This will start your agent on the default port (8000).
+
+### 2. Create a Copilot Runtime endpoint
+
+Create a simple Node.js server file to handle requests:
+
+```javascript
+import { createServer } from "node:http";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNodeHttpEndpoint,
+  langGraphPlatformEndpoint,
+} from "@copilotkit/runtime";
+
+const serviceAdapter = new ExperimentalEmptyAdapter();
+
+const server = createServer((req, res) => {
+  const runtime = new CopilotRuntime({
+    remoteEndpoints: [
+      langGraphPlatformEndpoint({
+        deploymentUrl: "http://localhost:8000", // make sure to replace with your real deployment url,
+        langsmithApiKey: process.env.LANGSMITH_API_KEY, // only used in LangGraph Platform deployments
+        agents: [
+          // List any agents available under "graphs" list in your langgraph.json file; give each a description explaining when it should be called.
+          {
+            name: "sample_agent",
+            description: "A helpful LLM agent.",
+            assistantId: "your-assistant-ID", // optional, but recommended!
+          },
+        ],
+      }),
+    ],
+  });
+
+  const handler = copilotRuntimeNodeHttpEndpoint({
+    endpoint: "/copilotkit",
+    runtime,
+    serviceAdapter,
+  });
+
+  return handler(req, res);
+});
+
+server.listen(4000, () => {
+  console.log("Listening at http://localhost:4000/copilotkit");
+});
+```
+
+Start your Copilot Runtime server:
+
+```bash
+node copilot-server.js
+```
+
+### 3. Set up the CopilotKit Provider in your React app
+
+Wrap your application with the CopilotKit Provider:
+
+```jsx
+import { CopilotKit } from "@copilotkit/react-core";
+
+function App() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      agent="sample_agent" // the name of the agent you want to use
+    >
+      <YourApp />
+    </CopilotKit>
+  );
+}
+```
+
+### 4. Add a Copilot UI component
+
+CopilotKit provides ready-to-use UI components. Add a chat interface to your app:
+
+```jsx
+import { CopilotChat } from "@copilotkit/react-ui";
+
+function MyComponent() {
+  return (
+    <div>
+      {/* Your app content */}
+
+      {/* Floating chat interface */}
+      <CopilotChat
+        instructions={
+          "You are assisting the user as best as you can. Answer in the best way possible given the data you have."
+        }
+        labels={{
+          title: "Your Assistant",
+          initial: "Hi! 👋 How can I assist you today?",
+        }}
+      />
+    </div>
+  );
+}
+```
+
+## Testing your integration
+
+Start your React application and talk to your agent! Try asking:
+
+```
+What can you help me with?
+```
+
+## Next steps
+
+You've added an agent to your existing app using CopilotKit. Here are some advanced features you can explore:
+
+- **Human-in-the-loop**: Enable collaboration between users and agents
+- **Shared state**: Synchronize agent state with UI state
+- **Generative UI**: Render agent outputs directly in your interface
+- **Frontend actions**: Allow agents to call frontend functions
+
+For more detailed guides and advanced options, refer to the [official CopilotKit documentation](https://docs.copilotkit.ai/coagents/quickstart/langgraph).

--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -5,7 +5,7 @@ description: How to accomplish common tasks in LangGraph
 
 # How-to Guides
 
-Here you’ll find answers to “How do I...?” types of questions. These guides are **goal-oriented** and concrete; they're meant to help you complete a specific task. For conceptual explanations see the [Conceptual guide](../concepts/index.md). For end-to-end walk-throughs see [Tutorials](../tutorials/index.md). For comprehensive descriptions of every class and function see the [API Reference](../reference/index.md).
+Here you'll find answers to "How do I...? " types of questions. These guides are **goal-oriented** and concrete; they're meant to help you complete a specific task. For conceptual explanations see the [Conceptual guide](../concepts/index.md). For end-to-end walk-throughs see [Tutorials](../tutorials/index.md). For comprehensive descriptions of every class and function see the [API Reference](../reference/index.md).
 
 ## LangGraph
 
@@ -262,10 +262,11 @@ Streaming the results of your LLM application is vital for ensuring a good user 
 
 ### Frontend and Generative UI
 
-With LangGraph Platform you can integrate LangGraph agents into your React applications and colocate UI components with your agent code. 
+With LangGraph Platform you can integrate LangGraph agents into your React applications and colocate UI components with your agent code.
 
 - [How to integrate LangGraph into your React application](../cloud/how-tos/use_stream_react.md)
 - [How to implement Generative User Interfaces with LangGraph](../cloud/how-tos/generative_ui_react.md)
+- [How to use CopilotKit with LangGraph](../cloud/how-tos/generative_ui_using_copilotkit_react.md)
 
 ### Human-in-the-loop
 


### PR DESCRIPTION
Add documentation explaining how to integrate LangGraph agents with CopilotKit
for React applications. This enables users to quickly add AI copilot interfaces
to their existing LangGraph applications.

- Create new guide at docs/cloud/how-tos/generative_ui_using_copilotkit_react.md
- Update index.md to include link under Frontend and Generative UI section