### PR TITLE
langgraph: allow passing a list of retry policies

### DIFF
--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Generic,
     Optional,
+    Sequence,
     TypeVar,
     Union,
     get_args,
@@ -38,7 +39,7 @@ from langgraph.types import _DC_KWARGS, RetryPolicy, StreamMode
 def task(
     *,
     name: Optional[str] = None,
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
 ) -> Callable[
     [Union[Callable[P, Awaitable[T]], Callable[P, T]]],
     Callable[P, SyncAsyncFuture[T]],
@@ -55,7 +56,7 @@ def task(
     __func_or_none__: Optional[Union[Callable[P, Awaitable[T]], Callable[P, T]]] = None,
     *,
     name: Optional[str] = None,
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
 ) -> Union[
     Callable[
         [Union[Callable[P, Awaitable[T]], Callable[P, T]]],

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -120,6 +120,10 @@ def task(
         await add_one.ainvoke([1, 2, 3])  # Returns [2, 3, 4]
         ```
     """
+    if isinstance(retry, RetryPolicy):
+        retry_policies: Optional[Sequence[RetryPolicy]] = [retry]
+    else:
+        retry_policies = retry
 
     def decorator(
         func: Union[Callable[P, Awaitable[T]], Callable[P, T]],
@@ -138,7 +142,7 @@ def task(
                 # handle regular functions / partials / callable classes, etc.
                 func.__name__ = name
 
-        call_func = functools.partial(call, func, retry=retry)
+        call_func = functools.partial(call, func, retry=retry_policies)
         object.__setattr__(call_func, "_is_pregel_task", True)
         return functools.update_wrapper(call_func, func)
 

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -38,7 +38,7 @@ from langgraph.types import _DC_KWARGS, RetryPolicy, StreamMode
 def task(
     *,
     name: Optional[str] = None,
-    retry: Optional[RetryPolicy] = None,
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
 ) -> Callable[
     [Union[Callable[P, Awaitable[T]], Callable[P, T]]],
     Callable[P, SyncAsyncFuture[T]],
@@ -55,7 +55,7 @@ def task(
     __func_or_none__: Optional[Union[Callable[P, Awaitable[T]], Callable[P, T]]] = None,
     *,
     name: Optional[str] = None,
-    retry: Optional[RetryPolicy] = None,
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
 ) -> Union[
     Callable[
         [Union[Callable[P, Awaitable[T]], Callable[P, T]]],

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -121,7 +121,7 @@ def task(
         ```
     """
     if isinstance(retry, RetryPolicy):
-        retry_policies: Optional[Sequence[RetryPolicy]] = [retry]
+        retry_policies: Optional[Sequence[RetryPolicy]] = (retry,)
     else:
         retry_policies = retry
 

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -109,7 +109,7 @@ class StateNodeSpec(NamedTuple):
     runnable: Runnable
     metadata: Optional[dict[str, Any]]
     input: Type[Any]
-    retry_policy: Optional[RetryPolicy]
+    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
     ends: Optional[Union[tuple[str, ...], dict[str, str]]] = EMPTY_SEQ
 
 
@@ -251,7 +251,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[RetryPolicy] = None,
+        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -276,7 +276,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[RetryPolicy] = None,
+        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -300,7 +300,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[RetryPolicy] = None,
+        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -312,7 +312,8 @@ class StateGraph(Graph):
             action (Optional[RunnableLike]): The action associated with the node. (default: None)
             metadata (Optional[dict[str, Any]]): The metadata associated with the node. (default: None)
             input (Optional[Type[Any]]): The input schema for the node. (default: the graph's input schema)
-            retry (Optional[RetryPolicy]): The policy for retrying the node. (default: None)
+            retry (Optional[Union[RetryPolicy, list[RetryPolicy]]]): The policy for retrying the node. (default: None)
+                If a list is provided, the first matching policy will be applied.
             destinations (Optional[Union[dict[str, str], tuple[str, ...]]]): Destinations that indicate where a node can route to.
                 This is useful for edgeless graphs with nodes that return `Command` objects.
                 If a dict is provided, the keys will be used as the target node names and the values will be used as the labels for the edges.

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -109,7 +109,7 @@ class StateNodeSpec(NamedTuple):
     runnable: Runnable
     metadata: Optional[dict[str, Any]]
     input: Type[Any]
-    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
     ends: Optional[Union[tuple[str, ...], dict[str, str]]] = EMPTY_SEQ
 
 
@@ -251,7 +251,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -276,7 +276,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -300,7 +300,7 @@ class StateGraph(Graph):
         *,
         metadata: Optional[dict[str, Any]] = None,
         input: Optional[Type[Any]] = None,
-        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
     ) -> Self:
         """Adds a new node to the state graph.
@@ -312,8 +312,8 @@ class StateGraph(Graph):
             action (Optional[RunnableLike]): The action associated with the node. (default: None)
             metadata (Optional[dict[str, Any]]): The metadata associated with the node. (default: None)
             input (Optional[Type[Any]]): The input schema for the node. (default: the graph's input schema)
-            retry (Optional[Union[RetryPolicy, list[RetryPolicy]]]): The policy for retrying the node. (default: None)
-                If a list is provided, the first matching policy will be applied.
+            retry (Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]): The policy for retrying the node. (default: None)
+                If a sequence is provided, the first matching policy will be applied.
             destinations (Optional[Union[dict[str, str], tuple[str, ...]]]): Destinations that indicate where a node can route to.
                 This is useful for edgeless graphs with nodes that return `Command` objects.
                 If a dict is provided, the keys will be used as the target node names and the values will be used as the labels for the edges.

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -498,7 +498,7 @@ class Pregel(PregelProtocol):
     store: Optional[BaseStore] = None
     """Memory store to use for SharedValues. Defaults to None."""
 
-    retry_policy: Optional[RetryPolicy] = None
+    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None
     """Retry policy to use when running tasks. Set to None to disable."""
 
     config_type: Optional[Type[Any]] = None

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -549,7 +549,7 @@ class Pregel(PregelProtocol):
         self.checkpointer = checkpointer
         self.store = store
         if isinstance(retry_policy, RetryPolicy):
-            self.retry_policy: Sequence[RetryPolicy] = [retry_policy]
+            self.retry_policy: Sequence[RetryPolicy] = (retry_policy,)
         else:
             self.retry_policy = retry_policy
         self.config_type = config_type

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -498,7 +498,7 @@ class Pregel(PregelProtocol):
     store: Optional[BaseStore] = None
     """Memory store to use for SharedValues. Defaults to None."""
 
-    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None
     """Retry policy to use when running tasks. Set to None to disable."""
 
     config_type: Optional[Type[Any]] = None

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -115,7 +115,7 @@ class Call:
 
     func: Callable
     input: Any
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]]
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
     callbacks: Callbacks
 
     def __init__(
@@ -123,7 +123,7 @@ class Call:
         func: Callable,
         input: Any,
         *,
-        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]],
+        retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]],
         callbacks: Callbacks,
     ) -> None:
         self.func = func

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -115,7 +115,7 @@ class Call:
 
     func: Callable
     input: Any
-    retry: Optional[RetryPolicy]
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]]
     callbacks: Callbacks
 
     def __init__(
@@ -123,7 +123,7 @@ class Call:
         func: Callable,
         input: Any,
         *,
-        retry: Optional[RetryPolicy],
+        retry: Optional[Union[RetryPolicy, list[RetryPolicy]]],
         callbacks: Callbacks,
     ) -> None:
         self.func = func

--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -115,7 +115,7 @@ class Call:
 
     func: Callable
     input: Any
-    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
+    retry: Optional[Sequence[RetryPolicy]]
     callbacks: Callbacks
 
     def __init__(
@@ -123,7 +123,7 @@ class Call:
         func: Callable,
         input: Any,
         *,
-        retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]],
+        retry: Optional[Sequence[RetryPolicy]],
         callbacks: Callbacks,
     ) -> None:
         self.func = func

--- a/libs/langgraph/langgraph/pregel/call.py
+++ b/libs/langgraph/langgraph/pregel/call.py
@@ -5,7 +5,17 @@ import functools
 import inspect
 import sys
 import types
-from typing import Any, Callable, Generator, Generic, Optional, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Generic,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from langchain_core.runnables import Runnable
 from typing_extensions import ParamSpec
@@ -224,7 +234,7 @@ class SyncAsyncFuture(Generic[T], concurrent.futures.Future[T]):
 def call(
     func: Callable[P, T],
     *args: Any,
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
     config = get_config()

--- a/libs/langgraph/langgraph/pregel/call.py
+++ b/libs/langgraph/langgraph/pregel/call.py
@@ -5,17 +5,7 @@ import functools
 import inspect
 import sys
 import types
-from typing import (
-    Any,
-    Callable,
-    Generator,
-    Generic,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Generator, Generic, Optional, Sequence, TypeVar, cast
 
 from langchain_core.runnables import Runnable
 from typing_extensions import ParamSpec
@@ -234,7 +224,7 @@ class SyncAsyncFuture(Generic[T], concurrent.futures.Future[T]):
 def call(
     func: Callable[P, T],
     *args: Any,
-    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
+    retry: Optional[Sequence[RetryPolicy]] = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
     config = get_config()

--- a/libs/langgraph/langgraph/pregel/call.py
+++ b/libs/langgraph/langgraph/pregel/call.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import sys
 import types
-from typing import Any, Callable, Generator, Generic, Optional, TypeVar, cast
+from typing import Any, Callable, Generator, Generic, Optional, TypeVar, Union, cast
 
 from langchain_core.runnables import Runnable
 from typing_extensions import ParamSpec
@@ -224,7 +224,7 @@ class SyncAsyncFuture(Generic[T], concurrent.futures.Future[T]):
 def call(
     func: Callable[P, T],
     *args: Any,
-    retry: Optional[RetryPolicy] = None,
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
     config = get_config()

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -144,8 +144,8 @@ class PregelNode(Runnable):
     """The main logic of the node. This will be invoked with the input from 
     `channels`."""
 
-    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
-    """The retry policy to use when invoking the node."""
+    retry_policy: Optional[Sequence[RetryPolicy]]
+    """The retry policies to use when invoking the node."""
 
     tags: Optional[Sequence[str]]
     """Tags to attach to the node for tracing."""
@@ -174,7 +174,10 @@ class PregelNode(Runnable):
         self.mapper = mapper
         self.writers = writers or []
         self.bound = bound if bound is not None else DEFAULT_BOUND
-        self.retry_policy = retry_policy
+        if isinstance(retry_policy, RetryPolicy):
+            self.retry_policy: Sequence[RetryPolicy] = [retry_policy]
+        else:
+            self.retry_policy = retry_policy
         self.tags = tags
         self.metadata = metadata
         if subgraphs is not None:

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -175,7 +175,7 @@ class PregelNode(Runnable):
         self.writers = writers or []
         self.bound = bound if bound is not None else DEFAULT_BOUND
         if isinstance(retry_policy, RetryPolicy):
-            self.retry_policy: Sequence[RetryPolicy] = [retry_policy]
+            self.retry_policy: Sequence[RetryPolicy] = (retry_policy,)
         else:
             self.retry_policy = retry_policy
         self.tags = tags

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -144,7 +144,7 @@ class PregelNode(Runnable):
     """The main logic of the node. This will be invoked with the input from 
     `channels`."""
 
-    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
     """The retry policy to use when invoking the node."""
 
     tags: Optional[Sequence[str]]
@@ -166,7 +166,7 @@ class PregelNode(Runnable):
         tags: Optional[list[str]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         bound: Optional[Runnable[Any, Any]] = None,
-        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         subgraphs: Optional[Sequence[PregelProtocol]] = None,
     ) -> None:
         self.channels = channels

--- a/libs/langgraph/langgraph/pregel/read.py
+++ b/libs/langgraph/langgraph/pregel/read.py
@@ -144,7 +144,7 @@ class PregelNode(Runnable):
     """The main logic of the node. This will be invoked with the input from 
     `channels`."""
 
-    retry_policy: Optional[RetryPolicy]
+    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
     """The retry policy to use when invoking the node."""
 
     tags: Optional[Sequence[str]]
@@ -166,7 +166,7 @@ class PregelNode(Runnable):
         tags: Optional[list[str]] = None,
         metadata: Optional[Mapping[str, Any]] = None,
         bound: Optional[Runnable[Any, Any]] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         subgraphs: Optional[Sequence[PregelProtocol]] = None,
     ) -> None:
         self.channels = channels

--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -89,7 +89,7 @@ def run_with_retry(
             # Apply backoff factor based on attempt count
             interval = min(
                 matching_policy.max_interval,
-                interval * matching_policy.backoff_factor,
+                interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
             # Apply jitter if configured
@@ -183,7 +183,7 @@ async def arun_with_retry(
             # Apply backoff factor based on attempt count
             interval = min(
                 matching_policy.max_interval,
-                interval * matching_policy.backoff_factor,
+                interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
             # Apply jitter if configured

--- a/libs/langgraph/langgraph/pregel/retry.py
+++ b/libs/langgraph/langgraph/pregel/retry.py
@@ -22,7 +22,7 @@ SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
 
 def run_with_retry(
     task: PregelExecutableTask,
-    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]],
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]],
     configurable: Optional[dict[str, Any]] = None,
 ) -> None:
     """Run a task with retries."""
@@ -64,8 +64,8 @@ def run_with_retry(
                 raise
 
             # Handle single RetryPolicy case
-            if not isinstance(retry_policy, list):
-                retry_policies = [retry_policy]
+            if isinstance(retry_policy, RetryPolicy):
+                retry_policies: Sequence[RetryPolicy] = [retry_policy]
             else:
                 retry_policies = retry_policy
 
@@ -109,7 +109,7 @@ def run_with_retry(
 
 async def arun_with_retry(
     task: PregelExecutableTask,
-    retry_policy: Optional[RetryPolicy | list[RetryPolicy]],
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]],
     stream: bool = False,
     configurable: Optional[dict[str, Any]] = None,
 ) -> None:
@@ -158,8 +158,8 @@ async def arun_with_retry(
                 raise
 
             # Handle single RetryPolicy case
-            if not isinstance(retry_policy, list):
-                retry_policies = [retry_policy]
+            if isinstance(retry_policy, RetryPolicy):
+                retry_policies: Sequence[RetryPolicy] = [retry_policy]
             else:
                 retry_policies = retry_policy
 

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -140,7 +140,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         get_waiter: Optional[Callable[[], concurrent.futures.Future[None]]] = None,
     ) -> Iterator[None]:
         tasks = tuple(tasks)
@@ -269,7 +269,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
         get_waiter: Optional[Callable[[], asyncio.Future[None]]] = None,
     ) -> AsyncIterator[None]:
         loop = asyncio.get_event_loop()
@@ -519,7 +519,7 @@ def _call(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
     callbacks: Callbacks = None,
     futures: weakref.ref[FuturesDict],
     schedule_task: weakref.ref[
@@ -600,7 +600,7 @@ def _acall(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
+    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict],

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -140,7 +140,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
+        retry_policy: Optional[Sequence[RetryPolicy]] = None,
         get_waiter: Optional[Callable[[], concurrent.futures.Future[None]]] = None,
     ) -> Iterator[None]:
         tasks = tuple(tasks)
@@ -269,7 +269,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
+        retry_policy: Optional[Sequence[RetryPolicy]] = None,
         get_waiter: Optional[Callable[[], asyncio.Future[None]]] = None,
     ) -> AsyncIterator[None]:
         loop = asyncio.get_event_loop()
@@ -519,7 +519,7 @@ def _call(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
+    retry: Optional[Sequence[RetryPolicy]] = None,
     callbacks: Callbacks = None,
     futures: weakref.ref[FuturesDict],
     schedule_task: weakref.ref[
@@ -600,7 +600,7 @@ def _acall(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
+    retry: Optional[Sequence[RetryPolicy]] = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict],

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -140,7 +140,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         get_waiter: Optional[Callable[[], concurrent.futures.Future[None]]] = None,
     ) -> Iterator[None]:
         tasks = tuple(tasks)
@@ -269,7 +269,7 @@ class PregelRunner:
         *,
         reraise: bool = True,
         timeout: Optional[float] = None,
-        retry_policy: Optional[RetryPolicy] = None,
+        retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
         get_waiter: Optional[Callable[[], asyncio.Future[None]]] = None,
     ) -> AsyncIterator[None]:
         loop = asyncio.get_event_loop()
@@ -519,7 +519,7 @@ def _call(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[RetryPolicy] = None,
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
     callbacks: Callbacks = None,
     futures: weakref.ref[FuturesDict],
     schedule_task: weakref.ref[
@@ -600,7 +600,7 @@ def _acall(
     func: Callable[[Any], Union[Awaitable[Any], Any]],
     input: Any,
     *,
-    retry: Optional[RetryPolicy] = None,
+    retry: Optional[Union[RetryPolicy, list[RetryPolicy]]] = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict],

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -172,7 +172,7 @@ class PregelExecutableTask:
     writes: deque[tuple[str, Any]]
     config: RunnableConfig
     triggers: Sequence[str]
-    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
+    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
     cache_policy: Optional[CachePolicy]
     id: str
     path: tuple[Union[str, int, tuple], ...]

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -75,6 +75,10 @@ def default_retry_on(exc: Exception) -> bool:
 
     if isinstance(exc, ConnectionError):
         return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    if isinstance(exc, requests.HTTPError):
+        return 500 <= exc.response.status_code < 600 if exc.response else True
     if isinstance(
         exc,
         (
@@ -93,10 +97,6 @@ def default_retry_on(exc: Exception) -> bool:
         ),
     ):
         return False
-    if isinstance(exc, httpx.HTTPStatusError):
-        return 500 <= exc.response.status_code < 600
-    if isinstance(exc, requests.HTTPError):
-        return 500 <= exc.response.status_code < 600 if exc.response else True
     return True
 
 
@@ -172,7 +172,7 @@ class PregelExecutableTask:
     writes: deque[tuple[str, Any]]
     config: RunnableConfig
     triggers: Sequence[str]
-    retry_policy: Optional[RetryPolicy]
+    retry_policy: Optional[Union[RetryPolicy, list[RetryPolicy]]]
     cache_policy: Optional[CachePolicy]
     id: str
     path: tuple[Union[str, int, tuple], ...]

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -172,7 +172,7 @@ class PregelExecutableTask:
     writes: deque[tuple[str, Any]]
     config: RunnableConfig
     triggers: Sequence[str]
-    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
+    retry_policy: Optional[Sequence[RetryPolicy]]
     cache_policy: Optional[CachePolicy]
     id: str
     path: tuple[Union[str, int, tuple], ...]

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -22,7 +22,7 @@ def test_should_retry_on_single_exception():
 
 def test_should_retry_on_sequence_of_exceptions():
     """Test retry with a sequence of exception types."""
-    policy = RetryPolicy(retry_on=[ValueError, KeyError])
+    policy = RetryPolicy(retry_on=(ValueError, KeyError))
 
     # Should retry on listed exceptions
     assert _should_retry_on(policy, ValueError("test error")) is True
@@ -72,7 +72,7 @@ def test_should_retry_on_invalid_type():
 
 def test_should_retry_on_empty_sequence():
     """Test retry with an empty sequence."""
-    policy = RetryPolicy(retry_on=[])
+    policy = RetryPolicy(retry_on=())
 
     # Should not retry when sequence is empty
     assert _should_retry_on(policy, ValueError("test error")) is False
@@ -282,7 +282,9 @@ def test_graph_with_multiple_retry_policies():
     graph = (
         StateGraph(State)
         .add_node(
-            "failing_node", failing_node, retry=[value_error_policy, key_error_policy]
+            "failing_node",
+            failing_node,
+            retry=(value_error_policy, key_error_policy),
         )
         .add_edge(START, "failing_node")
         .compile()

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1,0 +1,143 @@
+import pytest
+
+from langgraph.pregel.retry import _should_retry_on
+from langgraph.types import RetryPolicy
+
+
+def test_should_retry_on_single_exception():
+    """Test retry with a single exception type."""
+    policy = RetryPolicy(retry_on=ValueError)
+
+    # Should retry on ValueError
+    assert _should_retry_on(policy, ValueError("test error")) is True
+
+    # Should not retry on other exceptions
+    assert _should_retry_on(policy, TypeError("test error")) is False
+    assert _should_retry_on(policy, Exception("test error")) is False
+
+
+def test_should_retry_on_sequence_of_exceptions():
+    """Test retry with a sequence of exception types."""
+    policy = RetryPolicy(retry_on=[ValueError, KeyError])
+
+    # Should retry on listed exceptions
+    assert _should_retry_on(policy, ValueError("test error")) is True
+    assert _should_retry_on(policy, KeyError("test error")) is True
+
+    # Should not retry on other exceptions
+    assert _should_retry_on(policy, TypeError("test error")) is False
+    assert _should_retry_on(policy, Exception("test error")) is False
+
+
+def test_should_retry_on_subclass_of_exception():
+    """Test retry on subclass of specified exception."""
+
+    class CustomError(ValueError):
+        pass
+
+    policy = RetryPolicy(retry_on=ValueError)
+
+    # Should retry on subclass of specified exception
+    assert _should_retry_on(policy, CustomError("test error")) is True
+
+
+def test_should_retry_on_callable():
+    """Test retry with a callable predicate."""
+
+    # Only retry on ValueError with message containing 'retry'
+    def should_retry(exc: Exception) -> bool:
+        return isinstance(exc, ValueError) and "retry" in str(exc)
+
+    policy = RetryPolicy(retry_on=should_retry)
+
+    # Should retry when predicate returns True
+    assert _should_retry_on(policy, ValueError("please retry this")) is True
+
+    # Should not retry when predicate returns False
+    assert _should_retry_on(policy, ValueError("other error")) is False
+    assert _should_retry_on(policy, TypeError("please retry this")) is False
+
+
+def test_should_retry_on_invalid_type():
+    """Test retry with an invalid retry_on type."""
+    policy = RetryPolicy(retry_on=123)  # type: ignore
+
+    with pytest.raises(TypeError, match="retry_on must be an Exception class"):
+        _should_retry_on(policy, ValueError("test error"))
+
+
+def test_should_retry_on_empty_sequence():
+    """Test retry with an empty sequence."""
+    policy = RetryPolicy(retry_on=[])
+
+    # Should not retry when sequence is empty
+    assert _should_retry_on(policy, ValueError("test error")) is False
+
+
+def test_should_retry_default_retry_on():
+    """Test the default retry_on function."""
+    from unittest.mock import Mock
+
+    import httpx
+    import requests
+
+    # Create a RetryPolicy with default_retry_on
+    policy = RetryPolicy()
+
+    # Should retry on ConnectionError
+    assert _should_retry_on(policy, ConnectionError("connection refused")) is True
+
+    # Should not retry on common programming errors
+    assert _should_retry_on(policy, ValueError("invalid value")) is False
+    assert _should_retry_on(policy, TypeError("invalid type")) is False
+    assert _should_retry_on(policy, ArithmeticError("division by zero")) is False
+    assert _should_retry_on(policy, ImportError("module not found")) is False
+    assert _should_retry_on(policy, LookupError("key not found")) is False
+    assert _should_retry_on(policy, NameError("name not defined")) is False
+    assert _should_retry_on(policy, SyntaxError("invalid syntax")) is False
+    assert _should_retry_on(policy, RuntimeError("runtime error")) is False
+    assert _should_retry_on(policy, ReferenceError("weak reference")) is False
+    assert _should_retry_on(policy, StopIteration()) is False
+    assert _should_retry_on(policy, StopAsyncIteration()) is False
+    assert _should_retry_on(policy, OSError("file not found")) is False
+
+    # Should retry on httpx.HTTPStatusError with 5xx status code
+    response_5xx = Mock()
+    response_5xx.status_code = 503
+    http_error_5xx = httpx.HTTPStatusError(
+        "server error", request=Mock(), response=response_5xx
+    )
+    assert _should_retry_on(policy, http_error_5xx) is True
+
+    # Should not retry on httpx.HTTPStatusError with 4xx status code
+    response_4xx = Mock()
+    response_4xx.status_code = 404
+    http_error_4xx = httpx.HTTPStatusError(
+        "not found", request=Mock(), response=response_4xx
+    )
+    assert _should_retry_on(policy, http_error_4xx) is False
+
+    # Should retry on requests.HTTPError with 5xx status code
+    response_req_5xx = Mock()
+    response_req_5xx.status_code = 502
+    req_error_5xx = requests.HTTPError("bad gateway")
+    req_error_5xx.response = response_req_5xx
+    assert _should_retry_on(policy, req_error_5xx) is True
+
+    # Should not retry on requests.HTTPError with 4xx status code
+    response_req_4xx = Mock()
+    response_req_4xx.status_code = 400
+    req_error_4xx = requests.HTTPError("bad request")
+    req_error_4xx.response = response_req_4xx
+    assert _should_retry_on(policy, req_error_4xx) is False
+
+    # Should retry on requests.HTTPError with no response
+    req_error_no_resp = requests.HTTPError("connection error")
+    req_error_no_resp.response = None
+    assert _should_retry_on(policy, req_error_no_resp) is True
+
+    # Should retry on other exceptions by default
+    class CustomException(Exception):
+        pass
+
+    assert _should_retry_on(policy, CustomException("custom error")) is True


### PR DESCRIPTION
* support passing `retry=(RetryPolicy(...), RetryPolicy())`
* fix bugs with `default_retry_on` and backoff calculation
* add tests