### PR TITLE
docs: Add alpha and beta labels for respective LangGraph Platform deployment options

### DIFF
--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -1,5 +1,9 @@
 # How to Deploy to Cloud SaaS
 
+!!! info "Beta"
+
+    The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+
 Before deploying, review the [conceptual guide for the Cloud SaaS](../../concepts/langgraph_cloud.md) deployment option.
 
 ## Prerequisites

--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -1,8 +1,4 @@
-# How to Deploy to Cloud SaaS
-
-!!! info "Beta"
-
-    The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+# How to Deploy to Cloud SaaS (Beta)
 
 Before deploying, review the [conceptual guide for the Cloud SaaS](../../concepts/langgraph_cloud.md) deployment option.
 

--- a/docs/docs/cloud/deployment/self_hosted_control_plane.md
+++ b/docs/docs/cloud/deployment/self_hosted_control_plane.md
@@ -1,8 +1,4 @@
-# How to Deploy Self-Hosted Control Plane
-
-!!! info "Alpha"
-
-    The <b>Self-Hosted Control Plane</b> deployment option is currently in <b>alpha</b> stage.
+# How to Deploy Self-Hosted Control Plane (Beta)
 
 Before deploying, review the [conceptual guide for the Self-Hosted Control Plane](../../concepts/langgraph_self_hosted_control_plane.md) deployment option.
 

--- a/docs/docs/cloud/deployment/self_hosted_control_plane.md
+++ b/docs/docs/cloud/deployment/self_hosted_control_plane.md
@@ -1,5 +1,9 @@
 # How to Deploy Self-Hosted Control Plane
 
+!!! info "Alpha"
+
+    The <b>Self-Hosted Control Plane</b> deployment option is currently in <b>alpha</b> stage.
+
 Before deploying, review the [conceptual guide for the Self-Hosted Control Plane](../../concepts/langgraph_self_hosted_control_plane.md) deployment option.
 
 ## Prerequisites

--- a/docs/docs/cloud/deployment/self_hosted_data_plane.md
+++ b/docs/docs/cloud/deployment/self_hosted_data_plane.md
@@ -1,5 +1,9 @@
 # How to Deploy Self-Hosted Data Plane
 
+!!! info "Alpha"
+
+    The <b>Self-Hosted Data Plane</b> deployment option is currently in <b>alpha</b> stage.
+
 Before deploying, review the [conceptual guide for the Self-Hosted Data Plane](../../concepts/langgraph_self_hosted_data_plane.md) deployment option.
 
 ## Prerequisites

--- a/docs/docs/cloud/deployment/self_hosted_data_plane.md
+++ b/docs/docs/cloud/deployment/self_hosted_data_plane.md
@@ -1,8 +1,4 @@
-# How to Deploy Self-Hosted Data Plane
-
-!!! info "Alpha"
-
-    The <b>Self-Hosted Data Plane</b> deployment option is currently in <b>alpha</b> stage.
+# How to Deploy Self-Hosted Data Plane (Beta)
 
 Before deploying, review the [conceptual guide for the Self-Hosted Data Plane](../../concepts/langgraph_self_hosted_data_plane.md) deployment option.
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -10,23 +10,17 @@
 
 There are 4 main options for deploying with the LangGraph Platform:
 
-1. **[Cloud SaaS](#cloud-saas)***: Available for **Plus** and **Enterprise** plans.
+1. **[Cloud SaaS (Beta)](#cloud-saas)**: Available for **Plus** and **Enterprise** plans.
 
-1. **[Self-Hosted Data Plane](#self-hosted-data-plane)****: Available for the **Enterprise** plan.
+1. **[Self-Hosted Data Plane (Beta)](#self-hosted-data-plane)**: Available for the **Enterprise** plan.
 
-1. **[Self-Hosted Control Plane](#self-hosted-control-plane)****: Available for the **Enterprise** plan.
+1. **[Self-Hosted Control Plane (Beta)](#self-hosted-control-plane)**: Available for the **Enterprise** plan.
 
 1. **[Standalone Container](#standalone-container)**: Available for all plans.
 
 Please see the [LangGraph Platform Plans](./plans.md) for more information on the different plans.
 
 The guide below will explain the differences between the deployment options.
-
-!!! info "Alpha and Beta"
-
-    *The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
-
-    **The <b>Self-Hosted Data Plane</b> and <b>Self-Hosted Control Plane</b> deployment options are currently in <b>alpha</b> stage.
 
 ## Cloud SaaS
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -10,17 +10,23 @@
 
 There are 4 main options for deploying with the LangGraph Platform:
 
-1. **[Cloud SaaS](#cloud-saas)**: Available for **Plus** and **Enterprise** plans.
+1. **[Cloud SaaS](#cloud-saas)***: Available for **Plus** and **Enterprise** plans.
 
-1. **[Self-Hosted Data Plane](#self-hosted-data-plane)**: Available for the **Enterprise** plan.
+1. **[Self-Hosted Data Plane](#self-hosted-data-plane)****: Available for the **Enterprise** plan.
 
-1. **[Self-Hosted Control Plane](#self-hosted-control-plane)**: Available for the **Enterprise** plan.
+1. **[Self-Hosted Control Plane](#self-hosted-control-plane)****: Available for the **Enterprise** plan.
 
 1. **[Standalone Container](#standalone-container)**: Available for all plans.
 
 Please see the [LangGraph Platform Plans](./plans.md) for more information on the different plans.
 
 The guide below will explain the differences between the deployment options.
+
+!!! info "Alpha and Beta"
+
+    *The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+
+    **The <b>Self-Hosted Data Plane</b> and <b>Self-Hosted Control Plane</b> deployment options are currently in <b>alpha</b> stage.
 
 ## Cloud SaaS
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -10,11 +10,11 @@
 
 There are 4 main options for deploying with the LangGraph Platform:
 
-1. **[Cloud SaaS (Beta)](#cloud-saas)**: Available for **Plus** and **Enterprise** plans.
+1. **<a href="#cloud-saas">Cloud SaaS <sup>(Beta)</sup></a>**: Available for **Plus** and **Enterprise** plans.
 
-1. **[Self-Hosted Data Plane (Beta)](#self-hosted-data-plane)**: Available for the **Enterprise** plan.
+1. **<a href="#self-hosted-data-plane">Self-Hosted Data Plane <sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
 
-1. **[Self-Hosted Control Plane (Beta)](#self-hosted-control-plane)**: Available for the **Enterprise** plan.
+1. **<a href="#self-hosted-control-plane">Self-Hosted Control Plane <sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
 
 1. **[Standalone Container](#standalone-container)**: Available for all plans.
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -10,11 +10,11 @@
 
 There are 4 main options for deploying with the LangGraph Platform:
 
-1. **<a href="#cloud-saas">Cloud SaaS <sup>(Beta)</sup></a>**: Available for **Plus** and **Enterprise** plans.
+1. **<a href="#cloud-saas">Cloud SaaS<sup>(Beta)</sup></a>**: Available for **Plus** and **Enterprise** plans.
 
-1. **<a href="#self-hosted-data-plane">Self-Hosted Data Plane <sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
+1. **<a href="#self-hosted-data-plane">Self-Hosted Data Plane<sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
 
-1. **<a href="#self-hosted-control-plane">Self-Hosted Control Plane <sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
+1. **<a href="#self-hosted-control-plane">Self-Hosted Control Plane<sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
 
 1. **[Standalone Container](#standalone-container)**: Available for all plans.
 

--- a/docs/docs/concepts/langgraph_cloud.md
+++ b/docs/docs/concepts/langgraph_cloud.md
@@ -1,8 +1,4 @@
-# Cloud SaaS
-
-!!! info "Beta"
-
-    The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+# Cloud SaaS (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy to Cloud SaaS](../cloud/deployment/cloud.md).
 

--- a/docs/docs/concepts/langgraph_cloud.md
+++ b/docs/docs/concepts/langgraph_cloud.md
@@ -1,5 +1,9 @@
 # Cloud SaaS
 
+!!! info "Beta"
+
+    The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy to Cloud SaaS](../cloud/deployment/cloud.md).
 
 ## Overview

--- a/docs/docs/concepts/langgraph_self_hosted_control_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_control_plane.md
@@ -1,5 +1,9 @@
 # Self-Hosted Control Plane
 
+!!! info "Alpha"
+
+    The <b>Self-Hosted Control Plane</b> deployment option is currently in <b>alpha</b> stage.
+
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Control Plane](../cloud/deployment/self_hosted_control_plane.md).
 
 ## Overview

--- a/docs/docs/concepts/langgraph_self_hosted_control_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_control_plane.md
@@ -1,8 +1,4 @@
-# Self-Hosted Control Plane
-
-!!! info "Alpha"
-
-    The <b>Self-Hosted Control Plane</b> deployment option is currently in <b>alpha</b> stage.
+# Self-Hosted Control Plane (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Control Plane](../cloud/deployment/self_hosted_control_plane.md).
 

--- a/docs/docs/concepts/langgraph_self_hosted_data_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_data_plane.md
@@ -1,5 +1,9 @@
 # Self-Hosted Data Plane
 
+!!! info "Alpha"
+
+    The <b>Self-Hosted Data Plane</b> deployment option is currently in <b>alpha</b> stage.
+
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Data Plane](../cloud/deployment/self_hosted_data_plane.md).
 
 ## Overview

--- a/docs/docs/concepts/langgraph_self_hosted_data_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_data_plane.md
@@ -1,8 +1,4 @@
-# Self-Hosted Data Plane
-
-!!! info "Alpha"
-
-    The <b>Self-Hosted Data Plane</b> deployment option is currently in <b>alpha</b> stage.
+# Self-Hosted Data Plane (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Data Plane](../cloud/deployment/self_hosted_data_plane.md).
 

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -24,7 +24,7 @@ Get started deploying your LangGraph applications locally or on the cloud with
 
 A quick comparison...
 
-|                      | **Cloud SaaS<sup>(Beta)</sup>** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)<sup>(Beta)</sup>** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)<sup>(Beta)</sup>** | **Standalone Container** |
+|                      | **Cloud SaaS** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)** | **Standalone Container** |
 |----------------------|----------------|----------------------------|-------------------------------|--------------------------|
 | **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -17,14 +17,14 @@ Get started deploying your LangGraph applications locally or on the cloud with
 
 ## Deployment Options
 
-- [Cloud SaaS (Beta)](../concepts/langgraph_cloud.md): Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
-- [Self-Hosted Data Plane (Beta)](../concepts/langgraph_self_hosted_data_plane.md): Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
-- [Self-Hosted Control Plane (Beta)](../concepts/langgraph_self_hosted_control_plane.md#control-plane-ui): Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md) and deploy LangGraph Servers to your cloud. You manage everything.
+- <a href="../../concepts/langgraph_cloud/">Cloud SaaS <sup>(Beta)</sup></a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+- <a href="../../concepts/langgraph_self_hosted_data_plane/">Self-Hosted Data Plane <sup>(Beta)</sup></a>: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
+- <a href="../../concepts/langgraph_self_hosted_control_plane/">Self-Hosted Control Plane <sup>(Beta)</sup></a>: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.
 
 A quick comparison...
 
-|                      | **Cloud SaaS (Beta)** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md) (Beta)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md) (Beta)** | **Standalone Container** |
+|                      | **Cloud SaaS <sup>(Beta)</sup>** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md) <sup>(Beta)</sup>** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md) <sup>(Beta)</sup>** | **Standalone Container** |
 |----------------------|----------------|----------------------------|-------------------------------|--------------------------|
 | **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -17,14 +17,20 @@ Get started deploying your LangGraph applications locally or on the cloud with
 
 ## Deployment Options
 
-- [Cloud SaaS](../concepts/langgraph_cloud.md): Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
-- [Self-Hosted Data Plane](../concepts/langgraph_self_hosted_data_plane.md): Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
-- [Self-Hosted Control Plane](../concepts/langgraph_self_hosted_control_plane.md#control-plane-ui): Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md) and deploy LangGraph Servers to your cloud. You manage everything.
+- [Cloud SaaS](../concepts/langgraph_cloud.md)*: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+- [Self-Hosted Data Plane](../concepts/langgraph_self_hosted_data_plane.md)**: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
+- [Self-Hosted Control Plane](../concepts/langgraph_self_hosted_control_plane.md#control-plane-ui)**: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.
+
+!!! info "Alpha and Beta"
+
+    *The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
+
+    **The <b>Self-Hosted Data Plane</b> and <b>Self-Hosted Control Plane</b> deployment options are currently in <b>alpha</b> stage.
 
 A quick comparison...
 
-|                      | **Cloud SaaS** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)** | **Standalone Container** |
+|                      | **Cloud SaaS*** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)**** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)**** | **Standalone Container** |
 |----------------------|----------------|----------------------------|-------------------------------|--------------------------|
 | **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -17,14 +17,14 @@ Get started deploying your LangGraph applications locally or on the cloud with
 
 ## Deployment Options
 
-- <a href="../../concepts/langgraph_cloud/">Cloud SaaS <sup>(Beta)</sup></a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
-- <a href="../../concepts/langgraph_self_hosted_data_plane/">Self-Hosted Data Plane <sup>(Beta)</sup></a>: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
-- <a href="../../concepts/langgraph_self_hosted_control_plane/">Self-Hosted Control Plane <sup>(Beta)</sup></a>: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. You manage everything.
+- <a href="../../concepts/langgraph_cloud/">Cloud SaaS<sup>(Beta)</sup></a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+- <a href="../../concepts/langgraph_self_hosted_data_plane/">Self-Hosted Data Plane<sup>(Beta)</sup></a>: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
+- <a href="../../concepts/langgraph_self_hosted_control_plane/">Self-Hosted Control Plane<sup>(Beta)</sup></a>: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.
 
 A quick comparison...
 
-|                      | **Cloud SaaS <sup>(Beta)</sup>** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md) <sup>(Beta)</sup>** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md) <sup>(Beta)</sup>** | **Standalone Container** |
+|                      | **Cloud SaaS<sup>(Beta)</sup>** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)<sup>(Beta)</sup>** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)<sup>(Beta)</sup>** | **Standalone Container** |
 |----------------------|----------------|----------------------------|-------------------------------|--------------------------|
 | **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -17,20 +17,14 @@ Get started deploying your LangGraph applications locally or on the cloud with
 
 ## Deployment Options
 
-- [Cloud SaaS](../concepts/langgraph_cloud.md)*: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
-- [Self-Hosted Data Plane](../concepts/langgraph_self_hosted_data_plane.md)**: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
-- [Self-Hosted Control Plane](../concepts/langgraph_self_hosted_control_plane.md#control-plane-ui)**: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md) and deploy LangGraph Servers to your cloud. You manage everything.
+- [Cloud SaaS (Beta)](../concepts/langgraph_cloud.md): Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+- [Self-Hosted Data Plane (Beta)](../concepts/langgraph_self_hosted_data_plane.md): Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
+- [Self-Hosted Control Plane (Beta)](../concepts/langgraph_self_hosted_control_plane.md#control-plane-ui): Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.
-
-!!! info "Alpha and Beta"
-
-    *The <b>Cloud SaaS</b> deployment option is currently in open <b>beta</b> stage.
-
-    **The <b>Self-Hosted Data Plane</b> and <b>Self-Hosted Control Plane</b> deployment options are currently in <b>alpha</b> stage.
 
 A quick comparison...
 
-|                      | **Cloud SaaS*** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)**** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)**** | **Standalone Container** |
+|                      | **Cloud SaaS (Beta)** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md) (Beta)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md) (Beta)** | **Standalone Container** |
 |----------------------|----------------|----------------------------|-------------------------------|--------------------------|
 | **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |


### PR DESCRIPTION
### Summary
Examples:
![image](https://github.com/user-attachments/assets/2a36a262-5373-498d-9907-19d5447fbb6a)

![image](https://github.com/user-attachments/assets/70671e08-34b6-40ed-964d-9d195ea8308d)

![image](https://github.com/user-attachments/assets/fcb877a6-475c-47a4-b8af-91cbdc00f89b)


