### PR TITLE
Make docstring even less ambiguous

### DIFF
--- a/libs/sdk-py/langgraph_sdk/schema.py
+++ b/libs/sdk-py/langgraph_sdk/schema.py
@@ -125,7 +125,7 @@ class Checkpoint(TypedDict):
     thread_id: str
     """Unique identifier for the thread associated with this checkpoint."""
     checkpoint_ns: str
-    """Namespace for the checkpoint, used for organization and retrieval."""
+    """Namespace for the checkpoint; used internally to manage subgraph state."""
     checkpoint_id: Optional[str]
     """Optional unique identifier for the checkpoint itself."""
     checkpoint_map: Optional[dict[str, Any]]


### PR DESCRIPTION
Unsure if this is related to a recent user misconception about `checkpoint_ns`' role, but in any case would like to make all docstrings as unambiguous as possible.