### PR TITLE
Fix text fields naming

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -1320,7 +1320,7 @@ def _ensure_index_config(
     index_config = index_config.copy()
     tokenized: list[tuple[str, Union[Literal["$"], list[str]]]] = []
     tot = 0
-    text_fields = index_config.get("text_fields") or ["$"]
+    text_fields = index_config.get("fields") or ["$"]
     if isinstance(text_fields, str):
         text_fields = [text_fields]
     if not isinstance(text_fields, list):

--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langgraph-checkpoint-postgres"
-version = "2.0.20"
+version = "2.0.21"
 description = "Library with a Postgres implementation of LangGraph checkpoint saver."
 authors = []
 license = "MIT"

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -377,7 +377,7 @@ async def _create_vector_store(
             "vector_type": vector_type,
         },
         "distance_type": distance_type,
-        "text_fields": text_fields,
+        "fields": text_fields,
     }
 
     async with await AsyncConnection.connect(

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -401,7 +401,7 @@ def _create_vector_store(
             "vector_type": vector_type,
         },
         "distance_type": distance_type,
-        "text_fields": text_fields,
+        "fields": text_fields,
     }
 
     with Connection.connect(admin_conn_string, autocommit=True) as conn:


### PR DESCRIPTION
The configuration expects the key "fields", not "text_fields": I had failed to update across all implementations in the original PR