### PR TITLE
Fix invalid channels error message

### DIFF
--- a/libs/langgraph/langgraph/pregel/algo.py
+++ b/libs/langgraph/langgraph/pregel/algo.py
@@ -963,7 +963,7 @@ def _proc_input(
             return MISSING
     else:
         raise RuntimeError(
-            "Invalid channels type, expected list or dict, got {proc.channels}"
+            f"Invalid channels type, expected list or dict, got {proc.channels}"
         )
 
     # If the process has a mapper, apply it to the value


### PR DESCRIPTION
# PR Summary
This small PR resolves the error formatting in `libs/langgraph/langgraph/pregel/algo.py` so the `proc.channels` will be evaluated in the message.