### PR TITLE
docs: apply boosts and tag a few things

### DIFF
--- a/docs/docs/agents/agents.md
+++ b/docs/docs/agents/agents.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Agents
 
 ## What is an agent?

--- a/docs/docs/agents/agents.md
+++ b/docs/docs/agents/agents.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Agents

--- a/docs/docs/agents/context.md
+++ b/docs/docs/agents/context.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Context
 
 Agents often require more than a list of messages to function effectively. They need **context**.

--- a/docs/docs/agents/context.md
+++ b/docs/docs/agents/context.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Context

--- a/docs/docs/agents/deployment.md
+++ b/docs/docs/agents/deployment.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Deployment

--- a/docs/docs/agents/deployment.md
+++ b/docs/docs/agents/deployment.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Deployment
 
 To deploy your LangGraph agent, create and configure a LangGraph app. This setup supports both local development and production deployments.

--- a/docs/docs/agents/evals.md
+++ b/docs/docs/agents/evals.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Evals
 
 To evaluate your agent's performance you can use `LangSmith` [evaluations](https://docs.smith.langchain.com/evaluation). You would need to first define an evaluator function to judge the results from an agent, such as final outputs or trajectory. Depending on your evaluation technique, this may or may not involve a reference output:

--- a/docs/docs/agents/evals.md
+++ b/docs/docs/agents/evals.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Evals

--- a/docs/docs/agents/human-in-the-loop.md
+++ b/docs/docs/agents/human-in-the-loop.md
@@ -1,3 +1,13 @@
+---
+search:
+  boost: 2
+tags:
+   - human-in-the-loop
+   - hil
+hide:
+   - tags
+---
+
 # Human-in-the-loop
 
 To review, edit and approve tool calls in an agent you can use LangGraph's built-in [human-in-the-loop](../concepts/human_in_the_loop.md) features, specifically the [`interrupt()`][langgraph.types.interrupt] primitive.

--- a/docs/docs/agents/human-in-the-loop.md
+++ b/docs/docs/agents/human-in-the-loop.md
@@ -2,15 +2,16 @@
 search:
   boost: 2
 tags:
-   - human-in-the-loop
-   - hil
+  - human-in-the-loop
+  - hil
+  - agent
 hide:
-   - tags
+  - tags
 ---
 
 # Human-in-the-loop
 
-To review, edit and approve tool calls in an agent you can use LangGraph's built-in [human-in-the-loop](../concepts/human_in_the_loop.md) features, specifically the [`interrupt()`][langgraph.types.interrupt] primitive.
+To review, edit and approve tool calls in an agent you can use LangGraph's built-in [Human-In-the-Loop (HIL)](../concepts/human_in_the_loop.md) features, specifically the [`interrupt()`][langgraph.types.interrupt] primitive.
 
 LangGraph allows you to pause execution **indefinitely** — for minutes, hours, or even days—until human input is received.
 

--- a/docs/docs/agents/mcp.md
+++ b/docs/docs/agents/mcp.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # MCP Integration
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide tools and context to language models. LangGraph agents can use tools defined on MCP servers through the `langchain-mcp-adapters` library.

--- a/docs/docs/agents/mcp.md
+++ b/docs/docs/agents/mcp.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # MCP Integration

--- a/docs/docs/agents/memory.md
+++ b/docs/docs/agents/memory.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Memory

--- a/docs/docs/agents/memory.md
+++ b/docs/docs/agents/memory.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Memory
 
 LangGraph supports two types of memory essential for building conversational agents:

--- a/docs/docs/agents/models.md
+++ b/docs/docs/agents/models.md
@@ -3,17 +3,11 @@ search:
   boost: 2
 tags:
   - anthropic
-  - groq
-  - huggingface
   - openai
-  - fireworks
-  - llama
-  - llama2
-  - ollama
+  - agent
 hide:
   - tags
 ---
-<!-- material/tags { scope: true } -->
 
 # Models
 

--- a/docs/docs/agents/models.md
+++ b/docs/docs/agents/models.md
@@ -1,3 +1,20 @@
+---
+search:
+  boost: 2
+tags:
+  - anthropic
+  - groq
+  - huggingface
+  - openai
+  - fireworks
+  - llama
+  - llama2
+  - ollama
+hide:
+  - tags
+---
+<!-- material/tags { scope: true } -->
+
 # Models
 
 This page describes how to configure the chat model used by an agent.

--- a/docs/docs/agents/multi-agent.md
+++ b/docs/docs/agents/multi-agent.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Multi-agent

--- a/docs/docs/agents/multi-agent.md
+++ b/docs/docs/agents/multi-agent.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Multi-agent
 
 A single agent might struggle if it needs to specialize in multiple domains or manage many tools. To tackle this, you can break your agent into smaller, independent agents and composing them into a [multi-agent system](../concepts/multi_agent.md).

--- a/docs/docs/agents/overview.md
+++ b/docs/docs/agents/overview.md
@@ -2,6 +2,10 @@
 title: Overview
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Agent development with LangGraph

--- a/docs/docs/agents/overview.md
+++ b/docs/docs/agents/overview.md
@@ -1,5 +1,7 @@
 ---
 title: Overview
+search:
+  boost: 2
 ---
 
 # Agent development with LangGraph

--- a/docs/docs/agents/prebuilt.md
+++ b/docs/docs/agents/prebuilt.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - agent
+hide:
+  - tags
+---
+
 # Community Agents
 
 To share your project, simply open a Pull Request adding an entry for your package in our [packages.yml](https://github.com/langchain-ai/langgraph/blob/main/docs/_scripts/third_party_page/packages.yml) file.

--- a/docs/docs/agents/run_agents.md
+++ b/docs/docs/agents/run_agents.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Running agents
 
 

--- a/docs/docs/agents/run_agents.md
+++ b/docs/docs/agents/run_agents.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Running agents

--- a/docs/docs/agents/streaming.md
+++ b/docs/docs/agents/streaming.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Streaming
 
 Streaming is key to building responsive applications. There are a few types of data you’ll want to stream:

--- a/docs/docs/agents/streaming.md
+++ b/docs/docs/agents/streaming.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Streaming

--- a/docs/docs/agents/tools.md
+++ b/docs/docs/agents/tools.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # Tools

--- a/docs/docs/agents/tools.md
+++ b/docs/docs/agents/tools.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Tools
 
 [Tools](https://python.langchain.com/docs/concepts/tools/) are a way to encapsulate a function and its input schema in a way that can be passed to a chat model that supports tool calling. This allows the model to request the execution of this function with specific inputs.

--- a/docs/docs/agents/ui.md
+++ b/docs/docs/agents/ui.md
@@ -1,6 +1,10 @@
 ---
 search:
   boost: 2
+tags:
+  - agent
+hide:
+  - tags
 ---
 
 # UI

--- a/docs/docs/agents/ui.md
+++ b/docs/docs/agents/ui.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # UI
 
 You can use a prebuilt chat UI for interacting with any LangGraph agent through the [Agent Chat UI](https://github.com/langchain-ai/agent-chat-ui). Using the [deployed version](https://agentchat.vercel.app) is the quickest way to get started, and allows you to interact with both local and deployed graphs.

--- a/docs/docs/cloud/how-tos/interrupt_concurrent.md
+++ b/docs/docs/cloud/how-tos/interrupt_concurrent.md
@@ -1,4 +1,4 @@
-# Interrupt
+# How to use the interrupt option
 
 This guide assumes knowledge of what double-texting is, which you can learn about in the [double-texting conceptual guide](../../concepts/double_texting.md).
 

--- a/docs/docs/cloud/how-tos/rollback_concurrent.md
+++ b/docs/docs/cloud/how-tos/rollback_concurrent.md
@@ -1,4 +1,5 @@
-# Rollback
+# How to use the Rollback option
+
 
 This guide assumes knowledge of what double-texting is, which you can learn about in the [double-texting conceptual guide](../../concepts/double_texting.md).
 

--- a/docs/docs/concepts/agentic_concepts.md
+++ b/docs/docs/concepts/agentic_concepts.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Agent architectures
 
 Many LLM applications implement a particular control flow of steps before and / or after LLM calls. As an example, [RAG](https://github.com/langchain-ai/rag-from-scratch) performs retrieval of documents relevant to a user question, and passes those documents to an LLM in order to ground the model's response in the provided document context. 

--- a/docs/docs/concepts/application_structure.md
+++ b/docs/docs/concepts/application_structure.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Application Structure
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/assistants.md
+++ b/docs/docs/concepts/assistants.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Assistants
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/auth.md
+++ b/docs/docs/concepts/auth.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Authentication & Access Control
 
 LangGraph Platform provides a flexible authentication and authorization system that can integrate with most authentication schemes.

--- a/docs/docs/concepts/breakpoints.md
+++ b/docs/docs/concepts/breakpoints.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Breakpoints
 
 Breakpoints pause graph execution at specific points and enable stepping through execution step by step. Breakpoints are powered by LangGraph's [**persistence layer**](./persistence.md), which saves the state after each graph step. Breakpoints can also be used to enable [**human-in-the-loop**](./human_in_the_loop.md) workflows, though we recommend using the [`interrupt` function](./human_in_the_loop.md#interrupt) for this purpose.

--- a/docs/docs/concepts/bring_your_own_cloud.md
+++ b/docs/docs/concepts/bring_your_own_cloud.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Bring Your Own Cloud (BYOC)
 
 !!! note Prerequisites

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Deployment Options
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/double_texting.md
+++ b/docs/docs/concepts/double_texting.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Double Texting
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/durable_execution.md
+++ b/docs/docs/concepts/durable_execution.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Durable Execution
 
 **Durable execution** is a technique in which a process or workflow saves its progress at key points, allowing it to pause and later resume exactly where it left off. This is particularly useful in scenarios that require [human-in-the-loop](./human_in_the_loop.md), where users can inspect, validate, or modify the process before continuing, and in long-running tasks that might encounter interruptions or errors (e.g., calls to an LLM timing out). By preserving completed work, durable execution enables a process to resume without reprocessing previous steps -- even after a significant delay (e.g., a week later). 

--- a/docs/docs/concepts/faq.md
+++ b/docs/docs/concepts/faq.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # FAQ
 
 Common questions and their answers!

--- a/docs/docs/concepts/functional_api.md
+++ b/docs/docs/concepts/functional_api.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Functional API
 
 ## Overview

--- a/docs/docs/concepts/high_level.md
+++ b/docs/docs/concepts/high_level.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Why LangGraph?
 
 ## LLM applications

--- a/docs/docs/concepts/human_in_the_loop.md
+++ b/docs/docs/concepts/human_in_the_loop.md
@@ -1,3 +1,13 @@
+---
+search:
+  boost: 2
+tags:
+  - human-in-the-loop
+  - hil
+hide:
+  - tags
+---
+
 # Human-in-the-loop
 
 !!! tip "This guide uses the new `interrupt` function."

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -2,7 +2,7 @@
 title: Concepts
 description: Conceptual Guide for LangGraph
 search:
-  boost: 2
+  boost: 0.5
 ---
 
 # Conceptual Guide

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -1,6 +1,8 @@
 ---
 title: Concepts
 description: Conceptual Guide for LangGraph
+search:
+  boost: 2
 ---
 
 # Conceptual Guide

--- a/docs/docs/concepts/langgraph_cli.md
+++ b/docs/docs/concepts/langgraph_cli.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph CLI
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/langgraph_cloud.md
+++ b/docs/docs/concepts/langgraph_cloud.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Cloud SaaS (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy to Cloud SaaS](../cloud/deployment/cloud.md).

--- a/docs/docs/concepts/langgraph_control_plane.md
+++ b/docs/docs/concepts/langgraph_control_plane.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Control Plane
 
 The term "control plane" is used broadly to refer to the Control Plane UI where users create and update [LangGraph Servers](./langgraph_server.md) (deployments) and the Control Plane APIs that support the UI experience.

--- a/docs/docs/concepts/langgraph_data_plane.md
+++ b/docs/docs/concepts/langgraph_data_plane.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Data Plane
 
 The term "data plane" is used broadly to refer to [LangGraph Servers](./langgraph_server.md) (deployments), the corresponding infrastructure for each server, and the "listener" application that continuously polls for updates from the [LangGraph Control Plane](./langgraph_control_plane.md).

--- a/docs/docs/concepts/langgraph_self_hosted_control_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_control_plane.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Self-Hosted Control Plane (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Control Plane](../cloud/deployment/self_hosted_control_plane.md).

--- a/docs/docs/concepts/langgraph_self_hosted_data_plane.md
+++ b/docs/docs/concepts/langgraph_self_hosted_data_plane.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Self-Hosted Data Plane (Beta)
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy the Self-Hosted Data Plane](../cloud/deployment/self_hosted_data_plane.md).

--- a/docs/docs/concepts/langgraph_server.md
+++ b/docs/docs/concepts/langgraph_server.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Server
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/langgraph_standalone_container.md
+++ b/docs/docs/concepts/langgraph_standalone_container.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Standalone Container
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy a Standalone Container](../cloud/deployment/standalone_container.md).

--- a/docs/docs/concepts/langgraph_studio.md
+++ b/docs/docs/concepts/langgraph_studio.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Studio
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/low_level.md
+++ b/docs/docs/concepts/low_level.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Glossary
 
 ## Graphs

--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Memory
 
 ## What is Memory?

--- a/docs/docs/concepts/multi_agent.md
+++ b/docs/docs/concepts/multi_agent.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Multi-agent Systems
 
 An [agent](./agentic_concepts.md#agent-architectures) is _a system that uses an LLM to decide the control flow of an application_. As you develop these systems, they might grow more complex over time, making them harder to manage and scale. For example, you might run into the following problems:

--- a/docs/docs/concepts/persistence.md
+++ b/docs/docs/concepts/persistence.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Persistence
 
 LangGraph has a built-in persistence layer, implemented through checkpointers. When you compile graph with a checkpointer, the checkpointer saves a `checkpoint` of the graph state at every super-step. Those checkpoints are saved to a `thread`, which can be accessed after graph execution. Because `threads` allow access to graph's state after execution, several powerful capabilities including human-in-the-loop, memory, time travel, and fault-tolerance are all possible. See [this how-to guide](../how-tos/persistence.ipynb) for an end-to-end example on how to add and use checkpointers with your graph. Below, we'll discuss each of these concepts in more detail. 

--- a/docs/docs/concepts/plans.md
+++ b/docs/docs/concepts/plans.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Platform Plans
 
 

--- a/docs/docs/concepts/platform_architecture.md
+++ b/docs/docs/concepts/platform_architecture.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Platform Architecture
 
 ![](img/langgraph_platform_deployment_architecture.png)

--- a/docs/docs/concepts/pregel.md
+++ b/docs/docs/concepts/pregel.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph's Runtime (Pregel)
 
 [Pregel][langgraph.pregel.Pregel] implements LangGraph's runtime, managing the execution of LangGraph applications.

--- a/docs/docs/concepts/scalability_and_resilience.md
+++ b/docs/docs/concepts/scalability_and_resilience.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph Platform: Scalability & Resilience
 
 LangGraph Platform is designed to scale horizontally with your workload. Each instance of the service is stateless, and keeps no resources in memory. The service is designed to gracefully handle new instances being added or removed, including hard shutdown cases.

--- a/docs/docs/concepts/sdk.md
+++ b/docs/docs/concepts/sdk.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # LangGraph SDK
 
 !!! info "Prerequisites"

--- a/docs/docs/concepts/self_hosted.md
+++ b/docs/docs/concepts/self_hosted.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Self-Hosted
 
 !!! note Prerequisites

--- a/docs/docs/concepts/streaming.md
+++ b/docs/docs/concepts/streaming.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Streaming
 
 Building a responsive app for end-users? Real-time updates are key to keeping users engaged as your app progresses.

--- a/docs/docs/concepts/template_applications.md
+++ b/docs/docs/concepts/template_applications.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Template Applications
 
 Templates are open source reference applications designed to help you get started quickly when building with LangGraph. They provide working examples of common agentic workflows that can be customized to your needs.

--- a/docs/docs/concepts/time-travel.md
+++ b/docs/docs/concepts/time-travel.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Time Travel ⏱️
 
 !!! note "Prerequisites"

--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -1,6 +1,8 @@
 ---
 title: How-to Guides
 description: How to accomplish common tasks in LangGraph
+search:
+  boost: 0.5
 ---
 
 # How-to Guides

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -1,6 +1,8 @@
 ---
 title: Reference
 description: API reference for LangGraph
+search:
+  boost: 0.5
 ---
 
 <style>

--- a/docs/docs/troubleshooting/errors/index.md
+++ b/docs/docs/troubleshooting/errors/index.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 0.5
+---
 # Error reference
 
 This page contains guides around resolving common errors you may find while building with LangGraph.

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -1,5 +1,7 @@
 ---
 title: Tutorials
+search:
+  boost: 0.5
 ---
 
 # Tutorials

--- a/docs/docs/tutorials/workflows/index.md
+++ b/docs/docs/tutorials/workflows/index.md
@@ -1,3 +1,7 @@
+---
+search:
+    boost: 2 
+---
 # Workflows and Agents
 
 This guide reviews common patterns for agentic systems. In describing these systems, it can be useful to make a distinction between "workflows" and "agents". One way to think about this difference is nicely explained in [Anthropic's](https://python.langchain.com/docs/integrations/providers/anthropic/) `Building Effective Agents` blog post:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
   - search:
       separator: '[\s\u200b\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;'
   - autorefs
+  - tags
   - mkdocstrings:
       custom_templates: templates
       handlers:


### PR DESCRIPTION
Manual pass to apply a few heuristics:

* Boost conceptual pages
* Deboost (is that a word?) index pages that list all content
* Prefer Agents pages if search query contains the word "agent"
* Add tags for a few selected pages