### PR TITLE
docs: CopilotKit + LangGraph integrations

### DIFF
--- a/docs/docs/cloud/how-tos/use_copilotkit_react.md
+++ b/docs/docs/cloud/how-tos/use_copilotkit_react.md
@@ -10,7 +10,7 @@ CopilotKit provides React components to quickly integrate customizable AI copilo
 
 ```bash
 # Frontend packages
-npm install @copilotkit/react-core @copilotkit/react-ui @copilotkit/runtime
+npm install @copilotkit/react-core @copilotkit/react-ui
 ```
 
 ## Basic Setup
@@ -50,6 +50,14 @@ export function AIAssistantChatContainer() {
 
 ### Copilot Runtime
 
+If you're not using Copilotkit Cloud, you'll need to set up a runtime server to connect your frontend with LangGraph. First, install the runtime package:
+
+```bash
+npm install @copilotkit/runtime
+```
+
+Then create a server file with the following code:
+
 ```ts
 import { createServer } from "node:http";
 import {
@@ -58,8 +66,6 @@ import {
   copilotRuntimeNodeHttpEndpoint,
   langGraphPlatformEndpoint,
 } from "@copilotkit/runtime";
-
-const serviceAdapter = new ExperimentalEmptyAdapter();
 
 const server = createServer((req, res) => {
   const runtime = new CopilotRuntime({
@@ -79,9 +85,9 @@ const server = createServer((req, res) => {
   });
 
   const handler = copilotRuntimeNodeHttpEndpoint({
-    endpoint: "/copilotkit",
+    ...
+    endpoint: "/api/copilotkit",
     runtime,
-    serviceAdapter,
   });
 
   return handler(req, res);
@@ -91,6 +97,16 @@ server.listen(4000, () => {
   console.log("Listening at http://localhost:4000/copilotkit");
 });
 ```
+
+Start this server alongside your frontend application, and ensure your frontend's `CopilotKit` component points to this endpoint:
+
+```tsx
+<CopilotKit runtimeUrl="http://localhost:4000/api/copilotkit">
+  {children}
+</CopilotKit>
+```
+
+For more detailed information on self-hosting the Copilot Runtime, see the [CopilotKit Self-Hosting Guide](https://docs.copilotkit.ai/guides/self-hosting).
 
 ## Core Concepts
 
@@ -249,37 +265,6 @@ export function Page() {
   // Rest of component
 }
 ```
-
-To connect these actions to your LangGraph agent:
-
-1. Install the SDK:
-
-   ```bash
-   npm install @copilotkit/sdk-js
-   ```
-
-2. Inherit from CopilotKitState in your agent's state:
-
-   ```ts
-   import { Annotation } from "@langchain/langgraph";
-   import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
-
-   export const YourAgentStateAnnotation = Annotation.Root({
-     yourAdditionalProperty: Annotation<string>,
-     ...CopilotKitStateAnnotation.spec,
-   });
-   ```
-
-3. Use the actions in your agent node:
-   ```ts
-   async function agentNode(state: YourAgentState, config: RunnableConfig) {
-     const actions = state.copilotkit?.actions;
-     const model = ChatOpenAI({ model: "gpt-4o" }).bindTools(actions);
-     // ... use the model with actions
-   }
-   ```
-
-CopilotKit automatically provides these actions as LangChain-compatible tools, making them seamlessly available to your agent.
 
 ## Further Reading
 

--- a/docs/docs/cloud/how-tos/use_copilotkit_react.md
+++ b/docs/docs/cloud/how-tos/use_copilotkit_react.md
@@ -1,0 +1,320 @@
+# How to use LangGraph with CopilotKit in React
+
+!!! info "Prerequisites"
+
+    - [LangGraph Server](../../concepts/langgraph_server.md)
+
+CopilotKit provides React components to quickly integrate customizable AI copilots into your application. Combined with LangGraph, you can build sophisticated AI apps featuring bidirectional state synchronization and interactive UIs.
+
+## Installation
+
+```bash
+# Frontend packages
+npm install @copilotkit/react-core @copilotkit/react-ui @copilotkit/runtime
+```
+
+## Basic Setup
+
+Integrating LangGraph with CopilotKit involves two main steps: setting up the backend runtime and configuring your frontend components.
+
+### Copilot Runtime
+
+```ts
+import { createServer } from "node:http";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNodeHttpEndpoint,
+  langGraphPlatformEndpoint,
+} from "@copilotkit/runtime";
+
+const serviceAdapter = new ExperimentalEmptyAdapter();
+
+const server = createServer((req, res) => {
+  const runtime = new CopilotRuntime({
+    remoteEndpoints: [
+      langGraphPlatformEndpoint({
+        // make sure to replace with URL that points to your running LangGraph server
+        deploymentUrl: "http://localhost:8000",
+        langsmithApiKey: process.env.LANGSMITH_API_KEY, // only used in LangGraph Platform deployments
+        agents: [
+          {
+            name: "sample_agent",
+            description: "A helpful LLM agent.",
+          },
+        ],
+      }),
+    ],
+  });
+
+  const handler = copilotRuntimeNodeHttpEndpoint({
+    endpoint: "/copilotkit",
+    runtime,
+    serviceAdapter,
+  });
+
+  return handler(req, res);
+});
+
+server.listen(4000, () => {
+  console.log("Listening at http://localhost:4000/copilotkit");
+});
+```
+
+### Frontend
+
+```tsx
+// layout.tsx
+import { CopilotKit } from "@copilotkit/react-core";
+import { CopilotTextarea } from "@copilotkit/react-ui";
+
+function MyApp({ Component, pageProps }) {
+  return <CopilotKit runtimeUrl="/api/copilotkit">{children}</CopilotKit>;
+}
+
+import { CopilotChat } from "@copilotkit/react-ui";
+
+export function YourComponent() {
+  return (
+    <CopilotChat
+      instructions={
+        "You are assisting the user as best as you can. Answer in the best way possible given the data you have."
+      }
+      labels={{
+        title: "Your Assistant",
+        initial: "Hi! 👋 How can I assist you today?",
+      }}
+    />
+  );
+}
+```
+
+## Core Concepts
+
+### Shared State
+
+The `useCoAgent` hook enables shared state management between your React application and LangGraph agent, allowing bidirectional synchronization. You can:
+
+- Read the agent's current state in your UI components
+- Update the agent's state from your UI
+- Trigger agent reruns with updated state
+
+#### Defining Agent State
+
+```ts
+import { Annotation } from "@langchain/langgraph";
+import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+
+export const AgentStateAnnotation = Annotation.Root({
+  language: Annotation<"english" | "spanish">,
+  ...CopilotKitStateAnnotation.spec,
+});
+export type AgentState = typeof AgentStateAnnotation.State;
+
+async function chat_node(state: AgentState, config: RunnableConfig) {
+  // Use language from state or default to spanish
+  const language = state.language ?? "spanish";
+
+  // ... node implementation
+
+  return {
+    // Return language to make it available for next nodes & frontend
+    language,
+  };
+}
+```
+
+#### Reading and Writing Agent State
+
+The [`useCoAgent`](https://docs.copilotkit.ai/reference/hooks/useCoAgent) hook provides both state access and update capabilities:
+
+```ts
+import { useCoAgent } from "@copilotkit/react-core";
+
+// Define state type matching your agent's state
+type AgentState = {
+  language: "english" | "spanish";
+};
+
+function YourComponent() {
+  const { state, setState } = useCoAgent<AgentState>({
+    name: "sample_agent",
+    initialState: { language: "spanish" },
+  });
+
+  const toggleLanguage = () => {
+    setState({
+      language: state.language === "english" ? "spanish" : "english",
+    });
+  };
+
+  return (
+    <div>
+      <p>Current language: {state.language}</p>
+      <button onClick={toggleLanguage}>Toggle Language</button>
+    </div>
+  );
+}
+```
+
+The state in useCoAgent updates automatically when the agent's state changes.
+
+#### Rendering State in Chat UI
+
+You can also render the agent's state directly in the chat interface using [`useCoAgentStateRender`](https://docs.copilotkit.ai/reference/hooks/useCoAgentStateRender):
+
+```ts
+import { useCoAgentStateRender } from "@copilotkit/react-core";
+
+function YourComponent() {
+  // Render agent state in the chat UI
+  useCoAgentStateRender({
+    name: "sample_agent",
+    render: ({ state }) => {
+      if (!state.language) return null;
+      return <div>Language: {state.language}</div>;
+    },
+  });
+
+  // Rest of component
+}
+```
+
+#### Running the Agent Flow with `run`
+
+Use the `run` function to trigger the agent flow again whenever the state changes:
+
+```tsx
+import { useCoAgent } from "@copilotkit/react-core";
+import { TextMessage, MessageRole } from "@copilotkit/runtime-client-gql";
+
+function YourComponent() {
+  const { state, setState, run } = useCoAgent<AgentState>({
+    name: "sample_agent",
+    initialState: { language: "spanish" },
+  });
+
+  const toggleLanguage = () => {
+    const newLanguage = state.language === "english" ? "spanish" : "english";
+    setState({ language: newLanguage });
+
+    // Rerun with a hint about what changed
+    run(({ currentState }) => {
+      return new TextMessage({
+        role: MessageRole.User,
+        content: `The language has been updated to ${currentState.language}`,
+      });
+    });
+  };
+
+  // Component JSX
+}
+```
+
+By default, state updates only occur during node transitions. For continuous state updates, see the CopilotKit documentation on streaming intermediate state.
+
+### Frontend Actions
+
+Frontend actions enable your LangGraph agent to interact with and update your application's UI. They serve as bridges connecting your agent's logic to the interactive elements of your frontend.
+
+With frontend actions, your agent can:
+
+- Update UI elements dynamically
+- Trigger frontend animations or transitions
+- Show alerts or notifications
+- Modify application state
+- Handle user interactions programmatically
+
+#### Creating a Frontend Action
+
+```tsx
+import { useCopilotAction } from "@copilotkit/react-core";
+
+export function Page() {
+  useCopilotAction({
+    name: "sayHello",
+    description: "Say hello to the user",
+    available: "remote", // makes the action only available to the agent
+    parameters: [
+      {
+        name: "name",
+        type: "string",
+        description: "The name of the user to say hello to",
+        required: true,
+      },
+    ],
+    handler: async ({ name }) => {
+      alert(`Hello, ${name}!`);
+    },
+  });
+
+  // Rest of component
+}
+```
+
+This hook creates an action that the agent can trigger to interact with your UI.
+
+#### When should I use this?
+
+Frontend actions are essential when you want to create truly interactive AI applications where your agent needs to:
+
+- Dynamically update UI elements
+- Trigger frontend animations or transitions
+- Show alerts or notifications
+- Modify application state
+- Handle user interactions programmatically
+
+#### Implementation
+
+First, you'll need to create a frontend action using the useCopilotAction hook. Here's a simple one to get you started that says hello to the user.
+
+##### Install the CopilotKit SDK
+
+Any LangGraph agent can be used with CopilotKit. However, creating deep agentic experiences with CopilotKit requires our LangGraph SDK.
+
+```
+npm install @copilotkit/sdk-js
+```
+
+##### Inheriting from CopilotKitState
+
+To access the frontend actions provided by CopilotKit, you can inherit from CopilotKitState in your agent's state definition:
+
+```ts
+import { Annotation } from "@langchain/langgraph";
+import { CopilotKitStateAnnotation } from "@copilotkit/sdk-js/langgraph";
+
+export const YourAgentStateAnnotation = Annotation.Root({
+  yourAdditionalProperty: Annotation<string>,
+  ...CopilotKitStateAnnotation.spec,
+});
+export type YourAgentState = typeof YourAgentStateAnnotation.State;
+```
+
+##### Accessing Frontend Actions
+
+Once your agent's state includes the copilotkit property, you can access the frontend actions and utilize them within your agent's logic.
+
+Here's how you can call a frontend action from your agent:
+
+```ts
+async function agentNode(
+  state: YourAgentState,
+  config: RunnableConfig
+): Promise<YourAgentState> {
+  // Access the actions from the copilotkit property
+
+  const actions = state.copilotkit?.actions;
+  const model = ChatOpenAI({ model: "gpt-4o" }).bindTools(actions);
+
+  // ...
+}
+```
+
+CopilotKit automatically provides these actions as LangChain-compatible tools, letting your agent easily call them as needed.
+
+## Further Reading
+
+- [CopilotKit Documentation](https://docs.copilotkit.ai)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+- [React Hooks with CopilotKit](https://docs.copilotkit.ai/reference/hooks/useCoAgent)

--- a/docs/docs/cloud/how-tos/use_langgraph_interrupt.md
+++ b/docs/docs/cloud/how-tos/use_langgraph_interrupt.md
@@ -1,0 +1,226 @@
+# How to Build Interruptible LangGraph Agent With Copilotkit
+
+!!! info "Prerequisites"
+
+    - [LangGraph Server](../../concepts/langgraph_server.md)
+
+[CopilotKit](https://copilotkit.ai/) makes it easy to build human-in-the-loop workflows with LangGraph. It provides simple tools to handle interruptions, get user input, and smoothly include human decisions in your agent's flow.
+
+## Installation
+
+```bash
+npm install @copilotkit/react-core @copilotkit/react-ui @copilotkit/runtime
+```
+
+## Basic Setup
+
+Integrating LangGraph with CopilotKit involves two main steps: setting up the backend runtime and configuring your frontend components.
+
+### Copilot Runtime
+
+```ts
+import { createServer } from "node:http";
+import {
+  CopilotRuntime,
+  ExperimentalEmptyAdapter,
+  copilotRuntimeNodeHttpEndpoint,
+  langGraphPlatformEndpoint,
+} from "@copilotkit/runtime";
+
+const serviceAdapter = new ExperimentalEmptyAdapter();
+
+const server = createServer((req, res) => {
+  const runtime = new CopilotRuntime({
+    remoteEndpoints: [
+      langGraphPlatformEndpoint({
+        // make sure to replace with URL that points to your running LangGraph server
+        deploymentUrl: "http://localhost:8000",
+        langsmithApiKey: process.env.LANGSMITH_API_KEY, // only used in LangGraph Platform deployments
+        agents: [
+          {
+            name: "sample_agent",
+            description: "A helpful LLM agent.",
+          },
+        ],
+      }),
+    ],
+  });
+
+  const handler = copilotRuntimeNodeHttpEndpoint({
+    endpoint: "/copilotkit",
+    runtime,
+    serviceAdapter,
+  });
+
+  return handler(req, res);
+});
+
+server.listen(4000, () => {
+  console.log("Listening at http://localhost:4000/copilotkit");
+});
+```
+
+### Frontend
+
+```tsx
+// layout.tsx
+import { CopilotKit } from "@copilotkit/react-core";
+import { CopilotTextarea } from "@copilotkit/react-ui";
+
+function MyApp({ Component, pageProps }) {
+  return <CopilotKit runtimeUrl="/api/copilotkit">{children}</CopilotKit>;
+}
+
+import { CopilotChat } from "@copilotkit/react-ui";
+
+export function YourComponent() {
+  return (
+    <CopilotChat
+      instructions={
+        "You are assisting the user as best as you can. Answer in the best way possible given the data you have."
+      }
+      labels={{
+        title: "Your Assistant",
+        initial: "Hi! 👋 How can I assist you today?",
+      }}
+    />
+  );
+}
+```
+
+## Core Concepts
+
+### Interrupts
+
+Interrupts allow you to pause agent execution to get user input. With CopilotKit, you can:
+
+- Create interactive flows that require user decisions
+- Present custom UI elements during interrupts
+- Make your agent aware of interrupt interactions
+- Handle multiple types of interrupts
+
+#### Basic Interrupt Usage
+
+To use interrupts in your agent:
+
+```ts
+import { interrupt } from "@langchain/langgraph";
+
+async function chat_node(state: AgentState, config: RunnableConfig) {
+  if (!state.agentName) {
+    state.agentName = await interrupt(
+      "Before we start, what would you like to call me?"
+    );
+  }
+
+  // Continue with agent logic using the agentName
+  // ...
+}
+```
+
+#### Handling Interrupts in UI
+
+The [`useLangGraphInterrupt`](https://docs.copilotkit.ai/reference/hooks/useLangGraphInterrupt) hook renders UI components when an interrupt occurs:
+
+```tsx
+import { useLangGraphInterrupt } from "@copilotkit/react-core";
+
+function YourComponent() {
+  useLangGraphInterrupt({
+    render: ({ event, resolve }) => (
+      <div>
+        <p>{event.value}</p>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            resolve((e.target as HTMLFormElement).response.value);
+          }}
+        >
+          <input type="text" name="response" />
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    ),
+  });
+
+  // Rest of component
+}
+```
+
+#### Making Agents Aware of Interrupts
+
+By default, agents don't see interrupt interactions in their context. To include them:
+
+```ts
+import { copilotKitInterrupt } from "@copilotkit/sdk-js/langgraph";
+
+async function chat_node(state: AgentState, config: RunnableConfig) {
+  const { agentName, newMessages } = await copilotKitInterrupt(
+    "Before we start, what would you like to call me?"
+  );
+
+  state.messages = [...state.messages, ...newMessages];
+  state.agentName = agentName;
+
+  // Continue with agent logic
+}
+```
+
+#### Conditional Interrupts
+
+Handle multiple interrupt types with the `enabled` property:
+
+```ts
+// In your agent
+state.approval = await interrupt({
+  type: "approval",
+  content: "Please approve this action",
+});
+state.name = await interrupt({ type: "ask", content: "What's your name?" });
+
+// In your UI component
+useLangGraphInterrupt({
+  enabled: ({ eventValue }) => eventValue.type === "approval",
+  render: ({ event, resolve }) => (
+    <ApprovalComponent
+      onApprove={() => resolve(true)}
+      onReject={() => resolve(false)}
+    />
+  ),
+});
+
+useLangGraphInterrupt({
+  enabled: ({ eventValue }) => eventValue.type === "ask",
+  render: ({ event, resolve }) => (
+    <InputComponent
+      question={event.value.content}
+      onSubmit={(answer) => resolve(answer)}
+    />
+  ),
+});
+```
+
+#### Advanced Preprocessing
+
+Use the `handler` property to preprocess interrupts before rendering UI:
+
+```tsx
+useLangGraphInterrupt({
+  handler: async ({ event, resolve }) => {
+    // Process interrupt data
+    if (canAutoResolve(event.value)) {
+      resolve(computedResponse);
+      return;
+    }
+    return processedData;
+  },
+  render: ({ result, event, resolve }) => (
+    <CustomComponent data={result} onSubmit={(value) => resolve(value)} />
+  ),
+});
+```
+
+## Further Reading
+
+- [CopilotKit Documentation](https://docs.copilotkit.ai)
+- [Interrupt](https://docs.copilotkit.ai/coagents/human-in-the-loop/interrupt-flow)

--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -270,6 +270,7 @@ With LangGraph Platform you can integrate LangGraph agents into your React appli
 - [How to integrate LangGraph into your React application](../cloud/how-tos/use_stream_react.md)
 - [How to implement Generative User Interfaces with LangGraph](../cloud/how-tos/generative_ui_react.md)
 - [How to use LangGraph with CopilotKit in React](../cloud/how-tos/use_copilotkit_react.md)
+- [How to Build Interruptible Agent with LangGraph and Copilotkit](../cloud/how-tos/use_langgraph_interrupt.md)
 
 ### Human-in-the-loop {#human-in-the-loop-1}
 

--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -269,6 +269,7 @@ With LangGraph Platform you can integrate LangGraph agents into your React appli
 
 - [How to integrate LangGraph into your React application](../cloud/how-tos/use_stream_react.md)
 - [How to implement Generative User Interfaces with LangGraph](../cloud/how-tos/generative_ui_react.md)
+- [How to use LangGraph with CopilotKit in React](../cloud/how-tos/use_copilotkit_react.md)
 
 ### Human-in-the-loop {#human-in-the-loop-1}
 

--- a/docs/docs/how-tos/index.md
+++ b/docs/docs/how-tos/index.md
@@ -265,11 +265,11 @@ Streaming the results of your LLM application is vital for ensuring a good user 
 
 ### Frontend and Generative UI
 
-With LangGraph Platform you can integrate LangGraph agents into your React applications and colocate UI components with your agent code. 
+With LangGraph Platform you can integrate LangGraph agents into your React applications and colocate UI components with your agent code.
 
 - [How to integrate LangGraph into your React application](../cloud/how-tos/use_stream_react.md)
 - [How to implement Generative User Interfaces with LangGraph](../cloud/how-tos/generative_ui_react.md)
-- [How to use LangGraph with CopilotKit in React](../cloud/how-tos/use_copilotkit_react.md)
+- [How to integrate LangGraph with CopilotKit for deeper frontend integration](../cloud/how-tos/use_copilotkit_react.md)
 - [How to Build Interruptible Agent with LangGraph and Copilotkit](../cloud/how-tos/use_langgraph_interrupt.md)
 
 ### Human-in-the-loop {#human-in-the-loop-1}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -228,6 +228,7 @@ nav:
                 - cloud/how-tos/use_stream_react.md
                 - cloud/how-tos/generative_ui_react.md
                 - cloud/how-tos/use_copilotkit_react.md
+                - cloud/how-tos/use_langgraph_interrupt.md
             - Human-in-the-loop:
                 - cloud/how-tos/human_in_the_loop_breakpoint.md
                 - cloud/how-tos/human_in_the_loop_user_input.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -227,6 +227,7 @@ nav:
                 - cloud/how-tos/stream_multiple.md
                 - cloud/how-tos/use_stream_react.md
                 - cloud/how-tos/generative_ui_react.md
+                - cloud/how-tos/use_copilotkit_react.md
             - Human-in-the-loop:
                 - cloud/how-tos/human_in_the_loop_breakpoint.md
                 - cloud/how-tos/human_in_the_loop_user_input.md


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for integrating CopilotKit with LangGraph, focusing on frontend integration and interruptible agents. It includes two new guides and updates to the existing navigation structure.

## Changes

### Added
- New guide on building interruptible LangGraph agents with CopilotKit
- Detailed setup instructions for both cloud-based and self-hosted Copilot Runtime
- Examples of handling interrupts, shared state, and frontend actions
- References to relevant documentation in both LangGraph and CopilotKit


