### PR TITLE
Default to None in postgres checkpointer list method

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -99,7 +99,7 @@ class PostgresSaver(BasePostgresSaver):
 
     def list(
         self,
-        config: Optional[RunnableConfig],
+        config: Optional[RunnableConfig] = None,
         *,
         filter: Optional[dict[str, Any]] = None,
         before: Optional[RunnableConfig] = None,


### PR DESCRIPTION
Made the config parameter optional in the list method so that it is possible to list all checkpoints.