### PR TITLE
docs: Consolidate deployment options summary content

### DIFF
--- a/docs/docs/cloud/deployment/cloud.md
+++ b/docs/docs/cloud/deployment/cloud.md
@@ -1,4 +1,4 @@
-# How to Deploy to Cloud SaaS (Beta)
+# How to Deploy to Cloud SaaS
 
 Before deploying, review the [conceptual guide for the Cloud SaaS](../../concepts/langgraph_cloud.md) deployment option.
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -15,7 +15,7 @@ search:
 
 There are 4 main options for deploying with the LangGraph Platform:
 
-1. **<a href="#cloud-saas">Cloud SaaS<sup>(Beta)</sup></a>**: Available for **Plus** and **Enterprise** plans.
+1. **<a href="#cloud-saas">Cloud SaaS</a>**: Available for **Plus** and **Enterprise** plans.
 
 1. **<a href="#self-hosted-data-plane">Self-Hosted Data Plane<sup>(Beta)</sup></a>**: Available for the **Enterprise** plan.
 
@@ -23,9 +23,18 @@ There are 4 main options for deploying with the LangGraph Platform:
 
 1. **[Standalone Container](#standalone-container)**: Available for all plans.
 
-Please see the [LangGraph Platform Plans](./plans.md) for more information on the different plans.
+A quick comparison...
 
-The guide below will explain the differences between the deployment options.
+|                      | **Cloud SaaS** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)** | **Standalone Container** |
+|----------------------|----------------|----------------------------|-------------------------------|--------------------------|
+| **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
+| **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |
+| **Data/Compute Residency** | LangChain’s cloud | Your cloud | Your cloud | Your cloud |
+| **Required Permissions** | None | See details [here](). | See details [here](). | None |
+| **LangSmith Compatibility** | Trace to LangSmith SaaS | Trace to LangSmith SaaS | Trace to Self-Hosted LangSmith | Optional tracing |
+| **[Pricing](https://www.langchain.com/pricing-langgraph-platform)** | Plus | Enterprise | Enterprise | Developer |
+
+Please see the [LangGraph Platform Plans](./plans.md) for more information on the different plans. The guide below will explain the differences between the deployment options.
 
 ## Cloud SaaS
 

--- a/docs/docs/concepts/faq.md
+++ b/docs/docs/concepts/faq.md
@@ -45,15 +45,7 @@ LangGraph is a stateful, orchestration framework that brings added control to ag
 
 ## What are my deployment options for LangGraph Platform?
 
-We currently have the following deployment options for LangGraph applications:
-
-- **Cloud SaaS<sup>(Beta)**: A fully managed model for deployment where we manage the [control plane](./langgraph_control_plane.md) and [data plane](./langgraph_data_plane.md) in our cloud. This option provides a simple way to deploy and manage your LangGraph Servers. Available for **Plus** and **Enterprise** plans.
-
-- **Self-Hosted Data Plane<sup>(Beta)</sup>**: A "hybrid" model for deployemnt where we manage the [control plane](./langgraph_control_plane.md) in our cloud and you manage the [data plane](./langgraph_data_plane.md) in your cloud. This option provides a way to securely manage your data plane infrastructure, while offloading control plane management to us. Available for the **Enterprise** plan.
-
-- **Self-Hosted Control Plane<sup>(Beta)</sup>**: A fully self-hosted model for deployment where you manage the [control plane](./langgraph_control_plane.md) and [data plane](./langgraph_data_plane.md) in your cloud. This option give you full control and responsibility of the control plane and data plane infrastructure. Available for the **Enterprise** plan.
-
-- **Standalone Container**: The least restrictive model for deployment. Deploy standalone instances of a LangGraph Server in your cloud. Available for all plans.
+See the [deployment options guide](./deployment_options.md) for more details on each option.
 
 ## Is LangGraph Platform open source?
 

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -79,7 +79,7 @@ The LangGraph Platform comprises several components that work together to suppor
 
 ### Deployment Options
 
-- <a href="./langgraph_cloud/">Cloud SaaS<sup>(Beta)</sup></a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+- <a href="./langgraph_cloud/">Cloud SaaS</a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
 - <a href="./langgraph_self_hosted_data_plane/">Self-Hosted Data Plane<sup>(Beta)</sup></a>: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
 - <a href="./langgraph_self_hosted_control_plane/">Self-Hosted Control Plane<sup>(Beta)</sup></a>: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.

--- a/docs/docs/concepts/langgraph_cloud.md
+++ b/docs/docs/concepts/langgraph_cloud.md
@@ -3,7 +3,7 @@ search:
   boost: 2
 ---
 
-# Cloud SaaS (Beta)
+# Cloud SaaS
 
 To deploy a [LangGraph Server](../concepts/langgraph_server.md), follow the how-to guide for [how to deploy to Cloud SaaS](../cloud/deployment/cloud.md).
 

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -15,20 +15,11 @@ Get started deploying your LangGraph applications locally or on the cloud with
 - [Deploy with LangGraph Cloud Quickstart](../cloud/quick_start.md): Deploy a LangGraph app using LangGraph Cloud.
 
 
-## Deployment Options
+## More Deployment Options
 
-- <a href="../../concepts/langgraph_cloud/">Cloud SaaS<sup>(Beta)</sup></a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
+See the [deployment options guide](../concepts/deployment_options.md) for more details on each option.
+
+- <a href="../../concepts/langgraph_cloud/">Cloud SaaS</a>: Connect to your GitHub repositories and deploy LangGraph Servers to LangChain's cloud. We manage everything.
 - <a href="../../concepts/langgraph_self_hosted_data_plane/">Self-Hosted Data Plane<sup>(Beta)</sup></a>: Create deployments from the [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. We manage the [control plane](../concepts/langgraph_control_plane.md), you manage the deployments.
 - <a href="../../concepts/langgraph_self_hosted_control_plane/">Self-Hosted Control Plane<sup>(Beta)</sup></a>: Create deployments from a self-hosted [Control Plane UI](../concepts/langgraph_control_plane.md#control-plane-ui) and deploy LangGraph Servers to your cloud. You manage everything.
 - [Standalone Container](../concepts/langgraph_standalone_container.md): Deploy LangGraph Server Docker images however you like.
-
-A quick comparison...
-
-|                      | **Cloud SaaS** | **Self-Hosted [Data Plane](../concepts/langgraph_data_plane.md)** | **Self-Hosted [Control Plane](../concepts/langgraph_control_plane.md)** | **Standalone Container** |
-|----------------------|----------------|----------------------------|-------------------------------|--------------------------|
-| **[Control Plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
-| **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |
-| **Data/Compute Residency** | LangChain’s cloud | Your cloud | Your cloud | Your cloud |
-| **Required Permissions** | None | See details [here](). | See details [here](). | None |
-| **LangSmith Compatibility** | Trace to LangSmith SaaS | Trace to LangSmith SaaS | Trace to Self-Hosted LangSmith | Optional tracing |
-| **[Pricing](https://www.langchain.com/pricing-langgraph-platform)** | Plus | Enterprise | Enterprise | Developer |


### PR DESCRIPTION
### Summary
1. Move comparison table from `LangGraph` section to `LangGraph Platform` section. The level of detail in this table is more appropriate for the `LangGraph Platform section`.
1. Remove deployment options overview from FAQ. It's redundant. Instead, we'll like to the deployment options guide.
1. Remove `beta` label from Cloud SaaS deployment option.