### PR TITLE
docs: re-organize streaming concepts

### DIFF
--- a/docs/docs/cloud/concepts/streaming.md
+++ b/docs/docs/cloud/concepts/streaming.md
@@ -13,7 +13,7 @@ LangGraph Cloud supports five streaming modes:
 | **`updates`**        | Stream only the updates to the graph state after each node. [Guide](../how-tos/stream_updates.md)                                                              |
 | **`messages-tuple`** | Stream LLM tokens for any messages generated inside the graph (useful for chat apps). [Guide](../how-tos/stream_messages.md)                                   |
 | **`debug`**          | Stream debug information throughout graph execution. [Guide](../how-tos/stream_debug.md)                                                                       |
-| **`custom`**         | Stream custom data                                                                                                                                            |
+| **`custom`**         | Stream custom data                                                                                                                                             |
 | **`events`**         | Stream all events (including the state of the graph); mainly useful when migrating large LCEL apps. [Guide](../how-tos/stream_events.md)                       |
 
 ✅ You can also **combine multiple modes** at the same time.  See the [how-to guide](../how-tos/stream_multiple.md) for configuration details.

--- a/docs/docs/cloud/concepts/streaming.md
+++ b/docs/docs/cloud/concepts/streaming.md
@@ -1,0 +1,29 @@
+# Streaming
+
+Streaming is critical for making LLM applications feel responsive to end users.  
+When creating a streaming run, the **streaming mode** determines what kinds of data are streamed back to the API client.
+
+## Supported streaming modes
+
+LangGraph Cloud supports five streaming modes:
+
+| Mode                 | Description                                                                                                                                                    |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`values`**         | Stream the full graph state after each [super-step](https://langchain-ai.github.io/langgraph/concepts/low_level/#graphs). [Guide](../how-tos/stream_values.md) |
+| **`updates`**        | Stream only the updates to the graph state after each node. [Guide](../how-tos/stream_updates.md)                                                              |
+| **`messages-tuple`** | Stream LLM tokens for any messages generated inside the graph (useful for chat apps). [Guide](../how-tos/stream_messages.md)                                   |
+| **`debug`**          | Stream debug information throughout graph execution. [Guide](../how-tos/stream_debug.md)                                                                       |
+| **`custom`**         | Stream custom data                                                                                                                                            |
+| **`events`**         | Stream all events (including the state of the graph); mainly useful when migrating large LCEL apps. [Guide](../how-tos/stream_events.md)                       |
+
+✅ You can also **combine multiple modes** at the same time.  See the [how-to guide](../how-tos/stream_multiple.md) for configuration details.
+
+## Mapping to LangGraph library
+
+- The `values`, `updates`, `messages-tuple`, and `debug` modes map to `.stream()` / `.astream()` in the LangGraph Python library.
+- The `events` mode corresponds to using `.astream_events()` in the LangGraph library.
+
+## API Reference
+
+For API usage and implementation, refer to the [API reference](../reference/api/api_ref.html#tag/thread-runs/POST/threads/{thread_id}/runs/stream). 
+

--- a/docs/docs/concepts/streaming.md
+++ b/docs/docs/concepts/streaming.md
@@ -1,66 +1,31 @@
 ---
 search:
-  boost: 2
+boost: 2
 ---
 
 # Streaming
 
-Building a responsive app for end-users? Real-time updates are key to keeping users engaged as your app progresses.
+Building a responsive app for end users? Real-time updates are key to keeping users engaged as the application progresses.
 
-There are three main types of data you’ll want to stream:
+LangGraph’s streaming system lets you surface live feedback from graph runs to your app.  
+There are three main categories of data you can stream:
 
-1. Workflow progress (e.g., get state updates after each graph node is executed).
-2. LLM tokens as they’re generated.
-3. Custom updates (e.g., "Fetched 10/100 records").
+1. **Workflow progress** — get state updates after each graph node is executed.
+2. **LLM tokens** — stream language model tokens as they’re generated.
+3. **Custom updates** — emit user-defined signals (e.g., “Fetched 10/100 records”).
 
-## Streaming graph outputs (`.stream` and `.astream`)
-
-`.stream` and `.astream` are sync and async methods for streaming back outputs from a graph run.
-There are several different modes you can specify when calling these methods (e.g. `graph.stream(..., mode="...")):
-
-- [`"values"`](../how-tos/streaming.ipynb#values): This streams the full value of the state after each step of the graph.
-- [`"updates"`](../how-tos/streaming.ipynb#updates): This streams the updates to the state after each step of the graph. If multiple updates are made in the same step (e.g. multiple nodes are run) then those updates are streamed separately.
-- [`"custom"`](../how-tos/streaming.ipynb#custom): This streams custom data from inside your graph nodes.
-- [`"messages"`](../how-tos/streaming-tokens.ipynb): This streams LLM tokens and metadata for the graph node where LLM is invoked.
-- [`"debug"`](../how-tos/streaming.ipynb#debug): This streams as much information as possible throughout the execution of the graph.
-
-You can also specify multiple streaming modes at the same time by passing them as a list. When you do this, the streamed outputs will be tuples `(stream_mode, data)`. For example:
-
-```python
-graph.stream(..., stream_mode=["updates", "messages"])
-```
-
-```
-...
-('messages', (AIMessageChunk(content='Hi'), {'langgraph_step': 3, 'langgraph_node': 'agent', ...}))
-...
-('updates', {'agent': {'messages': [AIMessage(content="Hi, how can I help you?")]}})
-```
-
-The below visualization shows the difference between the `values` and `updates` modes:
-
-![values vs updates](../static/values_vs_updates.png)
+<figure markdown="1">
+![image](../../agents/assets/fast_parrot.png){: style="max-height:300px"}
+<figcaption>
+Waiting is for pigeons.
+</figcaption>
+</figure>
 
 
-## LangGraph Platform
+## What’s possible with LangGraph streaming
 
-Streaming is critical for making LLM applications feel responsive to end users. When creating a streaming run, the streaming mode determines what data is streamed back to the API client. LangGraph Platform supports five streaming modes:
-
-- `values`: Stream the full state of the graph after each [super-step](https://langchain-ai.github.io/langgraph/concepts/low_level/#graphs) is executed. See the [how-to guide](../cloud/how-tos/stream_values.md) for streaming values.
-- `messages-tuple`: Stream LLM tokens for any messages generated inside a node. This mode is primarily meant for powering chat applications. See the [how-to guide](../cloud/how-tos/stream_messages.md) for streaming messages.
-- `updates`: Streams updates to the state of the graph after each node is executed. See the [how-to guide](../cloud/how-tos/stream_updates.md) for streaming updates.
-- `debug`: Stream debug events throughout graph execution. See the [how-to guide](../cloud/how-tos/stream_debug.md) for streaming debug events.
-- `events`: Stream all events (including the state of the graph) that occur during graph execution. See the [how-to guide](../cloud/how-tos/stream_events.md) for streaming events. This mode is only useful for users migrating large LCEL applications to LangGraph. Generally, this mode is not necessary for most applications.
-
-You can also specify multiple streaming modes at the same time. See the [how-to guide](../cloud/how-tos/stream_multiple.md) for configuring multiple streaming modes at the same time.
-
-See the [API reference](../cloud/reference/api/api_ref.html#tag/threads-runs/POST/threads/{thread_id}/runs/stream) for how to create streaming runs.
-
-Streaming modes `values`, `updates`, `messages-tuple` and `debug` are very similar to modes available in the LangGraph library - for a deeper conceptual explanation of those, you can see the [previous section](#streaming-graph-outputs-stream-and-astream).
-
-Streaming mode `events` is the same as using `.astream_events` in the LangGraph library - for a deeper conceptual explanation of this, you can see the [previous section](#streaming-graph-outputs-stream-and-astream).
-
-All events emitted have two attributes:
-
-- `event`: This is the name of the event
-- `data`: This is data associated with the event
+- **Stream LLM tokens** — capture token streams from anywhere: inside nodes, subgraphs, or tools.
+- **Emit progress notifications from tools** — send custom updates or progress signals directly from tool functions.
+- **Stream from subgraphs** — include outputs from both the parent graph and any nested subgraphs.
+- **Use any LLM** — stream tokens from any LLM, even if it's not a LangChain model using the `custom` streaming mode.
+- **Use multiple streaming modes** — choose from `values` (full state), `updates` (state deltas), `messages` (LLM tokens + metadata), `custom` (arbitrary user data), or `debug` (detailed traces).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -261,14 +261,15 @@ nav:
         - cloud/how-tos/stateless_runs.md
         - cloud/how-tos/configurable_headers.md
       - Streaming:
-        - cloud/how-tos/stream_values.md
-        - cloud/how-tos/stream_updates.md
-        - cloud/how-tos/stream_messages.md
-        - cloud/how-tos/stream_events.md
-        - cloud/how-tos/stream_debug.md
-        - cloud/how-tos/stream_multiple.md
-        - cloud/how-tos/use_stream_react.md
-        - cloud/how-tos/generative_ui_react.md
+          - Overview: cloud/concepts/streaming.md
+          - cloud/how-tos/stream_values.md
+          - cloud/how-tos/stream_updates.md
+          - cloud/how-tos/stream_messages.md
+          - cloud/how-tos/stream_events.md
+          - cloud/how-tos/stream_debug.md
+          - cloud/how-tos/stream_multiple.md
+          - cloud/how-tos/use_stream_react.md
+          - cloud/how-tos/generative_ui_react.md
       - Human-in-the-loop:
         - cloud/how-tos/human_in_the_loop_breakpoint.md
         - cloud/how-tos/human_in_the_loop_user_input.md


### PR DESCRIPTION
* Split streaming concepts between OSS and langgraph platform
* LangGraph platform streaming requires more work