### PR TITLE
DOCS: Fix reference to Anthropic in how-to notebook (super-tiny)

### DIFF
--- a/docs/docs/how-tos/human_in_the_loop/time-travel.ipynb
+++ b/docs/docs/how-tos/human_in_the_loop/time-travel.ipynb
@@ -71,7 +71,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ANTHROPIC_API_KEY:  ········\n"
+      "OPENAI_API_KEY:  ········\n"
      ]
     }
    ],
@@ -108,7 +108,7 @@
    "source": [
     "## Build the agent\n",
     "\n",
-    "We can now build the agent. We will build a relatively simple ReAct-style agent that does tool calling. We will use Anthropic's models and fake tools (just for demo purposes)."
+    "We can now build the agent. We will build a relatively simple ReAct-style agent that does tool calling. We will use OpenAI's models and fake tools (just for demo purposes)."
    ]
   },
   {


### PR DESCRIPTION
## Description

One of the how-to's refers to using Anthropic models, but the tutorial actually uses OpenAI.