### PR TITLE
docs: Fixed incorrect tool in 'Write from tools' documentation

### DIFF
--- a/docs/docs/agents/memory.md
+++ b/docs/docs/agents/memory.md
@@ -282,7 +282,7 @@ def greet(
 
 agent = create_react_agent(
     model="anthropic:claude-3-7-sonnet-latest",
-    tools=[get_user_info, greet],
+    tools=[update_user_info, greet],
     # highlight-next-line
     state_schema=CustomState
 )


### PR DESCRIPTION
I was having trouble following this section of the docs and I realized it is because the incorrect tools is included in the tools list. `update_user_info` was defined earlier in the file but never used.