### PR TITLE
docs: add requests to code block in customer-support.ipynb

### DIFF
--- a/docs/docs/tutorials/customer-support/customer-support.ipynb
+++ b/docs/docs/tutorials/customer-support/customer-support.ipynb
@@ -185,6 +185,7 @@
    "outputs": [],
    "source": [
     "import re\n",
+    "import requests\n",
     "\n",
     "import numpy as np\n",
     "import openai\n",


### PR DESCRIPTION
Codeblock for Tools in customer-support tutorial is missing `import requests`: https://langchain-ai.github.io/langgraph/tutorials/customer-support/customer-support/#lookup-company-policies

Code block in question:
```python
import re

import numpy as np
import openai
from langchain_core.tools import tool

response = requests.get(
    "https://storage.googleapis.com/benchmarks-artifacts/travel-db/swiss_faq.md"
)
response.raise_for_status()
faq_text = response.text

docs = [{"page_content": txt} for txt in re.split(r"(?=\n##)", faq_text)]
```

Added import to codeblock.