### PR TITLE
docs: Remove self-hosted lite deployment option

### DIFF
--- a/docs/docs/concepts/auth.md
+++ b/docs/docs/concepts/auth.md
@@ -39,7 +39,7 @@ LangGraph Platform provides different security defaults:
 
 !!! note "Custom auth"
     Custom auth is supported for **Enterprise** self-hosted deployments.
-    Self-hosted lite deployments do not support custom auth natively.
+    Standalone Container deployments do not support custom auth natively.
 
 ## System Architecture
 

--- a/docs/docs/concepts/auth.md
+++ b/docs/docs/concepts/auth.md
@@ -39,7 +39,7 @@ LangGraph Platform provides different security defaults:
 
 !!! note "Custom auth"
     Custom auth is supported for **Enterprise** self-hosted deployments.
-    Standalone Container deployments do not support custom auth natively.
+    Standalone Container (Lite) deployments do not support custom auth natively.
 
 ## System Architecture
 

--- a/docs/docs/concepts/deployment_options.md
+++ b/docs/docs/concepts/deployment_options.md
@@ -18,14 +18,14 @@ There are 4 main options for deploying with the LangGraph Platform:
 
 A quick comparison:
 
-|                      | **Cloud SaaS** | **Self-Hosted Data Plane** | **Self-Hosted Control Plane** | **Standalone Container** | **Self-Hosted Lite** |
-|----------------------|----------------|----------------------------|-------------------------------|--------------------------| ---------------------|
-| **[Control plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No | No |
-| **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you | Managed externally by you |
-| **Data/compute residency** | LangChain’s cloud | Your cloud | Your cloud | Your cloud | Your cloud |
-| **LangSmith compatibility** | Trace to LangSmith SaaS | Trace to LangSmith SaaS | Trace to Self-Hosted LangSmith | Optional tracing | Optional tracing |
-| **[Server version compatibility](../concepts/langgraph_server.md#server-versions)** | Enterprise | Enterprise | Enterprise | Lite, Enterprise | Lite |
-| **[Pricing](https://www.langchain.com/pricing-langgraph-platform)** | Plus | Enterprise | Enterprise | Developer | Free with LangSmith |
+|                      | **Cloud SaaS** | **Self-Hosted Data Plane** | **Self-Hosted Control Plane** | **Standalone Container** |
+|----------------------|----------------|----------------------------|-------------------------------|--------------------------|
+| **[Control plane UI/API](../concepts/langgraph_control_plane.md)** | Yes | Yes | Yes | No |
+| **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you | Managed externally by you |
+| **Data/compute residency** | LangChain’s cloud | Your cloud | Your cloud | Your cloud |
+| **LangSmith compatibility** | Trace to LangSmith SaaS | Trace to LangSmith SaaS | Trace to Self-Hosted LangSmith | Optional tracing |
+| **[Server version compatibility](../concepts/langgraph_server.md#server-versions)** | Enterprise | Enterprise | Enterprise | Lite, Enterprise |
+| **[Pricing](https://www.langchain.com/pricing-langgraph-platform)** | Plus | Enterprise | Enterprise | Developer |
 
 ## Cloud SaaS
 

--- a/docs/docs/concepts/langgraph_standalone_container.md
+++ b/docs/docs/concepts/langgraph_standalone_container.md
@@ -30,3 +30,9 @@ The Standalone Container deployment option supports deploying data plane infrast
 ### Docker
 
 The Standalone Container deployment option supports deploying data plane infrastructure to any Docker-supported compute platform.
+
+## Lite vs Enterprise
+
+The Standalone Container deployment option supports the [server versions](../concepts/langgraph_server.md#langgraph-server): `Lite` and `Enterprise`.
+
+The `Lite` version is free, but has limited features. The `Enterprise` version has custom pricing and is fully featured. More details on feature differences are [here](../concepts/langgraph_server.md#server-versions).

--- a/docs/docs/concepts/langgraph_standalone_container.md
+++ b/docs/docs/concepts/langgraph_standalone_container.md
@@ -31,7 +31,7 @@ The Standalone Container deployment option supports deploying data plane infrast
 
 The Standalone Container deployment option supports deploying data plane infrastructure to any Docker-supported compute platform.
 
-## Lite vs Enterprise
+## Lite vs. Enterprise
 
 The Standalone Container deployment option supports the [server versions](../concepts/langgraph_server.md#langgraph-server): `Lite` and `Enterprise`.
 

--- a/docs/docs/concepts/langgraph_standalone_container.md
+++ b/docs/docs/concepts/langgraph_standalone_container.md
@@ -35,4 +35,5 @@ The Standalone Container deployment option supports deploying data plane infrast
 
 The Standalone Container deployment option supports the both [server versions](../concepts/langgraph_server.md#langgraph-server):
 
-The `Lite` version is free, but has limited features. The `Enterprise` version has custom pricing and is fully featured. More details on feature differences are [here](../concepts/langgraph_server.md#server-versions).
+- The `Lite` version is free, but has limited features.
+- The `Enterprise` version has custom pricing and is fully featured. For more details on feature difference, see [LangGraph Server](../concepts/langgraph_server.md#server-versions).

--- a/docs/docs/concepts/langgraph_standalone_container.md
+++ b/docs/docs/concepts/langgraph_standalone_container.md
@@ -33,6 +33,6 @@ The Standalone Container deployment option supports deploying data plane infrast
 
 ## Lite vs. Enterprise
 
-The Standalone Container deployment option supports the [server versions](../concepts/langgraph_server.md#langgraph-server): `Lite` and `Enterprise`.
+The Standalone Container deployment option supports the both [server versions](../concepts/langgraph_server.md#langgraph-server):
 
 The `Lite` version is free, but has limited features. The `Enterprise` version has custom pricing and is fully featured. More details on feature differences are [here](../concepts/langgraph_server.md#server-versions).

--- a/docs/docs/concepts/plans.md
+++ b/docs/docs/concepts/plans.md
@@ -10,7 +10,7 @@ search:
 LangGraph Platform is a commercial solution for deploying agentic applications in production.
 There are three different plans for using it.
 
-- **Developer**: All [LangSmith](https://smith.langchain.com/) users have access to this plan. You can sign up for this plan simply by creating a LangSmith account. This gives you access to the [Standalone Container](./deployment_options.md) deployment option.
+- **Developer**: All [LangSmith](https://smith.langchain.com/) users have access to this plan. You can sign up for this plan simply by creating a LangSmith account. This gives you access to the [Standalone Container (Lite)](./deployment_options.md) deployment option.
 - **Plus**: All [LangSmith](https://smith.langchain.com/) users with a [Plus account](https://docs.smith.langchain.com/administration/pricing) have access to this plan. You can sign up for this plan simply by upgrading your LangSmith account to the Plus plan type. This gives you access to the [Cloud](./deployment_options.md#cloud-saas) deployment option.
 - **Enterprise**: This is separate from LangSmith plans. You can sign up for this plan by contacting sales@langchain.dev. This gives you access to all [deployment options](./deployment_options.md).
 

--- a/docs/docs/concepts/plans.md
+++ b/docs/docs/concepts/plans.md
@@ -10,7 +10,7 @@ search:
 LangGraph Platform is a commercial solution for deploying agentic applications in production.
 There are three different plans for using it.
 
-- **Developer**: All [LangSmith](https://smith.langchain.com/) users have access to this plan. You can sign up for this plan simply by creating a LangSmith account. This gives you access to the [Self-Hosted Lite](./deployment_options.md) deployment option.
+- **Developer**: All [LangSmith](https://smith.langchain.com/) users have access to this plan. You can sign up for this plan simply by creating a LangSmith account. This gives you access to the [Standalone Container](./deployment_options.md) deployment option.
 - **Plus**: All [LangSmith](https://smith.langchain.com/) users with a [Plus account](https://docs.smith.langchain.com/administration/pricing) have access to this plan. You can sign up for this plan simply by upgrading your LangSmith account to the Plus plan type. This gives you access to the [Cloud](./deployment_options.md#cloud-saas) deployment option.
 - **Enterprise**: This is separate from LangSmith plans. You can sign up for this plan by contacting sales@langchain.dev. This gives you access to all [deployment options](./deployment_options.md).
 
@@ -19,7 +19,7 @@ There are three different plans for using it.
 
 |                                                                  | Developer                                   | Plus                                                  | Enterprise                                          |
 |------------------------------------------------------------------|---------------------------------------------|-------------------------------------------------------|-----------------------------------------------------|
-| Deployment Options                                               | Self-Hosted Lite                            | Cloud                                                 | Self-Hosted Enterprise, Cloud, Bring-Your-Own-Cloud |
+| Deployment Options                                               | Standalone Container (Lite)                          | Cloud SaaS                                         | <ul><li>Cloud SaaS</li><li>Self-Hosted Data Plane</li><li>Self-Hosted Control Plane</li><li>Standalone Container (Enterprise)</li></ul> |
 | Usage                                                            | Free, limited to 1M nodes executed per year | Free while in Beta, will be charged per node executed | Custom                                              |
 | APIs for retrieving and updating state and conversational history | ✅                                           | ✅                                                     | ✅                                                   |
 | APIs for retrieving and updating long-term memory                | ✅                                           | ✅                                                     | ✅                                                   |

--- a/docs/docs/troubleshooting/errors/INVALID_LICENSE.md
+++ b/docs/docs/troubleshooting/errors/INVALID_LICENSE.md
@@ -21,11 +21,11 @@ See the [local server](../../tutorials/langgraph-platform/local-server.md) docs 
 
 If you would like a fast managed environment, consider the [Cloud SaaS](../../concepts/langgraph_cloud.md) deployment option. This requires no additional license key.
 
-#### For Standalone container (Self-Hosted Lite)
+#### For Standalone Container (Lite)
 
-If your deployment is unlikely to see more than 1 million node executions per year and don't need Crons and other enterprise features, consider the [Self-Hosted Lite](../../concepts/deployment_options.md) deployment option.
+If your deployment is unlikely to see more than 1 million node executions per year and don't need Crons and other enterprise features, consider the [Standalone Container](../../concepts/deployment_options.md) deployment option.
 
-You can deploy with Self-Hosted Lite by setting a valid `LANGSMITH_API_KEY` in your environment (e.g., in the `.env` file referenced by `langgraph.json`) and building a Docker image. The API key must be associated with an account on a **Plus** plan or greater.
+You can deploy with Standalone Container by setting a valid `LANGSMITH_API_KEY` in your environment (e.g., in the `.env` file referenced by `langgraph.json`) and building a Docker image. The API key must be associated with an account on a **Plus** plan or greater.
 
 #### For Standalone Container (Enterprise)
 
@@ -38,7 +38,7 @@ For more information on deployment options and their features, see the [Deployme
 
 If you have confirmed that you would like to self-host LangGraph Platform, please verify your credentials.
 
-#### For Self-Hosted Lite
+#### For Standalone Container (Lite)
 
 1. Confirm that you have provided a working `LANGSMITH_API_KEY` environment variable in your deployment environment or `.env` file
 2. Confirm the provided API key is associated with an account on a **Plus** or **Enterprise** plan (or equivalent)

--- a/docs/docs/tutorials/deployment.md
+++ b/docs/docs/tutorials/deployment.md
@@ -8,7 +8,7 @@ search:
 There are two free options for deploying LangGraph applications via the LangGraph Server:
 
 - [Local](./langgraph-platform/local-server.md): Deploy for local testing and development. 
-- Self-Hosted Lite: A limited version of Standalone Container for deployments unlikely to see more that 1 million node executions per year and that do not need crons and other enterprise features. Self-Hosted Lite is free with a LangSmith API key.
+- Standalone Container (Lite): A limited version of Standalone Container for deployments unlikely to see more that 1 million node executions per year and that do not need crons and other enterprise features. Standalone Container (Lite) deployment option is free with a LangSmith API key.
 
 ## Other deployment options
 


### PR DESCRIPTION
### Summary
Self-Hosted Lite is a server version, not a deployment option.