### PR TITLE
docs: mcp adapters example for deployed graph

### DIFF
--- a/docs/docs/concepts/server-mcp.md
+++ b/docs/docs/concepts/server-mcp.md
@@ -162,7 +162,6 @@ Use an MCP-compliant client to connect to the LangGraph server. The following ex
 
 === "Python"
 
-    There is currently **no official MCP client for Python**, but you can use the [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters) package to access a remote graph and use the agents as if they were tools.
 
     Install the adapter with:
 

--- a/docs/docs/concepts/server-mcp.md
+++ b/docs/docs/concepts/server-mcp.md
@@ -162,7 +162,51 @@ Use an MCP-compliant client to connect to the LangGraph server. The following ex
 
 === "Python"
 
-    No official MCP client is available for Python yet.
+    There is currently **no official MCP client for Python**, but you can use the [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters) package to access a remote graph and use the agents as if they were tools.
+
+    Install the adapter with:
+
+    ```bash
+    pip install langchain-mcp-adapters
+    ```
+
+    Here is an example of how to connect to a remote MCP endpoint and use an agent as a tool:
+
+    ```python
+    # Create server parameters for stdio connection
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+    import asyncio
+
+    from langchain_mcp_adapters.tools import load_mcp_tools
+    from langgraph.prebuilt import create_react_agent
+
+    server_params = {
+        "url": "https://mcp-finance-agent.xxx.us.langgraph.app/mcp",
+        "headers": {
+            "X-Api-Key":"lsv2_pt_your_api_key"
+        }
+    }
+
+    async def main():
+        async with streamablehttp_client(**server_params) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                # Initialize the connection
+                await session.initialize()
+
+                # Load the remote graph as if it was a tool
+                tools = await load_mcp_tools(session)
+
+                # Create and run a react agent with the tools
+                agent = create_react_agent("openai:gpt-4.1", tools)
+
+                # Invoke the agent with a message
+                agent_response = await agent.ainvoke({"messages": "What can the finance agent do for me?"})
+                print(agent_response)
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    ```
 
 
 ## Session behavior  


### PR DESCRIPTION
Example to connect to the MCP server of a deployed graph in langgraph platform (langchain-mcp-adapters).
The graph can be used as a MCP tool.

![image](https://github.com/user-attachments/assets/fb5c36d4-0f04-4814-b0b7-bf7fcf6f8381)
