### PR TITLE
Improve how we match cached writes for async imperative tasks

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -2486,7 +2486,6 @@ class Pregel(PregelProtocol):
                         CONFIG_KEY_RUNNER_SUBMIT, weakref.WeakMethod(loop.submit)
                     ),
                     put_writes=weakref.WeakMethod(loop.put_writes),
-                    schedule_task=weakref.WeakMethod(loop.accept_push),
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
                 )
                 # enable subgraph streaming
@@ -2529,7 +2528,7 @@ class Pregel(PregelProtocol):
                         [t for t in loop.tasks.values() if not t.writes],
                         timeout=self.step_timeout,
                         get_waiter=get_waiter,
-                        match_cached_writes=loop.match_cached_writes,
+                        schedule_task=loop.accept_push,
                     ):
                         # emit output
                         yield from output()
@@ -2799,7 +2798,6 @@ class Pregel(PregelProtocol):
                         CONFIG_KEY_RUNNER_SUBMIT, weakref.WeakMethod(loop.submit)
                     ),
                     put_writes=weakref.WeakMethod(loop.put_writes),
-                    schedule_task=weakref.WeakMethod(loop.accept_push),
                     use_astream=do_stream,
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
                 )
@@ -2833,7 +2831,7 @@ class Pregel(PregelProtocol):
                         [t for t in loop.tasks.values() if not t.writes],
                         timeout=self.step_timeout,
                         get_waiter=get_waiter,
-                        match_cached_writes=loop.amatch_cached_writes,
+                        schedule_task=loop.aaccept_push,
                     ):
                         # emit output
                         for o in output():

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -1079,6 +1079,11 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
                 matched.append(task)
         return matched
 
+    def accept_push(self, task, write_idx, call=None):
+        if pushed := super().accept_push(task, write_idx, call):
+            self.match_cached_writes()
+        return pushed
+
     def put_writes(self, task_id: str, writes: WritesT) -> None:
         """Put writes for a task, to be read by the next tick."""
         super().put_writes(task_id, writes)
@@ -1267,6 +1272,13 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
                 task.writes.extend(values)
                 matched.append(task)
         return matched
+
+    async def aaccept_push(
+        self, task: PregelExecutableTask, write_idx: int, call: Optional[Call] = None
+    ) -> Optional[PregelExecutableTask]:
+        if pushed := super().accept_push(task, write_idx, call):
+            await self.amatch_cached_writes()
+        return pushed
 
     def put_writes(self, task_id: str, writes: WritesT) -> None:
         """Put writes for a task, to be read by the next tick."""

--- a/libs/langgraph/langgraph/pregel/loop.py
+++ b/libs/langgraph/langgraph/pregel/loop.py
@@ -1079,7 +1079,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
                 matched.append(task)
         return matched
 
-    def accept_push(self, task, write_idx, call=None):
+    def accept_push(
+        self, task: PregelExecutableTask, write_idx: int, call: Optional[Call] = None
+    ) -> Optional[PregelExecutableTask]:
         if pushed := super().accept_push(task, write_idx, call):
             self.match_cached_writes()
         return pushed

--- a/libs/langgraph/langgraph/pregel/runner.py
+++ b/libs/langgraph/langgraph/pregel/runner.py
@@ -539,7 +539,7 @@ def _call(
     # schedule PUSH tasks, collect futures
     scratchpad: PregelScratchpad = task().config[CONF][CONFIG_KEY_SCRATCHPAD]  # type: ignore[union-attr]
     # schedule the next task, if the callback returns one
-    if next_task := schedule_task(  # type: ignore[misc]
+    if next_task := schedule_task(
         task(),  # type: ignore[arg-type]
         scratchpad.call_counter(),
         Call(func, input, retry=retry, cache_policy=cache_policy, callbacks=callbacks),
@@ -677,7 +677,7 @@ async def _acall_impl(
         # schedule PUSH tasks, collect futures
         scratchpad: PregelScratchpad = task().config[CONF][CONFIG_KEY_SCRATCHPAD]  # type: ignore[union-attr]
         # schedule the next task, if the callback returns one
-        if next_task := await schedule_task(  # type: ignore[misc]
+        if next_task := await schedule_task(
             task(),  # type: ignore[arg-type]
             scratchpad.call_counter(),
             Call(

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -863,7 +863,9 @@ async def test_ainvoke():
     assert result == {"messages": [{"type": "human", "content": "world"}]}
 
 
-@pytest.mark.skip("Unskip this test to manually test the LangGraph Platform integration")
+@pytest.mark.skip(
+    "Unskip this test to manually test the LangGraph Platform integration"
+)
 @pytest.mark.anyio
 async def test_langgraph_cloud_integration():
     from langgraph_sdk.client import get_client, get_sync_client

--- a/libs/scheduler-kafka/langgraph/scheduler/kafka/executor.py
+++ b/libs/scheduler-kafka/langgraph/scheduler/kafka/executor.py
@@ -221,9 +221,10 @@ class AsyncKafkaExecutor(AbstractAsyncContextManager):
                 runner = PregelRunner(
                     submit=weakref.ref(submit),
                     put_writes=weakref.ref(put_writes),
-                    schedule_task=weakref.WeakMethod(self._schedule_task),
                 )
-                async for _ in runner.atick([task], reraise=False):
+                async for _ in runner.atick(
+                    [task], reraise=False, schedule_task=self._schedule_task
+                ):
                     pass
             else:
                 # task was not found
@@ -438,9 +439,10 @@ class KafkaExecutor(AbstractContextManager):
                 runner = PregelRunner(
                     submit=weakref.ref(submit),
                     put_writes=weakref.ref(put_writes),
-                    schedule_task=weakref.WeakMethod(self._schedule_task),
                 )
-                for _ in runner.tick([task], reraise=False):
+                for _ in runner.tick(
+                    [task], reraise=False, schedule_task=self._schedule_task
+                ):
                     pass
             else:
                 # task was not found


### PR DESCRIPTION
- remove match_cached_writes from PregelRunner args (now called by PregelLoop internally)
- this will be helpful when implementing distributed runner classes