### PR TITLE
Update sql-agent.ipynb

### DIFF
--- a/docs/docs/tutorials/sql-agent.ipynb
+++ b/docs/docs/tutorials/sql-agent.ipynb
@@ -583,7 +583,7 @@
     "def check_query(state: MessagesState):\n",
     "    system_message = {\n",
     "        \"role\": \"system\",\n",
-    "        \"content\": generate_query_system_prompt,\n",
+    "        \"content\": check_query_system_prompt,\n",
     "    }\n",
     "\n",
     "    # Generate an artificial user message to check\n",


### PR DESCRIPTION
On line 586, the check_query function should use check_query_system_prompt. Instead, small mistake it is using the generate_query_system_prompt prompt which is obviously incorrect.