### PR TITLE
Fix: Ensure route function returns "b" to enable a → b → a loop

### DIFF
--- a/docs/docs/how-tos/graph-api.ipynb
+++ b/docs/docs/how-tos/graph-api.ipynb
@@ -2215,7 +2215,7 @@
     "    if termination_condition(state):\n",
     "        return END\n",
     "    else:\n",
-    "        return \"a\"\n",
+    "        return \"b\"\n",
     "\n",
     "builder.add_edge(START, \"a\")\n",
     "builder.add_conditional_edges(\"a\", route)\n",


### PR DESCRIPTION
### Background

- The current graph structure is:

```
START → a
a --[route]--> a or END
b → a
```

- However, the route function only returns "a" or END, never "b". As a result, the flow can never reach node b, making it a "dead" or unreachable node.

### Analysis

- Every time the flow leaves a, route checks for termination. If not terminating, it returns "a", causing a loop on a. There is no logic that ever transitions to b.
- The edge b → a is only meaningful if the flow can actually reach b.

### Solution

- To enable an a → b → a loop, route should return "b" when not terminating, so the flow alternates between a and b.
- The corrected function:

```
def route(state: State) -> Literal["b", END]:
    if termination_condition(state):
        return END
    else:
        return "b"
```
### Summary

- This PR updates the route function to return "b" instead of "a" when not terminating.
- This allows the flow to correctly alternate between a and b (a → b → a ...) until the termination condition is met.
- Without this fix, node b is never executed and effectively dead code.