### PR TITLE
docs: fix example pregel reducer

### DIFF
--- a/docs/docs/concepts/pregel.md
+++ b/docs/docs/concepts/pregel.md
@@ -180,7 +180,7 @@ Below are a few different examples to give you a sense of the Pregel API.
 
     def reducer(current, update):
         if current:
-            return current + " | " + "update"
+            return current + " | " + update
         else:
             return update
 

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -412,7 +412,7 @@ class Pregel(PregelProtocol):
 
         def reducer(current, update):
             if current:
-                return current + " | " + "update"
+                return current + " | " + update
             else:
                 return update
 


### PR DESCRIPTION
Hi,
I have spotted a typo in the reducer examples of pregel graph, part "BinaryOperatorAggregate"

previous example code: 
```python
def reducer(current, update):
        if current:
            return current + " | " + "update"
        else:
            return update
```

corrected version
```python
def reducer(current, update):
        if current:
            return current + " | " + update
        else:
            return update
```