### PR TITLE
docs: typo in npx command to install LangGraph CLI

### DIFF
--- a/docs/docs/tutorials/langgraph-platform/local-server.md
+++ b/docs/docs/tutorials/langgraph-platform/local-server.md
@@ -21,7 +21,7 @@ Before you begin, ensure you have the following:
 === "Node server"
 
     ```shell
-    npx @langchain/langgraph-cl
+    npx @langchain/langgraph-cli
     ```
 
 ## 2. Create a LangGraph app 🌱


### PR DESCRIPTION
Docs have the wrong npx command to install LangGraph CLI:

`npx @langchain/langgraph-cl` instead of `npx @langchain/langgraph-cli`