### PR TITLE
Prebuild `rag agent`

### DIFF
--- a/docs/docs/tutorials/rag/langgraph_adaptive_rag.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_adaptive_rag.ipynb
@@ -912,7 +912,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/docs/tutorials/rag/langgraph_adaptive_rag_local.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_adaptive_rag_local.ipynb
@@ -908,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/docs/tutorials/rag/langgraph_agentic_rag.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_agentic_rag.ipynb
@@ -920,7 +920,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/docs/docs/tutorials/rag/langgraph_self_rag.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_self_rag.ipynb
@@ -778,7 +778,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/libs/prebuilt/langgraph/prebuilt/__init__.py
+++ b/libs/prebuilt/langgraph/prebuilt/__init__.py
@@ -1,6 +1,10 @@
 """langgraph.prebuilt exposes a higher-level API for creating and executing agents and tools."""
 
 from langgraph.prebuilt.chat_agent_executor import create_react_agent
+from langgraph.prebuilt.rag_agent_executor import (
+    create_rag_agent,
+    RagState,
+)
 from langgraph.prebuilt.tool_node import (
     InjectedState,
     InjectedStore,
@@ -11,6 +15,8 @@ from langgraph.prebuilt.tool_validator import ValidationNode
 
 __all__ = [
     "create_react_agent",
+    "create_rag_agent",
+    "RagState",
     "ToolNode",
     "tools_condition",
     "ValidationNode",

--- a/libs/prebuilt/langgraph/prebuilt/rag_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/rag_agent_executor.py
@@ -7,10 +7,10 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 from typing_extensions import TypedDict
 
-from langgraph.graph import END, StateGraph, CompiledGraph
+from langgraph.graph import END, StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.managed import IsLastStep, RemainingSteps
-from langgraph.store.base import Checkpointer
+from langgraph.checkpoint.base import BaseCheckpointSaver
 
 # Placeholder for VectorStoreRetriever if it's a custom or specific class
 # from langgraph.prebuilt import VectorStoreRetriever # Assuming this path, adjust if different
@@ -45,9 +45,9 @@ def create_rag_agent(
         "Use the retrieved documents to answer the question. "
         "If the documents are not relevant or insufficient, you can try to rephrase the question or search externally."
     ),
-    checkpointer: Optional[Checkpointer] = None,
+    checkpointer: Optional[BaseCheckpointSaver] = None,
     debug: bool = False,
-) -> CompiledGraph:
+) -> StateGraph:
     """Creates a RAG agent graph.
 
     Args:

--- a/libs/prebuilt/langgraph/prebuilt/rag_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/rag_agent_executor.py
@@ -1,0 +1,412 @@
+from typing import Any, Callable, Optional, Sequence, Union, Annotated
+
+from langchain_core.documents import Document
+from langchain_core.language_models import LanguageModelLike
+from langchain_core.messages import BaseMessage, AIMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from typing_extensions import TypedDict
+
+from langgraph.graph import END, StateGraph, CompiledGraph
+from langgraph.graph.message import add_messages
+from langgraph.managed import IsLastStep, RemainingSteps
+from langgraph.store.base import Checkpointer
+
+# Placeholder for VectorStoreRetriever if it's a custom or specific class
+# from langgraph.prebuilt import VectorStoreRetriever # Assuming this path, adjust if different
+# For now, assume vector_store.as_retriever() or retriever_tool is used, making this import flexible
+
+class RagState(TypedDict):
+    """The state of the RAG agent."""
+
+    messages: Annotated[Sequence[BaseMessage], add_messages]
+    question: str
+    original_question: str
+    documents: Optional[Sequence[Document]]
+    document_assessment: Optional[str]
+    generation: Optional[str]
+    iterations: int
+    current_phase_iterations: int
+    attempted_external_search: bool
+    is_last_step: IsLastStep
+    remaining_steps: RemainingSteps
+
+
+def create_rag_agent(
+    llm: LanguageModelLike,
+    embedding_model: Any,
+    vector_store: Any,
+    retriever_tool: Optional[BaseTool] = None,
+    external_search_tools: Optional[Sequence[BaseTool]] = None,
+    do_document_grading: bool = True,
+    do_external_search: bool = True,
+    system_message_prompt: Optional[str] = (
+        "You are a helpful RAG assistant. "
+        "Use the retrieved documents to answer the question. "
+        "If the documents are not relevant or insufficient, you can try to rephrase the question or search externally."
+    ),
+    checkpointer: Optional[Checkpointer] = None,
+    debug: bool = False,
+) -> CompiledGraph:
+    """Creates a RAG agent graph.
+
+    Args:
+        llm: The language model to use.
+        embedding_model: The embedding model to use (often implicitly used by vector_store or retriever_tool).
+        vector_store: The vector store for primary document retrieval.
+        retriever_tool: An optional pre-configured tool for document retrieval. If None, a retriever will be 
+                      created from vector_store.
+        external_search_tools: Optional list of tools for external search (e.g., web, ArXiv).
+        do_document_grading: If True, a step will be added to grade document relevance.
+        do_external_search: If True, external_search_tools will be used if initial retrieval is insufficient.
+        system_message_prompt: The system prompt to use for the LLM.
+        checkpointer: An optional checkpointer for persisting state.
+        debug: If True, enables debug logging for the graph.
+
+    Returns:
+        A compiled LangGraph runnable for the RAG agent.
+    """
+    MAX_QUERY_TRANSFORMATIONS = 2  # Max attempts to rephrase a query
+
+    _retriever: Union[BaseTool, Runnable]
+    if retriever_tool is not None:
+        _retriever = retriever_tool
+    elif hasattr(vector_store, 'as_retriever') and callable(vector_store.as_retriever):
+        # Standard LangChain vector stores have this method
+        _retriever = vector_store.as_retriever()
+    else:
+        # Fallback for simpler vector stores or direct use, assuming they are runnable/callable
+        # This part might need adjustment based on how `vector_store` is expected to be used if not a LangChain VS
+        # For now, assuming it's a LangChain VectorStore or compatible retriever
+        raise ValueError("vector_store must have an 'as_retriever' method if retriever_tool is not provided.")
+
+    # 1. Define Node Functions
+    def retrieve_documents_node(state: RagState) -> dict:
+        print("---RETRIEVING DOCUMENTS---")
+        question = state["question"]
+        if state.get("original_question") is None:
+            original_question = question
+        else:
+            original_question = state["original_question"]
+
+        try:
+            retrieved_docs = _retriever.invoke(question) # type: ignore
+        except Exception as e:
+            print(f"Error invoking retriever: {e}")
+            retrieved_docs = []
+
+        return {
+            "documents": retrieved_docs,
+            "original_question": original_question,
+            "iterations": state.get("iterations", 0) + 1,
+            "current_phase_iterations": 0,
+            "attempted_external_search": False,
+            "document_assessment": None,
+        }
+
+    def grade_retrieved_documents_node(state: RagState) -> dict:
+        print("---GRADING DOCUMENTS---")
+        question = state["question"]
+        documents = state["documents"]
+
+        if not documents:
+            print("No documents to grade.")
+            return {"document_assessment": "no_documents"}
+
+        formatted_docs = "\n\n".join([doc.page_content for doc in documents])
+        grading_prompt_template = (
+            "Given the following question and retrieved documents, assess if the documents are relevant to answer the question. "
+            "Respond with only 'relevant' or 'not_relevant'.\n\n"
+            "Question: {question}\n\n"
+            "Documents:\n{documents_text}\n\n"
+            "Assessment:"
+        )
+        grading_prompt = grading_prompt_template.format(
+            question=question, documents_text=formatted_docs
+        )
+
+        try:
+            response = llm.invoke(grading_prompt) # type: ignore
+            if hasattr(response, 'content'):
+                assessment = response.content.strip().lower()
+            elif isinstance(response, str):
+                assessment = response.strip().lower()
+            else:
+                print(f"Unexpected LLM response type for grading: {type(response)}")
+                assessment = "not_relevant"
+
+            if assessment not in ["relevant", "not_relevant"]:
+                print(f"LLM grader returned non-standard assessment: '{assessment}'. Defaulting to not_relevant.")
+                assessment = "not_relevant"
+
+        except Exception as e:
+            print(f"Error invoking LLM for grading: {e}")
+            assessment = "not_relevant"
+
+        print(f"Document assessment: {assessment}")
+        return {"document_assessment": assessment}
+
+    def generate_answer_node(state: RagState) -> dict:
+        print("---GENERATING ANSWER---")
+        question = state["question"]
+        documents = state["documents"]
+        document_assessment = state.get("document_assessment")
+
+        documents_text = ""
+        use_documents = False
+        if documents:
+            if not do_document_grading or document_assessment == "relevant":
+                documents_text = "\n\n".join([doc.page_content for doc in documents])
+                use_documents = True
+            elif document_assessment == "no_documents":
+                documents_text = "No documents were found during retrieval."
+            else:
+                documents_text = "The retrieved documents were not considered relevant to the question."
+        else:
+            documents_text = "No documents were retrieved."
+
+        prompt_parts = [system_message_prompt, f"User Question: {question}"]
+        if use_documents:
+            prompt_parts.append(f"Retrieved Documents:\n{documents_text}")
+            prompt_parts.append("Based on the question and the retrieved documents, provide a comprehensive answer.")
+        else:
+            prompt_parts.append(f"Context: {documents_text}")
+            prompt_parts.append("Please answer the question based on your general knowledge or indicate if you cannot answer without relevant documents.")
+        generation_prompt = "\n\n".join(prompt_parts)
+
+        try:
+            response = llm.invoke(generation_prompt) # type: ignore
+            if hasattr(response, 'content'):
+                generated_answer = response.content
+            elif isinstance(response, str):
+                generated_answer = response
+            else:
+                print(f"Unexpected LLM response type for generation: {type(response)}")
+                generated_answer = "Sorry, I encountered an error while generating the answer."
+        except Exception as e:
+            print(f"Error invoking LLM for generation: {e}")
+            generated_answer = "Sorry, I encountered an error and cannot provide an answer at this time."
+        print(f"Generated answer: {generated_answer[:100]}...")
+        new_messages = state.get("messages", []) + [AIMessage(content=generated_answer)]
+
+        return {
+            "generation": generated_answer,
+            "messages": new_messages
+        }
+
+    def transform_query_node(state: RagState) -> dict:
+        print("---TRANSFORMING QUERY---")
+        original_question = state["original_question"]
+        current_question = state["question"]
+        documents = state["documents"]
+        document_assessment = state.get("document_assessment")
+
+        transformation_context = f"The original question was: '{original_question}'."
+        transformation_context += f" The last attempted query was: '{current_question}'."
+
+        if not documents or document_assessment == "no_documents":
+            transformation_context += " No documents were found with the last query."
+        elif document_assessment == "not_relevant":
+            transformation_context += " The retrieved documents were not relevant to the question."
+
+        transformation_prompt_template = (
+            "You are an expert at rephrasing questions to improve information retrieval.\n"
+            "{context}\n\n"
+            "Based on the original question and the issues encountered, provide a new, rephrased question that might yield better search results. "
+            "Output ONLY the new question.\n\n"
+            "New Question:"
+        )
+        transformation_prompt = transformation_prompt_template.format(context=transformation_context)
+
+        try:
+            response = llm.invoke(transformation_prompt) # type: ignore
+            if hasattr(response, 'content'):
+                new_question = response.content.strip()
+            elif isinstance(response, str):
+                new_question = response.strip()
+            else:
+                print(f"Unexpected LLM response type for query transformation: {type(response)}")
+                new_question = original_question
+            
+            if not new_question or new_question.lower() == "new question:":
+                 print("Query transformation resulted in empty or boilerplate response. Using original question.")
+                 new_question = original_question
+
+        except Exception as e:
+            print(f"Error invoking LLM for query transformation: {e}")
+            new_question = original_question
+
+        print(f"Transformed query: {new_question}")
+        return {
+            "question": new_question,
+            "documents": None,
+            "document_assessment": None,
+            "generation": None,
+            "current_phase_iterations": state.get("current_phase_iterations", 0) + 1,
+        }
+
+    def perform_external_search_node(state: RagState) -> dict:
+        print("---PERFORMING EXTERNAL SEARCH---")
+        question = state["question"]
+        all_external_docs: list[Document] = []
+
+        if not external_search_tools:
+            return {"documents": [], "attempted_external_search": True}
+
+        for tool in external_search_tools:
+            try:
+                tool_name = tool.name if hasattr(tool, 'name') else 'UnnamedTool'
+                print(f"Invoking external search tool: {tool_name}")
+                tool_output = tool.invoke(question)
+                
+                if isinstance(tool_output, str):
+                    all_external_docs.append(Document(page_content=tool_output, metadata={"source": tool_name}))
+                elif isinstance(tool_output, Document):
+                    all_external_docs.append(tool_output)
+                elif isinstance(tool_output, list) and all(isinstance(doc, Document) for doc in tool_output):
+                    all_external_docs.extend(tool_output)
+                elif isinstance(tool_output, list) and all(isinstance(item, dict) and "page_content" in item for item in tool_output):
+                    for item_dict in tool_output:
+                        all_external_docs.append(Document(**item_dict))
+                else:
+                    print(f"Tool {tool_name} output not directly convertible to Document: {type(tool_output)}")
+
+            except Exception as e:
+                print(f"Error invoking external search tool {tool.name if hasattr(tool, 'name') else 'UnnamedTool'}: {e}")
+        
+        print(f"Found {len(all_external_docs)} documents from external search.")
+        return {
+            "documents": all_external_docs,
+            "attempted_external_search": True,
+            "document_assessment": None,
+            "current_phase_iterations": state.get("current_phase_iterations", 0),
+        }
+
+    workflow = StateGraph(RagState)
+    workflow.add_node("retrieve", retrieve_documents_node)
+    if do_document_grading:
+        workflow.add_node("grade_documents", grade_retrieved_documents_node)
+    workflow.add_node("generate", generate_answer_node)
+    workflow.add_node("transform_query", transform_query_node)
+    if do_external_search and external_search_tools:
+        workflow.add_node("external_search", perform_external_search_node)
+
+    def route_after_retrieval(state: RagState) -> str:
+        print(f"---ROUTING AFTER RETRIEVAL (iteration {state.get('iterations')}, phase iter {state.get('current_phase_iterations')})---")
+        documents = state.get("documents")
+        if documents:
+            print("Documents found by primary retriever.")
+            return "grade_documents" if do_document_grading else "generate"
+        else:
+            print("No documents found by primary retriever.")
+            if do_external_search and external_search_tools and not state.get("attempted_external_search"):
+                print("Attempting external search.")
+                return "external_search"
+            elif state.get("current_phase_iterations", 0) < MAX_QUERY_TRANSFORMATIONS:
+                print("Attempting to transform query.")
+                return "transform_query"
+            else:
+                print("Max transformations or no external search option. Ending.")
+                return END
+
+    def route_after_grading(state: RagState) -> str:
+        print(f"---ROUTING AFTER GRADING (assessment: {state.get('document_assessment')})---")
+        assessment = state.get("document_assessment")
+        if assessment == "relevant":
+            print("Documents relevant. Proceeding to generate.")
+            return "generate"
+        else:
+            print(f"Documents assessment: {assessment}. Fallback options.")
+            if do_external_search and external_search_tools and not state.get("attempted_external_search"):
+                print("Attempting external search due to poor grading.")
+                return "external_search"
+            elif state.get("current_phase_iterations", 0) < MAX_QUERY_TRANSFORMATIONS:
+                print("Attempting to transform query due to poor grading.")
+                return "transform_query"
+            else:
+                print("Max transformations or no external search after poor grading. Ending.")
+                return END
+
+    def route_after_generation(state: RagState) -> str:
+        print(f"---ROUTING AFTER GENERATION---")
+        generated_answer = state.get("generation", "").lower()
+        is_insufficient = (
+            len(generated_answer) < 20 or
+            any(phrase in generated_answer for phrase in ["don't know", "cannot answer", "not sure", "unable to find"])
+        )
+        if not is_insufficient:
+            print("Answer seems sufficient. Ending.")
+            return END
+        else:
+            print("Answer deemed insufficient.")
+            if do_external_search and external_search_tools and not state.get("attempted_external_search"):
+                print("Attempting external search due to insufficient answer.")
+                return "external_search"
+            elif state.get("current_phase_iterations", 0) < MAX_QUERY_TRANSFORMATIONS:
+                print("Attempting to transform query due to insufficient answer.")
+                return "transform_query"
+            else:
+                print("Max transformations or no external search after insufficient answer. Ending.")
+                return END
+
+    def route_after_transform_query(state: RagState) -> str:
+        print(f"---ROUTING AFTER TRANSFORM QUERY (new query: '{state.get('question')}')---")
+        return "retrieve"
+
+    def route_after_external_search(state: RagState) -> str:
+        print(f"---ROUTING AFTER EXTERNAL SEARCH---")
+        documents_from_external_search = state.get("documents")
+        if not documents_from_external_search:
+            print("External search yielded no documents.")
+            if state.get("current_phase_iterations", 0) < MAX_QUERY_TRANSFORMATIONS:
+                print("Attempting to transform query as external search failed.")
+                return "transform_query"
+            else:
+                print("Max transformations and external search also failed. Ending.")
+                return END
+        else:
+            print("Documents found from external search.")
+            return "grade_documents" if do_document_grading else "generate"
+
+    workflow.set_entry_point("retrieve")
+    workflow.add_conditional_edges("retrieve", route_after_retrieval,
+        {
+            "grade_documents": "grade_documents" if do_document_grading else "generate",
+            "generate": "generate",
+            "external_search": "external_search" if do_external_search and external_search_tools else "transform_query",
+            "transform_query": "transform_query",
+            END: END,
+        }
+    )
+
+    if do_document_grading:
+        workflow.add_conditional_edges("grade_documents", route_after_grading,
+            {
+                "generate": "generate",
+                "external_search": "external_search" if do_external_search and external_search_tools else "transform_query",
+                "transform_query": "transform_query",
+                END: END,
+            }
+        )
+    
+    workflow.add_conditional_edges("generate", route_after_generation,
+        {
+            "external_search": "external_search" if do_external_search and external_search_tools else "transform_query",
+            "transform_query": "transform_query",
+            END: END,
+        }
+    )
+
+    workflow.add_conditional_edges("transform_query", route_after_transform_query, {"retrieve": "retrieve"})
+
+    if do_external_search and external_search_tools:
+        workflow.add_conditional_edges("external_search", route_after_external_search,
+            {
+                "grade_documents": "grade_documents" if do_document_grading else "generate",
+                "generate": "generate",
+                "transform_query": "transform_query",
+                END: END,
+            }
+        )
+
+    return workflow.compile(checkpointer=checkpointer, debug=debug)

--- a/libs/prebuilt/tests/conftest.py
+++ b/libs/prebuilt/tests/conftest.py
@@ -4,7 +4,6 @@ from uuid import UUID
 import pytest
 from langchain_core import __version__ as core_version
 from packaging import version
-from pytest_mock import MockerFixture
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.store.base import BaseStore
@@ -43,7 +42,7 @@ def anyio_backend():
 
 
 @pytest.fixture()
-def deterministic_uuids(mocker: MockerFixture) -> MockerFixture:
+def deterministic_uuids(mocker: "MockerFixture") -> "MockerFixture":
     side_effect = (
         UUID(f"00000000-0000-4000-8000-{i:012}", version=4) for i in range(10000)
     )

--- a/libs/prebuilt/tests/conftest_store.py
+++ b/libs/prebuilt/tests/conftest_store.py
@@ -3,10 +3,22 @@ from contextlib import asynccontextmanager, contextmanager
 from uuid import uuid4
 
 import pytest
-from psycopg import AsyncConnection, Connection
+
+# Initialize PSYCOPG_AVAILABLE and related names
+PSYCOPG_AVAILABLE = False
+AsyncConnection = None
+Connection = None
+PostgresStore = None
+AsyncPostgresStore = None
+
+try:
+    from psycopg import AsyncConnection, Connection
+    from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
+    PSYCOPG_AVAILABLE = True
+except ImportError:
+    pass # psycopg or langgraph.store.postgres not available
 
 from langgraph.store.memory import InMemoryStore
-from langgraph.store.postgres import AsyncPostgresStore, PostgresStore
 
 DEFAULT_POSTGRES_URI = "postgres://postgres:postgres@localhost:5442/"
 
@@ -19,6 +31,8 @@ def _store_memory():
 
 @contextmanager
 def _store_postgres():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     database = f"test_{uuid4().hex[:16]}"
     # create unique db
     with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
@@ -36,6 +50,8 @@ def _store_postgres():
 
 @contextmanager
 def _store_postgres_pipe():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     database = f"test_{uuid4().hex[:16]}"
     # create unique db
     with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
@@ -56,6 +72,8 @@ def _store_postgres_pipe():
 
 @contextmanager
 def _store_postgres_pool():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     database = f"test_{uuid4().hex[:16]}"
     # create unique db
     with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
@@ -75,6 +93,8 @@ def _store_postgres_pool():
 
 @asynccontextmanager
 async def _store_postgres_aio():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     if sys.version_info < (3, 10):
         pytest.skip("Async Postgres tests require Python 3.10+")
     database = f"test_{uuid4().hex[:16]}"
@@ -97,6 +117,8 @@ async def _store_postgres_aio():
 
 @asynccontextmanager
 async def _store_postgres_aio_pipe():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     if sys.version_info < (3, 10):
         pytest.skip("Async Postgres tests require Python 3.10+")
     database = f"test_{uuid4().hex[:16]}"
@@ -122,6 +144,8 @@ async def _store_postgres_aio_pipe():
 
 @asynccontextmanager
 async def _store_postgres_aio_pool():
+    if not PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg or langgraph.store.postgres not available")
     if sys.version_info < (3, 10):
         pytest.skip("Async Postgres tests require Python 3.10+")
     database = f"test_{uuid4().hex[:16]}"

--- a/libs/prebuilt/tests/test_rag_agent.py
+++ b/libs/prebuilt/tests/test_rag_agent.py
@@ -11,7 +11,6 @@ from langchain_core.runnables import RunnableConfig
 
 from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointMetadata, CheckpointTuple, JsonPlusSerializer, ChannelVersions
 from langgraph.prebuilt import create_rag_agent, RagState
-from tests.messages import _AnyIdHumanMessage, _AnyIdAIMessage
 
 
 pytestmark = pytest.mark.anyio

--- a/libs/prebuilt/tests/test_rag_agent.py
+++ b/libs/prebuilt/tests/test_rag_agent.py
@@ -1,0 +1,259 @@
+import asyncio
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.language_models.fake_chat_models import FakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, BaseMessage, SystemMessage
+from langchain_core.tools import tool as dec_tool, BaseTool
+from pydantic import BaseModel
+from langchain_core.runnables import RunnableConfig
+
+from langgraph.checkpoint.base import BaseCheckpointSaver, Checkpoint, CheckpointMetadata, CheckpointTuple, JsonPlusSerializer, ChannelVersions
+from langgraph.prebuilt import create_rag_agent, RagState
+from tests.messages import _AnyIdHumanMessage, _AnyIdAIMessage
+
+
+pytestmark = pytest.mark.anyio
+
+
+class MockInMemoryCheckpointSaver(BaseCheckpointSaver):
+    """Minimal in-memory checkpoint saver for testing purposes."""
+
+    def __init__(self, *, serde: Optional[JsonPlusSerializer] = None):
+        super().__init__(serde=serde)
+        self.checkpoints: Dict[str, CheckpointTuple] = {}
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        thread_id = config["configurable"]["thread_id"]
+        return self.checkpoints.get(thread_id)
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        return self.get_tuple(config)
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        thread_id = config["configurable"]["thread_id"]
+        self.checkpoints[thread_id] = CheckpointTuple(
+            config=config,
+            checkpoint=checkpoint,
+            metadata=metadata,
+            parent_config=None # Not strictly needed for these tests
+        )
+        return config
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return self.put(config, checkpoint, metadata, new_versions)
+
+
+class FakeRAGModel(FakeChatModel):
+    """Fake ChatModel for RAG agent tests."""
+
+    def invoke(
+        self, input: Union[str, List[BaseMessage]], config: Optional[dict] = None, **kwargs: Any
+    ) -> Union[str, BaseMessage]:
+        prompt_str = "".join(msg.content for msg in input) if isinstance(input, list) else input
+
+        if "Assess if the documents are relevant" in prompt_str:
+            # Simulate grading
+            if "bad_query" in prompt_str.lower() or "no_docs_query" in prompt_str.lower():
+                return AIMessage(content="not_relevant")
+            return AIMessage(content="relevant")
+        elif "rephrasing questions" in prompt_str:
+            # Simulate query transformation
+            if "original_query_transformed_once" in prompt_str:
+                 return AIMessage(content="original_query_transformed_twice")
+            return AIMessage(content="original_query_transformed_once")
+        elif "User Question:" in prompt_str:
+            # Simulate generation
+            if "no_docs_for_generation" in prompt_str:
+                 return AIMessage(content="Sorry, I found no documents to answer that.")
+            if "original_query_transformed_once" in prompt_str:
+                 return AIMessage(content="Answer based on transformed_once query.")
+            return AIMessage(content="Generated answer based on relevant documents.")
+        return AIMessage(content="Default LLM response.")
+
+    async def ainvoke(
+        self, input: Union[str, List[BaseMessage]], config: Optional[dict] = None, **kwargs: Any
+    ) -> Union[str, BaseMessage]:
+        return self.invoke(input, config, **kwargs)
+
+
+@dec_tool
+def mock_retriever_tool(query: str) -> List[Document]:
+    """Simulates retrieving documents."""
+    if query == "original_query":
+        return [
+            Document(page_content="Content of doc1 from original_query"),
+            Document(page_content="Content of doc2 from original_query"),
+        ]
+    elif query == "original_query_transformed_once":
+        return [
+            Document(page_content="Content of docA from transformed_once"),
+        ]
+    elif query == "bad_query": # for testing not_relevant grading
+        return [Document(page_content="Irrelevant content for bad_query")]
+    elif query == "no_docs_query": # for testing no documents found pathway
+        return []
+    return []
+
+@dec_tool
+def mock_external_search_tool(query: str) -> List[Document]:
+    """Simulates external search."""
+    if "external_search_needed_query" in query:
+        return [Document(page_content="Document from external search.")]
+    return []
+
+
+# --- Test Cases --- 
+
+def test_rag_agent_basic_retrieval_grading_generation(): 
+    llm = FakeRAGModel()
+    # For this test, vector_store and embedding_model are not directly used 
+    # because retriever_tool is provided.
+    mock_checkpointer = MockInMemoryCheckpointSaver()
+    agent = create_rag_agent(
+        llm=llm,
+        embedding_model=None, # Not used if retriever_tool is present
+        vector_store=None, # Not used if retriever_tool is present
+        retriever_tool=mock_retriever_tool,
+        do_document_grading=True,
+        do_external_search=False,
+        checkpointer=mock_checkpointer, 
+    )
+
+    inputs = [HumanMessage(content="original_query")]
+    thread = {"configurable": {"thread_id": "rag_test_1"}}
+
+    response = agent.invoke({"messages": inputs}, thread)
+
+    assert len(response["messages"]) == 2
+    assert isinstance(response["messages"][0], HumanMessage)
+    assert response["messages"][0].content == "original_query"
+    assert isinstance(response["messages"][1], AIMessage)
+    assert response["messages"][1].content == "Generated answer based on relevant documents."
+
+    # Check RagState in checkpoint
+    saved_state_tuple = mock_checkpointer.get_tuple(thread) 
+    assert saved_state_tuple is not None
+    checkpoint_rag_state: RagState = saved_state_tuple.checkpoint["channel_values"]
+    
+    assert checkpoint_rag_state["question"] == "original_query"
+    assert checkpoint_rag_state["original_question"] == "original_query"
+    assert checkpoint_rag_state["document_assessment"] == "relevant"
+    assert len(checkpoint_rag_state["documents"]) == 2
+    assert checkpoint_rag_state["documents"][0].page_content == "Content of doc1 from original_query"
+    assert checkpoint_rag_state["generation"] == "Generated answer based on relevant documents."
+    assert checkpoint_rag_state["iterations"] > 0
+
+async def test_rag_agent_basic_retrieval_no_grading_generation(async_checkpointer: BaseCheckpointSaver):
+    """
+    Tests the RAG agent flow when document grading is disabled.
+    1. Input a query ("original_query").
+    2. mock_retriever_tool returns relevant documents.
+    3. Grading node is skipped.
+    4. FakeRAGModel generates an answer based on the retrieved documents.
+    5. Verifies the final messages and that document_assessment in RagState is None.
+    """
+    llm = FakeRAGModel()
+    agent = create_rag_agent(
+        llm=llm,
+        embedding_model=None, 
+        vector_store=None, 
+        retriever_tool=mock_retriever_tool,
+        do_document_grading=False, # Grading disabled
+        do_external_search=False,
+        checkpointer=async_checkpointer,
+    )
+
+    inputs = [HumanMessage(content="original_query")]
+    thread = {"configurable": {"thread_id": "rag_test_no_grading_1"}}
+
+    response = await agent.ainvoke({"messages": inputs}, thread)
+
+    assert len(response["messages"]) == 2
+    assert isinstance(response["messages"][1], AIMessage)
+    assert response["messages"][1].content == "Generated answer based on relevant documents."
+
+    saved_state = await async_checkpointer.aget_tuple(thread)
+    assert saved_state is not None
+    checkpoint_rag_state: RagState = saved_state.checkpoint["channel_values"]
+    
+    assert checkpoint_rag_state["question"] == "original_query"
+    assert checkpoint_rag_state["document_assessment"] is None # Grading was skipped
+    assert len(checkpoint_rag_state["documents"]) == 2
+    assert checkpoint_rag_state["generation"] == "Generated answer based on relevant documents."
+
+
+def test_rag_agent_not_relevant_grading_then_transform(sync_checkpointer: BaseCheckpointSaver):
+    """
+    Tests the RAG agent flow where:
+    1. Initial retrieval provides documents.
+    2. These documents are graded as "not_relevant".
+    3. External search is DISABLED for this test, forcing query transformation.
+    4. The query is transformed by the LLM.
+    5. The new (transformed) query is used for a second retrieval attempt.
+    6. Documents from the second retrieval are graded as "relevant".
+    7. An answer is generated based on the documents from the second retrieval.
+    Verifies the final answer and key RagState fields like the transformed question.
+    """
+    llm = FakeRAGModel()
+    agent = create_rag_agent(
+        llm=llm,
+        embedding_model=None, 
+        vector_store=None, 
+        retriever_tool=mock_retriever_tool,
+        do_document_grading=True,
+        do_external_search=False,  # External search disabled to force transformation path
+        external_search_tools=None, # Explicitly none
+        checkpointer=sync_checkpointer,
+    )
+
+    # This query will lead to "not_relevant" grading by FakeRAGModel
+    inputs = [HumanMessage(content="bad_query")] 
+    thread = {"configurable": {"thread_id": "rag_test_not_relevant_transform_1"}}
+
+    response = agent.invoke({"messages": inputs}, thread)
+
+    # Expected final answer is based on the transformed query
+    assert len(response["messages"]) == 2
+    assert isinstance(response["messages"][0], HumanMessage)
+    assert response["messages"][0].content == "bad_query"
+    assert isinstance(response["messages"][1], AIMessage)
+    # FakeRAGModel is set to return "Answer based on transformed_once query." after transformation of "bad_query"
+    assert response["messages"][1].content == "Answer based on transformed_once query."
+
+    saved_state = sync_checkpointer.get_tuple(thread)
+    assert saved_state is not None
+    checkpoint_rag_state: RagState = saved_state.checkpoint["channel_values"]
+
+    assert checkpoint_rag_state["original_question"] == "bad_query"
+    # FakeRAGModel transforms "bad_query" to "original_query_transformed_once"
+    assert checkpoint_rag_state["question"] == "original_query_transformed_once" 
+    # The final successful grading after transformation should be "relevant"
+    assert checkpoint_rag_state["document_assessment"] == "relevant" 
+    # Documents should be from the successful retrieval using "original_query_transformed_once"
+    assert len(checkpoint_rag_state["documents"]) == 1 
+    assert checkpoint_rag_state["documents"][0].page_content == "Content of docA from transformed_once"
+    assert checkpoint_rag_state["generation"] == "Answer based on transformed_once query."
+    # Iterations should reflect multiple steps (initial retrieve, grade, transform, retrieve, grade, generate)
+    assert checkpoint_rag_state["iterations"] > 1 
+    # current_phase_iterations should show at least one transformation attempt
+    # (it's reset on successful retrieval, so this checks the state *during* transformation phase if it were to be captured then,
+    # or the count on the transform_query node's output. Here we check after the full run)
+    # The exact value depends on where current_phase_iterations is incremented and reset.
+    # The transform_query_node increments it. retrieve_documents_node resets it.
+    # So, if we end after generation, current_phase_iterations might be 0 (reset by the last retrieve_documents_node).
+    # Let's verify that the *question was indeed transformed* which implies the path was taken.
+    # The 'iterations' count being >1 is also a good indicator of multiple main loop cycles.


### PR DESCRIPTION
Update:
- Add a prebuilt `RAG agent` as the `create_rag_agent` function.

REASON:
- `CrewAI` uses the **default** RAG component a lot, in many workflows. I like it. It speeds up the experimentations, decreases the cognitive load. It is the same as the `ReAct agent`.

CONS:
- Compared with `ReAct agent`, the `RAG agent` has a heavyweight component, a vector store, which requires a separate initialization.

Discussion:
@eyurtsev  Eugene, I did this PR only as a discussion. If you want to move with it, let me know, and I will  proceed with these next steps:
- add a notebook with examples;
- ? What else?