### PR TITLE
prebuilt: support provider builtin tools in `create_react_agent`

### DIFF
--- a/docs/docs/agents/tools.md
+++ b/docs/docs/agents/tools.md
@@ -280,7 +280,21 @@ LangGraph allows access to short-term and long-term memory from tools. See [Memo
 
 ## Prebuilt tools
 
-LangChain supports a wide range of prebuilt tool integrations for interacting with APIs, databases, file systems, web data, and more. These tools extend the functionality of agents and enable rapid development.
+You can use prebuilt tools from model providers by passing a dictionary with tool specs to the `tools` parameter of `create_react_agent`. For example, to use the `web_search_preview` tool from OpenAI:
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(
+    model="openai:gpt-4o-mini", 
+    tools=[{"type": "web_search_preview"}]
+)
+response = agent.invoke(
+    {"messages": ["What was a positive news story from today?"]}
+)
+```
+
+Additionally, LangChain supports a wide range of prebuilt tool integrations for interacting with APIs, databases, file systems, web data, and more. These tools extend the functionality of agents and enable rapid development.
 
 You can browse the full list of available integrations in the [LangChain integrations directory](https://python.langchain.com/docs/integrations/tools/).
 

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -444,11 +444,12 @@ def create_react_agent(
 
     tool_calling_enabled = len(tool_classes) > 0
 
-    if _should_bind_tools(model, tool_classes) and len(tool_classes) > 0:
-        model = cast(BaseChatModel, model).bind_tools(tool_classes)
-
-    if len(llm_builtin_tools) > 0:
-        model = cast(BaseChatModel, model).bind_tools(llm_builtin_tools)
+    if (
+        _should_bind_tools(model, tool_classes)
+        and len(tool_classes) > 0
+        or (len(llm_builtin_tools) > 0)
+    ):
+        model = cast(BaseChatModel, model).bind_tools(tool_classes + llm_builtin_tools)  # type: ignore[operator]
 
     model_runnable = _get_prompt_runnable(prompt) | model
 

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -140,7 +140,7 @@ def _get_prompt_runnable(prompt: Optional[Prompt]) -> Runnable:
     return prompt_runnable
 
 
-def _should_bind_tools(model: LanguageModelLike, tools: Sequence[Union[BaseTool, dict[str, Any]]]) -> bool:
+def _should_bind_tools(model: LanguageModelLike, tools: Sequence[BaseTool]) -> bool:
     if isinstance(model, RunnableSequence):
         model = next(
             (
@@ -443,10 +443,12 @@ def create_react_agent(
         model = cast(BaseChatModel, init_chat_model(model))
 
     tool_calling_enabled = len(tool_classes) > 0
-    builtin_tool_calling_enabled = len(llm_builtin_tools) > 0
 
-    if (_should_bind_tools(model, tool_classes) and tool_calling_enabled) or builtin_tool_calling_enabled:
-        model = cast(BaseChatModel, model).bind_tools(tool_classes + llm_builtin_tools)
+    if _should_bind_tools(model, tool_classes) and len(tool_classes) > 0:
+        model = cast(BaseChatModel, model).bind_tools(tool_classes)
+
+    if len(llm_builtin_tools) > 0:
+        model = cast(BaseChatModel, model).bind_tools(llm_builtin_tools)
 
     model_runnable = _get_prompt_runnable(prompt) | model
 


### PR DESCRIPTION
Patch to support llm provider hosted tools (server tools) in `create_react_agent`, like:

```py
from langgraph.prebuilt import create_react_agent

def add(a: int, b: int):
    """Add two numbers"""
    return a + b

# OpenAI
web_search = {
    "type": "web_search_preview"
}
agent = create_react_agent(
    model="openai:gpt-4.1",
    tools=[add, web_search]
)
search_result = agent.invoke({
    "messages": [{"role": "user", "content": "what's the weather in nyc today?"}]
})
math_result = agent.invoke({
    "messages": [{"role": "user", "content": "what's 42 + 7?"}]
})

# Anthropic
web_search = {
    "type": "web_search_20250305",
    "name": "web_search",
    "max_uses": 3
}
agent = create_react_agent(
    model="anthropic:claude-3-5-sonnet-latest",
    tools=[add, web_search]
)
search_result = agent.invoke({
    "messages": [{"role": "user", "content": "what's the weather in nyc today?"}]
})
math_result = agent.invoke({
    "messages": [{"role": "user", "content": "what's 42 + 7?"}]
})
```

Thanks @vbarda for getting this started (via https://github.com/langchain-ai/langgraph/pull/4728)! I think we'll probably want to add more typed support for this in `create_agent` or whatever may come next.