### PR TITLE
Added homepage metadata to [project] section for better package info

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,6 +7,7 @@ name = "langgraph-docs"
 version = "0.0.1"
 description = "LangGraph docs"
 authors = []
+homepage = "https://github.com/langchain-ai/langgraph"
 requires-python = "~=3.10"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
### Summary

This pull request updates the package metadata to include the `homepage` field in `pyproject.toml`.

### Changes
- Added `homepage` pointing to the project’s GitHub repository

### Motivation
Adding this metadata improves:
- Package discoverability
- Transparency and metadata completeness
- Compatibility with tools like PyPI and dependency scanners

This is a standard best practice, especially for public or shared internal packages.

### Notes
If there's a preferred homepage URL, feel free to suggest a change.
