### PR TITLE
(docs) fix broken link to Anthropic's API Keys page

### DIFF
--- a/docs/docs/agents/agents.md
+++ b/docs/docs/agents/agents.md
@@ -15,7 +15,7 @@ This guide shows you how to set up and use LangGraph's **prebuilt**, **reusable*
 
 Before you start this tutorial, ensure you have the following:
 
-- An [Anthropic](https://console.anthropic.com/settings/admin-keys) API key 
+- An [Anthropic](https://console.anthropic.com/settings/keys) API key 
 
 ## 1. Install dependencies
 


### PR DESCRIPTION
The link to Anthropic's API keys page is broken in [LangGraph quickstart](https://langchain-ai.github.io/langgraph/agents/agents/).

This PR fixes it.