### PR TITLE
feat: support custom tracer when creating run in ts sdk

### DIFF
--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -979,6 +979,7 @@ export class RunsClient<
       after_seconds: payload?.afterSeconds,
       if_not_exists: payload?.ifNotExists,
       checkpoint_during: payload?.checkpointDuring,
+      langsmith_tracer: payload?._langsmithTracer,
     };
 
     const [run, response] = await this.fetch<Run>(`/threads/${threadId}/runs`, {
@@ -1059,6 +1060,7 @@ export class RunsClient<
       after_seconds: payload?.afterSeconds,
       if_not_exists: payload?.ifNotExists,
       checkpoint_during: payload?.checkpointDuring,
+      langsmith_tracer: payload?._langsmithTracer,
     };
     const endpoint =
       threadId == null ? `/runs/wait` : `/threads/${threadId}/runs/wait`;

--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -1060,7 +1060,12 @@ export class RunsClient<
       after_seconds: payload?.afterSeconds,
       if_not_exists: payload?.ifNotExists,
       checkpoint_during: payload?.checkpointDuring,
-      langsmith_tracer: payload?._langsmithTracer,
+      langsmith_tracer: payload?._langsmithTracer
+        ? {
+            project_name: payload?._langsmithTracer?.projectName,
+            example_id: payload?._langsmithTracer?.exampleId,
+          }
+        : undefined,
     };
     const endpoint =
       threadId == null ? `/runs/wait` : `/threads/${threadId}/runs/wait`;

--- a/libs/sdk-js/src/types.ts
+++ b/libs/sdk-js/src/types.ts
@@ -1,3 +1,4 @@
+import { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
 import { Checkpoint, Config, Metadata } from "./schema.js";
 import { StreamMode } from "./types.stream.js";
 
@@ -145,10 +146,7 @@ interface RunsInvokePayload {
    * @internal
    * For LangSmith tracing purposes only. Not part of the public API.
    */
-  _langsmithTracer?: {
-    project_name: string;
-    example_id: string;
-  };
+  _langsmithTracer?: LangChainTracer;
 }
 
 export interface RunsStreamPayload<

--- a/libs/sdk-js/src/types.ts
+++ b/libs/sdk-js/src/types.ts
@@ -140,6 +140,15 @@ interface RunsInvokePayload {
    * Callback when a run is created.
    */
   onRunCreated?: (params: { run_id: string; thread_id?: string }) => void;
+
+  /**
+   * @internal
+   * For LangSmith tracing purposes only. Not part of the public API.
+   */
+  _langsmithTracer?: {
+    project_name: string;
+    example_id: string;
+  };
 }
 
 export interface RunsStreamPayload<


### PR DESCRIPTION
This adds support for passing in a custom langchain tracer to the runs client (specifically `create` and `wait`) which gets passed directly into the api.

Only adding this for the `js` sdk because this is meant to be internal only and the context that we are using this in only uses the js sdk.