### PR TITLE
Improve type checking on graph `init` and `invoke`/`stream`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ Chinook.db
 .vercel
 .turbo
 .editorconfig
+.scratch

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -8,7 +8,7 @@ import weakref
 from collections import defaultdict, deque
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from functools import partial
-from typing import Any, Callable, Union, cast, get_type_hints
+from typing import Any, Callable, Generic, Union, cast, get_type_hints
 from uuid import UUID, uuid5
 
 from langchain_core.globals import get_debug
@@ -107,6 +107,7 @@ from langgraph.types import (
     StreamChunk,
     StreamMode,
 )
+from langgraph.typing import InputT
 from langgraph.utils.config import (
     ensure_config,
     merge_configs,
@@ -297,7 +298,7 @@ class NodeBuilder:
         )
 
 
-class Pregel(PregelProtocol):
+class Pregel(PregelProtocol[InputT], Generic[InputT]):
     """Pregel manages the runtime behavior for LangGraph applications.
 
     ## Overview
@@ -738,7 +739,8 @@ class Pregel(PregelProtocol):
         }
 
     def copy(self, update: dict[str, Any] | None = None) -> Self:
-        attrs = {**self.__dict__, **(update or {})}
+        attrs = {k: v for k, v in self.__dict__.items() if k != "__orig_class__"}
+        attrs.update(update or {})
         return self.__class__(**attrs)
 
     def with_config(self, config: RunnableConfig | None = None, **kwargs: Any) -> Self:
@@ -2279,7 +2281,7 @@ class Pregel(PregelProtocol):
 
     def stream(
         self,
-        input: dict[str, Any] | Any,
+        input: InputT,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode | list[StreamMode] | None = None,
@@ -2500,7 +2502,7 @@ class Pregel(PregelProtocol):
 
     async def astream(
         self,
-        input: dict[str, Any] | Any,
+        input: InputT,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode | list[StreamMode] | None = None,
@@ -2736,7 +2738,7 @@ class Pregel(PregelProtocol):
 
     def invoke(
         self,
-        input: dict[str, Any] | Any,
+        input: InputT,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode = "values",
@@ -2802,7 +2804,7 @@ class Pregel(PregelProtocol):
 
     async def ainvoke(
         self,
-        input: dict[str, Any] | Any,
+        input: InputT,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode = "values",

--- a/libs/langgraph/langgraph/pregel/protocol.py
+++ b/libs/langgraph/langgraph/pregel/protocol.py
@@ -1,21 +1,19 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator, Sequence
-from typing import (
-    Any,
-    Optional,
-    Union,
-)
+from typing import Any, Generic, Optional, Union
 
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.runnables.graph import Graph as DrawableGraph
 from typing_extensions import Self
 
 from langgraph.pregel.types import All, StateSnapshot, StateUpdate, StreamMode
+from langgraph.typing import InputT
 
 
-class PregelProtocol(
-    Runnable[Union[dict[str, Any], Any], Union[dict[str, Any], Any]], ABC
-):
+# TODO: remove Runnable inheritance here!
+class PregelProtocol(Runnable[InputT, Any], Generic[InputT], ABC):
     @abstractmethod
     def with_config(
         self, config: Optional[RunnableConfig] = None, **kwargs: Any
@@ -100,7 +98,7 @@ class PregelProtocol(
     @abstractmethod
     def stream(
         self,
-        input: Union[dict[str, Any], Any],
+        input: InputT,
         config: Optional[RunnableConfig] = None,
         *,
         stream_mode: Optional[Union[StreamMode, list[StreamMode]]] = None,
@@ -112,7 +110,7 @@ class PregelProtocol(
     @abstractmethod
     def astream(
         self,
-        input: Union[dict[str, Any], Any],
+        input: InputT,
         config: Optional[RunnableConfig] = None,
         *,
         stream_mode: Optional[Union[StreamMode, list[StreamMode]]] = None,
@@ -124,7 +122,7 @@ class PregelProtocol(
     @abstractmethod
     def invoke(
         self,
-        input: Union[dict[str, Any], Any],
+        input: InputT,
         config: Optional[RunnableConfig] = None,
         *,
         interrupt_before: Optional[Union[All, Sequence[str]]] = None,
@@ -134,7 +132,7 @@ class PregelProtocol(
     @abstractmethod
     async def ainvoke(
         self,
-        input: Union[dict[str, Any], Any],
+        input: InputT,
         config: Optional[RunnableConfig] = None,
         *,
         interrupt_before: Optional[Union[All, Sequence[str]]] = None,

--- a/libs/langgraph/langgraph/typing.py
+++ b/libs/langgraph/langgraph/typing.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import Field
+from typing import Any, ClassVar, Protocol, Union
+
+from pydantic import BaseModel
+from typing_extensions import TypeAlias, TypeVar
+
+
+class _TypedDictLike(Protocol):
+    """Protocol to represent types that behave like TypedDicts."""
+
+    __required_keys__: ClassVar[frozenset[str]]
+    __optional_keys__: ClassVar[frozenset[str]]
+
+
+class _DataclassLike(Protocol):
+    """Protocol to represent types that behave like dataclasses.
+
+    Inspired by the private _DataclassT from dataclasses that uses a similar protocol as a bound."""
+
+    __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
+
+
+StateLike: TypeAlias = Union[_TypedDictLike, _DataclassLike, BaseModel]
+"""Type alias for state-like types.
+
+It can either be a `TypedDict`, `dataclass`, or Pydantic `BaseModel`.
+Note: we cannot use either `TypedDict` or `dataclass` directly due to limitations in type checking."""
+
+
+class Unset:
+    """Sentinel representing an unset value."""
+
+
+UNSET = Unset()
+
+StateT = TypeVar("StateT", bound=StateLike)
+"""Type variable used to represent the state in a graph."""
+
+StateT_co = TypeVar("StateT_co", bound=StateLike, covariant=True)
+
+StateT_contra = TypeVar("StateT_contra", bound=StateLike, contravariant=True)
+
+InputT = TypeVar("InputT", bound=Union[StateLike, Unset])
+"""Type variable used to represent the input to a graph.
+
+In practice, InputT might be represented by either the `input_type` or `state_type` of a graph.
+If `input_type` is not specified, it defaults to `StateType`."""
+
+OutputT = TypeVar("OutputT", bound=Union[StateLike, Unset])
+"""Type variable used to represent the output of a graph."""

--- a/libs/langgraph/langgraph/typing.py
+++ b/libs/langgraph/langgraph/typing.py
@@ -1,17 +1,33 @@
 from __future__ import annotations
 
 from dataclasses import Field
-from typing import Any, ClassVar, Protocol, Union
+from typing import (
+    Any,
+    ClassVar,
+    Protocol,
+    Union,
+)
 
 from pydantic import BaseModel
 from typing_extensions import TypeAlias, TypeVar
 
 
-class _TypedDictLike(Protocol):
-    """Protocol to represent types that behave like TypedDicts."""
+class _TypedDictLikeV1(Protocol):
+    """Protocol to represent types that behave like TypedDicts
+
+    Version 1: using `ClassVar` for keys."""
 
     __required_keys__: ClassVar[frozenset[str]]
     __optional_keys__: ClassVar[frozenset[str]]
+
+
+class _TypedDictLikeV2(Protocol):
+    """Protocol to represent types that behave like TypedDicts
+
+    Version 2: not using `ClassVar` for keys."""
+
+    __required_keys__: frozenset[str]
+    __optional_keys__: frozenset[str]
 
 
 class _DataclassLike(Protocol):
@@ -22,7 +38,9 @@ class _DataclassLike(Protocol):
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
 
 
-StateLike: TypeAlias = Union[_TypedDictLike, _DataclassLike, BaseModel]
+StateLike: TypeAlias = Union[
+    _TypedDictLikeV1, _TypedDictLikeV2, _DataclassLike, BaseModel
+]
 """Type alias for state-like types.
 
 It can either be a `TypedDict`, `dataclass`, or Pydantic `BaseModel`.
@@ -42,11 +60,11 @@ StateT_co = TypeVar("StateT_co", bound=StateLike, covariant=True)
 
 StateT_contra = TypeVar("StateT_contra", bound=StateLike, contravariant=True)
 
-InputT = TypeVar("InputT", bound=Union[StateLike, Unset])
+InputT = TypeVar("InputT", bound=Union[StateLike, Unset], default=Unset)
 """Type variable used to represent the input to a graph.
 
 In practice, InputT might be represented by either the `input_type` or `state_type` of a graph.
 If `input_type` is not specified, it defaults to `StateType`."""
 
-OutputT = TypeVar("OutputT", bound=Union[StateLike, Unset])
+OutputT = TypeVar("OutputT", bound=Union[StateLike, Unset], default=Unset)
 """Type variable used to represent the output of a graph."""

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Optional
 from typing import Annotated as Annotated2
 
 import pytest
-from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -241,14 +241,6 @@ def test_state_schema_default_values(kw_only_: bool):
 
 
 def test__get_node_name() -> None:
-    # default runnable name
-    assert _get_node_name(RunnableLambda(func=lambda x: x)) == "RunnableLambda"
-    # custom runnable name
-    assert (
-        _get_node_name(RunnableLambda(name="my_runnable", func=lambda x: x))
-        == "my_runnable"
-    )
-
     # lambda
     assert _get_node_name(lambda x: x) == "<lambda>"
 

--- a/libs/langgraph/tests/test_type_checking.py
+++ b/libs/langgraph/tests/test_type_checking.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+from operator import add
+from typing import Annotated, Any
+
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+from langgraph.graph import StateGraph
+
+
+def test_typed_dict_state() -> None:
+    class TypedDictState(TypedDict):
+        info: Annotated[list[str], add]
+
+    graph_builder = StateGraph(TypedDictState)
+
+    def valid(state: TypedDictState) -> Any: ...
+
+    def valid_with_config(state: TypedDictState, config: RunnableConfig) -> Any: ...
+
+    def invalid() -> Any: ...
+
+    def invalid_node() -> Any: ...
+
+    graph_builder.add_node("valid", valid)
+    graph_builder.add_node("invalid", valid_with_config)
+    graph_builder.add_node("invalid_node", invalid_node)  # type: ignore[call-overload]
+    graph_builder.set_entry_point("valid")
+    graph = graph_builder.compile()
+
+    graph.invoke({"info": ["hello", "world"]})
+    graph.invoke({"invalid": 1})  # type: ignore[arg-type]
+
+
+def test_dataclass_state() -> None:
+    @dataclass
+    class DataclassState:
+        info: Annotated[list[str], add]
+
+    def valid(state: DataclassState) -> Any: ...
+
+    def valid_with_config(state: DataclassState, config: RunnableConfig) -> Any: ...
+
+    def invalid() -> Any: ...
+
+    graph_builder = StateGraph(DataclassState)
+    graph_builder.add_node("valid", valid)
+    graph_builder.add_node("invalid", valid_with_config)
+    graph_builder.add_node("invalid_node", invalid)  # type: ignore[call-overload]
+
+    graph_builder.set_entry_point("valid")
+    graph = graph_builder.compile()
+
+    graph.invoke(DataclassState(info=["hello", "world"]))
+    graph.invoke({"invalid": 1})  # type: ignore[arg-type]
+    graph.invoke({"info": 1})  # type: ignore[arg-type]
+
+
+def test_base_model_state() -> None:
+    class PydanticState(BaseModel):
+        info: Annotated[list[str], add]
+
+    def valid(state: PydanticState) -> Any: ...
+
+    def valid_with_config(state: PydanticState, config: RunnableConfig) -> Any: ...
+
+    def invalid() -> Any: ...
+
+    graph_builder = StateGraph(PydanticState)
+    graph_builder.add_node("valid", valid)
+    graph_builder.add_node("invalid", valid_with_config)
+    graph_builder.add_node("invalid_node", invalid)  # type: ignore[call-overload]
+
+    graph_builder.set_entry_point("valid")
+    graph = graph_builder.compile()
+
+    graph.invoke(PydanticState(info=["hello", "world"]))
+    graph.invoke({"invalid": 1})  # type: ignore[arg-type]
+    graph.invoke({"info": ["hello", "world"]})  # type: ignore[arg-type]
+
+
+def test_plain_class_not_allowed() -> None:
+    class NotAllowed:
+        info: Annotated[list[str], add]
+
+    StateGraph(NotAllowed)  # type: ignore[type-var]
+
+
+def test_input_state_specified() -> None:
+    class InputState(TypedDict):
+        something: int
+
+    class State(InputState):
+        info: Annotated[list[str], add]
+
+    def valid(state: State) -> Any: ...
+
+    new_builder = StateGraph(State, input=InputState)
+    new_builder.add_node("valid", valid)
+    new_builder.set_entry_point("valid")
+    new_graph = new_builder.compile()
+
+    new_graph.invoke({"something": 1})
+    new_graph.invoke({"something": 2, "info": ["hello", "world"]})  # type: ignore[arg-type]

--- a/libs/langgraph/tests/test_type_checking.py
+++ b/libs/langgraph/tests/test_type_checking.py
@@ -30,7 +30,7 @@ def test_typed_dict_state() -> None:
     graph = graph_builder.compile()
 
     graph.invoke({"info": ["hello", "world"]})
-    graph.invoke({"invalid": 1})  # type: ignore[arg-type]
+    graph.invoke({"invalid": "lalala"})  # type: ignore[arg-type]
 
 
 def test_dataclass_state() -> None:
@@ -54,7 +54,7 @@ def test_dataclass_state() -> None:
 
     graph.invoke(DataclassState(info=["hello", "world"]))
     graph.invoke({"invalid": 1})  # type: ignore[arg-type]
-    graph.invoke({"info": 1})  # type: ignore[arg-type]
+    graph.invoke({"info": ["hello", "world"]})  # type: ignore[arg-type]
 
 
 def test_base_model_state() -> None:


### PR DESCRIPTION
* Type checking on input for `invoke`, `stream`, etc matches that of either `InputT` or `StateT`, depending on if `InputT` is specified
* Type checking on node signatures, requiring `state` to be typed as `StateT`
* Ensuring the type used for `state_schema` is a typed dict spec, dataclass, or base model type

```py
from typing import Annotated, Any

from langgraph.checkpoint.memory import InMemorySaver
from typing_extensions import TypedDict

from langgraph.graph import StateGraph
from operator import add


class State(TypedDict):
    info: Annotated[list[str], add]


graph_builder = StateGraph(State)


def start(state: State) -> Any:
    return {"info": state["info"] + ["!"]}


def invalid_node() -> Any: ...


graph_builder.add_node("start", start)
graph_builder.add_node("invalid", invalid_node, input=State)
"""
Argument of type "() -> Any" cannot be assigned to parameter "action" of type "CallableStateNode[State]" in function "add_node"
  Type "() -> Any" is not assignable to type "CallableStateNode[State]"
    Type "() -> Any" is not assignable to type "(state: State) -> Any"
      Function accepts too many positional parameters; expected 0 but received 1
    Type "() -> Any" is not assignable to type "(state: State, config: RunnableConfig) -> Any"
      Function accepts too many positional parameters; expected 0 but received 
"""
graph_builder.set_entry_point("start")
graph = graph_builder.compile(checkpointer=InMemorySaver())

result = graph.invoke(
    {"info": ["hello", "world"]}, config={"configurable": {"thread_id": 1}}
)
graph.invoke({"wrong": 1}, config={"configurable": {"thread_id": 1}})
"""
Argument of type "dict[str, int]" cannot be assigned to parameter "input" of type "State" in function "invoke"
"""


class InputState(TypedDict):
    something: int


class State(InputState):
    info: Annotated[list[str], add]


new_builder = StateGraph(State, input=InputState)
new_builder.add_node("start", start)
new_builder.set_entry_point("start")
new_graph = new_builder.compile(checkpointer=InMemorySaver())

result = new_graph.invoke({"something": 1})
result = new_graph.invoke({"something": 2, "info": ["hello", "world"]})
"""
Argument of type "dict[str, int | list[str]]" cannot be assigned to parameter "input" of type "InputState" in function "invoke"
"""
```

TODO, largely in future PRs:
* Add `OutputT` as a generic on `StateGraph`, related to typing output for `invoke` and `stream`
* Investigate `Runnable` use internally - migrating away from this where possible
* Investigate accepting callables with arbitrary args via `ParamSpec`, then can remove typing for store/writer
* Add new `RunContext`
* Rename args to `StateGraph` (`input` -> `input_type` etc)
* Figure out how to handle sync and async functions
* Make better use of defined `Unset` types