### PR TITLE
Allow same-name channels and nodes in StateGraph

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -369,8 +369,6 @@ class StateGraph(Generic[StateT, InputT]):
                 If a dict is provided, the keys will be used as the target node names and the values will be used as the labels for the edges.
                 If a tuple is provided, the values will be used as the target node names.
                 NOTE: this is only used for graph rendering and doesn't have any effect on the graph execution.
-        Raises:
-            ValueError: If the key is already being used as a state key.
 
         Example:
             ```python
@@ -410,8 +408,6 @@ class StateGraph(Generic[StateT, InputT]):
                 raise ValueError(
                     "Node name must be provided if action is not a function"
                 )
-        if node in self.channels:
-            raise ValueError(f"'{node}' is already being used as a state key")
         if self.compiled:
             logger.warning(
                 "Adding a node to a graph that has already been compiled. This will "


### PR DESCRIPTION
- We no longer auto create a same-name channel for each node, so this limitation can now be lifted