### PR TITLE
Fix ensure_config docstring

### DIFF
--- a/libs/langgraph/langgraph/utils/config.py
+++ b/libs/langgraph/langgraph/utils/config.py
@@ -276,14 +276,13 @@ def _is_not_empty(value: Any) -> bool:
 
 
 def ensure_config(*configs: Optional[RunnableConfig]) -> RunnableConfig:
-    """Ensure that a config is a dict with all keys present.
+    """Return a config with all keys, merging any provided configs.
 
     Args:
-        config (Optional[RunnableConfig], optional): The config to ensure.
-          Defaults to None.
+        *configs: Configs to merge before ensuring defaults.
 
     Returns:
-        RunnableConfig: The ensured config.
+        RunnableConfig: The merged and ensured config.
     """
     empty = RunnableConfig(
         tags=[],


### PR DESCRIPTION
## Summary
- clarify docstring for `ensure_config`

## Testing
- `uv run ruff format libs/langgraph/langgraph/utils/config.py`
- `uv run ruff check libs/langgraph/langgraph/utils/config.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c0d5a74832d9dc7013b762a9a62