### PR TITLE
Fix async callback manager tag handling

### DIFF
--- a/libs/langgraph/langgraph/utils/config.py
+++ b/libs/langgraph/langgraph/utils/config.py
@@ -263,7 +263,7 @@ def get_async_callback_manager_for_config(
         # otherwise create a new manager
         return AsyncCallbackManager.configure(
             inheritable_callbacks=config.get("callbacks"),
-            inheritable_tags=config.get("tags"),
+            inheritable_tags=all_tags,
             inheritable_metadata=config.get("metadata"),
         )
 

--- a/libs/langgraph/tests/test_config_async.py
+++ b/libs/langgraph/tests/test_config_async.py
@@ -1,0 +1,19 @@
+import pytest
+from langchain_core.callbacks import AsyncCallbackManager
+
+from langgraph.utils.config import get_async_callback_manager_for_config
+
+pytestmark = pytest.mark.anyio
+
+
+def test_new_async_manager_includes_tags() -> None:
+    config = {"callbacks": None}
+    manager = get_async_callback_manager_for_config(config, tags=["x", "y"])
+    assert isinstance(manager, AsyncCallbackManager)
+    assert manager.inheritable_tags == ["x", "y"]
+
+
+def test_new_async_manager_merges_tags_with_config() -> None:
+    config = {"callbacks": None, "tags": ["a"]}
+    manager = get_async_callback_manager_for_config(config, tags=["b"])
+    assert manager.inheritable_tags == ["a", "b"]


### PR DESCRIPTION
## Summary
- ensure `get_async_callback_manager_for_config` forwards merged tags when creating a new manager
- add tests covering async callback manager tag merging

## Testing
- `pytest langgraph/tests/test_config_async.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7c024b80832d814d9a0a6f056fbc