### PR TITLE
🐛 [CLI] Generate one `--build-context` argument for each dependency in the `docker build` command.

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -318,10 +318,8 @@ def _build(
     )
     # add additional_contexts
     if additional_contexts:
-        additional_contexts_str = ",".join(
-            f"{k}={v}" for k, v in additional_contexts.items()
-        )
-        args.extend(["--build-context", additional_contexts_str])
+        for k, v in additional_contexts.items():
+            args.extend(["--build-context", f"{k}={v}"])
     # run docker build
     runner.run(
         subp_exec(


### PR DESCRIPTION
A given `langgraph.json` with more than one `dependencies`:

```
{
  "python_version": "3.12",
  "dependencies": [
    ".",
    "../../libs/proto",
    "../../libs/common"
  ],
  ...
}
```

Will produce a docker build command:

`docker build --build-context proto=abs_path,common=abs_path`

which is not valid. It is not possible to separate the different --build-context using a comma. Rather the following command should be generated:

`docker build --build-context proto=abs_path --build-context common=abs_path`

I am using the latest `Docker version 28.2.2, build e6534b4` but I don't believe it ever worked.