### PR TITLE
lint: use pep 604 union syntax and pep 585 generic syntax

### DIFF
--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -56,7 +56,7 @@ lint.select = [
   "B",  # flake8-bugbear
   "I",  # isort
 ]
-lint.ignore = ["E501", "B008", "UP007", "UP006"]
+lint.ignore = ["E501", "B008"]
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/libs/checkpoint-sqlite/pyproject.toml
+++ b/libs/checkpoint-sqlite/pyproject.toml
@@ -54,7 +54,7 @@ lint.select = [
   "B",  # flake8-bugbear
   "I",  # isort
 ]
-lint.ignore = ["E501", "B008", "UP007", "UP006"]
+lint.ignore = ["E501", "B008"]
 
 [tool.pytest-watcher]
 now = true

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -2,7 +2,6 @@ from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import (  # noqa: UP035
     Any,
     Generic,
-    List,
     Literal,
     NamedTuple,
     Optional,
@@ -99,7 +98,7 @@ class CheckpointTuple(NamedTuple):
     checkpoint: Checkpoint
     metadata: CheckpointMetadata
     parent_config: Optional[RunnableConfig] = None
-    pending_writes: Optional[List[PendingWrite]] = None
+    pending_writes: Optional[list[PendingWrite]] = None
 
 
 class BaseCheckpointSaver(Generic[V]):

--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -46,7 +46,7 @@ lint.select = [
   "B",  # flake8-bugbear
   "I",  # isort
 ]
-lint.ignore = ["E501", "B008", "UP007", "UP006"]
+lint.ignore = ["E501", "B008"]
 
 [tool.pytest-watcher]
 now = true

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -15,7 +15,6 @@ from typing import (
     Generic,
     Literal,
     NamedTuple,
-    Optional,
     Protocol,
     Union,
     cast,
@@ -91,7 +90,7 @@ from langgraph.warnings import LangGraphDeprecatedSinceV10
 logger = logging.getLogger(__name__)
 
 
-def _warn_invalid_state_schema(schema: Union[type[Any], Any]) -> None:
+def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
     if isinstance(schema, type):
         return
     if typing.get_args(schema):
@@ -174,11 +173,11 @@ class StateNodeSpec(NamedTuple):
     # TODO: rename this callable, also move away from NamedTuple so that we can use
     # a generic StateNode, so maybe a dataclass
     runnable: StateNode
-    metadata: Optional[dict[str, Any]]
+    metadata: dict[str, Any] | None
     input: type[Any]
-    retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]]
-    cache_policy: Optional[CachePolicy]
-    ends: Optional[Union[tuple[str, ...], dict[str, str]]] = EMPTY_SEQ
+    retry_policy: RetryPolicy | Sequence[RetryPolicy] | None
+    cache_policy: CachePolicy | None
+    ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
 
 
@@ -239,7 +238,7 @@ class StateGraph(Generic[StateT, InputT]):
     branches: defaultdict[str, dict[str, Branch]]
     channels: dict[str, BaseChannel]
     managed: dict[str, ManagedValueSpec]
-    schemas: dict[type[Any], dict[str, Union[BaseChannel, ManagedValueSpec]]]
+    schemas: dict[type[Any], dict[str, BaseChannel | ManagedValueSpec]]
 
     def __init__(
         self,
@@ -313,11 +312,11 @@ class StateGraph(Generic[StateT, InputT]):
         node: StateNode[StateT],
         *,
         defer: bool = False,
-        metadata: Optional[dict[str, Any]] = None,
-        input: Optional[type[Any]] = None,
-        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
-        cache_policy: Optional[CachePolicy] = None,
-        destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
+        metadata: dict[str, Any] | None = None,
+        input: type[Any] | None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the state graph.
@@ -332,11 +331,11 @@ class StateGraph(Generic[StateT, InputT]):
         action: StateNode[StateT],
         *,
         defer: bool = False,
-        metadata: Optional[dict[str, Any]] = None,
-        input: Optional[type[Any]] = None,
-        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
-        cache_policy: Optional[CachePolicy] = None,
-        destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
+        metadata: dict[str, Any] | None = None,
+        input: type[Any] | None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the state graph."""
@@ -344,15 +343,15 @@ class StateGraph(Generic[StateT, InputT]):
 
     def add_node(
         self,
-        node: Union[str, StateNode[StateT]],
-        action: Optional[StateNode[StateT]] = None,
+        node: str | StateNode[StateT],
+        action: StateNode[StateT] | None = None,
         *,
         defer: bool = False,
-        metadata: Optional[dict[str, Any]] = None,
-        input: Optional[type[Any]] = None,
-        retry_policy: Optional[Union[RetryPolicy, Sequence[RetryPolicy]]] = None,
-        cache_policy: Optional[CachePolicy] = None,
-        destinations: Optional[Union[dict[str, str], tuple[str, ...]]] = None,
+        metadata: dict[str, Any] | None = None,
+        input: type[Any] | None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the state graph.
@@ -445,7 +444,7 @@ class StateGraph(Generic[StateT, InputT]):
                     f"'{character}' is a reserved character and is not allowed in the node names."
                 )
 
-        ends: Union[tuple[str, ...], dict[str, str]] = EMPTY_SEQ
+        ends: tuple[str, ...] | dict[str, str] = EMPTY_SEQ
         try:
             if (
                 isfunction(action)
@@ -506,7 +505,7 @@ class StateGraph(Generic[StateT, InputT]):
         )
         return self
 
-    def add_edge(self, start_key: Union[str, list[str]], end_key: str) -> Self:
+    def add_edge(self, start_key: str | list[str], end_key: str) -> Self:
         """Add a directed edge from the start node (or list of start nodes) to the end node.
 
         When a single start node is provided, the graph will wait for that node to complete
@@ -563,12 +562,10 @@ class StateGraph(Generic[StateT, InputT]):
     def add_conditional_edges(
         self,
         source: str,
-        path: Union[
-            Callable[..., Union[Hashable, list[Hashable]]],
-            Callable[..., Awaitable[Union[Hashable, list[Hashable]]]],
-            Runnable[Any, Union[Hashable, list[Hashable]]],
-        ],
-        path_map: Optional[Union[dict[Hashable, str], list[str]]] = None,
+        path: Callable[..., Hashable | list[Hashable]]
+        | Callable[..., Awaitable[Hashable | list[Hashable]]]
+        | Runnable[Any, Hashable | list[Hashable]],
+        path_map: dict[Hashable, str] | list[str] | None = None,
     ) -> Self:
         """Add a conditional edge from the starting node to any number of destination nodes.
 
@@ -610,7 +607,7 @@ class StateGraph(Generic[StateT, InputT]):
 
     def add_sequence(
         self,
-        nodes: Sequence[Union[StateNode[StateT], tuple[str, StateNode[StateT]]]],
+        nodes: Sequence[StateNode[StateT] | tuple[str, StateNode[StateT]]],
     ) -> Self:
         """Add a sequence of nodes that will be executed in the provided order.
 
@@ -629,7 +626,7 @@ class StateGraph(Generic[StateT, InputT]):
         if len(nodes) < 1:
             raise ValueError("Sequence requires at least one node.")
 
-        previous_name: Optional[str] = None
+        previous_name: str | None = None
         for node in nodes:
             if isinstance(node, tuple) and len(node) == 2:
                 name, node = node
@@ -665,12 +662,10 @@ class StateGraph(Generic[StateT, InputT]):
 
     def set_conditional_entry_point(
         self,
-        path: Union[
-            Callable[..., Union[Hashable, list[Hashable]]],
-            Callable[..., Awaitable[Union[Hashable, list[Hashable]]]],
-            Runnable[Any, Union[Hashable, list[Hashable]]],
-        ],
-        path_map: Optional[Union[dict[Hashable, str], list[str]]] = None,
+        path: Callable[..., Hashable | list[Hashable]]
+        | Callable[..., Awaitable[Hashable | list[Hashable]]]
+        | Runnable[Any, Hashable | list[Hashable]],
+        path_map: dict[Hashable, str] | list[str] | None = None,
     ) -> Self:
         """Sets a conditional entry point in the graph.
 
@@ -699,7 +694,7 @@ class StateGraph(Generic[StateT, InputT]):
         """
         return self.add_edge(key, END)
 
-    def validate(self, interrupt: Optional[Sequence[str]] = None) -> Self:
+    def validate(self, interrupt: Sequence[str] | None = None) -> Self:
         # assemble sources
         all_sources = {src for src, _ in self._all_edges}
         for start, branches in self.branches.items():
@@ -753,12 +748,12 @@ class StateGraph(Generic[StateT, InputT]):
         self: StateGraph[StateT, Unset],
         checkpointer: Checkpointer = None,
         *,
-        cache: Optional[BaseCache] = None,
-        store: Optional[BaseStore] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
+        cache: BaseCache | None = None,
+        store: BaseStore | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
         debug: bool = False,
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> CompiledStateGraph[StateT, StateT]: ...
 
     @overload
@@ -766,25 +761,25 @@ class StateGraph(Generic[StateT, InputT]):
         self: StateGraph[StateT, InputT],
         checkpointer: Checkpointer = None,
         *,
-        cache: Optional[BaseCache] = None,
-        store: Optional[BaseStore] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
+        cache: BaseCache | None = None,
+        store: BaseStore | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
         debug: bool = False,
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> CompiledStateGraph[StateT, InputT]: ...
 
     def compile(
         self,
         checkpointer: Checkpointer = None,
         *,
-        cache: Optional[BaseCache] = None,
-        store: Optional[BaseStore] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
+        cache: BaseCache | None = None,
+        store: BaseStore | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
         debug: bool = False,
-        name: Optional[str] = None,
-    ) -> Union[CompiledStateGraph[StateT, StateT], CompiledStateGraph[StateT, InputT]]:
+        name: str | None = None,
+    ) -> CompiledStateGraph[StateT, StateT] | CompiledStateGraph[StateT, InputT]:
         """Compiles the state graph into a `CompiledStateGraph` object.
 
         The compiled graph implements the `Runnable` interface and can be invoked,
@@ -836,7 +831,7 @@ class StateGraph(Generic[StateT, InputT]):
             ]
         )
 
-        ResolvedInputT: Union[type[InputT], type[StateT]] = self.input or self.schema
+        ResolvedInputT: type[InputT] | type[StateT] = self.input or self.schema
         compiled = CompiledStateGraph[StateT, ResolvedInputT](  # type: ignore[valid-type]
             builder=self,
             schema_to_mapper={},
@@ -887,22 +882,20 @@ class StateGraph(Generic[StateT, InputT]):
 
 class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
     builder: StateGraph[StateT, InputT]
-    schema_to_mapper: dict[type[Any], Optional[Callable[[Any], Any]]]
+    schema_to_mapper: dict[type[Any], Callable[[Any], Any] | None]
 
     def __init__(
         self,
         *,
         builder: StateGraph[StateT, InputT],
-        schema_to_mapper: dict[type[Any], Optional[Callable[[Any], Any]]],
+        schema_to_mapper: dict[type[Any], Callable[[Any], Any] | None],
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.builder = builder
         self.schema_to_mapper = schema_to_mapper
 
-    def get_input_schema(
-        self, config: Optional[RunnableConfig] = None
-    ) -> type[BaseModel]:
+    def get_input_schema(self, config: RunnableConfig | None = None) -> type[BaseModel]:
         return _get_schema(
             typ=self.builder.input,
             schemas=self.builder.schemas,
@@ -911,7 +904,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
         )
 
     def get_output_schema(
-        self, config: Optional[RunnableConfig] = None
+        self, config: RunnableConfig | None = None
     ) -> type[BaseModel]:
         return _get_schema(
             typ=self.builder.output,
@@ -920,7 +913,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
             name=self.get_name("Output"),
         )
 
-    def attach_node(self, key: str, node: Optional[StateNodeSpec]) -> None:
+    def attach_node(self, key: str, node: StateNodeSpec | None) -> None:
         if key == START:
             output_keys = [
                 k
@@ -933,8 +926,8 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
             ]
 
         def _get_updates(
-            input: Union[None, dict, Any],
-        ) -> Optional[Sequence[tuple[str, Any]]]:
+            input: None | dict | Any,
+        ) -> Sequence[tuple[str, Any]] | None:
             if input is None:
                 return None
             elif isinstance(input, dict):
@@ -971,7 +964,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
                 raise InvalidUpdateError(msg)
 
         # state updaters
-        write_entries: tuple[Union[ChannelWriteEntry, ChannelWriteTupleEntry], ...] = (
+        write_entries: tuple[ChannelWriteEntry | ChannelWriteTupleEntry, ...] = (
             ChannelWriteTupleEntry(
                 mapper=_get_root if output_keys == ["__root__"] else _get_updates
             ),
@@ -1026,7 +1019,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
         else:
             raise RuntimeError
 
-    def attach_edge(self, starts: Union[str, Sequence[str]], end: str) -> None:
+    def attach_edge(self, starts: str | Sequence[str], end: str) -> None:
         if isinstance(starts, str):
             # subscribe to start channel
             if end != END:
@@ -1056,8 +1049,8 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
         self, start: str, name: str, branch: Branch, *, with_reader: bool = True
     ) -> None:
         def get_writes(
-            packets: Sequence[Union[str, Send]], static: bool = False
-        ) -> Sequence[Union[ChannelWriteEntry, Send]]:
+            packets: Sequence[str | Send], static: bool = False
+        ) -> Sequence[ChannelWriteEntry | Send]:
             writes = [
                 (
                     ChannelWriteEntry(
@@ -1088,7 +1081,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
                 mapper = _pick_mapper(channels, schema)
                 self.schema_to_mapper[schema] = mapper
             # create reader
-            reader: Optional[Callable[[RunnableConfig], Any]] = partial(
+            reader: Callable[[RunnableConfig], Any] | None = partial(
                 ChannelRead.do_read,
                 select=channels[0] if channels == ["__root__"] else channels,
                 fresh=True,
@@ -1208,7 +1201,7 @@ class CompiledStateGraph(Pregel[InputT], Generic[StateT, InputT]):
 
 def _pick_mapper(
     state_keys: Sequence[str], schema: type[Any]
-) -> Optional[Callable[[Any], Any]]:
+) -> Callable[[Any], Any] | None:
     if state_keys == ["__root__"]:
         return None
     if isclass(schema) and issubclass(schema, dict):
@@ -1249,8 +1242,8 @@ def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
 
 
 def _control_static(
-    ends: Union[tuple[str, ...], dict[str, str]],
-) -> Sequence[tuple[str, Any, Optional[str]]]:
+    ends: tuple[str, ...] | dict[str, str],
+) -> Sequence[tuple[str, Any, str | None]]:
     if isinstance(ends, dict):
         return [
             (k if k == END else CHANNEL_BRANCH_TO.format(k), None, label)
@@ -1262,7 +1255,7 @@ def _control_static(
         ]
 
 
-def _get_root(input: Any) -> Optional[Sequence[tuple[str, Any]]]:
+def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
     if isinstance(input, Command):
         if input.graph == Command.PARENT:
             return ()
@@ -1317,12 +1310,12 @@ def _get_channel(
 @overload
 def _get_channel(
     name: str, annotation: Any, *, allow_managed: Literal[True] = True
-) -> Union[BaseChannel, ManagedValueSpec]: ...
+) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
     name: str, annotation: Any, *, allow_managed: bool = True
-) -> Union[BaseChannel, ManagedValueSpec]:
+) -> BaseChannel | ManagedValueSpec:
     if manager := _is_field_managed_value(name, annotation):
         if allow_managed:
             return manager
@@ -1340,7 +1333,7 @@ def _get_channel(
     return fallback
 
 
-def _is_field_channel(typ: type[Any]) -> Optional[BaseChannel]:
+def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and isinstance(meta[-1], BaseChannel):
@@ -1350,7 +1343,7 @@ def _is_field_channel(typ: type[Any]) -> Optional[BaseChannel]:
     return None
 
 
-def _is_field_binop(typ: type[Any]) -> Optional[BinaryOperatorAggregate]:
+def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and callable(meta[-1]):
@@ -1371,7 +1364,7 @@ def _is_field_binop(typ: type[Any]) -> Optional[BinaryOperatorAggregate]:
     return None
 
 
-def _is_field_managed_value(name: str, typ: type[Any]) -> Optional[ManagedValueSpec]:
+def _is_field_managed_value(name: str, typ: type[Any]) -> ManagedValueSpec | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1:

--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -2766,8 +2766,8 @@ class Pregel(PregelProtocol[InputT], Generic[InputT]):
         """
         output_keys = output_keys if output_keys is not None else self.output_channels
 
-        latest: Union[dict[str, Any], Any] = None
-        chunks: list[Union[dict[str, Any], Any]] = []
+        latest: dict[str, Any] | Any = None
+        chunks: list[dict[str, Any] | Any] = []
         interrupts: list[Interrupt] = []
 
         for chunk in self.stream(
@@ -2833,8 +2833,8 @@ class Pregel(PregelProtocol[InputT], Generic[InputT]):
 
         output_keys = output_keys if output_keys is not None else self.output_channels
 
-        latest: Union[dict[str, Any], Any] = None
-        chunks: list[Union[dict[str, Any], Any]] = []
+        latest: dict[str, Any] | Any = None
+        chunks: list[dict[str, Any] | Any] = []
         interrupts: list[Interrupt] = []
 
         async for chunk in self.astream(

--- a/libs/langgraph/langgraph/pregel/protocol.py
+++ b/libs/langgraph/langgraph/pregel/protocol.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator, Sequence
-from typing import Any, Generic, Optional, Union
+from typing import Any, Generic
 
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.runnables.graph import Graph as DrawableGraph
@@ -16,23 +16,23 @@ from langgraph.typing import InputT
 class PregelProtocol(Runnable[InputT, Any], Generic[InputT], ABC):
     @abstractmethod
     def with_config(
-        self, config: Optional[RunnableConfig] = None, **kwargs: Any
+        self, config: RunnableConfig | None = None, **kwargs: Any
     ) -> Self: ...
 
     @abstractmethod
     def get_graph(
         self,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        xray: Union[int, bool] = False,
+        xray: int | bool = False,
     ) -> DrawableGraph: ...
 
     @abstractmethod
     async def aget_graph(
         self,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        xray: Union[int, bool] = False,
+        xray: int | bool = False,
     ) -> DrawableGraph: ...
 
     @abstractmethod
@@ -50,9 +50,9 @@ class PregelProtocol(Runnable[InputT, Any], Generic[InputT], ABC):
         self,
         config: RunnableConfig,
         *,
-        filter: Optional[dict[str, Any]] = None,
-        before: Optional[RunnableConfig] = None,
-        limit: Optional[int] = None,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
     ) -> Iterator[StateSnapshot]: ...
 
     @abstractmethod
@@ -60,9 +60,9 @@ class PregelProtocol(Runnable[InputT, Any], Generic[InputT], ABC):
         self,
         config: RunnableConfig,
         *,
-        filter: Optional[dict[str, Any]] = None,
-        before: Optional[RunnableConfig] = None,
-        limit: Optional[int] = None,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
     ) -> AsyncIterator[StateSnapshot]: ...
 
     @abstractmethod
@@ -83,58 +83,58 @@ class PregelProtocol(Runnable[InputT, Any], Generic[InputT], ABC):
     def update_state(
         self,
         config: RunnableConfig,
-        values: Optional[Union[dict[str, Any], Any]],
-        as_node: Optional[str] = None,
+        values: dict[str, Any] | Any | None,
+        as_node: str | None = None,
     ) -> RunnableConfig: ...
 
     @abstractmethod
     async def aupdate_state(
         self,
         config: RunnableConfig,
-        values: Optional[Union[dict[str, Any], Any]],
-        as_node: Optional[str] = None,
+        values: dict[str, Any] | Any | None,
+        as_node: str | None = None,
     ) -> RunnableConfig: ...
 
     @abstractmethod
     def stream(
         self,
         input: InputT,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stream_mode: Optional[Union[StreamMode, list[StreamMode]]] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
         subgraphs: bool = False,
-    ) -> Iterator[Union[dict[str, Any], Any]]: ...
+    ) -> Iterator[dict[str, Any] | Any]: ...
 
     @abstractmethod
     def astream(
         self,
         input: InputT,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        stream_mode: Optional[Union[StreamMode, list[StreamMode]]] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
         subgraphs: bool = False,
-    ) -> AsyncIterator[Union[dict[str, Any], Any]]: ...
+    ) -> AsyncIterator[dict[str, Any] | Any]: ...
 
     @abstractmethod
     def invoke(
         self,
         input: InputT,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-    ) -> Union[dict[str, Any], Any]: ...
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+    ) -> dict[str, Any] | Any: ...
 
     @abstractmethod
     async def ainvoke(
         self,
         input: InputT,
-        config: Optional[RunnableConfig] = None,
+        config: RunnableConfig | None = None,
         *,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-    ) -> Union[dict[str, Any], Any]: ...
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+    ) -> dict[str, Any] | Any: ...

--- a/libs/langgraph/langgraph/pregel/write.py
+++ b/libs/langgraph/langgraph/pregel/write.py
@@ -40,7 +40,7 @@ class ChannelWriteTupleEntry(NamedTuple):
     """Function to extract tuples from value."""
     value: Any = PASSTHROUGH
     """Value to write, or PASSTHROUGH to use the input."""
-    static: Optional[Sequence[tuple[str, Any, Optional[str]]]] = None
+    static: Sequence[tuple[str, Any, str | None]] | None = None
     """Optional, declared writes for static analysis."""
 
 
@@ -138,7 +138,7 @@ class ChannelWrite(RunnableCallable):
     @staticmethod
     def get_static_writes(
         runnable: Runnable,
-    ) -> Optional[Sequence[tuple[str, Any, Optional[str]]]]:
+    ) -> Sequence[tuple[str, Any, str | None]] | None:
         """Used to get conditional writes a writer declares for static analysis."""
         if isinstance(runnable, ChannelWrite):
             return [
@@ -160,9 +160,7 @@ class ChannelWrite(RunnableCallable):
     @staticmethod
     def register_writer(
         runnable: R,
-        static: Optional[
-            Sequence[tuple[Union[ChannelWriteEntry, Send], Optional[str]]]
-        ] = None,
+        static: Sequence[tuple[ChannelWriteEntry | Send, str | None]] | None = None,
     ) -> R:
         """Used to mark a runnable as a writer, so that it can be detected by is_writer.
         Instances of ChannelWrite are automatically marked as writers.
@@ -174,7 +172,7 @@ class ChannelWrite(RunnableCallable):
 
 
 def _assemble_writes(
-    writes: Sequence[Union[ChannelWriteEntry, ChannelWriteTupleEntry, Send]],
+    writes: Sequence[ChannelWriteEntry | ChannelWriteTupleEntry | Send],
 ) -> list[tuple[str, Any]]:
     """Assembles the writes into a list of tuples."""
     tuples: list[tuple[str, Any]] = []

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -63,7 +63,7 @@ langgraph-sdk = { path = "../sdk-py", editable = true }
 
 [tool.ruff]
 lint.select = [ "E", "F", "I", "TID251", "UP" ]
-lint.ignore = [ "E501", "UP007" ]
+lint.ignore = [ "E501" ]
 line-length = 88
 indent-width = 4
 extend-include = ["*.ipynb"]

--- a/libs/langgraph/tests/test_runnable.py
+++ b/libs/langgraph/tests/test_runnable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -85,7 +85,7 @@ def test_runnable_callable_injectable_arguments() -> None:
     """
 
     # Test Optional[BaseStore] annotation.
-    def func_optional_store(inputs: Any, store: Optional[BaseStore]) -> str:
+    def func_optional_store(inputs: Any, store: BaseStore | None) -> str:
         """Test function that accepts an optional store parameter."""
         assert store is None
         return "success"
@@ -159,12 +159,12 @@ async def test_runnable_callable_injectable_arguments_async() -> None:
     """
 
     # Test Optional[BaseStore] annotation.
-    def func_optional_store(inputs: Any, store: Optional[BaseStore]) -> str:
+    def func_optional_store(inputs: Any, store: BaseStore | None) -> str:
         """Test function that accepts an optional store parameter."""
         assert store is None
         return "success"
 
-    async def afunc_optional_store(inputs: Any, store: Optional[BaseStore]) -> str:
+    async def afunc_optional_store(inputs: Any, store: BaseStore | None) -> str:
         """Async version of func_optional_store."""
         assert store is None
         return "success"

--- a/libs/sdk-py/langgraph_sdk/auth/types.py
+++ b/libs/sdk-py/langgraph_sdk/auth/types.py
@@ -56,10 +56,8 @@ Values:
 """
 
 FilterType = typing.Union[
-    typing.Dict[
-        str, typing.Union[str, typing.Dict[typing.Literal["$eq", "$contains"], str]]
-    ],
-    typing.Dict[str, str],
+    dict[str, typing.Union[str, dict[typing.Literal["$eq", "$contains"], str]]],
+    dict[str, str],
 ]
 """Response type for authorization handlers.
 
@@ -100,7 +98,7 @@ Values:
     - error: Thread encountered an error
 """
 
-MetadataInput = typing.Dict[str, typing.Any]
+MetadataInput = dict[str, typing.Any]
 """Type for arbitrary metadata attached to entities.
 
 Allows storing custom key-value pairs with any entity.
@@ -541,7 +539,7 @@ class RunsCreate(typing.TypedDict, total=False):
     after_seconds: int
     """Number of seconds to wait before creating the run."""
 
-    kwargs: typing.Dict[str, typing.Any]
+    kwargs: dict[str, typing.Any]
     """Keyword arguments to pass to the run."""
 
     action: typing.Optional[typing.Literal["interrupt", "rollback"]]
@@ -570,7 +568,7 @@ class AssistantsCreate(typing.TypedDict, total=False):
     graph_id: str
     """Graph ID to use for this assistant."""
 
-    config: typing.Optional[typing.Union[typing.Dict[str, typing.Any], typing.Any]]
+    config: typing.Optional[typing.Union[dict[str, typing.Any], typing.Any]]
     """typing.Optional configuration for the assistant."""
 
     metadata: MetadataInput
@@ -624,7 +622,7 @@ class AssistantsUpdate(typing.TypedDict, total=False):
     graph_id: typing.Optional[str]
     """typing.Optional graph ID to update."""
 
-    config: typing.Optional[typing.Union[typing.Dict[str, typing.Any], typing.Any]]
+    config: typing.Optional[typing.Union[dict[str, typing.Any], typing.Any]]
     """typing.Optional configuration to update."""
 
     metadata: MetadataInput
@@ -695,7 +693,7 @@ class CronsCreate(typing.TypedDict, total=False):
         ```
     """
 
-    payload: typing.Dict[str, typing.Any]
+    payload: dict[str, typing.Any]
     """Payload for the cron job."""
 
     schedule: str
@@ -760,7 +758,7 @@ class CronsUpdate(typing.TypedDict, total=False):
     cron_id: UUID
     """Unique identifier for the cron job."""
 
-    payload: typing.Optional[typing.Dict[str, typing.Any]]
+    payload: typing.Optional[dict[str, typing.Any]]
     """typing.Optional payload to update."""
 
     schedule: typing.Optional[str]
@@ -900,7 +898,7 @@ class on:
         ```
     """
 
-    value = typing.Dict[str, typing.Any]
+    value = dict[str, typing.Any]
 
     class threads:
         """Types for thread-related operations."""

--- a/libs/sdk-py/langgraph_sdk/client.py
+++ b/libs/sdk-py/langgraph_sdk/client.py
@@ -72,7 +72,7 @@ logger = logging.getLogger(__name__)
 RESERVED_HEADERS = ("x-api-key",)
 
 
-def _get_api_key(api_key: Optional[str] = None) -> Optional[str]:
+def _get_api_key(api_key: str | None = None) -> str | None:
     """Get the API key from the environment.
     Precedence:
         1. explicit argument
@@ -89,7 +89,7 @@ def _get_api_key(api_key: Optional[str] = None) -> Optional[str]:
 
 
 def _get_headers(
-    api_key: Optional[str], custom_headers: Optional[dict[str, str]]
+    api_key: str | None, custom_headers: dict[str, str] | None
 ) -> dict[str, str]:
     """Combine api_key and custom user-provided headers."""
     custom_headers = custom_headers or {}
@@ -127,7 +127,7 @@ _RUN_METADATA_PATTERN = re.compile(
 
 def _get_run_metadata_from_response(
     response: httpx.Response,
-) -> Optional[RunCreateMetadata]:
+) -> RunCreateMetadata | None:
     """Extract run metadata from the response headers."""
     if (content_location := response.headers.get("Content-Location")) and (
         match := _RUN_METADATA_PATTERN.search(content_location)
@@ -142,10 +142,10 @@ def _get_run_metadata_from_response(
 
 def get_client(
     *,
-    url: Optional[str] = None,
-    api_key: Optional[str] = None,
-    headers: Optional[dict[str, str]] = None,
-    timeout: Optional[TimeoutTypes] = None,
+    url: str | None = None,
+    api_key: str | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: TimeoutTypes | None = None,
 ) -> LangGraphClient:
     """Get a LangGraphClient instance.
 
@@ -180,7 +180,7 @@ def get_client(
         ```
     """
 
-    transport: Optional[httpx.AsyncBaseTransport] = None
+    transport: httpx.AsyncBaseTransport | None = None
     if url is None:
         if os.environ.get("__LANGGRAPH_DEFER_LOOPBACK_TRANSPORT") == "true":
             transport = get_asgi_transport()(app=None, root_path="/noauth")
@@ -248,9 +248,9 @@ class HttpClient:
         self,
         path: str,
         *,
-        params: Optional[QueryParamTypes] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        params: QueryParamTypes | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a GET request."""
         r = await self.client.get(path, params=params, headers=headers)
@@ -271,9 +271,9 @@ class HttpClient:
         self,
         path: str,
         *,
-        json: Optional[dict],
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: dict | None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a POST request."""
         if json is not None:
@@ -302,8 +302,8 @@ class HttpClient:
         path: str,
         *,
         json: dict,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a PUT request."""
         request_headers, content = await _aencode_json(json)
@@ -328,8 +328,8 @@ class HttpClient:
         path: str,
         *,
         json: dict,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a PATCH request."""
         request_headers, content = await _aencode_json(json)
@@ -353,9 +353,9 @@ class HttpClient:
         self,
         path: str,
         *,
-        json: Optional[Any] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> None:
         """Send a DELETE request."""
         r = await self.client.request("DELETE", path, json=json, headers=headers)
@@ -376,10 +376,10 @@ class HttpClient:
         path: str,
         method: str,
         *,
-        json: Optional[dict] = None,
-        params: Optional[QueryParamTypes] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: dict | None = None,
+        params: QueryParamTypes | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> AsyncIterator[StreamPart]:
         """Stream results using SSE."""
         request_headers, content = await _aencode_json(json)
@@ -462,7 +462,7 @@ class AssistantsClient:
         self.http = http
 
     async def get(
-        self, assistant_id: str, *, headers: Optional[dict[str, str]] = None
+        self, assistant_id: str, *, headers: dict[str, str] | None = None
     ) -> Assistant:
         """Get an assistant by ID.
 
@@ -503,8 +503,8 @@ class AssistantsClient:
         self,
         assistant_id: str,
         *,
-        xray: Union[int, bool] = False,
-        headers: Optional[dict[str, str]] = None,
+        xray: int | bool = False,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         """Get the graph of an assistant by ID.
 
@@ -552,7 +552,7 @@ class AssistantsClient:
         )
 
     async def get_schemas(
-        self, assistant_id: str, *, headers: Optional[dict[str, str]] = None
+        self, assistant_id: str, *, headers: dict[str, str] | None = None
     ) -> GraphSchema:
         """Get the schemas of an assistant by ID.
 
@@ -670,10 +670,10 @@ class AssistantsClient:
     async def get_subgraphs(
         self,
         assistant_id: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         recurse: bool = False,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Subgraphs:
         """Get the schemas of an assistant by ID.
 
@@ -702,15 +702,15 @@ class AssistantsClient:
 
     async def create(
         self,
-        graph_id: Optional[str],
-        config: Optional[Config] = None,
+        graph_id: str | None,
+        config: Config | None = None,
         *,
         metadata: Json = None,
-        assistant_id: Optional[str] = None,
-        if_exists: Optional[OnConflictBehavior] = None,
-        name: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
-        description: Optional[str] = None,
+        assistant_id: str | None = None,
+        if_exists: OnConflictBehavior | None = None,
+        name: str | None = None,
+        headers: dict[str, str] | None = None,
+        description: str | None = None,
     ) -> Assistant:
         """Create a new assistant.
 
@@ -766,12 +766,12 @@ class AssistantsClient:
         self,
         assistant_id: str,
         *,
-        graph_id: Optional[str] = None,
-        config: Optional[Config] = None,
+        graph_id: str | None = None,
+        config: Config | None = None,
         metadata: Json = None,
-        name: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        headers: dict[str, str] | None = None,
+        description: str | None = None,
     ) -> Assistant:
         """Update an assistant.
 
@@ -825,7 +825,7 @@ class AssistantsClient:
         self,
         assistant_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete an assistant.
 
@@ -852,12 +852,12 @@ class AssistantsClient:
         self,
         *,
         metadata: Json = None,
-        graph_id: Optional[str] = None,
+        graph_id: str | None = None,
         limit: int = 10,
         offset: int = 0,
-        sort_by: Optional[AssistantSortBy] = None,
-        sort_order: Optional[SortOrder] = None,
-        headers: Optional[dict[str, str]] = None,
+        sort_by: AssistantSortBy | None = None,
+        sort_order: SortOrder | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Assistant]:
         """Search for assistants.
 
@@ -911,7 +911,7 @@ class AssistantsClient:
         limit: int = 10,
         offset: int = 0,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[AssistantVersion]:
         """List all versions of an assistant.
 
@@ -950,7 +950,7 @@ class AssistantsClient:
         assistant_id: str,
         version: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Assistant:
         """Change the version of an assistant.
 
@@ -1000,7 +1000,7 @@ class ThreadsClient:
         self.http = http
 
     async def get(
-        self, thread_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, *, headers: dict[str, str] | None = None
     ) -> Thread:
         """Get a thread by ID.
 
@@ -1040,11 +1040,11 @@ class ThreadsClient:
         self,
         *,
         metadata: Json = None,
-        thread_id: Optional[str] = None,
-        if_exists: Optional[OnConflictBehavior] = None,
-        supersteps: Optional[Sequence[dict[str, Sequence[dict[str, Any]]]]] = None,
-        graph_id: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        thread_id: str | None = None,
+        if_exists: OnConflictBehavior | None = None,
+        supersteps: Sequence[dict[str, Sequence[dict[str, Any]]]] | None = None,
+        graph_id: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Thread:
         """Create a new thread.
 
@@ -1105,7 +1105,7 @@ class ThreadsClient:
         thread_id: str,
         *,
         metadata: dict[str, Any],
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Thread:
         """Update a thread.
 
@@ -1132,7 +1132,7 @@ class ThreadsClient:
         )
 
     async def delete(
-        self, thread_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, *, headers: dict[str, str] | None = None
     ) -> None:
         """Delete a thread.
 
@@ -1160,12 +1160,12 @@ class ThreadsClient:
         *,
         metadata: Json = None,
         values: Json = None,
-        status: Optional[ThreadStatus] = None,
+        status: ThreadStatus | None = None,
         limit: int = 10,
         offset: int = 0,
-        sort_by: Optional[ThreadSortBy] = None,
-        sort_order: Optional[SortOrder] = None,
-        headers: Optional[dict[str, str]] = None,
+        sort_by: ThreadSortBy | None = None,
+        sort_order: SortOrder | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Thread]:
         """Search for threads.
 
@@ -1217,7 +1217,7 @@ class ThreadsClient:
         )
 
     async def copy(
-        self, thread_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, *, headers: dict[str, str] | None = None
     ) -> None:
         """Copy a thread.
 
@@ -1245,11 +1245,11 @@ class ThreadsClient:
     async def get_state(
         self,
         thread_id: str,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,  # deprecated
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,  # deprecated
         *,
         subgraphs: bool = False,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> ThreadState:
         """Get the state of a thread.
 
@@ -1372,12 +1372,12 @@ class ThreadsClient:
     async def update_state(
         self,
         thread_id: str,
-        values: Optional[Union[dict, Sequence[dict]]],
+        values: dict | Sequence[dict] | None,
         *,
-        as_node: Optional[str] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,  # deprecated
-        headers: Optional[dict[str, str]] = None,
+        as_node: str | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,  # deprecated
+        headers: dict[str, str] | None = None,
     ) -> ThreadUpdateStateResponse:
         """Update the state of a thread.
 
@@ -1435,10 +1435,10 @@ class ThreadsClient:
         thread_id: str,
         *,
         limit: int = 10,
-        before: Optional[str | Checkpoint] = None,
-        metadata: Optional[dict] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        headers: Optional[dict[str, str]] = None,
+        before: str | Checkpoint | None = None,
+        metadata: dict | None = None,
+        checkpoint: Checkpoint | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[ThreadState]:
         """Get the state history of a thread.
 
@@ -1501,26 +1501,26 @@ class RunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> AsyncIterator[StreamPart]: ...
 
     @overload
@@ -1529,52 +1529,52 @@ class RunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        webhook: Optional[str] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        webhook: str | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> AsyncIterator[StreamPart]: ...
 
     def stream(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> AsyncIterator[StreamPart]:
         """Create a run and stream the results.
 
@@ -1692,22 +1692,22 @@ class RunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        checkpoint_during: Optional[bool] = None,
-        config: Optional[Config] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        checkpoint_during: bool | None = None,
+        config: Config | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run: ...
 
     @overload
@@ -1716,50 +1716,50 @@ class RunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run: ...
 
     async def create(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run:
         """Create a background run.
 
@@ -1914,24 +1914,24 @@ class RunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
         raise_error: bool = True,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]: ...
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]: ...
 
     @overload
     async def wait(
@@ -1939,47 +1939,47 @@ class RunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
         raise_error: bool = True,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]: ...
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]: ...
 
     async def wait(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
         raise_error: bool = True,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]:
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]:
         """Create a run, wait until it finishes and return the final state.
 
         Args:
@@ -2113,8 +2113,8 @@ class RunsClient:
         *,
         limit: int = 10,
         offset: int = 0,
-        status: Optional[RunStatus] = None,
-        headers: Optional[dict[str, str]] = None,
+        status: RunStatus | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Run]:
         """List runs.
 
@@ -2151,7 +2151,7 @@ class RunsClient:
         )
 
     async def get(
-        self, thread_id: str, run_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, run_id: str, *, headers: dict[str, str] | None = None
     ) -> Run:
         """Get a run.
 
@@ -2186,7 +2186,7 @@ class RunsClient:
         *,
         wait: bool = False,
         action: CancelAction = "interrupt",
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Get a run.
 
@@ -2221,7 +2221,7 @@ class RunsClient:
         )
 
     async def join(
-        self, thread_id: str, run_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, run_id: str, *, headers: dict[str, str] | None = None
     ) -> dict:
         """Block until a run is done. Returns the final state of the thread.
 
@@ -2254,9 +2254,9 @@ class RunsClient:
         run_id: str,
         *,
         cancel_on_disconnect: bool = False,
-        stream_mode: Optional[Union[StreamMode, Sequence[StreamMode]]] = None,
-        headers: Optional[dict[str, str]] = None,
-        last_event_id: Optional[str] = None,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
+        headers: dict[str, str] | None = None,
+        last_event_id: str | None = None,
     ) -> AsyncIterator[StreamPart]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
@@ -2302,7 +2302,7 @@ class RunsClient:
         )
 
     async def delete(
-        self, thread_id: str, run_id: str, *, headers: Optional[dict[str, str]] = None
+        self, thread_id: str, run_id: str, *, headers: dict[str, str] | None = None
     ) -> None:
         """Delete a run.
 
@@ -2361,15 +2361,15 @@ class CronClient:
         assistant_id: str,
         *,
         schedule: str,
-        input: Optional[dict] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        input: dict | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Run:
         """Create a cron job for a thread.
 
@@ -2435,15 +2435,15 @@ class CronClient:
         assistant_id: str,
         *,
         schedule: str,
-        input: Optional[dict] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        input: dict | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Run:
         """Create a cron run.
 
@@ -2502,7 +2502,7 @@ class CronClient:
     async def delete(
         self,
         cron_id: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete a cron.
 
@@ -2528,11 +2528,11 @@ class CronClient:
     async def search(
         self,
         *,
-        assistant_id: Optional[str] = None,
-        thread_id: Optional[str] = None,
+        assistant_id: str | None = None,
+        thread_id: str | None = None,
         limit: int = 10,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Cron]:
         """Get a list of cron jobs.
 
@@ -2617,9 +2617,9 @@ class StoreClient:
         /,
         key: str,
         value: dict[str, Any],
-        index: Optional[Union[Literal[False], list[str]]] = None,
-        ttl: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
+        index: Literal[False] | list[str] | None = None,
+        ttl: int | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Store or update an item.
 
@@ -2667,8 +2667,8 @@ class StoreClient:
         /,
         key: str,
         *,
-        refresh_ttl: Optional[bool] = None,
-        headers: Optional[dict[str, str]] = None,
+        refresh_ttl: bool | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Item:
         """Retrieve a single item.
 
@@ -2719,7 +2719,7 @@ class StoreClient:
         namespace: Sequence[str],
         /,
         key: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete an item.
 
@@ -2751,12 +2751,12 @@ class StoreClient:
         self,
         namespace_prefix: Sequence[str],
         /,
-        filter: Optional[dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         limit: int = 10,
         offset: int = 0,
-        query: Optional[str] = None,
-        refresh_ttl: Optional[bool] = None,
-        headers: Optional[dict[str, str]] = None,
+        query: str | None = None,
+        refresh_ttl: bool | None = None,
+        headers: dict[str, str] | None = None,
     ) -> SearchItemsResponse:
         """Search for items within a namespace prefix.
 
@@ -2822,12 +2822,12 @@ class StoreClient:
 
     async def list_namespaces(
         self,
-        prefix: Optional[list[str]] = None,
-        suffix: Optional[list[str]] = None,
-        max_depth: Optional[int] = None,
+        prefix: list[str] | None = None,
+        suffix: list[str] | None = None,
+        max_depth: int | None = None,
         limit: int = 100,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> ListNamespaceResponse:
         """List namespaces with optional match conditions.
 
@@ -2879,10 +2879,10 @@ class StoreClient:
 
 def get_sync_client(
     *,
-    url: Optional[str] = None,
-    api_key: Optional[str] = None,
-    headers: Optional[dict[str, str]] = None,
-    timeout: Optional[TimeoutTypes] = None,
+    url: str | None = None,
+    api_key: str | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: TimeoutTypes | None = None,
 ) -> SyncLangGraphClient:
     """Get a synchronous LangGraphClient instance.
 
@@ -2974,9 +2974,9 @@ class SyncHttpClient:
         self,
         path: str,
         *,
-        params: Optional[QueryParamTypes] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        params: QueryParamTypes | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a GET request."""
         r = self.client.get(path, params=params, headers=headers)
@@ -2997,9 +2997,9 @@ class SyncHttpClient:
         self,
         path: str,
         *,
-        json: Optional[dict],
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: dict | None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a POST request."""
         if json is not None:
@@ -3027,8 +3027,8 @@ class SyncHttpClient:
         path: str,
         *,
         json: dict,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a PUT request."""
         request_headers, content = _encode_json(json)
@@ -3054,8 +3054,8 @@ class SyncHttpClient:
         path: str,
         *,
         json: dict,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Any:
         """Send a PATCH request."""
         request_headers, content = _encode_json(json)
@@ -3079,9 +3079,9 @@ class SyncHttpClient:
         self,
         path: str,
         *,
-        json: Optional[Any] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> None:
         """Send a DELETE request."""
         r = self.client.request("DELETE", path, json=json, headers=headers)
@@ -3102,10 +3102,10 @@ class SyncHttpClient:
         path: str,
         method: str,
         *,
-        json: Optional[dict] = None,
-        params: Optional[QueryParamTypes] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_response: Optional[Callable[[httpx.Response], None]] = None,
+        json: dict | None = None,
+        params: QueryParamTypes | None = None,
+        headers: dict[str, str] | None = None,
+        on_response: Callable[[httpx.Response], None] | None = None,
     ) -> Iterator[StreamPart]:
         """Stream the results of a request using SSE."""
         request_headers, content = _encode_json(json)
@@ -3180,7 +3180,7 @@ class SyncAssistantsClient:
         self,
         assistant_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Assistant:
         """Get an assistant by ID.
 
@@ -3220,8 +3220,8 @@ class SyncAssistantsClient:
         self,
         assistant_id: str,
         *,
-        xray: Union[int, bool] = False,
-        headers: Optional[dict[str, str]] = None,
+        xray: int | bool = False,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         """Get the graph of an assistant by ID.
 
@@ -3268,7 +3268,7 @@ class SyncAssistantsClient:
         self,
         assistant_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> GraphSchema:
         """Get the schemas of an assistant by ID.
 
@@ -3382,10 +3382,10 @@ class SyncAssistantsClient:
     def get_subgraphs(
         self,
         assistant_id: str,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         recurse: bool = False,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Subgraphs:
         """Get the schemas of an assistant by ID.
 
@@ -3412,15 +3412,15 @@ class SyncAssistantsClient:
 
     def create(
         self,
-        graph_id: Optional[str],
-        config: Optional[Config] = None,
+        graph_id: str | None,
+        config: Config | None = None,
         *,
         metadata: Json = None,
-        assistant_id: Optional[str] = None,
-        if_exists: Optional[OnConflictBehavior] = None,
-        name: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
-        description: Optional[str] = None,
+        assistant_id: str | None = None,
+        if_exists: OnConflictBehavior | None = None,
+        name: str | None = None,
+        headers: dict[str, str] | None = None,
+        description: str | None = None,
     ) -> Assistant:
         """Create a new assistant.
 
@@ -3476,12 +3476,12 @@ class SyncAssistantsClient:
         self,
         assistant_id: str,
         *,
-        graph_id: Optional[str] = None,
-        config: Optional[Config] = None,
+        graph_id: str | None = None,
+        config: Config | None = None,
         metadata: Json = None,
-        name: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        headers: dict[str, str] | None = None,
+        description: str | None = None,
     ) -> Assistant:
         """Update an assistant.
 
@@ -3534,7 +3534,7 @@ class SyncAssistantsClient:
         self,
         assistant_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete an assistant.
 
@@ -3561,10 +3561,10 @@ class SyncAssistantsClient:
         self,
         *,
         metadata: Json = None,
-        graph_id: Optional[str] = None,
+        graph_id: str | None = None,
         limit: int = 10,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Assistant]:
         """Search for assistants.
 
@@ -3612,7 +3612,7 @@ class SyncAssistantsClient:
         limit: int = 10,
         offset: int = 0,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[AssistantVersion]:
         """List all versions of an assistant.
 
@@ -3652,7 +3652,7 @@ class SyncAssistantsClient:
         assistant_id: str,
         version: int,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Assistant:
         """Change the version of an assistant.
 
@@ -3704,7 +3704,7 @@ class SyncThreadsClient:
         self,
         thread_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Thread:
         """Get a thread by ID.
 
@@ -3743,11 +3743,11 @@ class SyncThreadsClient:
         self,
         *,
         metadata: Json = None,
-        thread_id: Optional[str] = None,
-        if_exists: Optional[OnConflictBehavior] = None,
-        supersteps: Optional[Sequence[dict[str, Sequence[dict[str, Any]]]]] = None,
-        graph_id: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        thread_id: str | None = None,
+        if_exists: OnConflictBehavior | None = None,
+        supersteps: Sequence[dict[str, Sequence[dict[str, Any]]]] | None = None,
+        graph_id: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Thread:
         """Create a new thread.
 
@@ -3809,7 +3809,7 @@ class SyncThreadsClient:
         thread_id: str,
         *,
         metadata: dict[str, Any],
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Thread:
         """Update a thread.
 
@@ -3839,7 +3839,7 @@ class SyncThreadsClient:
         self,
         thread_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete a thread.
 
@@ -3866,10 +3866,10 @@ class SyncThreadsClient:
         *,
         metadata: Json = None,
         values: Json = None,
-        status: Optional[ThreadStatus] = None,
+        status: ThreadStatus | None = None,
         limit: int = 10,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Thread]:
         """Search for threads.
 
@@ -3913,7 +3913,7 @@ class SyncThreadsClient:
         self,
         thread_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Copy a thread.
 
@@ -3939,11 +3939,11 @@ class SyncThreadsClient:
     def get_state(
         self,
         thread_id: str,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,  # deprecated
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,  # deprecated
         *,
         subgraphs: bool = False,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> ThreadState:
         """Get the state of a thread.
 
@@ -4066,12 +4066,12 @@ class SyncThreadsClient:
     def update_state(
         self,
         thread_id: str,
-        values: Optional[Union[dict, Sequence[dict]]],
+        values: dict | Sequence[dict] | None,
         *,
-        as_node: Optional[str] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,  # deprecated
-        headers: Optional[dict[str, str]] = None,
+        as_node: str | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,  # deprecated
+        headers: dict[str, str] | None = None,
     ) -> ThreadUpdateStateResponse:
         """Update the state of a thread.
 
@@ -4127,10 +4127,10 @@ class SyncThreadsClient:
         thread_id: str,
         *,
         limit: int = 10,
-        before: Optional[str | Checkpoint] = None,
-        metadata: Optional[dict] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        headers: Optional[dict[str, str]] = None,
+        before: str | Checkpoint | None = None,
+        metadata: dict | None = None,
+        checkpoint: Checkpoint | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[ThreadState]:
         """Get the state history of a thread.
 
@@ -4195,25 +4195,25 @@ class SyncRunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Iterator[StreamPart]: ...
 
     @overload
@@ -4222,52 +4222,52 @@ class SyncRunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        webhook: Optional[str] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        webhook: str | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Iterator[StreamPart]: ...
 
     def stream(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        feedback_keys: Optional[Sequence[str]] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        feedback_keys: Sequence[str] | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Iterator[StreamPart]:
         """Create a run and stream the results.
 
@@ -4383,22 +4383,22 @@ class SyncRunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run: ...
 
     @overload
@@ -4407,50 +4407,50 @@ class SyncRunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run: ...
 
     def create(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        stream_mode: Union[StreamMode, Sequence[StreamMode]] = "values",
+        input: dict | None = None,
+        command: Command | None = None,
+        stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
         stream_resumable: bool = False,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
     ) -> Run:
         """Create a background run.
 
@@ -4591,7 +4591,7 @@ class SyncRunsClient:
         )
 
     def create_batch(
-        self, payloads: list[RunCreate], *, headers: Optional[dict[str, str]] = None
+        self, payloads: list[RunCreate], *, headers: dict[str, str] | None = None
     ) -> list[Run]:
         """Create a batch of stateless background runs."""
 
@@ -4607,23 +4607,23 @@ class SyncRunsClient:
         thread_id: str,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]: ...
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]: ...
 
     @overload
     def wait(
@@ -4631,45 +4631,45 @@ class SyncRunsClient:
         thread_id: None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]: ...
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]: ...
 
     def wait(
         self,
-        thread_id: Optional[str],
+        thread_id: str | None,
         assistant_id: str,
         *,
-        input: Optional[dict] = None,
-        command: Optional[Command] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        checkpoint: Optional[Checkpoint] = None,
-        checkpoint_id: Optional[str] = None,
-        interrupt_before: Optional[Union[All, Sequence[str]]] = None,
-        interrupt_after: Optional[Union[All, Sequence[str]]] = None,
-        webhook: Optional[str] = None,
-        on_disconnect: Optional[DisconnectMode] = None,
-        on_completion: Optional[OnCompletionBehavior] = None,
-        multitask_strategy: Optional[MultitaskStrategy] = None,
-        if_not_exists: Optional[IfNotExists] = None,
-        after_seconds: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
-        on_run_created: Optional[Callable[[RunCreateMetadata], None]] = None,
-    ) -> Union[list[dict], dict[str, Any]]:
+        input: dict | None = None,
+        command: Command | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        headers: dict[str, str] | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+    ) -> list[dict] | dict[str, Any]:
         """Create a run, wait until it finishes and return the final state.
 
         Args:
@@ -4794,7 +4794,7 @@ class SyncRunsClient:
         *,
         limit: int = 10,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Run]:
         """List runs.
 
@@ -4828,7 +4828,7 @@ class SyncRunsClient:
         thread_id: str,
         run_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> Run:
         """Get a run.
 
@@ -4860,7 +4860,7 @@ class SyncRunsClient:
         *,
         wait: bool = False,
         action: CancelAction = "interrupt",
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Get a run.
 
@@ -4899,7 +4899,7 @@ class SyncRunsClient:
         thread_id: str,
         run_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> dict:
         """Block until a run is done. Returns the final state of the thread.
 
@@ -4931,10 +4931,10 @@ class SyncRunsClient:
         thread_id: str,
         run_id: str,
         *,
-        stream_mode: Optional[Union[StreamMode, Sequence[StreamMode]]] = None,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
         cancel_on_disconnect: bool = False,
-        headers: Optional[dict[str, str]] = None,
-        last_event_id: Optional[str] = None,
+        headers: dict[str, str] | None = None,
+        last_event_id: str | None = None,
     ) -> Iterator[StreamPart]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
@@ -4983,7 +4983,7 @@ class SyncRunsClient:
         thread_id: str,
         run_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete a run.
 
@@ -5036,15 +5036,15 @@ class SyncCronClient:
         assistant_id: str,
         *,
         schedule: str,
-        input: Optional[dict] = None,
-        metadata: Optional[dict] = None,
-        checkpoint_during: Optional[bool] = None,
-        config: Optional[Config] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        input: dict | None = None,
+        metadata: dict | None = None,
+        checkpoint_during: bool | None = None,
+        config: Config | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Run:
         """Create a cron job for a thread.
 
@@ -5107,15 +5107,15 @@ class SyncCronClient:
         assistant_id: str,
         *,
         schedule: str,
-        input: Optional[dict] = None,
-        metadata: Optional[dict] = None,
-        config: Optional[Config] = None,
-        checkpoint_during: Optional[bool] = None,
-        interrupt_before: Optional[Union[All, list[str]]] = None,
-        interrupt_after: Optional[Union[All, list[str]]] = None,
-        webhook: Optional[str] = None,
-        multitask_strategy: Optional[str] = None,
-        headers: Optional[dict[str, str]] = None,
+        input: dict | None = None,
+        metadata: dict | None = None,
+        config: Config | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
+        webhook: str | None = None,
+        multitask_strategy: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Run:
         """Create a cron run.
 
@@ -5175,7 +5175,7 @@ class SyncCronClient:
         self,
         cron_id: str,
         *,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete a cron.
 
@@ -5201,11 +5201,11 @@ class SyncCronClient:
     def search(
         self,
         *,
-        assistant_id: Optional[str] = None,
-        thread_id: Optional[str] = None,
+        assistant_id: str | None = None,
+        thread_id: str | None = None,
         limit: int = 10,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> list[Cron]:
         """Get a list of cron jobs.
 
@@ -5289,9 +5289,9 @@ class SyncStoreClient:
         /,
         key: str,
         value: dict[str, Any],
-        index: Optional[Union[Literal[False], list[str]]] = None,
-        ttl: Optional[int] = None,
-        headers: Optional[dict[str, str]] = None,
+        index: Literal[False] | list[str] | None = None,
+        ttl: int | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Store or update an item.
 
@@ -5337,8 +5337,8 @@ class SyncStoreClient:
         /,
         key: str,
         *,
-        refresh_ttl: Optional[bool] = None,
-        headers: Optional[dict[str, str]] = None,
+        refresh_ttl: bool | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Item:
         """Retrieve a single item.
 
@@ -5390,7 +5390,7 @@ class SyncStoreClient:
         namespace: Sequence[str],
         /,
         key: str,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         """Delete an item.
 
@@ -5420,12 +5420,12 @@ class SyncStoreClient:
         self,
         namespace_prefix: Sequence[str],
         /,
-        filter: Optional[dict[str, Any]] = None,
+        filter: dict[str, Any] | None = None,
         limit: int = 10,
         offset: int = 0,
-        query: Optional[str] = None,
-        refresh_ttl: Optional[bool] = None,
-        headers: Optional[dict[str, str]] = None,
+        query: str | None = None,
+        refresh_ttl: bool | None = None,
+        headers: dict[str, str] | None = None,
     ) -> SearchItemsResponse:
         """Search for items within a namespace prefix.
 
@@ -5487,12 +5487,12 @@ class SyncStoreClient:
 
     def list_namespaces(
         self,
-        prefix: Optional[list[str]] = None,
-        suffix: Optional[list[str]] = None,
-        max_depth: Optional[int] = None,
+        prefix: list[str] | None = None,
+        suffix: list[str] | None = None,
+        max_depth: int | None = None,
         limit: int = 100,
         offset: int = 0,
-        headers: Optional[dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
     ) -> ListNamespaceResponse:
         """List namespaces with optional match conditions.
 

--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -48,4 +48,4 @@ lint.select = [
   "B",  # flake8-bugbear
   "I",  # isort
 ]
-lint.ignore = ["E501", "B008", "UP007", "UP006"]
+lint.ignore = ["E501", "B008"]


### PR DESCRIPTION
Enables the following pyupgrade rules:
* https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/ (`Union[X, Y]` -> `X | Y`)
* https://docs.astral.sh/ruff/rules/non-pep585-annotation/ (`List[str]` -> `list[str]`)