### PR TITLE
Centralized CheckpointTuple creation into a shared function for checkpoint_postgres

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -421,7 +421,7 @@ class PostgresSaver(BasePostgresSaver):
         Convert a database row into a CheckpointTuple object.
 
         Args:
-            value (DictRow): A row from the database containing checkpoint data.
+            value: A row from the database containing checkpoint data.
 
         Returns:
             CheckpointTuple: A structured representation of the checkpoint,

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -162,32 +162,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                             value["channel_values"],
                         )
             for value in values:
-                yield CheckpointTuple(
-                    {
-                        "configurable": {
-                            "thread_id": value["thread_id"],
-                            "checkpoint_ns": value["checkpoint_ns"],
-                            "checkpoint_id": value["checkpoint_id"],
-                        }
-                    },
-                    {
-                        **value["checkpoint"],
-                        "channel_values": self._load_blobs(value["channel_values"]),
-                    },
-                    value["metadata"],
-                    (
-                        {
-                            "configurable": {
-                                "thread_id": value["thread_id"],
-                                "checkpoint_ns": value["checkpoint_ns"],
-                                "checkpoint_id": value["parent_checkpoint_id"],
-                            }
-                        }
-                        if value["parent_checkpoint_id"]
-                        else None
-                    ),
-                    await asyncio.to_thread(self._load_writes, value["pending_writes"]),
-                )
+                yield await self._load_checkpoint_tuple(value)
 
     async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database asynchronously.
@@ -238,32 +213,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                         value["channel_values"],
                     )
 
-            return CheckpointTuple(
-                {
-                    "configurable": {
-                        "thread_id": thread_id,
-                        "checkpoint_ns": checkpoint_ns,
-                        "checkpoint_id": value["checkpoint_id"],
-                    }
-                },
-                {
-                    **value["checkpoint"],
-                    "channel_values": self._load_blobs(value["channel_values"]),
-                },
-                value["metadata"],
-                (
-                    {
-                        "configurable": {
-                            "thread_id": thread_id,
-                            "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": value["parent_checkpoint_id"],
-                        }
-                    }
-                    if value["parent_checkpoint_id"]
-                    else None
-                ),
-                await asyncio.to_thread(self._load_writes, value["pending_writes"]),
-            )
+            return await self._load_checkpoint_tuple(value)
 
     async def aput(
         self,
@@ -423,6 +373,45 @@ class AsyncPostgresSaver(BasePostgresSaver):
             else:
                 async with conn.cursor(binary=True, row_factory=dict_row) as cur:
                     yield cur
+
+    async def _load_checkpoint_tuple(self, value: DictRow) -> CheckpointTuple:
+        """
+        Convert a database row into a CheckpointTuple object.
+
+        Args:
+            value (DictRow): A row from the database containing checkpoint data.
+
+        Returns:
+            CheckpointTuple: A structured representation of the checkpoint,
+            including its configuration, metadata, parent checkpoint (if any),
+            and pending writes.
+        """
+        return CheckpointTuple(
+            {
+                "configurable": {
+                    "thread_id": value["thread_id"],
+                    "checkpoint_ns": value["checkpoint_ns"],
+                    "checkpoint_id": value["checkpoint_id"],
+                }
+            },
+            {
+                **value["checkpoint"],
+                "channel_values": self._load_blobs(value["channel_values"]),
+            },
+            value["metadata"],
+            (
+                {
+                    "configurable": {
+                        "thread_id": value["thread_id"],
+                        "checkpoint_ns": value["checkpoint_ns"],
+                        "checkpoint_id": value["parent_checkpoint_id"],
+                    }
+                }
+                if value["parent_checkpoint_id"]
+                else None
+            ),
+            await asyncio.to_thread(self._load_writes, value["pending_writes"]),
+        )
 
     def list(
         self,

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -379,7 +379,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         Convert a database row into a CheckpointTuple object.
 
         Args:
-            value (DictRow): A row from the database containing checkpoint data.
+            value: A row from the database containing checkpoint data.
 
         Returns:
             CheckpointTuple: A structured representation of the checkpoint,


### PR DESCRIPTION
I am working on creating a checkpointer for the oracle database and am referring to the postgres checkpointer.

I noticed that `get_tuple` and `list` (and also `aget_tuple` and `alist`) generate `CheckpointTuple`, but the code is duplicated.

In this PR, a new method to generate `CheckpointTuple` is created and reused.

The original implementation of `get_tuple`(`aget_tuple`) does not read the `thread_id` and `checkpoint_ns` from the `value`, but even if they were read from the `value`, the overhead would be negligible and the code duplication elimination would be more beneficial.
