### PR TITLE
Fix fork checkpoint

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1579,7 +1579,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
                         "Cannot copy checkpoint with multiple updates"
                     )
 
-                next_checkpoint = create_checkpoint(checkpoint, None, step)
+                next_checkpoint = create_checkpoint(checkpoint, None, step, is_fork=True)
                 # copy checkpoint
                 next_config = checkpointer.put(
                     saved.parent_config or saved.config if saved else checkpoint_config,
@@ -1742,7 +1742,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            checkpoint = create_checkpoint(checkpoint, channels, step + 1, is_fork=True)
             next_config = checkpointer.put(
                 checkpoint_config,
                 checkpoint,
@@ -1999,7 +1999,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
                         "Cannot copy checkpoint with multiple updates"
                     )
 
-                next_checkpoint = create_checkpoint(checkpoint, None, step)
+                next_checkpoint = create_checkpoint(checkpoint, None, step, is_fork=True)
                 # copy checkpoint
                 next_config = await checkpointer.aput(
                     saved.parent_config or saved.config if saved else checkpoint_config,
@@ -2159,7 +2159,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            checkpoint = create_checkpoint(checkpoint, channels, step + 1, is_fork=True)
             # save checkpoint, after applying writes
             next_config = await checkpointer.aput(
                 checkpoint_config,

--- a/libs/langgraph/langgraph/pregel/checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/checkpoint.py
@@ -29,6 +29,7 @@ def create_checkpoint(
     step: int,
     *,
     id: str | None = None,
+    is_fork: bool = False,
 ) -> Checkpoint:
     """Create a checkpoint for the given channels."""
     ts = datetime.now(timezone.utc).isoformat()
@@ -42,10 +43,14 @@ def create_checkpoint(
             v = channels[k].checkpoint()
             if v is not MISSING:
                 values[k] = v
+    
+    # Generate new ID if is_fork=True or no ID provided
+    checkpoint_id = id if id and not is_fork else str(uuid6(clock_seq=step))
+    
     return Checkpoint(
         v=LATEST_VERSION,
         ts=ts,
-        id=id or str(uuid6(clock_seq=step)),
+        id=checkpoint_id,
         channel_values=values,
         channel_versions=checkpoint["channel_versions"],
         versions_seen=checkpoint["versions_seen"],

--- a/libs/langgraph/tests/test_checkpoint_forking.py
+++ b/libs/langgraph/tests/test_checkpoint_forking.py
@@ -1,0 +1,66 @@
+import pytest
+from langgraph.pregel.checkpoint import create_checkpoint, empty_checkpoint
+
+
+class MockLastValue:
+    """Mock compatible with LangGraph's LastValue channel interface."""
+    def __init__(self, initial_value):
+        self._value = initial_value
+        self._version = 1
+
+    def update(self, new_values):
+        self._value = new_values[-1]
+        self._version += 1
+
+    def snapshot(self):
+        return self._value
+
+    @property
+    def version(self):
+        return self._version
+
+    def checkpoint(self):
+        return self._value
+
+
+@pytest.mark.parametrize("explicit_id", ["test-id-123", "another-id"])
+def test_checkpoint_id_generation(explicit_id):
+    initial = empty_checkpoint()
+    checkpoint1 = create_checkpoint(initial, None, 0, id=explicit_id)
+    assert checkpoint1["id"] == explicit_id
+
+    # Fork with explicit ID should ignore the ID and generate new one
+    checkpoint2 = create_checkpoint(initial, None, 0, id=explicit_id, is_fork=True)
+    assert checkpoint2["id"] != explicit_id
+    assert checkpoint2["id"] != initial["id"]
+
+
+def test_checkpoint_with_counter_only():
+    counter_channel = MockLastValue(42)
+    channels = {"counter": counter_channel}
+
+    initial = empty_checkpoint()
+    initial["channel_versions"] = {"counter": 1}
+    checkpoint1 = create_checkpoint(initial, channels, 0)
+    print("Checkpoint 1 Channel Values:", checkpoint1["channel_values"])
+
+    counter_channel.update([99])
+
+    fork = create_checkpoint(checkpoint1, channels, 1, is_fork=True)
+    print("Fork Channel Values:", fork["channel_values"])
+
+    assert fork["channel_values"]["counter"] == 99
+    assert fork["id"] != checkpoint1["id"]
+
+
+def test_checkpoint_metadata_preservation():
+    initial = empty_checkpoint()
+    initial["versions_seen"] = {"node1": {"channel1": 1}}
+    initial["channel_versions"] = {"channel1": 1}
+
+    fork = create_checkpoint(initial, None, 0, is_fork=True)
+
+    assert fork["versions_seen"] == initial["versions_seen"]
+    assert fork["channel_versions"] == initial["channel_versions"]
+    assert fork["v"] == initial["v"]
+    assert fork["id"] != initial["id"]


### PR DESCRIPTION
# What this PR does
- Updated all code paths that create a new checkpoint during a fork or replay to use `is_fork=True` when calling `create_checkpoint`.
- This ensures that a new, unique checkpoint ID is generated for each new step after a fork, preserving the integrity of the checkpoint history.

**Example of the fix:**

```python
# Before (buggy)
next_checkpoint = create_checkpoint(checkpoint, None, step)
checkpoint = create_checkpoint(checkpoint, channels, step + 1)

# After (fixed)
next_checkpoint = create_checkpoint(checkpoint, None, step, is_fork=True)
checkpoint = create_checkpoint(checkpoint, channels, step + 1, is_fork=True)
``` 
Fixes #4987