### PR TITLE
Use asyncio.to_thread in adelete_thread to ensure async compatibility

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, ExitStack
 from types import TracebackType
 from typing import Any
+import asyncio
 
 from langchain_core.runnables import RunnableConfig
 
@@ -502,15 +503,8 @@ class InMemorySaver(
         return self.put_writes(config, writes, task_id, task_path)
 
     async def adelete_thread(self, thread_id: str) -> None:
-        """Delete all checkpoints and writes associated with a thread ID.
-
-        Args:
-            thread_id: The thread ID to delete.
-
-        Returns:
-            None
-        """
-        return self.delete_thread(thread_id)
+        """Delete all checkpoints and writes associated with a thread ID (async)."""
+        await asyncio.to_thread(self.delete_thread, thread_id)
 
     def get_next_version(self, current: str | None) -> str:
         if current is None:

--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -205,6 +205,39 @@ class TestMemorySaver:
         ]
         assert len(search_results_4) == 0
 
+    def test_delete_thread_sync(self) -> None:
+        # Save a checkpoint and get the config with checkpoint_id
+        saved_config = self.memory_saver.put(
+            self.config_1, self.chkpnt_1, self.metadata_1, self.chkpnt_1["channel_versions"]
+        )
+        # Ensure it exists
+        assert self.memory_saver.get_tuple(saved_config) is not None
+        # Delete synchronously
+        self.memory_saver.delete_thread(self.config_1["configurable"]["thread_id"])
+        # Ensure it is gone
+        assert self.memory_saver.get_tuple(saved_config) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_thread_async(self) -> None:
+        saved_config = self.memory_saver.put(
+            self.config_2, self.chkpnt_2, self.metadata_2, self.chkpnt_2["channel_versions"]
+        )
+        assert self.memory_saver.get_tuple(saved_config) is not None
+        await self.memory_saver.adelete_thread(self.config_2["configurable"]["thread_id"])
+        assert self.memory_saver.get_tuple(saved_config) is None
+
+    @pytest.mark.asyncio
+    async def test_adelete_thread_is_coroutine(self) -> None:
+        saved_config = self.memory_saver.put(
+            self.config_3, self.chkpnt_3, self.metadata_3, self.chkpnt_3["channel_versions"]
+        )
+        assert self.memory_saver.get_tuple(saved_config) is not None
+        import asyncio
+        coro = self.memory_saver.adelete_thread(self.config_3["configurable"]["thread_id"])
+        assert asyncio.iscoroutine(coro)
+        await coro
+        assert self.memory_saver.get_tuple(saved_config) is None
+
 
 def test_memory_saver() -> None:
     from langgraph.checkpoint.memory import MemorySaver


### PR DESCRIPTION
# Fix: Make `adelete_thread` a True Coroutine in InMemorySaver


## Problem

The original implementation of `adelete_thread` in `InMemorySaver` was:

```python
async def adelete_thread(self, thread_id: str) -> None:
    return self.delete_thread(thread_id)
```

This is not a true coroutine. It simply calls the synchronous method and returns `None`. When user code does `await adelete_thread(...)`, Python expects a coroutine, but gets `None`, resulting in a `RuntimeWarning`.

## The Fix

I updated the implementation to:

```python
async def adelete_thread(self, thread_id: str) -> None:
    await asyncio.to_thread(self.delete_thread, thread_id)
```

This ensures that `adelete_thread` is always a true coroutine, can be awaited, and never blocks the event loop.

## Why This Resolves the Issue
- `adelete_thread` is now a real coroutine and can be safely awaited in async code.
- No more `RuntimeWarning` about un-awaited coroutines.
- The async interface is now consistent with other checkpointers.

## Additional Improvements
- Added tests to ensure both sync and async deletion work, and that `adelete_thread` is a true coroutine.

Fixes #4880