### PR TITLE
Add `response_schema` to `interrupt` and `Interrupt`

### DIFF
--- a/libs/sdk-js/src/schema.ts
+++ b/libs/sdk-js/src/schema.ts
@@ -149,6 +149,7 @@ export interface Interrupt<TValue = unknown> {
   when: "during" | (string & {});
   resumable?: boolean;
   ns?: string[];
+  response_schema?: Record<string, any> | null;
 }
 
 export interface Thread<ValuesType = DefaultValues> {

--- a/libs/sdk-py/langgraph_sdk/schema.py
+++ b/libs/sdk-py/langgraph_sdk/schema.py
@@ -216,6 +216,8 @@ class Interrupt(TypedDict, total=False):
     """Whether the interrupt can be resumed."""
     ns: list[str] | None
     """Optional namespace for the interrupt."""
+    response_schema: dict | None
+    """Optional JSON schema to validate the resume value when execution resumes."""
 
 
 class Thread(TypedDict):


### PR DESCRIPTION
 close #5027 

### Summary
Adds optional `response_schema` parameter to `interrupt()` function and `Interrupt` dataclass to enable structured validation of resume values in human-in-the-loop workflows.

### Changes
- **Core functionality**: Added `response_schema: dict | None` field to `Interrupt` dataclass
- **API enhancement**: Modified `interrupt(value, *, response_schema=None)` to accept Pydantic model classes
- **Validation**: Resume values are validated against the schema and converted to model instances
- **Error handling**: Invalid data triggers new interrupts with detailed validation error messages

### Technical Details
- Stores JSON schema dictionaries (not Pydantic classes) for proper serialization
- Compatible with all checkpointers and graph state persistence
- Maintains backward compatibility - existing code works unchanged
- Validation errors include detailed field-level feedback
