### PR TITLE
docs: fixed a wrong import in persistence docs

### DIFF
--- a/docs/docs/how-tos/persistence.ipynb
+++ b/docs/docs/how-tos/persistence.ipynb
@@ -1107,10 +1107,10 @@
    "source": [
     "### Use in production\n",
     "\n",
-    "In production, you would want to use a checkpointer backed by a database:\n",
+    "In production, you would want to use a store backed by a database:\n",
     "\n",
     "```python\n",
-    "from langgraph.checkpoint.postgres import PostgresSaver\n",
+    "from langgraph.store.postgres import PostgresStore\n",
     "\n",
     "DB_URI = \"postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable\"\n",
     "# highlight-next-line\n",


### PR DESCRIPTION
Hi, I think I found an error in the docs on the persistence page [Click here for reference in docs](https://langchain-ai.github.io/langgraph/how-tos/persistence/#use-in-production_1) and I fixed it