### PR TITLE
Add docs for checkpoint encryption

### DIFF
--- a/docs/docs/concepts/persistence.md
+++ b/docs/docs/concepts/persistence.md
@@ -470,8 +470,33 @@ If the checkpointer is used with asynchronous graph execution (i.e. executing th
 
 ### Serializer
 
-When checkpointers save the graph state, they need to serialize the channel values in the state. This is done using serializer objects. 
+When checkpointers save the graph state, they need to serialize the channel values in the state. This is done using serializer objects.
 `langgraph_checkpoint` defines [protocol][langgraph.checkpoint.serde.base.SerializerProtocol] for implementing serializers provides a default implementation ([JsonPlusSerializer][langgraph.checkpoint.serde.jsonplus.JsonPlusSerializer]) that handles a wide variety of types, including LangChain and LangGraph primitives, datetimes, enums and more.
+
+#### Encryption
+
+Checkpointers can optionally encrypt all persisted state. To enable this, pass an instance of [`EncryptedSerializer`][langgraph.checkpoint.serde.encrypted.EncryptedSerializer] to the `serde` argument of any `BaseCheckpointSaver` implementation. The easiest way to create an encrypted serializer is via [`from_pycryptodome_aes`][langgraph.checkpoint.serde.encrypted.EncryptedSerializer.from_pycryptodome_aes], which reads the AES key from the `LANGGRAPH_AES_KEY` environment variable (or accepts a `key` argument):
+
+```python
+import sqlite3
+
+from langgraph.checkpoint.serde.encrypted import EncryptedSerializer
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+serde = EncryptedSerializer.from_pycryptodome_aes()  # reads LANGGRAPH_AES_KEY
+checkpointer = SqliteSaver(sqlite3.connect("checkpoint.db"), serde=serde)
+```
+
+```python
+from langgraph.checkpoint.serde.encrypted import EncryptedSerializer
+from langgraph.checkpoint.postgres import PostgresSaver
+
+serde = EncryptedSerializer.from_pycryptodome_aes()
+checkpointer = PostgresSaver.from_conn_string("postgresql://...", serde=serde)
+checkpointer.setup()
+```
+
+When running on LangGraph Platform, encryption is automatically enabled whenever `LANGGRAPH_AES_KEY` is present, so you only need to provide the environment variable. Other encryption schemes can be used by implementing [`CipherProtocol`][langgraph.checkpoint.serde.base.CipherProtocol] and supplying it to `EncryptedSerializer`.
 
 ## Capabilities
 

--- a/docs/docs/reference/checkpoints.md
+++ b/docs/docs/reference/checkpoints.md
@@ -12,11 +12,17 @@
     options:
       members:
         - SerializerProtocol
+        - CipherProtocol
 
 ::: langgraph.checkpoint.serde.jsonplus
     options:
       members:
         - JsonPlusSerializer
+
+::: langgraph.checkpoint.serde.encrypted
+    options:
+      members:
+        - EncryptedSerializer
 
 ::: langgraph.checkpoint.memory
 


### PR DESCRIPTION
## Summary
- document using `EncryptedSerializer` with checkpointers
- list `CipherProtocol` and `EncryptedSerializer` in checkpoint API reference

## Testing
- `make format-docs`
- `make lint-docs`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_68488efea548832dba0fb0fd508fca25