### PR TITLE
remove use of importlib.metadata for version access - Replace importl…

### DIFF
--- a/libs/cli/langgraph_cli/version.py
+++ b/libs/cli/langgraph_cli/version.py
@@ -1,10 +1,3 @@
 """Main entrypoint into package."""
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "0.3.1"

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-cli"
-version = "0.3.1"
+dynamic = ["version"]
 description = "CLI for interacting with LangGraph API"
 authors = []
 requires-python = ">=3.9"
@@ -60,3 +60,9 @@ lint.select = [
   "I",  # isort
 ]
 lint.ignore = ["E501", "B008"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.3.1"

--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,10 +1,3 @@
 """Exports package version."""
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "0.4.7"

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "0.4.7"
+dynamic = ["version"]
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.9"
@@ -106,3 +106,9 @@ packages = ["langgraph"]
 
 [tool.pytest.ini_options]
 addopts = "--full-trace --strict-markers --strict-config --durations=5 --snapshot-warn-unused"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.4.7"

--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -1,11 +1,6 @@
 from langgraph_sdk.auth import Auth
 from langgraph_sdk.client import get_client, get_sync_client
 
-try:
-    from importlib import metadata
-
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    __version__ = "unknown"
+__version__ = "0.1.70"
 
 __all__ = ["Auth", "get_client", "get_sync_client"]

--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-sdk"
-version = "0.1.70"
+dynamic = ["version"]
 description = "SDK for interacting with LangGraph API"
 authors = []
 requires-python = ">=3.9"
@@ -49,3 +49,9 @@ lint.select = [
   "I",  # isort
 ]
 lint.ignore = ["E501", "B008"]
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.1.70"


### PR DESCRIPTION
## Summary
Removes `importlib.metadata` usage for version access and implements UV dynamic versioning as requested in #5040.

## Changes Made
- **Removed `importlib.metadata` imports** from version files across all packages
- **Replaced with simple hardcoded versions** for runtime access
- **Added `uv-dynamic-versioning`** to build systems for modern version management
- **Configured fallback versions** for development environments

## Packages Affected
- `langgraph` (main package)
- `langgraph-cli` 
- `langgraph-sdk`

## Performance Benefits
- Eliminates runtime metadata lookups during imports
- Reduces import overhead by removing `importlib.metadata` dependency
- Maintains clean version access through simple string constants

## Implementation Details
### Before:
```python
from importlib import metadata
try:
    __version__ = metadata.version(__package__)
except metadata.PackageNotFoundError:
    __version__ = ""
```

### After:
```python
__version__ = "0.4.7"  # Simple fallback
```

### Build Configuration:
```toml
[build-system]
requires = ["hatchling", "uv-dynamic-versioning"]

[project]
dynamic = ["version"]

[tool.hatch.version]
source = "uv-dynamic-versioning"
```


Fixes #5040