### PR TITLE
feat(react): enhance useStream with initialValues, newThreadId, and onStop callback for improved UX

### DIFF
--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -1014,8 +1014,8 @@ export class RunsClient<
     const stream: ReadableStream<{ event: any; data: any }> = (
       response.body || new ReadableStream({ start: (ctrl) => ctrl.close() })
     )
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     yield* IterableReadableStream.fromReadableStream(stream);
   }
@@ -1318,8 +1318,8 @@ export class RunsClient<
     const stream: ReadableStream<{ event: string; data: any }> = (
       response.body || new ReadableStream({ start: (ctrl) => ctrl.close() })
     )
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     yield* IterableReadableStream.fromReadableStream(stream);
   }

--- a/libs/sdk-js/src/react/stream.tsx
+++ b/libs/sdk-js/src/react/stream.tsx
@@ -1095,7 +1095,7 @@ export function useStream<
           };
         }
 
-        return historyValues;
+        return { ...historyValues };
       });
 
       let usableThreadId = threadId;

--- a/libs/sdk-js/src/react/stream.tsx
+++ b/libs/sdk-js/src/react/stream.tsx
@@ -517,6 +517,13 @@ export interface UseStreamOptions<
   threadId?: string | null;
 
   /**
+   * The ID to use when creating a new thread. When provided, this ID will be used
+   * for thread creation when threadId is null. This enables optimistic UI updates
+   * where you know the thread ID before the thread is actually created.
+   */
+  newThreadId?: string;
+
+  /**
    * Callback that is called when the thread ID is updated (ie when a new thread is created).
    */
   onThreadId?: (threadId: string) => void;
@@ -1013,7 +1020,9 @@ export function useStream<
 
       let usableThreadId = threadId;
       if (!usableThreadId) {
-        const thread = await client.threads.create();
+        const thread = await client.threads.create({
+          threadId: options.newThreadId,
+        });
         onThreadId(thread.thread_id);
         usableThreadId = thread.thread_id;
       }

--- a/libs/sdk-js/src/tests/sse.test.ts
+++ b/libs/sdk-js/src/tests/sse.test.ts
@@ -20,7 +20,7 @@ describe("BytesLineDecoder", () => {
 
   test("handles single line with newline", async () => {
     const input = createStream([textEncoder.encode("hello\n")]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(1);
@@ -29,7 +29,7 @@ describe("BytesLineDecoder", () => {
 
   test("handles multiple lines", async () => {
     const input = createStream([textEncoder.encode("line1\nline2\nline3\n")]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(3);
@@ -44,7 +44,7 @@ describe("BytesLineDecoder", () => {
       textEncoder.encode("ne1\nli"),
       textEncoder.encode("ne2\n"),
     ]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(2);
@@ -54,7 +54,7 @@ describe("BytesLineDecoder", () => {
 
   test("handles CR LF line endings", async () => {
     const input = createStream([textEncoder.encode("line1\r\nline2\r\n")]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(2);
@@ -67,7 +67,7 @@ describe("BytesLineDecoder", () => {
       textEncoder.encode("line1\r"),
       textEncoder.encode("\nline2\r\n"),
     ]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(2);
@@ -77,7 +77,7 @@ describe("BytesLineDecoder", () => {
 
   test("handles stale line", async () => {
     const input = createStream([textEncoder.encode("hello")]);
-    const decoded = input.pipeThrough(new BytesLineDecoder());
+    const decoded = input.pipeThrough(BytesLineDecoder());
     const results = await gather(decoded);
 
     expect(results.length).toBe(1);
@@ -99,8 +99,8 @@ describe("SSEDecoder", () => {
       "\n",
     ]);
     const decoded = input
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     const results = await gather(decoded);
     expect(results.length).toBe(1);
@@ -117,8 +117,8 @@ describe("SSEDecoder", () => {
       'data: {"message": "hello"}\n',
     ]);
     const decoded = input
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     const results = await gather(decoded);
     expect(results.length).toBe(1);
@@ -138,8 +138,8 @@ describe("SSEDecoder", () => {
       "\n",
     ]);
     const decoded = input
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     const results = await gather(decoded);
     expect(results.length).toBe(2);
@@ -156,8 +156,8 @@ describe("SSEDecoder", () => {
   test("end event without data", async () => {
     const input = createStream(["event: test\n"]);
     const decoded = input
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     const results = await gather(decoded);
     expect(results.length).toBe(1);
@@ -170,8 +170,8 @@ describe("SSEDecoder", () => {
   test("end event without newline", async () => {
     const input = createStream(["event: end"]);
     const decoded = input
-      .pipeThrough(new BytesLineDecoder())
-      .pipeThrough(new SSEDecoder());
+      .pipeThrough(BytesLineDecoder())
+      .pipeThrough(SSEDecoder());
 
     const results = await gather(decoded);
     expect(results.length).toBe(1);

--- a/libs/sdk-js/src/tests/stream.test.tsx
+++ b/libs/sdk-js/src/tests/stream.test.tsx
@@ -138,4 +138,132 @@ describe("useStream", () => {
       expect(screen.getByTestId("loading")).toHaveTextContent("Not loading");
     });
   });
+
+  it("displays initial values immediately", () => {
+    const initialValues = {
+      messages: [
+        { id: "cached-1", type: "human", content: "Cached user message" },
+        { id: "cached-2", type: "ai", content: "Cached AI response" },
+      ],
+    };
+
+    function TestCachedComponent() {
+      const { messages, values } = useStream({
+        assistantId: "test-assistant",
+        apiKey: "test-api-key",
+        initialValues,
+      });
+
+      return (
+        <div>
+          <div data-testid="messages">
+            {messages.map((msg, i) => (
+              <div key={msg.id ?? i} data-testid={`message-${i}`}>
+                {typeof msg.content === "string"
+                  ? msg.content
+                  : JSON.stringify(msg.content)}
+              </div>
+            ))}
+          </div>
+          <div data-testid="values">{JSON.stringify(values)}</div>
+        </div>
+      );
+    }
+
+    render(<TestCachedComponent />);
+
+    // Should immediately show cached messages
+    expect(screen.getByTestId("message-0")).toHaveTextContent("Cached user message");
+    expect(screen.getByTestId("message-1")).toHaveTextContent("Cached AI response");
+    
+    // Values should include initial values
+    expect(screen.getByTestId("values")).toHaveTextContent("Cached user message");
+  });
+
+  it("handles null initial values", () => {
+    function TestNullInitialComponent() {
+      const { messages, values } = useStream({
+        assistantId: "test-assistant",
+        apiKey: "test-api-key",
+        initialValues: null,
+      });
+
+      return (
+        <div>
+          <div data-testid="message-count">{messages.length}</div>
+          <div data-testid="values">{JSON.stringify(values)}</div>
+        </div>
+      );
+    }
+
+    render(<TestNullInitialComponent />);
+
+    // Should handle null initialValues gracefully
+    expect(screen.getByTestId("message-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("values")).toHaveTextContent("{}");
+  });
+
+  it("accepts newThreadId option without errors", () => {
+    // Test that newThreadId option can be passed without causing errors
+    function TestNewThreadComponent() {
+      const stream = useStream({
+        assistantId: "test-assistant",
+        apiKey: "test-api-key",
+        threadId: null, // Start with no thread
+        newThreadId: "predetermined-thread-id",
+        onThreadId: () => {}, // Mock callback
+      });
+
+      return (
+        <div>
+          <div data-testid="loading">
+            {stream.isLoading ? "Loading..." : "Not loading"}
+          </div>
+          <div data-testid="thread-id">{stream.client ? "Client ready" : "No client"}</div>
+        </div>
+      );
+    }
+
+    render(<TestNewThreadComponent />);
+
+    // Should render without errors
+    expect(screen.getByTestId("loading")).toHaveTextContent("Not loading");
+    expect(screen.getByTestId("thread-id")).toHaveTextContent("Client ready");
+  });
+
+  it("shows initial values before any streaming", () => {
+    const initialValues = {
+      messages: [
+        { id: "initial-1", type: "human", content: "Initial message" },
+      ],
+      customField: "initial-value"
+    };
+
+    function TestInitialValuesComponent() {
+      const stream = useStream({
+        assistantId: "test-assistant",
+        apiKey: "test-api-key",
+        initialValues,
+      });
+
+              return (
+          <div>
+            <div data-testid="message-0">
+              {typeof stream.messages[0]?.content === "string" 
+                ? stream.messages[0]?.content 
+                : JSON.stringify(stream.messages[0]?.content)}
+            </div>
+            <div data-testid="custom-field">{stream.values.customField}</div>
+            <div data-testid="loading">{stream.isLoading ? "Loading" : "Not loading"}</div>
+          </div>
+        );
+    }
+
+    render(<TestInitialValuesComponent />);
+
+    // Should immediately show initial values without any loading
+    expect(screen.getByTestId("message-0")).toHaveTextContent("Initial message");
+    expect(screen.getByTestId("custom-field")).toHaveTextContent("initial-value");
+    expect(screen.getByTestId("loading")).toHaveTextContent("Not loading");
+  });
 });

--- a/libs/sdk-js/src/tests/stream.test.tsx
+++ b/libs/sdk-js/src/tests/stream.test.tsx
@@ -199,7 +199,7 @@ describe("useStream", () => {
       "Cached user message",
     );
 
-    // Submiting should clear out the cached messages
+    // Submitting should clear out the cached messages
     await user.click(screen.getByTestId("submit"));
 
     // Wait for messages to appear

--- a/libs/sdk-js/src/tests/stream.test.tsx
+++ b/libs/sdk-js/src/tests/stream.test.tsx
@@ -267,7 +267,7 @@ describe("useStream", () => {
 
     function TestComponent() {
       const { submit, stop } = useStream({
-        assistantId: "test-assistant",
+        assistantId: "agent",
         apiKey: "test-api-key",
         onStop: onStopCallback,
       });
@@ -368,7 +368,7 @@ describe("useStream", () => {
 
     function TestComponent() {
       const { submit, stop, values } = useStream({
-        assistantId: "test-assistant",
+        assistantId: "agent",
         apiKey: "test-api-key",
         initialValues: {
           counter: 5,
@@ -423,7 +423,7 @@ describe("useStream", () => {
 
     function TestComponent() {
       const { submit } = useStream({
-        assistantId: "test-assistant",
+        assistantId: "agent",
         apiKey: "test-api-key",
         onStop: onStopCallback,
       });

--- a/libs/sdk-js/src/utils/sse.ts
+++ b/libs/sdk-js/src/utils/sse.ts
@@ -6,90 +6,88 @@ const SPACE = " ".charCodeAt(0);
 
 const TRAILING_NEWLINE = [CR, LF];
 
-export class BytesLineDecoder extends TransformStream<Uint8Array, Uint8Array> {
-  constructor() {
-    let buffer: Uint8Array[] = [];
-    let trailingCr = false;
+export function BytesLineDecoder() {
+  let buffer: Uint8Array[] = [];
+  let trailingCr = false;
 
-    super({
-      start() {
-        buffer = [];
+  return new TransformStream<Uint8Array, Uint8Array>({
+    start() {
+      buffer = [];
+      trailingCr = false;
+    },
+
+    transform(chunk, controller) {
+      // See https://docs.python.org/3/glossary.html#term-universal-newlines
+      let text = chunk;
+
+      // Handle trailing CR from previous chunk
+      if (trailingCr) {
+        text = joinArrays([[CR], text]);
         trailingCr = false;
-      },
+      }
 
-      transform(chunk, controller) {
-        // See https://docs.python.org/3/glossary.html#term-universal-newlines
-        let text = chunk;
+      // Check for trailing CR in current chunk
+      if (text.length > 0 && text.at(-1) === CR) {
+        trailingCr = true;
+        text = text.subarray(0, -1);
+      }
 
-        // Handle trailing CR from previous chunk
-        if (trailingCr) {
-          text = joinArrays([[CR], text]);
-          trailingCr = false;
-        }
+      if (!text.length) return;
+      const trailingNewline = TRAILING_NEWLINE.includes(text.at(-1)!);
 
-        // Check for trailing CR in current chunk
-        if (text.length > 0 && text.at(-1) === CR) {
-          trailingCr = true;
-          text = text.subarray(0, -1);
-        }
+      const lastIdx = text.length - 1;
+      const { lines } = text.reduce<{ lines: Uint8Array[]; from: number }>(
+        (acc, cur, idx) => {
+          if (acc.from > idx) return acc;
 
-        if (!text.length) return;
-        const trailingNewline = TRAILING_NEWLINE.includes(text.at(-1)!);
-
-        const lastIdx = text.length - 1;
-        const { lines } = text.reduce<{ lines: Uint8Array[]; from: number }>(
-          (acc, cur, idx) => {
-            if (acc.from > idx) return acc;
-
-            if (cur === CR || cur === LF) {
-              acc.lines.push(text.subarray(acc.from, idx));
-              if (cur === CR && text[idx + 1] === LF) {
-                acc.from = idx + 2;
-              } else {
-                acc.from = idx + 1;
-              }
+          if (cur === CR || cur === LF) {
+            acc.lines.push(text.subarray(acc.from, idx));
+            if (cur === CR && text[idx + 1] === LF) {
+              acc.from = idx + 2;
+            } else {
+              acc.from = idx + 1;
             }
+          }
 
-            if (idx === lastIdx && acc.from <= lastIdx) {
-              acc.lines.push(text.subarray(acc.from));
-            }
+          if (idx === lastIdx && acc.from <= lastIdx) {
+            acc.lines.push(text.subarray(acc.from));
+          }
 
-            return acc;
-          },
-          { lines: [], from: 0 },
-        );
+          return acc;
+        },
+        { lines: [], from: 0 },
+      );
 
-        if (lines.length === 1 && !trailingNewline) {
-          buffer.push(lines[0]);
-          return;
-        }
+      if (lines.length === 1 && !trailingNewline) {
+        buffer.push(lines[0]);
+        return;
+      }
 
-        if (buffer.length) {
-          // Include existing buffer in first line
-          buffer.push(lines[0]);
-          lines[0] = joinArrays(buffer);
-          buffer = [];
-        }
+      if (buffer.length) {
+        // Include existing buffer in first line
+        buffer.push(lines[0]);
+        lines[0] = joinArrays(buffer);
+        buffer = [];
+      }
 
-        if (!trailingNewline) {
-          // If the last segment is not newline terminated,
-          // buffer it for the next chunk
-          if (lines.length) buffer = [lines.pop()!];
-        }
+      if (!trailingNewline) {
+        // If the last segment is not newline terminated,
+        // buffer it for the next chunk
+        if (lines.length) buffer = [lines.pop()!];
+      }
 
-        // Enqueue complete lines
-        for (const line of lines) {
-          controller.enqueue(line);
-        }
-      },
+      // Enqueue complete lines
+      for (const line of lines) {
+        controller.enqueue(line);
+      }
+    },
 
-      flush(controller) {
-        if (buffer.length) {
-          controller.enqueue(joinArrays(buffer));
-        }
-      },
-    });
-  }
+    flush(controller) {
+      if (buffer.length) {
+        controller.enqueue(joinArrays(buffer));
+      }
+    },
+  });
 }
 
 interface StreamPart {
@@ -98,69 +96,67 @@ interface StreamPart {
   data: unknown;
 }
 
-export class SSEDecoder extends TransformStream<Uint8Array, StreamPart> {
-  constructor() {
-    let event = "";
-    let data: Uint8Array[] = [];
-    let lastEventId = "";
-    let retry: number | null = null;
+export function SSEDecoder() {
+  let event = "";
+  let data: Uint8Array[] = [];
+  let lastEventId = "";
+  let retry: number | null = null;
 
-    const decoder = new TextDecoder();
+  const decoder = new TextDecoder();
 
-    super({
-      transform(chunk, controller) {
-        // Handle empty line case
-        if (!chunk.length) {
-          if (!event && !data.length && !lastEventId && retry == null) return;
+  return new TransformStream<Uint8Array, StreamPart>({
+    transform(chunk, controller) {
+      // Handle empty line case
+      if (!chunk.length) {
+        if (!event && !data.length && !lastEventId && retry == null) return;
 
-          const sse = {
-            id: lastEventId || undefined,
-            event,
-            data: data.length ? decodeArraysToJson(decoder, data) : null,
-          };
+        const sse = {
+          id: lastEventId || undefined,
+          event,
+          data: data.length ? decodeArraysToJson(decoder, data) : null,
+        };
 
-          // NOTE: as per the SSE spec, do not reset lastEventId
-          event = "";
-          data = [];
-          retry = null;
+        // NOTE: as per the SSE spec, do not reset lastEventId
+        event = "";
+        data = [];
+        retry = null;
 
-          controller.enqueue(sse);
-          return;
-        }
+        controller.enqueue(sse);
+        return;
+      }
 
-        // Ignore comments
-        if (chunk[0] === COLON) return;
+      // Ignore comments
+      if (chunk[0] === COLON) return;
 
-        const sepIdx = chunk.indexOf(COLON);
-        if (sepIdx === -1) return;
+      const sepIdx = chunk.indexOf(COLON);
+      if (sepIdx === -1) return;
 
-        const fieldName = decoder.decode(chunk.subarray(0, sepIdx));
-        let value = chunk.subarray(sepIdx + 1);
-        if (value[0] === SPACE) value = value.subarray(1);
+      const fieldName = decoder.decode(chunk.subarray(0, sepIdx));
+      let value = chunk.subarray(sepIdx + 1);
+      if (value[0] === SPACE) value = value.subarray(1);
 
-        if (fieldName === "event") {
-          event = decoder.decode(value);
-        } else if (fieldName === "data") {
-          data.push(value);
-        } else if (fieldName === "id") {
-          if (value.indexOf(NULL) === -1) lastEventId = decoder.decode(value);
-        } else if (fieldName === "retry") {
-          const retryNum = Number.parseInt(decoder.decode(value));
-          if (!Number.isNaN(retryNum)) retry = retryNum;
-        }
-      },
+      if (fieldName === "event") {
+        event = decoder.decode(value);
+      } else if (fieldName === "data") {
+        data.push(value);
+      } else if (fieldName === "id") {
+        if (value.indexOf(NULL) === -1) lastEventId = decoder.decode(value);
+      } else if (fieldName === "retry") {
+        const retryNum = Number.parseInt(decoder.decode(value));
+        if (!Number.isNaN(retryNum)) retry = retryNum;
+      }
+    },
 
-      flush(controller) {
-        if (event) {
-          controller.enqueue({
-            id: lastEventId || undefined,
-            event,
-            data: data.length ? decodeArraysToJson(decoder, data) : null,
-          });
-        }
-      },
-    });
-  }
+    flush(controller) {
+      if (event) {
+        controller.enqueue({
+          id: lastEventId || undefined,
+          event,
+          data: data.length ? decodeArraysToJson(decoder, data) : null,
+        });
+      }
+    },
+  });
 }
 
 function joinArrays(data: ArrayLike<number>[]) {


### PR DESCRIPTION
## Summary
Adds three new options to the `useStream` React hook to improve user experience in common chat application scenarios:

- **`initialValues`**: Display cached thread data immediately while history loads
- **`newThreadId`**: Enable optimistic thread creation with predetermined IDs  
- **`onStop`**: Customize UI behavior when streams are stopped/cancelled

## Features Added

### `initialValues` Option
- Shows cached thread data instantly when navigating to existing threads
- Improves perceived performance by eliminating loading states for cached content
- Values priority: `streamValues > initialValues > historyValues`
- Backward compatible

### `newThreadId` Option  
- Enables optimistic UI patterns for thread creation
- Prevents 404 errors when automatically fetching thread history when navigating to routes before thread exists
- Allows predetermined thread IDs for better URL management in practice (e.g. when navigating to `/[threadId]` routes when submitting a message)
- Works with `threadId: null` for new thread creation

### `onStop` Callback
- Enables custom behavior when streams are stopped or cancelled
- Provides immediate local state updates via `mutate` function
- Particularly useful for handling loading states in generative UI components
- Prevents loading components from remaining in infinite loading state after cancellation
- Supports optional server thread state updates

```typescript
const stream = useStream({
  assistantId: "my-assistant",
  onStop: async ({ mutate }) => {
    // Immediate UI update - stop loading components
    mutate((prev) => ({
      ...prev,
      ui: prev.ui?.map(component =>
        component.props?.isLoading
          ? {
              ...component,
              props: {
                ...component.props,
                isLoading: false,
                isStopped: true
              }
            }
          : component
      )
    }));

    // Optional server thread state update
    if (stream.threadId) {
      await stream.client.threads.updateState(stream.threadId, {
        values: { ui: prev.ui }
      });
    }
  }
});
```

## Documentation & Testing
- Added comprehensive documentation with examples for all features
- Test coverage for `initialValues`, `newThreadId`, and `onStop` callback
- Updated React integration guide
- Clean test implementation with proper cleanup

## Use Cases
- **Cached display**: Show cached thread data while server loads
- **Optimistic navigation**: Navigate to `/threads/[id]` before thread creation
- **Better UX**: Eliminate loading states and navigation delays
- **Graceful cancellation**: Handle stopped streams with custom UI updates
- **Generative UI**: Properly manage loading states in dynamic components

## Breaking Changes
None - all three options are optional and fully backward compatible.