### PR TITLE
fix of TypeError: Type is not msgpack serializable: AIMessage

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -672,5 +672,15 @@ _option = (
 )
 
 
+def message_to_dict(msg):
+    # Handles HumanMessage, AIMessage, ToolMessage, etc.
+    if hasattr(msg, "to_dict"):
+        return msg.to_dict()
+    elif isinstance(msg, dict):
+        return msg
+    else:
+        # Fallback: try to extract content and role
+        return {"role": getattr(msg, "role", "user"), "content": str(getattr(msg, "content", msg))}
+    
 def _msgpack_enc(data: Any) -> bytes:
-    return ormsgpack.packb(data, default=_msgpack_default, option=_option)
+    return ormsgpack.packb(message_to_dict(data), default=_msgpack_default, option=_option)


### PR DESCRIPTION
We received this error while using memory and threads in langgraph for multiple tools.
Traceback (most recent call last):
  File "/Users/h0p0303/Documents/PersonalWork/PersonalRepos/gen-ai-learning-session/test_ormsgpack.py", line 19, in <module>
    packed = ormsgpack.packb(msg)
TypeError: Type is not msgpack serializable: AIMessage

I have changed the code for ormsgpack to use the dictionary object rather than AIMessage.