### PR TITLE
[fix] snippet for Agents as a Tool

### DIFF
--- a/docs/docs/concepts/multi_agent.md
+++ b/docs/docs/concepts/multi_agent.md
@@ -87,6 +87,7 @@ One of the most common agent types is a [tool-calling agent](../agents/overview.
 ```python
 from langchain_core.tools import tool
 
+@tool
 def transfer_to_bob():
     """Transfer to bob."""
     return Command(


### PR DESCRIPTION
snippet had a missing decorator that might lead the user to confuse whether it is really a tool