### PR TITLE
Allow React useStream client changes for thread/{id}/history requests

### DIFF
--- a/libs/sdk-js/src/react/stream.tsx
+++ b/libs/sdk-js/src/react/stream.tsx
@@ -324,6 +324,7 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
   const fetcher = useCallback(
     (
       threadId: string | undefined | null,
+      client: Client,
     ): Promise<ThreadState<StateType>[]> => {
       if (threadId != null) {
         return fetchHistory<StateType>(client, threadId).then((history) => {
@@ -341,12 +342,12 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
 
   useEffect(() => {
     if (submittingRef.current) return;
-    fetcher(threadId);
-  }, [fetcher, submittingRef, threadId]);
+    fetcher(threadId, client);
+  }, [fetcher, submittingRef, threadId, client]);
 
   return {
     data: history,
-    mutate: (mutateId?: string) => fetcher(mutateId ?? threadId),
+    mutate: (mutateId?: string) => fetcher(mutateId ?? threadId, client),
   };
 }
 


### PR DESCRIPTION
# Update the useThreadHistory logic to respond to stream client  change

## Problem definition

The useStream is a React hook that should react to component rerenders (ex, state changes).

React useStream encapsulates multiple calls, like `/threads`, `/threads/{id}/runs/stream`, `/threads/{id}/runs/history`.

First and second endpoints respond to options changes (defaultHeaders and apiKey in my case), but `/threads/{id}/runs/history` is not. Even if threadId is changed, new option changes are unavailable at the history level.
I hope this fix will solve this behavior

This fix is working on my local machine, but I'm not sure if the stable history client is a necessary logic. If it is true, I'd like to see a reason description in the code or the docs. The actual [example section in documentation](https://langchain-ai.github.io/langgraph/cloud/how-tos/use_stream_react/#example) doesn't respond to my question.

--- 

## References

I'm not sure that it is a bug, so I prepared [discussion](https://github.com/langchain-ai/langgraph/discussions/5202). It includes more description about my case.

I found a similar issue to this behavior: https://github.com/langchain-ai/langgraph/issues/4596




