### PR TITLE
DOC: Add missing docs_txt = format_docs() lines in adaptive RAG tutorial

### DIFF
--- a/docs/docs/tutorials/rag/langgraph_adaptive_rag.ipynb
+++ b/docs/docs/tutorials/rag/langgraph_adaptive_rag.ipynb
@@ -336,7 +336,8 @@
     "rag_chain = prompt | llm | StrOutputParser()\n",
     "\n",
     "# Run\n",
-    "generation = rag_chain.invoke({\"context\": docs, \"question\": question})\n",
+    "docs_txt = format_docs(docs)\n",
+    "generation = rag_chain.invoke({\"context\": docs_txt, \"question\": question})\n",
     "print(generation)"
    ]
   },
@@ -625,7 +626,8 @@
     "    documents = state[\"documents\"]\n",
     "\n",
     "    # RAG generation\n",
-    "    generation = rag_chain.invoke({\"context\": documents, \"question\": question})\n",
+    "    docs_txt = format_docs(documents)\n",
+    "    generation = rag_chain.invoke({\"context\": docs_txt, \"question\": question})\n",
     "    return {\"documents\": documents, \"question\": question, \"generation\": generation}\n",
     "\n",
     "\n",


### PR DESCRIPTION
## Summary
Fixes missing `docs_txt = format_docs(docs)` lines in the adaptive RAG tutorial that were causing raw document objects to be passed directly to the RAG chain instead of properly formatted text.

## Issue Fixed
Closes #5216 

## Details
The `format_docs` function was already properly defined in the notebook:
```python
def format_docs(docs):
    return "\n\n".join(doc.page_content for doc in docs)
```

However, it wasn't being called before passing documents to the RAG chain. This caused Document objects to be passed directly instead of formatted text strings, which is the expected input format.

### Before:
```python
generation = rag_chain.invoke({"context": documents, "question": question})
```

### After:
```python
docs_txt = format_docs(documents)
generation = rag_chain.invoke({"context": docs_txt, "question": question})
```

## Testing
The tutorial notebook should now work correctly with properly formatted document context being passed to the RAG chain.

## Type of Change
- [x] Documentation fix
- [x] Bug fix (non-breaking change which fixes an issue)