### PR TITLE
fix[prebuilt]: bind tools even if it's only provider tools

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -448,7 +448,7 @@ def create_react_agent(
 
     if (
         _should_bind_tools(model, tool_classes, num_builtin=len(llm_builtin_tools))
-        and len(tool_classes) > 0
+        and len(tool_classes + llm_builtin_tools) > 0
     ):
         model = cast(BaseChatModel, model).bind_tools(tool_classes + llm_builtin_tools)  # type: ignore[operator]
 


### PR DESCRIPTION
Enabling:

```py
from langgraph.prebuilt import create_react_agent
from langchain_openai import ChatOpenAI

research_agent = create_react_agent(
    ChatOpenAI(
        model="o3-deep-research",
        use_responses_api=True,
    ),
    tools=[{"type": "web_search_preview"}],
    prompt="You are a professional researcher preparing a structured, data-driven report...",
)

response = research_agent.invoke(
    {
        "messages": [
            "How do microplastics in the food chain impact human health, and what solutions exist?"
        ]
    },
)
```