### PR TITLE
fix(sdk-js): avoid stale client when fetching history

### DIFF
--- a/libs/sdk-js/package.json
+++ b/libs/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-sdk",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Client library for interacting with the LangGraph API",
   "type": "module",
   "packageManager": "yarn@1.22.19",

--- a/libs/sdk-js/src/client.ts
+++ b/libs/sdk-js/src/client.ts
@@ -1658,7 +1658,30 @@ export class Client<
    */
   public "~ui": UiClient;
 
+  /**
+   * @internal Used to obtain a stable key representing the client.
+   */
+  private "~configHash": string | undefined;
+
   constructor(config?: ClientConfig) {
+    this["~configHash"] = (() =>
+      JSON.stringify({
+        apiUrl: config?.apiUrl,
+        apiKey: config?.apiKey,
+        timeoutMs: config?.timeoutMs,
+        defaultHeaders: config?.defaultHeaders,
+
+        maxConcurrency: config?.callerOptions?.maxConcurrency,
+        maxRetries: config?.callerOptions?.maxRetries,
+
+        callbacks: {
+          onFailedResponseHook:
+            config?.callerOptions?.onFailedResponseHook != null,
+          onRequest: config?.onRequest != null,
+          fetch: config?.callerOptions?.fetch != null,
+        },
+      }))();
+
     this.assistants = new AssistantsClient(config);
     this.threads = new ThreadsClient(config);
     this.runs = new RunsClient(config);
@@ -1666,4 +1689,11 @@ export class Client<
     this.store = new StoreClient(config);
     this["~ui"] = new UiClient(config);
   }
+}
+
+/**
+ * @internal Used to obtain a stable key representing the client.
+ */
+export function getClientConfigHash(client: Client): string | undefined {
+  return client["~configHash"];
 }

--- a/libs/sdk-js/src/react/stream.tsx
+++ b/libs/sdk-js/src/react/stream.tsx
@@ -321,10 +321,9 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
 ) {
   const [history, setHistory] = useState<ThreadState<StateType>[]>([]);
 
+  const clientHash = getClientConfigHash(client);
   const clientRef = useRef(client);
   clientRef.current = client;
-
-  const clientHash = getClientConfigHash(client);
 
   const fetcher = useCallback(
     (
@@ -342,13 +341,13 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
       clearCallbackRef.current?.();
       return Promise.resolve([]);
     },
-    [clientHash],
+    [],
   );
 
   useEffect(() => {
     if (submittingRef.current) return;
     fetcher(threadId);
-  }, [fetcher, submittingRef, threadId]);
+  }, [fetcher, clientHash, submittingRef, threadId]);
 
   return {
     data: history,

--- a/libs/sdk-js/src/react/stream.tsx
+++ b/libs/sdk-js/src/react/stream.tsx
@@ -1,7 +1,7 @@
 /* __LC_ALLOW_ENTRYPOINT_SIDE_EFFECTS__ */
 "use client";
 
-import { Client, type ClientConfig } from "../client.js";
+import { Client, getClientConfigHash, type ClientConfig } from "../client.js";
 import type {
   Command,
   DisconnectMode,
@@ -321,11 +321,17 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
 ) {
   const [history, setHistory] = useState<ThreadState<StateType>[]>([]);
 
+  const clientRef = useRef(client);
+  clientRef.current = client;
+
+  const clientHash = getClientConfigHash(client);
+
   const fetcher = useCallback(
     (
       threadId: string | undefined | null,
     ): Promise<ThreadState<StateType>[]> => {
       if (threadId != null) {
+        const client = clientRef.current;
         return fetchHistory<StateType>(client, threadId).then((history) => {
           setHistory(history);
           return history;
@@ -336,7 +342,7 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
       clearCallbackRef.current?.();
       return Promise.resolve([]);
     },
-    [],
+    [clientHash],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Similar to #5208 we do want to avoid stale client when fetching `/history`. Use our best attempt to serialize the user provided client config. 