### PR TITLE
Value Error fix at line 736 - END cannot be a start node

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -699,7 +699,7 @@ class StateGraph(Generic[StateT, InputT, OutputT]):
         Returns:
             Self: The instance of the graph, allowing for method chaining.
         """
-        return self.add_edge(START, key)
+        return self.add_edge(START,key) 
 
     def set_conditional_entry_point(
         self,
@@ -733,7 +733,7 @@ class StateGraph(Generic[StateT, InputT, OutputT]):
         Returns:
             Self: The instance of the graph, allowing for method chaining.
         """
-        return self.add_edge(key, END)
+        return self.add_edge(START,key)
 
     def validate(self, interrupt: Sequence[str] | None = None) -> Self:
         # assemble sources


### PR DESCRIPTION
I was working on the langgraph and found this Value Error that END cannot be a start node whereas the original logic is same, but the positional argument is considering it as a START_KEY as the value intended for finish key. Even if the finish point is END.
Following is the usage example:
```
graph = StateGraph(GraphState)
graph.add_node("generate_sql", generate_sql)
graph.add_node("execute_sql", execute_sql)
graph.add_conditional_edges("execute_sql", decide_next_node, {"generate_sql", END})
graph.add_edge("generate_sql", "execute_sql")
graph.set_entry_point("generate_sql")
graph.set_finish_point(END)  
```