### PR TITLE
docs: fix typo in application_structure

### DIFF
--- a/docs/docs/concepts/application_structure.md
+++ b/docs/docs/concepts/application_structure.md
@@ -48,7 +48,7 @@ Below are examples of directory structures for Python and JavaScript application
     │   ├── utils # utilities for your graph
     │   │   ├── __init__.py
     │   │   ├── tools.py # tools for your graph
-    │   │   ├── nodes.py # node functions for you graph
+    │   │   ├── nodes.py # node functions for your graph
     │   │   └── state.py # state definition of your graph
     │   ├── __init__.py
     │   └── agent.py # code for constructing your graph
@@ -64,7 +64,7 @@ Below are examples of directory structures for Python and JavaScript application
     ├── src # all project code lies within here
     │   ├── utils # optional utilities for your graph
     │   │   ├── tools.ts # tools for your graph
-    │   │   ├── nodes.ts # node functions for you graph
+    │   │   ├── nodes.ts # node functions for your graph
     │   │   └── state.ts # state definition of your graph
     │   └── agent.ts # code for constructing your graph
     ├── package.json # package dependencies


### PR DESCRIPTION
This pull request includes minor corrections to comments in the `docs/docs/concepts/application_structure.md` file. Specifically, it fixes a small typographical error in the comments for Python and JavaScript directory structure examples. 

No functional changes were made. 

Changes:

* Fixed a typo in the comment for the `nodes.py` file in the Python directory structure example (`you graph` → `your graph`).
* Fixed a typo in the comment for the `nodes.ts` file in the JavaScript directory structure example (`you graph` → `your graph`).