### PR TITLE
langgraph: remove support for `thread_ts` (old alias for `checkpoint_id`)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -284,7 +284,7 @@ class PostgresSaver(BasePostgresSaver):
         configurable = config["configurable"].copy()
         thread_id = configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
-        checkpoint_id = configurable.pop("checkpoint_id")
+        checkpoint_id = configurable.pop("checkpoint_id", None)
         copy = checkpoint.copy()
         next_config = {
             "configurable": {

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -284,10 +284,7 @@ class PostgresSaver(BasePostgresSaver):
         configurable = config["configurable"].copy()
         thread_id = configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
-        checkpoint_id = configurable.pop(
-            "checkpoint_id", configurable.pop("thread_ts", None)
-        )
-
+        checkpoint_id = configurable.pop("checkpoint_id")
         copy = checkpoint.copy()
         next_config = {
             "configurable": {

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -240,9 +240,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         configurable = config["configurable"].copy()
         thread_id = configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
-        checkpoint_id = configurable.pop(
-            "checkpoint_id", configurable.pop("thread_ts", None)
-        )
+        checkpoint_id = configurable.pop("checkpoint_id")
 
         copy = checkpoint.copy()
         next_config = {

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -240,7 +240,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         configurable = config["configurable"].copy()
         thread_id = configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
-        checkpoint_id = configurable.pop("checkpoint_id")
+        checkpoint_id = configurable.pop("checkpoint_id", None)
 
         copy = checkpoint.copy()
         next_config = {

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -161,8 +161,7 @@ def test_data():
     config_1: RunnableConfig = {
         "configurable": {
             "thread_id": "thread-1",
-            # for backwards compatibility testing
-            "thread_ts": "1",
+            "checkpoint_id": "1",
             "checkpoint_ns": "",
         }
     }

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -143,8 +143,7 @@ def test_data():
     config_1: RunnableConfig = {
         "configurable": {
             "thread_id": "thread-1",
-            # for backwards compatibility testing
-            "thread_ts": "1",
+            "checkpoint_id": "1",
             "checkpoint_ns": "",
         }
     }

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -19,8 +19,7 @@ class TestAsyncSqliteSaver:
         self.config_1: RunnableConfig = {
             "configurable": {
                 "thread_id": "thread-1",
-                # for backwards compatibility testing
-                "thread_ts": "1",
+                "checkpoint_id": "1",
                 "checkpoint_ns": "",
             }
         }

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -21,7 +21,7 @@ class TestSqliteSaver:
             "configurable": {
                 "thread_id": "thread-1",
                 # for backwards compatibility testing
-                "thread_ts": "1",
+                "checkpoint_id": "1",
                 "checkpoint_ns": "",
             }
         }

--- a/libs/checkpoint/README.md
+++ b/libs/checkpoint/README.md
@@ -36,7 +36,7 @@ Each checkpointer should conform to `langgraph.checkpoint.base.BaseCheckpointSav
 
 - `.put` - Store a checkpoint with its configuration and metadata.
 - `.put_writes` - Store intermediate writes linked to a checkpoint (i.e. pending writes).
-- `.get_tuple` - Fetch a checkpoint tuple using for a given configuration (`thread_id` and `thread_ts`).
+- `.get_tuple` - Fetch a checkpoint tuple using for a given configuration (`thread_id` and `checkpoint_id`).
 - `.list` - List checkpoints that match a given configuration and filter criteria.
 
 If the checkpointer will be used with asynchronous graph execution (i.e. executing the graph via `.ainvoke`, `.astream`, `.abatch`), checkpointer must implement asynchronous versions of the above methods (`.aput`, `.aput_writes`, `.aget_tuple`, `.alist`).

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -375,10 +375,8 @@ class EmptyChannelError(Exception):
 
 
 def get_checkpoint_id(config: RunnableConfig) -> str | None:
-    """Get checkpoint ID in a backwards-compatible manner (fallback on thread_ts)."""
-    return config["configurable"].get(
-        "checkpoint_id", config["configurable"].get("thread_ts")
-    )
+    """Get checkpoint ID."""
+    return config["configurable"].get("checkpoint_id")
 
 
 def get_checkpoint_metadata(
@@ -413,7 +411,6 @@ WRITES_IDX_MAP = {ERROR: -1, SCHEDULED: -2, INTERRUPT: -3, RESUME: -4}
 
 EXCLUDED_METADATA_KEYS = {
     "thread_id",
-    "thread_ts",
     "checkpoint_id",
     "checkpoint_ns",
     "checkpoint_map",

--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -22,8 +22,7 @@ class TestMemorySaver:
             "configurable": {
                 "thread_id": "thread-1",
                 "checkpoint_ns": "",
-                # for backwards compatibility testing
-                "thread_ts": "1",
+                "checkpoint_id": "1",
             }
         }
         self.config_2: RunnableConfig = {


### PR DESCRIPTION
Usage removed long ago (like a year) in https://github.com/langchain-ai/langgraph/commit/d9854b36ebb6690a5106ad73a3099ef3ee386259