### PR TITLE
ci: test against min versions of direct dependencies

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -58,3 +58,13 @@ jobs:
           # grep will exit non-zero if the target message isn't found,
           # and `set -e` above will cause the step to fail.
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
+
+      - name: Install min version of deps
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: uv sync --no-default-groups --resolution lowest-direct --no-sources --force-reinstall
+
+      - name: Run tests with min version of deps
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: make test

--- a/.github/workflows/_test_langgraph.yml
+++ b/.github/workflows/_test_langgraph.yml
@@ -53,3 +53,13 @@ jobs:
           # grep will exit non-zero if the target message isn't found,
           # and `set -e` above will cause the step to fail.
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
+
+      - name: Install min version of deps
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: uv sync --no-default-groups --resolution lowest-direct --no-sources --force-reinstall
+
+      - name: Run tests with min version of deps
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: make test

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "langgraph-sdk>=0.1.42,<0.2.0",
     "langgraph-prebuilt>=0.5.0,<0.6.0",
     "xxhash>=3.5.0",
-    "pydantic>=2.7.4",
+    "pydantic>=2.7.4; python_version < '3.13'",
+    "pydantic>=2.0.0; python_version >= '3.13'",
 ]
 
 [project.urls]

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1246,7 +1246,8 @@ requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-prebuilt", editable = "../prebuilt" },
     { name = "langgraph-sdk", editable = "../sdk-py" },
-    { name = "pydantic", specifier = ">=2.7.4" },
+    { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.7.4" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'", specifier = ">=2.0.0" },
     { name = "xxhash", specifier = ">=3.5.0" },
 ]
 

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version >= '3.12.4'",
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.12.4' and python_full_version < '3.13'",
     "python_full_version < '3.12.4'",
 ]
 
@@ -337,7 +338,8 @@ requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-prebuilt", editable = "." },
     { name = "langgraph-sdk", editable = "../sdk-py" },
-    { name = "pydantic", specifier = ">=2.7.4" },
+    { name = "pydantic", marker = "python_full_version < '3.13'", specifier = ">=2.7.4" },
+    { name = "pydantic", marker = "python_full_version >= '3.13'", specifier = ">=2.0.0" },
     { name = "xxhash", specifier = ">=3.5.0" },
 ]
 


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langgraph/issues/5026

Unfortunate. `uv` doesn't recognize `--resolution` with groups, but rather the whole suite of deps. Harder than expected.