### PR TITLE
Updated TAVILY Key Setup

### DIFF
--- a/docs/docs/tutorials/get-started/2-add-tools.md
+++ b/docs/docs/tutorials/get-started/2-add-tools.md
@@ -23,12 +23,16 @@ pip install -U langchain-tavily
 
 Configure your environment with your search engine API key:
 
-```bash
+```python
+def _set_env(var: str):
+    if not os.environ.get(var):
+        os.environ[var] = getpass.getpass(f"{var}: ")
+
 _set_env("TAVILY_API_KEY")
 ```
 
 ```
-TAVILY_API_KEY:  ········
+os.environ["TAVILY_API_KEY"]:  "········"
 ```
 
 ## 3. Define the tool


### PR DESCRIPTION
Definition of _set_env was missing from [Add Tools page](https://langchain-ai.github.io/langgraph/tutorials/get-started/2-add-tools/#2-configure-your-environment)