### PR TITLE
docs: Update quick_start.md Rest API Guide

### DIFF
--- a/docs/docs/cloud/quick_start.md
+++ b/docs/docs/cloud/quick_start.md
@@ -154,8 +154,9 @@ You can now test the API:
 
     ```bash
     curl -s --request POST \
-        --url <DEPLOYMENT_URL> \
+        --url <DEPLOYMENT_URL>/runs/stream \
         --header 'Content-Type: application/json' \
+        --header "X-Api-Key: <LANGSMITH API KEY> \
         --data "{
             \"assistant_id\": \"agent\",
             \"input\": {


### PR DESCRIPTION
A minor change to the curl command in the quick start guide that are needed to make the command work out of the box. I hope by adding these changes then new users can get started more quickly