### PR TITLE
dcos: Fix deprecation of TavilySearch

### DIFF
--- a/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
+++ b/docs/docs/tutorials/multi_agent/hierarchical_agent_teams.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U langgraph langchain_community langchain_anthropic langchain_experimental"
+    "%pip install -U langgraph langchain_community langchain_anthropic langchain-tavily langchain_experimental"
    ]
   },
   {
@@ -121,10 +121,10 @@
     "from typing import Annotated, List\n",
     "\n",
     "from langchain_community.document_loaders import WebBaseLoader\n",
-    "from langchain_community.tools.tavily_search import TavilySearchResults\n",
+    "from langchain_tavily import TavilySearch\n",
     "from langchain_core.tools import tool\n",
     "\n",
-    "tavily_tool = TavilySearchResults(max_results=5)\n",
+    "tavily_tool = TavilySearch(max_results=5)\n",
     "\n",
     "\n",
     "@tool\n",

--- a/docs/docs/tutorials/multi_agent/multi-agent-collaboration.ipynb
+++ b/docs/docs/tutorials/multi_agent/multi-agent-collaboration.ipynb
@@ -37,7 +37,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U langchain_community langchain_anthropic langchain_experimental matplotlib langgraph"
+    "%pip install -U langchain_community langchain_anthropic langchain-tavily langchain_experimental matplotlib langgraph"
    ]
   },
   {
@@ -92,11 +92,11 @@
    "source": [
     "from typing import Annotated\n",
     "\n",
-    "from langchain_community.tools.tavily_search import TavilySearchResults\n",
+    "from langchain_tavily import TavilySearch\n",
     "from langchain_core.tools import tool\n",
     "from langchain_experimental.utilities import PythonREPL\n",
     "\n",
-    "tavily_tool = TavilySearchResults(max_results=5)\n",
+    "tavily_tool = TavilySearch(max_results=5)\n",
     "\n",
     "# Warning: This executes code locally, which can be unsafe when not sandboxed\n",
     "\n",


### PR DESCRIPTION
The class `TavilySearchResults` was deprecated in LangChain 0.3.25 and will be removed in 1.0