### PR TITLE
change[langgraph]: clean up `Interrupt` interface for v1

### DIFF
--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -86,8 +86,11 @@ class GraphInterrupt(GraphBubbleUp):
 class NodeInterrupt(GraphInterrupt):
     """Raised by a node to interrupt execution."""
 
-    def __init__(self, value: Any) -> None:
-        super().__init__([Interrupt(value=value)])
+    def __init__(self, value: Any, id: str | None = None) -> None:
+        if id is None:
+            super().__init__([Interrupt(value=value)])
+        else:
+            super().__init__([Interrupt(value=value, id=id)])
 
 
 class ParentCommand(GraphBubbleUp):

--- a/libs/langgraph/tests/test_deprecation.py
+++ b/libs/langgraph/tests/test_deprecation.py
@@ -3,7 +3,7 @@ from typing_extensions import TypedDict
 
 from langgraph.func import entrypoint, task
 from langgraph.graph import StateGraph
-from langgraph.types import RetryPolicy
+from langgraph.types import Interrupt, RetryPolicy
 from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
 
 
@@ -88,3 +88,31 @@ def test_pregel_deprecation() -> None:
         match="Importing from langgraph.pregel.types is deprecated. Please use 'from langgraph.types import ...' instead.",
     ):
         from langgraph.pregel.types import StateSnapshot  # noqa: F401
+
+
+def test_interrupt_attributes_deprecation() -> None:
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="The `when` field is deprecated. Interrupts are always constructed 'during' the execution of a node/task.",
+    ):
+        Interrupt(value="question", id="123", when="during")
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="The `resumable` field is deprecated. All interrupts are by nature resumable=True.",
+    ):
+        Interrupt(value="question", id="123", resumable=True)
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="The `ns` field is deprecated. You can use `interrupt_id` to map a resume value to an interrupt.",
+    ):
+        Interrupt(value="question", id="123", ns=["graph:"])
+
+    interrupt = Interrupt(value="question", id="abc")
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`interrupt_id` is deprecated. Use `id` instead.",
+    ):
+        interrupt.interrupt_id


### PR DESCRIPTION
This PR introduces a few changes to the `Interrupt` interface:

## Deprecations:
* `when` - always `'during'`, so this doesn't have much value
* `resumable` - always `True`, so doesn't have much value
* `ns` - largely internal information, `id` can be used for mapping interrupt -> resume value

## Renaming:
* `interrupt_id` -> `id`

WIP:
* Fix tests
* Update docs