### PR TITLE
docs: fix typo in types.py in the interrupt example

### DIFF
--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -428,7 +428,7 @@ def interrupt(value: Any) -> Any:
         from langgraph.checkpoint.memory import MemorySaver
         from langgraph.constants import START
         from langgraph.graph import StateGraph
-        from langgraph.types import interrupt
+        from langgraph.types import interrupt, Command
 
 
         class State(TypedDict):


### PR DESCRIPTION
This example still lacked to include `Command`.

This change ensures that the snippet can actually be executed.
Without it one would receive an error message when running it.