### PR TITLE
feat: add type checking for matching `node` signatures vs `input_schema` for nodes

### DIFF
--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, NamedTuple, Protocol, Union
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, Union
 
 from langchain_core.runnables import Runnable, RunnableConfig
 from typing_extensions import TypeAlias
@@ -9,47 +10,47 @@ from typing_extensions import TypeAlias
 from langgraph.constants import EMPTY_SEQ
 from langgraph.store.base import BaseStore
 from langgraph.types import CachePolicy, RetryPolicy, StreamWriter
-from langgraph.typing import StateT_contra
+from langgraph.typing import NodeInputT, NodeInputT_contra
 
 
-class _Node(Protocol[StateT_contra]):
-    def __call__(self, state: StateT_contra) -> Any: ...
+class _Node(Protocol[NodeInputT_contra]):
+    def __call__(self, state: NodeInputT_contra) -> Any: ...
 
 
-class _NodeWithConfig(Protocol[StateT_contra]):
-    def __call__(self, state: StateT_contra, config: RunnableConfig) -> Any: ...
+class _NodeWithConfig(Protocol[NodeInputT_contra]):
+    def __call__(self, state: NodeInputT_contra, config: RunnableConfig) -> Any: ...
 
 
-class _NodeWithWriter(Protocol[StateT_contra]):
-    def __call__(self, state: StateT_contra, *, writer: StreamWriter) -> Any: ...
+class _NodeWithWriter(Protocol[NodeInputT_contra]):
+    def __call__(self, state: NodeInputT_contra, *, writer: StreamWriter) -> Any: ...
 
 
-class _NodeWithStore(Protocol[StateT_contra]):
-    def __call__(self, state: StateT_contra, *, store: BaseStore) -> Any: ...
+class _NodeWithStore(Protocol[NodeInputT_contra]):
+    def __call__(self, state: NodeInputT_contra, *, store: BaseStore) -> Any: ...
 
 
-class _NodeWithWriterStore(Protocol[StateT_contra]):
+class _NodeWithWriterStore(Protocol[NodeInputT_contra]):
     def __call__(
-        self, state: StateT_contra, *, writer: StreamWriter, store: BaseStore
+        self, state: NodeInputT_contra, *, writer: StreamWriter, store: BaseStore
     ) -> Any: ...
 
 
-class _NodeWithConfigWriter(Protocol[StateT_contra]):
+class _NodeWithConfigWriter(Protocol[NodeInputT_contra]):
     def __call__(
-        self, state: StateT_contra, *, config: RunnableConfig, writer: StreamWriter
+        self, state: NodeInputT_contra, *, config: RunnableConfig, writer: StreamWriter
     ) -> Any: ...
 
 
-class _NodeWithConfigStore(Protocol[StateT_contra]):
+class _NodeWithConfigStore(Protocol[NodeInputT_contra]):
     def __call__(
-        self, state: StateT_contra, *, config: RunnableConfig, store: BaseStore
+        self, state: NodeInputT_contra, *, config: RunnableConfig, store: BaseStore
     ) -> Any: ...
 
 
-class _NodeWithConfigWriterStore(Protocol[StateT_contra]):
+class _NodeWithConfigWriterStore(Protocol[NodeInputT_contra]):
     def __call__(
         self,
-        state: StateT_contra,
+        state: NodeInputT_contra,
         *,
         config: RunnableConfig,
         writer: StreamWriter,
@@ -61,23 +62,23 @@ class _NodeWithConfigWriterStore(Protocol[StateT_contra]):
 # we move to adding a context arg. Maybe what we do is we add support for kwargs with param spec
 # this is purely for typing purposes though, so can easily change in the coming weeks.
 StateNode: TypeAlias = Union[
-    _Node[StateT_contra],
-    _NodeWithConfig[StateT_contra],
-    _NodeWithWriter[StateT_contra],
-    _NodeWithStore[StateT_contra],
-    _NodeWithWriterStore[StateT_contra],
-    _NodeWithConfigWriter[StateT_contra],
-    _NodeWithConfigStore[StateT_contra],
-    _NodeWithConfigWriterStore[StateT_contra],
-    Runnable[StateT_contra, Any],
+    _Node[NodeInputT],
+    _NodeWithConfig[NodeInputT],
+    _NodeWithWriter[NodeInputT],
+    _NodeWithStore[NodeInputT],
+    _NodeWithWriterStore[NodeInputT],
+    _NodeWithConfigWriter[NodeInputT],
+    _NodeWithConfigStore[NodeInputT],
+    _NodeWithConfigWriterStore[NodeInputT],
+    Runnable[NodeInputT, Any],
 ]
 
 
-# TODO: use a dataclass generic on NodeInputType
-class StateNodeSpec(NamedTuple):
-    runnable: StateNode
+@dataclass
+class StateNodeSpec(Generic[NodeInputT]):
+    runnable: StateNode[NodeInputT]
     metadata: dict[str, Any] | None
-    input_schema: type[Any]
+    input_schema: type[NodeInputT]
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None
     cache_policy: CachePolicy | None
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -118,6 +118,7 @@ from langgraph.types import (
     All,
     CachePolicy,
     Checkpointer,
+    Command,
     Interrupt,
     Send,
     StateSnapshot,
@@ -2346,7 +2347,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
 
     def stream(
         self,
-        input: InputT,
+        input: InputT | Command | None,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode | Sequence[StreamMode] | None = None,
@@ -2568,7 +2569,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
 
     async def astream(
         self,
-        input: InputT,
+        input: InputT | Command | None,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode | Sequence[StreamMode] | None = None,
@@ -2812,7 +2813,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
 
     def invoke(
         self,
-        input: InputT,
+        input: InputT | Command | None,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode = "values",
@@ -2887,7 +2888,7 @@ class Pregel(PregelProtocol[StateT, InputT, OutputT], Generic[StateT, InputT, Ou
 
     async def ainvoke(
         self,
-        input: InputT,
+        input: InputT | Command | None,
         config: RunnableConfig | None = None,
         *,
         stream_mode: StreamMode = "values",

--- a/libs/langgraph/langgraph/typing.py
+++ b/libs/langgraph/langgraph/typing.py
@@ -27,6 +27,9 @@ InputT = TypeVar("InputT", bound=StateLike, default=StateT)
 Defaults to `StateT`.
 """
 
-
 OutputT = TypeVar("OutputT", bound=Union[StateLike, None], default=StateT)
 """Type variable used to represent the output of a state graph."""
+
+NodeInputT = TypeVar("NodeInputT", bound=StateLike)
+
+NodeInputT_contra = TypeVar("NodeInputT_contra", bound=StateLike, contravariant=True)

--- a/libs/langgraph/tests/test_type_checking.py
+++ b/libs/langgraph/tests/test_type_checking.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from langgraph.graph import StateGraph
+from langgraph.types import Command
 
 
 def test_typed_dict_state() -> None:
@@ -103,3 +104,56 @@ def test_input_state_specified() -> None:
 
     new_graph.invoke({"something": 1})
     new_graph.invoke({"something": 2, "info": ["hello", "world"]})  # type: ignore[arg-type]
+
+
+def test_invoke_with_all_valid_types() -> None:
+    class State(TypedDict):
+        a: int
+
+    def a(state: State) -> Any: ...
+
+    graph = StateGraph(State).add_node("a", a).set_entry_point("a").compile()
+    graph.invoke({"a": 1})
+    graph.invoke(None)
+    graph.invoke(Command())
+
+
+def test_add_node_with_explicit_input_schema() -> None:
+    class A(TypedDict):
+        a1: int
+        a2: str
+
+    class B(TypedDict):
+        b1: int
+        b2: str
+
+    class ANarrow(TypedDict):
+        a1: int
+
+    class BNarrow(TypedDict):
+        b1: int
+
+    class State(A, B): ...
+
+    def a(state: A) -> Any: ...
+
+    def b(state: B) -> Any: ...
+
+    workflow = StateGraph(State)
+    # input schema matches typed schemas
+    workflow.add_node("a", a, input_schema=A)
+    workflow.add_node("b", b, input_schema=B)
+
+    # input schema does not match typed schemas
+    workflow.add_node("a_wrong", a, input_schema=B)  # type: ignore[arg-type]
+    workflow.add_node("b_wrong", b, input_schema=A)  # type: ignore[arg-type]
+
+    # input schema is more broad than the typed schemas, which is allowed
+    # by the principles of contravariance
+    workflow.add_node("a_inclusive", a, input_schema=State)
+    workflow.add_node("b_inclusive", b, input_schema=State)
+
+    # input schema is more narrow than the typed schemas, which is not allowed
+    # because it violates the principles of contravariance
+    workflow.add_node("a_narrow", a, input_schema=ANarrow)  # type: ignore[arg-type]
+    workflow.add_node("b_narrow", b, input_schema=BNarrow)  # type: ignore[arg-type]


### PR DESCRIPTION
When you call `add_node`, if `input_schema` is specified, the type checker will warn if the node signature isn't compatible.

Also, ensures `StateT | Command | None` is accepted for `invoke` / `stream` methods, with corresponding tests.

For example:

```py
from typing import Any, TypedDict
from langgraph.graph import StateGraph, END
from typing import Sequence

class A(TypedDict):
    a: int

class B(TypedDict):
    b: int

class State(A, B):
    ...

def a(state: A) -> Any:
    ...

def b(state: B) -> Any:
    ...

# Create and configure the graph
workflow = StateGraph(State)
workflow.add_node("a", a, input_schema=A)
workflow.add_node("b", b, input_schema=B)

workflow.add_node("a_wrong", a, input_schema=B) # warns (B doesn't match A)
workflow.add_node("b_wrong", b, input_schema=A) # warns (A doesn't match B)
```