### PR TITLE
fix: llm.txt url link broken 

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -101,7 +101,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             };
             option2.onmouseout = function() { this.style.background = 'transparent'; };
             option2.onclick = function() {
-                window.open('/llms-txt-overview/', '_blank');
+                window.open('/langgraph/llms-txt-overview/', '_blank');
                 dropdown.style.display = 'none';
             };
             


### PR DESCRIPTION
Somehow the link isn't working well,

in prod it's now linking to https://langchain-ai.github.io/llms-txt-overview/
while it should be https://langchain-ai.github.io/langgraph/llms-txt-overview/
