### PR TITLE
fix(docs): broken URL in _AIO_ERROR_MSG for AsyncSqliteSaver

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -521,7 +521,6 @@ class SqliteSaver(BaseCheckpointSaver[str]):
         raise NotImplementedError(_AIO_ERROR_MSG)
         yield
 
-
     async def aput(
         self,
         config: RunnableConfig,


### PR DESCRIPTION
remove unreachable `yield` from unimplemented async methods