### PR TITLE
fix(langgraph): remove `ABC` spec for `PregelProtocol`

### DIFF
--- a/libs/langgraph/langgraph/pregel/protocol.py
+++ b/libs/langgraph/langgraph/pregel/protocol.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import Any, Generic
 


### PR DESCRIPTION
`ABC` is inherited from `Runnable` and was causing issues re MRO after https://github.com/langchain-ai/langchain/pull/31877.

This should not change behavior at all.