### PR TITLE
refactor(langgraph): fix typing for channels

### DIFF
--- a/libs/langgraph/langgraph/_internal/_typing.py
+++ b/libs/langgraph/langgraph/_internal/_typing.py
@@ -52,3 +52,6 @@ UNSET: Unset = Unset()
 
 class DeprecatedKwargs(TypedDict):
     """TypedDict to use for extra keyword arguments, enabling type checking warnings for deprecated arguments."""
+
+
+EMPTY_SEQ: tuple[str, ...] = tuple()

--- a/libs/langgraph/langgraph/_internal/_typing.py
+++ b/libs/langgraph/langgraph/_internal/_typing.py
@@ -48,6 +48,7 @@ class Unset:
 
 
 UNSET: Unset = Unset()
+"""Unset sentinel value."""
 
 
 class DeprecatedKwargs(TypedDict):
@@ -55,3 +56,4 @@ class DeprecatedKwargs(TypedDict):
 
 
 EMPTY_SEQ: tuple[str, ...] = tuple()
+"""An empty sequence of strings."""

--- a/libs/langgraph/langgraph/_internal/_typing.py
+++ b/libs/langgraph/langgraph/_internal/_typing.py
@@ -43,11 +43,11 @@ Note: we cannot use either `TypedDict` or `dataclass` directly due to limitation
 """
 
 
-class Unset:
+class UnsetType:
     """A sentinel value to represent an unset type."""
 
 
-UNSET: Unset = Unset()
+UNSET: UnsetType = UnsetType()
 """Unset sentinel value."""
 
 

--- a/libs/langgraph/langgraph/channels/any_value.py
+++ b/libs/langgraph/langgraph/channels/any_value.py
@@ -3,7 +3,7 @@ from typing import Any, Generic
 
 from typing_extensions import Self
 
-from langgraph._internal._typing import UNSET
+from langgraph._internal._typing import UNSET, UnsetType
 from langgraph.channels.base import BaseChannel, Value
 from langgraph.errors import EmptyChannelError
 
@@ -15,6 +15,8 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
     received, they are all equal."""
 
     __slots__ = ("typ", "value")
+
+    value: Value | UnsetType
 
     def __init__(self, typ: Any, key: str = "") -> None:
         super().__init__(typ, key)
@@ -39,9 +41,9 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
         empty.value = self.value
         return empty
 
-    def from_checkpoint(self, checkpoint: Value) -> Self:
+    def from_checkpoint(self, checkpoint: Value | UnsetType) -> Self:
         empty = self.__class__(self.typ, self.key)
-        if checkpoint is not UNSET:
+        if not isinstance(checkpoint, UnsetType):
             empty.value = checkpoint
         return empty
 
@@ -57,12 +59,12 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
-        if self.value is UNSET:
+        if isinstance(self.value, UnsetType):
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
         return self.value is not UNSET
 
-    def checkpoint(self) -> Value:
+    def checkpoint(self) -> Value | UnsetType:
         return self.value

--- a/libs/langgraph/langgraph/channels/any_value.py
+++ b/libs/langgraph/langgraph/channels/any_value.py
@@ -3,8 +3,8 @@ from typing import Any, Generic
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError
 
 __all__ = ("AnyValue",)
@@ -18,7 +18,7 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def __init__(self, typ: Any, key: str = "") -> None:
         super().__init__(typ, key)
-        self.value = MISSING
+        self.value = UNSET
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, AnyValue)
@@ -41,28 +41,28 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
         empty = self.__class__(self.typ, self.key)
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.value = checkpoint
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
         if len(values) == 0:
-            if self.value is MISSING:
+            if self.value is UNSET:
                 return False
             else:
-                self.value = MISSING
+                self.value = UNSET
                 return True
 
         self.value = values[-1]
         return True
 
     def get(self) -> Value:
-        if self.value is MISSING:
+        if self.value is UNSET:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING
+        return self.value is not UNSET
 
     def checkpoint(self) -> Value:
         return self.value

--- a/libs/langgraph/langgraph/channels/base.py
+++ b/libs/langgraph/langgraph/channels/base.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, TypeVar
 
 from typing_extensions import Self
 
-from langgraph.constants import MISSING
+from langgraph._internal._typing import UNSET
 from langgraph.errors import EmptyChannelError
 
 Value = TypeVar("Value")
@@ -48,7 +48,7 @@ class BaseChannel(Generic[Value, Update, C], ABC):
         try:
             return self.get()
         except EmptyChannelError:
-            return MISSING
+            return UNSET
 
     @abstractmethod
     def from_checkpoint(self, checkpoint: C) -> Self:

--- a/libs/langgraph/langgraph/channels/base.py
+++ b/libs/langgraph/langgraph/channels/base.py
@@ -4,17 +4,17 @@ from typing import Any, Generic, TypeVar
 
 from typing_extensions import Self
 
-from langgraph._internal._typing import UNSET
+from langgraph._internal._typing import UNSET, UnsetType
 from langgraph.errors import EmptyChannelError
 
 Value = TypeVar("Value")
 Update = TypeVar("Update")
-C = TypeVar("C")
+Checkpoint = TypeVar("Checkpoint")
 
 __all__ = ("BaseChannel",)
 
 
-class BaseChannel(Generic[Value, Update, C], ABC):
+class BaseChannel(Generic[Value, Update, Checkpoint], ABC):
     """Base class for all channels."""
 
     __slots__ = ("key", "typ")
@@ -41,7 +41,7 @@ class BaseChannel(Generic[Value, Update, C], ABC):
         Subclasses can override this method with a more efficient implementation."""
         return self.from_checkpoint(self.checkpoint())
 
-    def checkpoint(self) -> C:
+    def checkpoint(self) -> Checkpoint | UnsetType:
         """Return a serializable representation of the channel's current state.
         Raises EmptyChannelError if the channel is empty (never updated yet),
         or doesn't support checkpoints."""
@@ -51,7 +51,7 @@ class BaseChannel(Generic[Value, Update, C], ABC):
             return UNSET
 
     @abstractmethod
-    def from_checkpoint(self, checkpoint: C) -> Self:
+    def from_checkpoint(self, checkpoint: Checkpoint | UnsetType) -> Self:
         """Return a new identical channel, optionally initialized from a checkpoint.
         If the checkpoint contains complex data structures, they should be copied."""
 

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -4,8 +4,8 @@ from typing import Callable, Generic
 
 from typing_extensions import NotRequired, Required, Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError
 
 __all__ = ("BinaryOperatorAggregate",)
@@ -49,7 +49,7 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
         try:
             self.value = typ()
         except Exception:
-            self.value = MISSING
+            self.value = UNSET
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, BinaryOperatorAggregate) and (
@@ -79,14 +79,14 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def from_checkpoint(self, checkpoint: Value) -> Self:
         empty = self.__class__(self.typ, self.operator)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.value = checkpoint
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
+        if self.value is UNSET:
             self.value = values[0]
             values = values[1:]
         for value in values:
@@ -94,12 +94,12 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
-        if self.value is MISSING:
+        if self.value is UNSET:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING
+        return self.value is not UNSET
 
     def checkpoint(self) -> Value:
         return self.value

--- a/libs/langgraph/langgraph/channels/ephemeral_value.py
+++ b/libs/langgraph/langgraph/channels/ephemeral_value.py
@@ -3,7 +3,7 @@ from typing import Any, Generic
 
 from typing_extensions import Self
 
-from langgraph._internal._typing import UNSET
+from langgraph._internal._typing import UNSET, UnsetType
 from langgraph.channels.base import BaseChannel, Value
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
@@ -14,6 +14,9 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
     """Stores the value received in the step immediately preceding, clears after."""
 
     __slots__ = ("value", "guard")
+
+    value: Value | UnsetType
+    guard: bool
 
     def __init__(self, typ: Any, guard: bool = True) -> None:
         super().__init__(typ)
@@ -40,14 +43,14 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
         empty.value = self.value
         return empty
 
-    def from_checkpoint(self, checkpoint: Value) -> Self:
+    def from_checkpoint(self, checkpoint: Value | UnsetType) -> Self:
         empty = self.__class__(self.typ, self.guard)
         empty.key = self.key
-        if checkpoint is not UNSET:
+        if isinstance(checkpoint, UnsetType):
             empty.value = checkpoint
         return empty
 
-    def update(self, values: Sequence[Value]) -> bool:
+    def update(self, values: Sequence[Value | UnsetType]) -> bool:
         if len(values) == 0:
             if self.value is not UNSET:
                 self.value = UNSET

--- a/libs/langgraph/langgraph/channels/ephemeral_value.py
+++ b/libs/langgraph/langgraph/channels/ephemeral_value.py
@@ -3,8 +3,8 @@ from typing import Any, Generic
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
 __all__ = ("EphemeralValue",)
@@ -18,7 +18,7 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __init__(self, typ: Any, guard: bool = True) -> None:
         super().__init__(typ)
         self.guard = guard
-        self.value = MISSING
+        self.value = UNSET
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, EphemeralValue) and value.guard == self.guard
@@ -43,14 +43,14 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def from_checkpoint(self, checkpoint: Value) -> Self:
         empty = self.__class__(self.typ, self.guard)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.value = checkpoint
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
         if len(values) == 0:
-            if self.value is not MISSING:
-                self.value = MISSING
+            if self.value is not UNSET:
+                self.value = UNSET
                 return True
             else:
                 return False
@@ -63,12 +63,12 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
-        if self.value is MISSING:
+        if self.value is UNSET:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING
+        return self.value is not UNSET
 
     def checkpoint(self) -> Value:
         return self.value

--- a/libs/langgraph/langgraph/channels/last_value.py
+++ b/libs/langgraph/langgraph/channels/last_value.py
@@ -3,8 +3,8 @@ from typing import Any, Generic
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import (
     EmptyChannelError,
     ErrorCode,
@@ -22,7 +22,7 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def __init__(self, typ: Any, key: str = "") -> None:
         super().__init__(typ, key)
-        self.value = MISSING
+        self.value = UNSET
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, LastValue)
@@ -45,7 +45,7 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
         empty = self.__class__(self.typ, self.key)
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.value = checkpoint
         return empty
 
@@ -63,12 +63,12 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
-        if self.value is MISSING:
+        if self.value is UNSET:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING
+        return self.value is not UNSET
 
     def checkpoint(self) -> Value:
         return self.value
@@ -84,7 +84,7 @@ class LastValueAfterFinish(
 
     def __init__(self, typ: Any, key: str = "") -> None:
         super().__init__(typ, key)
-        self.value = MISSING
+        self.value = UNSET
         self.finished = False
 
     def __eq__(self, value: object) -> bool:
@@ -101,14 +101,14 @@ class LastValueAfterFinish(
         return self.typ
 
     def checkpoint(self) -> tuple[Value, bool]:
-        if self.value is MISSING:
-            return MISSING
+        if self.value is UNSET:
+            return UNSET
         return (self.value, self.finished)
 
     def from_checkpoint(self, checkpoint: tuple[Value, bool]) -> Self:
         empty = self.__class__(self.typ)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.value, empty.finished = checkpoint
         return empty
 
@@ -123,22 +123,22 @@ class LastValueAfterFinish(
     def consume(self) -> bool:
         if self.finished:
             self.finished = False
-            self.value = MISSING
+            self.value = UNSET
             return True
 
         return False
 
     def finish(self) -> bool:
-        if not self.finished and self.value is not MISSING:
+        if not self.finished and self.value is not UNSET:
             self.finished = True
             return True
         else:
             return False
 
     def get(self) -> Value:
-        if self.value is MISSING or not self.finished:
+        if self.value is UNSET or not self.finished:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING and self.finished
+        return self.value is not UNSET and self.finished

--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -3,8 +3,8 @@ from typing import Generic
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
 __all__ = ("NamedBarrierValue", "NamedBarrierValueAfterFinish")
@@ -49,7 +49,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
     def from_checkpoint(self, checkpoint: set[Value]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.seen = checkpoint
         return empty
 
@@ -127,7 +127,7 @@ class NamedBarrierValueAfterFinish(
     def from_checkpoint(self, checkpoint: tuple[set[Value], bool]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             empty.seen, empty.finished = checkpoint
         return empty
 

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -5,8 +5,8 @@ from typing import Any, Generic, Union
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError
 
 __all__ = ("Topic",)
@@ -66,7 +66,7 @@ class Topic(
     def from_checkpoint(self, checkpoint: list[Value]) -> Self:
         empty = self.__class__(self.typ, self.accumulate)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not UNSET:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
                 empty.values = checkpoint[1]

--- a/libs/langgraph/langgraph/channels/untracked_value.py
+++ b/libs/langgraph/langgraph/channels/untracked_value.py
@@ -3,7 +3,7 @@ from typing import Generic
 
 from typing_extensions import Self
 
-from langgraph._internal._typing import UNSET
+from langgraph._internal._typing import UNSET, UnsetType
 from langgraph.channels.base import BaseChannel, Value
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
@@ -14,6 +14,9 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
     """Stores the last value received, never checkpointed."""
 
     __slots__ = ("value", "guard")
+
+    guard: bool
+    value: Value | UnsetType
 
     def __init__(self, typ: type[Value], guard: bool = True) -> None:
         super().__init__(typ)
@@ -40,7 +43,7 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
         empty.value = self.value
         return empty
 
-    def checkpoint(self) -> Value:
+    def checkpoint(self) -> Value | UnsetType:
         return UNSET
 
     def from_checkpoint(self, checkpoint: Value) -> Self:

--- a/libs/langgraph/langgraph/channels/untracked_value.py
+++ b/libs/langgraph/langgraph/channels/untracked_value.py
@@ -3,8 +3,8 @@ from typing import Generic
 
 from typing_extensions import Self
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel, Value
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
 __all__ = ("UntrackedValue",)
@@ -18,7 +18,7 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __init__(self, typ: type[Value], guard: bool = True) -> None:
         super().__init__(typ)
         self.guard = guard
-        self.value = MISSING
+        self.value = UNSET
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, UntrackedValue) and value.guard == self.guard
@@ -41,7 +41,7 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
         return empty
 
     def checkpoint(self) -> Value:
-        return MISSING
+        return UNSET
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
         empty = self.__class__(self.typ, self.guard)
@@ -60,9 +60,9 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
-        if self.value is MISSING:
+        if self.value is UNSET:
             raise EmptyChannelError()
         return self.value
 
     def is_available(self) -> bool:
-        return self.value is not MISSING
+        return self.value is not UNSET

--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -31,9 +31,6 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module has no attribute '{name}'")
 
 
-# --- Empty read-only containers ---
-MISSING = object()
-
 # --- Public constants ---
 TAG_NOSTREAM = sys.intern("nostream")
 """Tag to disable streaming for a chat model."""

--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -32,7 +32,6 @@ def __getattr__(name: str) -> Any:
 
 
 # --- Empty read-only containers ---
-EMPTY_SEQ: tuple[str, ...] = tuple()
 MISSING = object()
 
 # --- Public constants ---

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, Protocol, Union
 from langchain_core.runnables import Runnable, RunnableConfig
 from typing_extensions import TypeAlias
 
-from langgraph.constants import EMPTY_SEQ
+from langgraph._internal._typing import EMPTY_SEQ
 from langgraph.runtime import Runtime
 from langgraph.store.base import BaseStore
 from langgraph.types import CachePolicy, RetryPolicy, StreamWriter

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -34,7 +34,7 @@ from langgraph._internal._fields import (
 )
 from langgraph._internal._pydantic import create_model
 from langgraph._internal._runnable import coerce_to_runnable
-from langgraph._internal._typing import UNSET, DeprecatedKwargs
+from langgraph._internal._typing import EMPTY_SEQ, UNSET, DeprecatedKwargs
 from langgraph.cache.base import BaseCache
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -46,7 +46,6 @@ from langgraph.channels.named_barrier_value import (
 )
 from langgraph.checkpoint.base import Checkpoint
 from langgraph.constants import (
-    EMPTY_SEQ,
     END,
     INTERRUPT,
     MISSING,

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -48,7 +48,6 @@ from langgraph.checkpoint.base import Checkpoint
 from langgraph.constants import (
     END,
     INTERRUPT,
-    MISSING,
     NS_END,
     NS_SEP,
     START,
@@ -1192,7 +1191,7 @@ class CompiledStateGraph(
                     continue
                 if k in self.nodes:
                     v = versions.pop(k)
-                    c = values.pop(k, MISSING)
+                    c = values.pop(k, UNSET)
                     for end in source_to_target[k]:
                         # get next version
                         new_k = f"branch:to:{end}"
@@ -1206,13 +1205,13 @@ class CompiledStateGraph(
                                 else:
                                     ss[new_k] = s
                         # update value
-                        if new_k not in values and c is not MISSING:
+                        if new_k not in values and c is not UNSET:
                             values[new_k] = c
                         # update version
                         versions[new_k] = new_v
                     # pop interrupt seen
                     if INTERRUPT in seen:
-                        seen[INTERRUPT].pop(k, MISSING)
+                        seen[INTERRUPT].pop(k, UNSET)
 
 
 def _pick_mapper(

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -27,7 +27,7 @@ from xxhash import xxh3_128_hexdigest
 
 from langgraph._internal._config import merge_configs, patch_config
 from langgraph._internal._runtime import patch_runtime_non_null
-from langgraph._internal._typing import EMPTY_SEQ
+from langgraph._internal._typing import EMPTY_SEQ, UNSET
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
 from langgraph.checkpoint.base import (
@@ -52,7 +52,6 @@ from langgraph.constants import (
     CONFIG_KEY_TASK_ID,
     ERROR,
     INTERRUPT,
-    MISSING,
     NO_WRITES,
     NS_END,
     NS_SEP,
@@ -812,7 +811,7 @@ def prepare_single_task(
                     input_cache=input_cache,
                     scratchpad=scratchpad,
                 )
-                if val is MISSING:
+                if val is UNSET:
                     return
             except Exception as exc:
                 if SUPPORTS_EXC_NOTES:
@@ -1040,9 +1039,9 @@ def _proc_input(
             if channels[proc.channels].is_available():
                 val = channels[proc.channels].get()
             else:
-                return MISSING
+                return UNSET
         else:
-            return MISSING
+            return UNSET
     else:
         raise RuntimeError(
             f"Invalid channels type, expected list or dict, got {proc.channels}"

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -27,6 +27,7 @@ from xxhash import xxh3_128_hexdigest
 
 from langgraph._internal._config import merge_configs, patch_config
 from langgraph._internal._runtime import patch_runtime_non_null
+from langgraph._internal._typing import EMPTY_SEQ
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
 from langgraph.checkpoint.base import (
@@ -49,7 +50,6 @@ from langgraph.constants import (
     CONFIG_KEY_SCRATCHPAD,
     CONFIG_KEY_SEND,
     CONFIG_KEY_TASK_ID,
-    EMPTY_SEQ,
     ERROR,
     INTERRUPT,
     MISSING,

--- a/libs/langgraph/langgraph/pregel/_checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/_checkpoint.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import datetime, timezone
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel
 from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.base.id import uuid6
-from langgraph.constants import MISSING
 from langgraph.managed.base import ManagedValueMapping, ManagedValueSpec
 
 LATEST_VERSION = 4
@@ -40,7 +40,7 @@ def create_checkpoint(
             if k not in checkpoint["channel_versions"]:
                 continue
             v = channels[k].checkpoint()
-            if v is not MISSING:
+            if v is not UNSET:
                 values[k] = v
     return Checkpoint(
         v=LATEST_VERSION,
@@ -66,7 +66,7 @@ def channels_from_checkpoint(
             managed_specs[k] = v
     return (
         {
-            k: v.from_checkpoint(checkpoint["channel_values"].get(k, MISSING))
+            k: v.from_checkpoint(checkpoint["channel_values"].get(k, UNSET))
             for k, v in channel_specs.items()
         },
         managed_specs,

--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -4,12 +4,11 @@ from collections import Counter
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Literal
 
-from langgraph._internal._typing import EMPTY_SEQ
+from langgraph._internal._typing import EMPTY_SEQ, UNSET
 from langgraph.channels.base import BaseChannel, EmptyChannelError
 from langgraph.constants import (
     ERROR,
     INTERRUPT,
-    MISSING,
     NULL_TASK_ID,
     RESUME,
     RETURN,
@@ -134,8 +133,8 @@ def map_output_updates(
         return
     updated: list[tuple[str, Any]] = []
     for task, writes in output_tasks:
-        rtn = next((value for chan, value in writes if chan == RETURN), MISSING)
-        if rtn is not MISSING:
+        rtn = next((value for chan, value in writes if chan == RETURN), UNSET)
+        if rtn is not UNSET:
             updated.append((task.name, rtn))
         elif isinstance(output_channels, str):
             updated.extend(

--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -4,9 +4,9 @@ from collections import Counter
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Literal
 
+from langgraph._internal._typing import EMPTY_SEQ
 from langgraph.channels.base import BaseChannel, EmptyChannelError
 from langgraph.constants import (
-    EMPTY_SEQ,
     ERROR,
     INTERRUPT,
     MISSING,

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -28,6 +28,7 @@ from langchain_core.runnables import RunnableConfig
 from typing_extensions import ParamSpec, Self
 
 from langgraph._internal._config import patch_configurable
+from langgraph._internal._typing import EMPTY_SEQ
 from langgraph.cache.base import BaseCache
 from langgraph.channels.base import BaseChannel
 from langgraph.checkpoint.base import (
@@ -50,7 +51,6 @@ from langgraph.constants import (
     CONFIG_KEY_STREAM,
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
-    EMPTY_SEQ,
     ERROR,
     INPUT,
     INTERRUPT,

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -28,7 +28,7 @@ from langchain_core.runnables import RunnableConfig
 from typing_extensions import ParamSpec, Self
 
 from langgraph._internal._config import patch_configurable
-from langgraph._internal._typing import EMPTY_SEQ
+from langgraph._internal._typing import EMPTY_SEQ, UNSET
 from langgraph.cache.base import BaseCache
 from langgraph.channels.base import BaseChannel
 from langgraph.checkpoint.base import (
@@ -54,7 +54,6 @@ from langgraph.constants import (
     ERROR,
     INPUT,
     INTERRUPT,
-    MISSING,
     NS_END,
     NS_SEP,
     NULL_TASK_ID,
@@ -581,7 +580,7 @@ class PregelLoop:
                 or (
                     not self.is_nested
                     and self.config.get("metadata", {}).get("run_id")
-                    == self.checkpoint_metadata.get("run_id", MISSING)
+                    == self.checkpoint_metadata.get("run_id", UNSET)
                 ),
             )
         )

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -20,13 +20,13 @@ from typing import (
 from langchain_core.callbacks import Callbacks
 
 from langgraph._internal._future import chain_future, run_coroutine_threadsafe
+from langgraph._internal._typing import UNSET
 from langgraph.constants import (
     CONF,
     CONFIG_KEY_CALL,
     CONFIG_KEY_SCRATCHPAD,
     ERROR,
     INTERRUPT,
-    MISSING,
     NO_WRITES,
     RESUME,
     RETURN,
@@ -567,8 +567,8 @@ def _call(
         elif next_task.writes:
             # if it already ran, return the result
             fut = concurrent.futures.Future()
-            ret = next((v for c, v in next_task.writes if c == RETURN), MISSING)
-            if ret is not MISSING:
+            ret = next((v for c, v in next_task.writes if c == RETURN), UNSET)
+            if ret is not UNSET:
                 fut.set_result(ret)
             elif exc := next((v for c, v in next_task.writes if c == ERROR), None):
                 fut.set_exception(
@@ -710,8 +710,8 @@ async def _acall_impl(
             elif next_task.writes:
                 # if it already ran, return the result
                 fut = asyncio.Future(loop=loop)
-                ret = next((v for c, v in next_task.writes if c == RETURN), MISSING)
-                if ret is not MISSING:
+                ret = next((v for c, v in next_task.writes if c == RETURN), UNSET)
+                if ret is not UNSET:
                     fut.set_result(ret)
                 elif exc := next((v for c, v in next_task.writes if c == ERROR), None):
                     fut.set_exception(

--- a/libs/langgraph/langgraph/pregel/_write.py
+++ b/libs/langgraph/langgraph/pregel/_write.py
@@ -14,7 +14,8 @@ from typing import (
 from langchain_core.runnables import Runnable, RunnableConfig
 
 from langgraph._internal._runnable import RunnableCallable
-from langgraph.constants import CONF, CONFIG_KEY_SEND, MISSING, TASKS
+from langgraph._internal._typing import UNSET
+from langgraph.constants import CONF, CONFIG_KEY_SEND, TASKS
 from langgraph.errors import InvalidUpdateError
 from langgraph.types import Send
 
@@ -132,7 +133,7 @@ class ChannelWrite(RunnableCallable):
         """Used by PregelNode to distinguish between writers and other runnables."""
         return (
             isinstance(runnable, ChannelWrite)
-            or getattr(runnable, "_is_channel_writer", MISSING) is not MISSING
+            or getattr(runnable, "_is_channel_writer", UNSET) is not UNSET
         )
 
     @staticmethod
@@ -147,8 +148,8 @@ class ChannelWrite(RunnableCallable):
                 if isinstance(entry, ChannelWriteTupleEntry) and entry.static
                 for w in entry.static
             ] or None
-        elif writes := getattr(runnable, "_is_channel_writer", MISSING):
-            if writes is not MISSING:
+        elif writes := getattr(runnable, "_is_channel_writer", UNSET):
+            if writes is not UNSET:
                 writes = cast(
                     Sequence[tuple[Union[ChannelWriteEntry, Send], Optional[str]]],
                     writes,

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -9,6 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from typing_extensions import TypedDict
 
 from langgraph._internal._config import patch_checkpoint_map
+from langgraph._internal._typing import UNSET
 from langgraph.channels.base import BaseChannel
 from langgraph.checkpoint.base import CheckpointMetadata, PendingWrite
 from langgraph.constants import (
@@ -16,7 +17,6 @@ from langgraph.constants import (
     CONFIG_KEY_CHECKPOINT_NS,
     ERROR,
     INTERRUPT,
-    MISSING,
     NS_END,
     NS_SEP,
     RETURN,
@@ -194,7 +194,7 @@ def tasks_w_writes(
                 for tid, chan, val in pending_writes
                 if tid == task.id and chan == RETURN
             ),
-            MISSING,
+            UNSET,
         )
         out.append(
             PregelTask(
@@ -218,7 +218,7 @@ def tasks_w_writes(
                 states.get(task.id) if states else None,
                 (
                     rtn
-                    if rtn is not MISSING
+                    if rtn is not UNSET
                     else next(
                         (
                             val

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -4,17 +4,17 @@ from typing import Union
 
 import pytest
 
+from langgraph._internal._typing import UNSET
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
-from langgraph.constants import MISSING
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 
 pytestmark = pytest.mark.anyio
 
 
 def test_last_value() -> None:
-    channel = LastValue(int).from_checkpoint(MISSING)
+    channel = LastValue(int).from_checkpoint(UNSET)
     assert channel.ValueType is int
     assert channel.UpdateType is int
 
@@ -33,7 +33,7 @@ def test_last_value() -> None:
 
 
 def test_topic() -> None:
-    channel = Topic(str).from_checkpoint(MISSING)
+    channel = Topic(str).from_checkpoint(UNSET)
     assert channel.ValueType == Sequence[str]
     assert channel.UpdateType is Union[str, list[str]]
 
@@ -57,7 +57,7 @@ def test_topic() -> None:
 
 
 def test_topic_accumulate() -> None:
-    channel = Topic(str, accumulate=True).from_checkpoint(MISSING)
+    channel = Topic(str, accumulate=True).from_checkpoint(UNSET)
     assert channel.ValueType == Sequence[str]
     assert channel.UpdateType is Union[str, list[str]]
 
@@ -75,7 +75,7 @@ def test_topic_accumulate() -> None:
 
 
 def test_binop() -> None:
-    channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(MISSING)
+    channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(UNSET)
     assert channel.ValueType is int
     assert channel.UpdateType is int
 


### PR DESCRIPTION
* Use global `UnsetType` and `Unset`, moved to `_internal/_typing.py`
* Use `EMPTY_SEQ` from `_internal/_typing.py`