### PR TITLE
Fix: Handle END node specially in _control_branch to prevent unknown …

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1239,12 +1239,14 @@ def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
         if isinstance(command.goto, Send):
             rtn.append((TASKS, command.goto))
         elif isinstance(command.goto, str):
-            rtn.append((CHANNEL_BRANCH_TO.format(command.goto), None))
+            # Handle END specially - don't create a branch channel for it
+            channel_name = command.goto if command.goto == END else CHANNEL_BRANCH_TO.format(command.goto)
+            rtn.append((channel_name, None))
         else:
             rtn.extend(
                 (TASKS, go)
                 if isinstance(go, Send)
-                else (CHANNEL_BRANCH_TO.format(go), None)
+                else (go if go == END else CHANNEL_BRANCH_TO.format(go), None)
                 for go in command.goto
             )
     return rtn


### PR DESCRIPTION
…channel warning

Fixes the "unknown channel branch:to:end" warning that occurs when using Command(goto=END, update={...}) in subgraphs. The issue was caused by the _control_branch function creating a branch channel for the END node, which is a special terminal node that should be handled directly like in the _control_static function.

Changes made:

Modified _control_branch function to handle END node specially
When Command(goto=END) is used, now returns END directly instead of creating "branch:to:end" channel
Applied the same logic for both single and multiple destination cases
Maintains consistency with existing _control_static function behavior
Closes #5572

Issue
#5572

Dependencies
None - this is a pure bug fix that doesn't introduce new dependencies.

Testing
Verified fix eliminates the warning while preserving all functionality
Tested with existing test_graph_validation_with_command test case
Confirmed backward compatibility with normal node routing
No breaking changes introduced