### PR TITLE
Remove duplicated pretty_print_messages helper in  Multi‑agent supervisor tutorial

### DIFF
--- a/docs/docs/tutorials/multi_agent/agent_supervisor.md
+++ b/docs/docs/tutorials/multi_agent/agent_supervisor.md
@@ -85,49 +85,6 @@ Let's [run the agent](../../agents/run_agents.md) to verify that it behaves as e
 
 !!! note "We'll use `pretty_print_messages` helper to render the streamed agent outputs nicely"
 
-    ```python
-    from langchain_core.messages import convert_to_messages
-    
-    
-    def pretty_print_message(message, indent=False):
-        pretty_message = message.pretty_repr(html=True)
-        if not indent:
-            print(pretty_message)
-            return
-    
-        indented = "\n".join("\t" + c for c in pretty_message.split("\n"))
-        print(indented)
-    
-    
-    def pretty_print_messages(update, last_message=False):
-        is_subgraph = False
-        if isinstance(update, tuple):
-            ns, update = update
-            # skip parent graph updates in the printouts
-            if len(ns) == 0:
-                return
-    
-            graph_id = ns[-1].split(":")[0]
-            print(f"Update from subgraph {graph_id}:")
-            print("\n")
-            is_subgraph = True
-    
-        for node_name, node_update in update.items():
-            update_label = f"Update from node {node_name}:"
-            if is_subgraph:
-                update_label = "\t" + update_label
-    
-            print(update_label)
-            print("\n")
-    
-            messages = convert_to_messages(node_update["messages"])
-            if last_message:
-                messages = messages[-1:]
-    
-            for m in messages:
-                pretty_print_message(m, indent=is_subgraph)
-            print("\n")
-    ```
 
 ```python
 from langchain_core.messages import convert_to_messages


### PR DESCRIPTION
**Description:**  
Closes #___

Removed the redundant `pretty_print_message`/`pretty_print_messages` helper snippet from  
`docs/docs/tutorials/multi_agent/agent_supervisor.md`. Now there is a single, authoritative definition of these functions, which:

- Simplifies the tutorial  
- Avoids reader confusion over which helper to use  
- Prevents future drift between duplicate code blocks  

**Issue:** Closes #___  
**Dependencies:** None  
