### PR TITLE
release(prebuilt): 0.6.0

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "langchain-core>=0.1",
     "langgraph-checkpoint>=2.1.0,<3.0.0",
     "langgraph-sdk>=0.2.0,<0.3.0",
-    "langgraph-prebuilt>=0.5.0,<0.6.0",
+    "langgraph-prebuilt>=0.6.0,<0.7.0",
     "xxhash>=3.5.0",
     "pydantic>=2.7.4",
 ]

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1394,7 +1394,7 @@ dev = [
 
 [[package]]
 name = "langgraph-cli"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "../cli" }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1433,7 +1433,7 @@ dev = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "../prebuilt" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/pyproject.toml
+++ b/libs/prebuilt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-prebuilt"
-version = "0.5.2"
+version = "0.6.0"
 description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
 authors = []
 requires-python = ">=3.9"

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -460,7 +460,7 @@ dev = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Corresponds with langgraph v0.6.0 release

Keeping tight bound so that imports work well. Hopefully won't have to deal with this much longer if we move to langchain for prebuilts.