### PR TITLE
feat(prebuilt): Add dynamic model to create_react_agent

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -557,14 +557,14 @@ def create_react_agent(
             model = cast(BaseChatModel, init_chat_model(model))
 
         if (
-            _should_bind_tools(model, tool_classes, num_builtin=len(llm_builtin_tools))
+            _should_bind_tools(model, tool_classes, num_builtin=len(llm_builtin_tools))  # type: ignore[arg-type]
             and len(tool_classes + llm_builtin_tools) > 0
         ):
             model = cast(BaseChatModel, model).bind_tools(
                 tool_classes + llm_builtin_tools  # type: ignore[operator]
             )
 
-        static_model: Optional[Runnable] = _get_prompt_runnable(prompt) | model
+        static_model: Optional[Runnable] = _get_prompt_runnable(prompt) | model  # type: ignore[operator]
     else:
         # For dynamic models, we'll create the runnable at runtime
         static_model = None
@@ -576,7 +576,7 @@ def create_react_agent(
     def _resolve_model(state: StateSchema, config: RunnableConfig) -> LanguageModelLike:
         """Resolve the model to use, handling both static and dynamic models."""
         if is_dynamic_model:
-            return _get_prompt_runnable(prompt) | model(state, config)
+            return _get_prompt_runnable(prompt) | model(state, config)  # type: ignore[operator]
         else:
             return static_model
 
@@ -630,9 +630,9 @@ def create_react_agent(
         if is_dynamic_model:
             # Resolve dynamic model at runtime and apply prompt
             dynamic_model = _resolve_model(state, config)
-            response = cast(AIMessage, dynamic_model.invoke(model_input, config))
+            response = cast(AIMessage, dynamic_model.invoke(model_input, config))  # type: ignore[arg-type]
         else:
-            response = cast(AIMessage, static_model.invoke(model_input, config))
+            response = cast(AIMessage, static_model.invoke(model_input, config))  # type: ignore[union-attr]
 
         # add agent name to the AIMessage
         response.name = name
@@ -655,9 +655,9 @@ def create_react_agent(
         if is_dynamic_model:
             # Resolve dynamic model at runtime and apply prompt
             dynamic_model = _resolve_model(state, config)
-            response = cast(AIMessage, await dynamic_model.ainvoke(model_input, config))
+            response = cast(AIMessage, await dynamic_model.ainvoke(model_input, config))  # type: ignore[arg-type]
         else:
-            response = cast(AIMessage, await static_model.ainvoke(model_input, config))
+            response = cast(AIMessage, await static_model.ainvoke(model_input, config))  # type: ignore[union-attr]
 
         # add agent name to the AIMessage
         response.name = name

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -245,11 +245,10 @@ def _validate_chat_history(
     raise ValueError(error_message)
 
 
-DynamicModel = Callable[[StateSchema, RunnableConfig], BaseChatModel]
-
-
 def create_react_agent(
-    model: Union[str, LanguageModelLike, DynamicModel],
+    model: Union[
+        str, LanguageModelLike, Callable[[StateSchema, RunnableConfig], BaseChatModel]
+    ],
     tools: Union[Sequence[Union[BaseTool, Callable, dict[str, Any]]], ToolNode],
     *,
     prompt: Optional[Prompt] = None,

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -432,7 +432,6 @@ def create_react_agent(
     ```
 
     Example:
-        Basic usage with static model:
         ```python
         from langgraph.prebuilt import create_react_agent
 
@@ -447,52 +446,6 @@ def create_react_agent(
         )
         inputs = {"messages": [{"role": "user", "content": "what is the weather in sf"}]}
         for chunk in graph.stream(inputs, stream_mode="updates"):
-            print(chunk)
-        ```
-
-        Dynamic model selection example:
-        ```python
-        from dataclasses import dataclass
-        from langchain_openai import ChatOpenAI
-        from langgraph.prebuilt import create_react_agent
-        from langgraph.prebuilt.chat_agent_executor import AgentState
-        from langgraph.runtime import Runtime
-
-        @dataclass
-        class ModelContext:
-            model_name: str = "gpt-3.5-turbo"
-
-        def check_weather(location: str) -> str:
-            '''Return the weather forecast for the specified location.'''
-            return f"It's always sunny in {location}"
-
-        # Instantiate models in global scope to avoid recreating clients
-        gpt4_model = ChatOpenAI(model="gpt-4")
-        gpt35_model = ChatOpenAI(model="gpt-3.5-turbo")
-
-        def select_model(state: AgentState, runtime: Runtime[ModelContext]) -> ChatOpenAI:
-            # Select model based on context
-            model_name = runtime.context.model_name
-
-            if model_name == "gpt-4":
-                model = gpt4_model
-            else:
-                model = gpt35_model
-
-            # Bind tools to the selected model
-            return model.bind_tools([check_weather])
-
-        graph = create_react_agent(
-            select_model,
-            tools=[check_weather],
-            prompt="You are a helpful assistant",
-            context_schema=ModelContext,
-        )
-
-        # Use different models via context
-        context = ModelContext(model_name="gpt-4")
-        inputs = {"messages": [{"role": "user", "content": "what is the weather in sf"}]}
-        for chunk in graph.stream(inputs, context=context, stream_mode="updates"):
             print(chunk)
         ```
     """

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -585,8 +585,8 @@ def create_react_agent(
     ) -> LanguageModelLike:
         """Async resolve the model to use, handling both static and dynamic models."""
         if is_async_dynamic_model:
-            resolved_model = await model(state, runtime)  # type: ignore[misc]
-            return _get_prompt_runnable(prompt) | resolved_model  # type: ignore[operator]
+            resolved_model = await model(state, runtime)  # type: ignore[misc,operator]
+            return _get_prompt_runnable(prompt) | resolved_model
         elif is_dynamic_model:
             return _get_prompt_runnable(prompt) | model(state, runtime)  # type: ignore[operator]
         else:

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -276,16 +276,16 @@ def create_react_agent(
     Args:
         model: The language model for the agent. Supports static and dynamic
             model selection.
-            
+
             - **Static model**: A chat model instance (e.g., `ChatOpenAI()`) or
               string identifier (e.g., `"openai:gpt-4"`)
-            - **Dynamic model**: A callable with signature 
+            - **Dynamic model**: A callable with signature
               `(state, config) -> BaseChatModel` that returns different models
               based on runtime context
-            
+
             Dynamic functions receive graph state and configuration, enabling
             context-dependent model selection. Must return a `BaseChatModel`
-            instance. For tool calling, bind tools using `.bind_tools()`. 
+            instance. For tool calling, bind tools using `.bind_tools()`.
             Bound tools must be a subset of the `tools` parameter.
 
             Dynamic model example:
@@ -293,18 +293,18 @@ def create_react_agent(
             # Instantiate models globally
             gpt4_model = ChatOpenAI(model="gpt-4")
             gpt35_model = ChatOpenAI(model="gpt-3.5-turbo")
-            
+
             def select_model(state: AgentState, config: RunnableConfig) -> ChatOpenAI:
                 model_name = config.get("configurable", {}).get("model", "gpt-3.5-turbo")
                 model = gpt4_model if model_name == "gpt-4" else gpt35_model
                 return model.bind_tools(tools)
             ```
-            
+
             !!! note "Dynamic Model Requirements"
-                Ensure returned models have appropriate tools bound via 
+                Ensure returned models have appropriate tools bound via
                 `.bind_tools()` and support required functionality. Bound tools
                 must be a subset of those specified in the `tools` parameter.
-        
+
         tools: A list of tools or a ToolNode instance.
             If an empty list is provided, the agent will consist of a single LLM node without tool calling.
         prompt: An optional prompt for the LLM. Can take a few different forms:
@@ -439,7 +439,7 @@ def create_react_agent(
         for chunk in graph.stream(inputs, stream_mode="updates"):
             print(chunk)
         ```
-        
+
         Dynamic model selection example:
         ```python
         from langchain_core.runnables import RunnableConfig
@@ -458,12 +458,12 @@ def create_react_agent(
         def select_model(state: AgentState, config: RunnableConfig) -> ChatOpenAI:
             # Select model based on configuration
             model_name = config.get("configurable", {}).get("model", "gpt-3.5-turbo")
-            
+
             if model_name == "gpt-4":
                 model = gpt4_model
             else:
                 model = gpt35_model
-            
+
             # Bind tools to the selected model
             return model.bind_tools([check_weather])
 
@@ -472,7 +472,7 @@ def create_react_agent(
             tools=[check_weather],
             prompt="You are a helpful assistant",
         )
-        
+
         # Use different models via configuration
         config = {"configurable": {"model": "gpt-4"}}
         inputs = {"messages": [{"role": "user", "content": "what is the weather in sf"}]}

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -745,7 +745,7 @@ def create_react_agent(
         return {"structured_response": response}
 
     async def agenerate_structured_response(
-        state: StateSchema, runtime: Runtime, config: RunnableConfig
+        state: StateSchema, runtime: Runtime[ContextT], config: RunnableConfig
     ) -> StateSchema:
         messages = _get_state_value(state, "messages")
         structured_response_schema = response_format

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -28,6 +28,9 @@ from langchain_core.tools import InjectedToolCallId, ToolException
 from langchain_core.tools import tool as dec_tool
 from pydantic import BaseModel, Field
 from pydantic.v1 import BaseModel as BaseModelV1
+from tests.any_str import AnyStr
+from tests.messages import _AnyIdHumanMessage, _AnyIdToolMessage
+from tests.model import FakeToolCallingModel
 from typing_extensions import TypedDict
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -56,9 +59,6 @@ from langgraph.prebuilt.tool_node import (
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
 from langgraph.types import Command, Interrupt, interrupt
-from tests.any_str import AnyStr
-from tests.messages import _AnyIdHumanMessage, _AnyIdToolMessage
-from tests.model import FakeToolCallingModel
 
 pytestmark = pytest.mark.anyio
 
@@ -1616,7 +1616,7 @@ def test_dynamic_model_state_dependent_tools(version: Literal["v1", "v2"]) -> No
 
 
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
-def test_dynamic_model_error_handling(version: str) -> None:
+def test_dynamic_model_error_handling(version: Literal["v1", "v2"]) -> None:
     """Test error handling in dynamic model."""
 
     def failing_dynamic_model(state, config):

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1682,7 +1682,7 @@ def test_dynamic_model_receives_correct_state():
     class CustomAgentState(AgentState):
         custom_field: str
 
-    def dynamic_model(state, runtime: Runtime):
+    def dynamic_model(state, runtime: Runtime) -> BaseChatModel:
         # Capture the state that's passed to the dynamic model function
         received_states.append(state)
         return FakeToolCallingModel(tool_calls=[])

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1373,7 +1373,7 @@ def test_get_model() -> None:
 def test_dynamic_model_basic(version: str) -> None:
     """Test basic dynamic model functionality."""
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         # Return different models based on state
         if "urgent" in state["messages"][-1].content:
             return FakeToolCallingModel(tool_calls=[])
@@ -1442,7 +1442,7 @@ def test_dynamic_model_with_tools(version: Literal["v1", "v2"]) -> None:
 def test_dynamic_model_with_config(version: str) -> None:
     """Test dynamic model using config parameters."""
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         # Use config to determine model behavior
         user_type = config.get("configurable", {}).get("user_type", "basic")
         if user_type == "premium":
@@ -1537,7 +1537,7 @@ def test_dynamic_model_with_structured_response(version: str) -> None:
         message: str
         confidence: float
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         expected_response = TestResponse(message="dynamic response", confidence=0.9)
         return FakeToolCallingModel(
             tool_calls=[], structured_response=expected_response
@@ -1598,7 +1598,7 @@ def test_dynamic_model_state_dependent_tools(version: Literal["v1", "v2"]) -> No
         """Tool B."""
         return f"B: {x}"
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         # Switch tools based on message history
         if any("use_b" in msg.content for msg in state["messages"]):
             return FakeToolCallingModel(
@@ -1628,7 +1628,7 @@ def test_dynamic_model_state_dependent_tools(version: Literal["v1", "v2"]) -> No
 def test_dynamic_model_error_handling(version: Literal["v1", "v2"]) -> None:
     """Test error handling in dynamic model."""
 
-    def failing_dynamic_model(state, config):
+    def failing_dynamic_model(state, config: RunnableConfig):
         if "fail" in state["messages"][-1].content:
             raise ValueError("Dynamic model failed")
         return FakeToolCallingModel(tool_calls=[])
@@ -1651,7 +1651,7 @@ def test_dynamic_model_vs_static_model_behavior():
     static_agent = create_react_agent(static_model, [])
 
     # Dynamic model returning the same model
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         return FakeToolCallingModel(tool_calls=[])
 
     dynamic_agent = create_react_agent(dynamic_model, [])
@@ -1674,7 +1674,7 @@ def test_dynamic_model_receives_correct_state():
     class CustomAgentState(AgentState):
         custom_field: str
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         # Capture the state that's passed to the dynamic model function
         received_states.append(state)
         return FakeToolCallingModel(tool_calls=[])
@@ -1705,7 +1705,7 @@ async def test_dynamic_model_receives_correct_state_async():
     class CustomAgentStateAsync(AgentState):
         custom_field: str
 
-    def dynamic_model(state, config):
+    def dynamic_model(state, config: RunnableConfig):
         # Capture the state that's passed to the dynamic model function
         received_states.append(state)
         return FakeToolCallingModel(tool_calls=[])

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1557,10 +1557,17 @@ def test_dynamic_model_with_checkpointer(sync_checkpointer):
     """Test dynamic model with checkpointer."""
     call_count = 0
 
-    def dynamic_model(state, config):
+    def dynamic_model(state: AgentState, config: RunnableConfig) -> BaseChatModel:
         nonlocal call_count
         call_count += 1
-        return FakeToolCallingModel(tool_calls=[])
+        return FakeToolCallingModel(
+            tool_calls=[],
+            # Incrementing the call count as it is used to assign an id
+            # to the AIMessage.
+            # The default reducer semantics are to overwrite an existing message
+            # with the new one if the id matches.
+            index=call_count,
+        )
 
     agent = create_react_agent(dynamic_model, [], checkpointer=sync_checkpointer)
     config = {"configurable": {"thread_id": "test_dynamic"}}

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1445,7 +1445,7 @@ class Context:
 
 
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
-def test_dynamic_model_with_config(version: str) -> None:
+def test_dynamic_model_with_context(version: str) -> None:
     """Test dynamic model using config parameters."""
 
     def dynamic_model(state, runtime: Runtime[Context]):
@@ -1482,7 +1482,7 @@ def test_dynamic_model_with_state_schema(version: Literal["v1", "v2"]) -> None:
     class CustomDynamicState(AgentState):
         model_preference: str = "default"
 
-    def dynamic_model(state: dict, runtime: Runtime) -> BaseChatModel:
+    def dynamic_model(state: CustomDynamicState, runtime: Runtime) -> BaseChatModel:
         # Use custom state field to determine model
         if state.get("model_preference") == "advanced":
             return FakeToolCallingModel(tool_calls=[])

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -18,20 +18,17 @@ from langchain_core.messages import (
     AIMessage,
     AnyMessage,
     HumanMessage,
+    MessageLikeRepresentation,
     RemoveMessage,
     SystemMessage,
     ToolCall,
     ToolMessage,
-    MessageLikeRepresentation,
 )
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.tools import InjectedToolCallId, ToolException
 from langchain_core.tools import tool as dec_tool
 from pydantic import BaseModel, Field
 from pydantic.v1 import BaseModel as BaseModelV1
-from tests.any_str import AnyStr
-from tests.messages import _AnyIdHumanMessage, _AnyIdToolMessage
-from tests.model import FakeToolCallingModel
 from typing_extensions import TypedDict
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -60,6 +57,9 @@ from langgraph.prebuilt.tool_node import (
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
 from langgraph.types import Command, Interrupt, interrupt
+from tests.any_str import AnyStr
+from tests.messages import _AnyIdHumanMessage, _AnyIdToolMessage
+from tests.model import FakeToolCallingModel
 
 pytestmark = pytest.mark.anyio
 


### PR DESCRIPTION
Proposal for allowing to switch models and model configuration (including tools) at run time.

```python
def create_react_agent(
    model: Union[
        str, 
	LanguageModelLike,
        Callable[[SateLike, Runtime...], BaseChatModel], # <--- New
    ],
    tools: Union[
      Sequence[Union[BaseTool, Callable, dict[str, Any]]], ToolNode]
    ],
    *,
....


llm = init_chat_model(...)

def prepare_model(state, runtime):
   selected_tool_names = func(state, context)
   return llm.bind(tools=selected_tool_names)

create_react_agent(
  prepare_model,
  tools=all_known_tools
)
```

## Semantics

1. `tools` = are the known tools, used to configure ToolNode and will configure:
    1. model provided as string
    2. model provided as BaseChatModel (if it has no tools bound to it)
2. If a user provides a dynamic model (callable), the user is responsible for binding tools


Alternative considered:

1. Passing `Callable[[SateLike, Config...], list[BaseTool]]` to tools
2. Passing `Callable[[SateLike, Config...], list[str]]` to a tool selector

Both have the issue that there's non obvious interplay between tool selection and dynamic models. (i.e., if we want to introduce dynamic models at in the future, the API will become tricky to explain)