### PR TITLE
fix(langgraph): backwards compat config utils

### DIFF
--- a/libs/langgraph/langgraph/utils/config.py
+++ b/libs/langgraph/langgraph/utils/config.py
@@ -1,4 +1,4 @@
 """Backwards compat imports for config utilities, to be removed in v1."""
 
-from langgraph._internal._config import ensure_config  # noqa: F401
+from langgraph._internal._config import ensure_config, patch_configurable  # noqa: F401
 from langgraph.config import get_config, get_store  # noqa: F401

--- a/libs/langgraph/utils/__init__.py
+++ b/libs/langgraph/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Legacy utilities module, to be removed in v1."""

--- a/libs/langgraph/utils/__init__.py
+++ b/libs/langgraph/utils/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy utilities module, to be removed in v1."""

--- a/libs/langgraph/utils/config.py
+++ b/libs/langgraph/utils/config.py
@@ -1,0 +1,4 @@
+"""Backwards compat imports for config utilities, to be removed in v1."""
+
+from langgraph._internal._config import ensure_config, patch_configurable  # noqa: F401
+from langgraph.config import get_config, get_store  # noqa: F401

--- a/libs/langgraph/utils/config.py
+++ b/libs/langgraph/utils/config.py
@@ -1,4 +1,0 @@
-"""Backwards compat imports for config utilities, to be removed in v1."""
-
-from langgraph._internal._config import ensure_config, patch_configurable  # noqa: F401
-from langgraph.config import get_config, get_store  # noqa: F401

--- a/libs/langgraph/utils/runnable.py
+++ b/libs/langgraph/utils/runnable.py
@@ -1,3 +1,0 @@
-"""Backwards compat imports for runnable utilities, to be removed in v1."""
-
-from langgraph._internal._runnable import RunnableCallable, RunnableLike  # noqa: F401

--- a/libs/langgraph/utils/runnable.py
+++ b/libs/langgraph/utils/runnable.py
@@ -1,2 +1,3 @@
-# import for backwards compatibility
-from langgraph._internal._runnable import RunnableCallable, RunnableSeq  # noqa: F401
+"""Backwards compat imports for runnable utilities, to be removed in v1."""
+
+from langgraph._internal._runnable import RunnableCallable, RunnableLike  # noqa: F401


### PR DESCRIPTION
Don't need top level file, just `langgraph.utils`