### PR TITLE
fix(langgraph): always use parent runtime info if available

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -12,6 +12,7 @@ from dataclasses import is_dataclass
 from functools import partial
 from inspect import isclass
 from typing import Any, Callable, Generic, Optional, Union, cast, get_type_hints
+from unittest.mock import DEFAULT
 from uuid import UUID, uuid5
 
 from langchain_core.globals import get_debug
@@ -116,7 +117,7 @@ from langgraph.pregel._validate import validate_graph, validate_keys
 from langgraph.pregel._write import ChannelWrite, ChannelWriteEntry
 from langgraph.pregel.debug import get_bolded_text, get_colored_text, tasks_w_writes
 from langgraph.pregel.protocol import PregelProtocol, StreamChunk, StreamProtocol
-from langgraph.runtime import Runtime
+from langgraph.runtime import DEFAULT_RUNTIME, Runtime
 from langgraph.store.base import BaseStore
 from langgraph.types import (
     All,
@@ -2570,12 +2571,16 @@ class Pregel(
             if durability is not None or deprecated_checkpoint_during is not None:
                 config[CONF][CONFIG_KEY_DURABILITY] = durability_
 
-            config[CONF][CONFIG_KEY_RUNTIME] = Runtime(
+            runtime = Runtime(
                 context=context,
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
             )
+            parent_runtime = config[CONF].get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME)
+            runtime = parent_runtime.merge(runtime)
+            config[CONF][CONFIG_KEY_RUNTIME] = runtime
+
             with SyncPregelLoop(
                 input,
                 stream=StreamProtocol(stream.put, stream_modes),
@@ -2861,12 +2866,16 @@ class Pregel(
             if durability is not None or deprecated_checkpoint_during is not None:
                 config[CONF][CONFIG_KEY_DURABILITY] = durability_
 
-            config[CONF][CONFIG_KEY_RUNTIME] = Runtime(
+            runtime = Runtime(
                 context=context,
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
             )
+            parent_runtime = config[CONF].get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME)
+            runtime = parent_runtime.merge(runtime)
+            config[CONF][CONFIG_KEY_RUNTIME] = runtime
+
             async with AsyncPregelLoop(
                 input,
                 stream=StreamProtocol(stream.put_nowait, stream_modes),

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -12,7 +12,6 @@ from dataclasses import is_dataclass
 from functools import partial
 from inspect import isclass
 from typing import Any, Callable, Generic, Optional, Union, cast, get_type_hints
-from unittest.mock import DEFAULT
 from uuid import UUID, uuid5
 
 from langchain_core.globals import get_debug

--- a/libs/langgraph/tests/test_runtime.py
+++ b/libs/langgraph/tests/test_runtime.py
@@ -72,7 +72,7 @@ def test_merge_runtime() -> None:
     runtime3 = Runtime(context=None)
 
     assert runtime1.merge(runtime2).context.api_key == "def"
-    # override only appies to non-falsy values
+    # override only applies to non-falsy values
     assert runtime1.merge(runtime3).context.api_key == "abc"  # type: ignore
 
 

--- a/libs/langgraph/tests/test_runtime.py
+++ b/libs/langgraph/tests/test_runtime.py
@@ -79,11 +79,11 @@ def test_runtime_propogated_to_subgraph() -> None:
         username: str
 
     class State(TypedDict, total=False):
-        foo: str
-        bar: str
+        subgraph: str
+        main: str
 
     def subgraph_node_1(state: State, runtime: Runtime[Context]):
-        return {"bar": f"hi {runtime.context.username}!"}
+        return {"subgraph": f"{runtime.context.username}!"}
 
     subgraph_builder = StateGraph(State, context_schema=Context)
     subgraph_builder.add_node(subgraph_node_1)
@@ -91,7 +91,7 @@ def test_runtime_propogated_to_subgraph() -> None:
     subgraph = subgraph_builder.compile()
 
     def main_node(state: State, runtime: Runtime[Context]):
-        return {"foo": f"hello {runtime.context.username}!"}
+        return {"main": f"{runtime.context.username}!"}
 
     builder = StateGraph(State, context_schema=Context)
     builder.add_node(main_node)
@@ -102,4 +102,4 @@ def test_runtime_propogated_to_subgraph() -> None:
 
     context = Context(username="Alice")
     result = graph.invoke({}, context=context)
-    assert result == {"foo": "hello Alice!", "bar": "hi Alice!"}
+    assert result == {"subgraph": "Alice!", "main": "Alice!"}

--- a/libs/langgraph/tests/test_runtime.py
+++ b/libs/langgraph/tests/test_runtime.py
@@ -57,9 +57,9 @@ def test_override_runtime() -> None:
     class Context:
         api_key: str
 
-    runtime1 = Runtime(context=Context(api_key="abc"))
-    runtime = runtime1.override(context=Context(api_key="def"))
-    assert runtime.context.api_key == "def"
+    prev = Runtime(context=Context(api_key="abc"))
+    new = prev.override(context=Context(api_key="def"))
+    assert new.override(context=Context(api_key="def")).context.api_key == "def"
 
 
 def test_merge_runtime() -> None:
@@ -69,8 +69,11 @@ def test_merge_runtime() -> None:
 
     runtime1 = Runtime(context=Context(api_key="abc"))
     runtime2 = Runtime(context=Context(api_key="def"))
-    runtime = runtime1.merge(runtime2)
-    assert runtime.context.api_key == "def"
+    runtime3 = Runtime(context=None)
+
+    assert runtime1.merge(runtime2).context.api_key == "def"
+    # override only appies to non-falsy values
+    assert runtime1.merge(runtime3).context.api_key == "abc"  # type: ignore
 
 
 def test_runtime_propogated_to_subgraph() -> None:


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langgraph/issues/5700

I also considered an `override_if_not_none` but merge does that