### PR TITLE
fix(langgraph): enforce config injection even when optional

### DIFF
--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -132,7 +132,13 @@ ASYNCIO_ACCEPTS_CONTEXT = sys.version_info >= (3, 11)
 KWARGS_CONFIG_KEYS: tuple[tuple[str, tuple[Any, ...], str, Any], ...] = (
     (
         "config",
-        (RunnableConfig, "RunnableConfig", inspect.Parameter.empty),
+        (
+            RunnableConfig,
+            "RunnableConfig",
+            Optional[RunnableConfig],
+            "Optional[RunnableConfig]",
+            inspect.Parameter.empty,
+        ),
         # for now, use config directly, eventually, will pop off of Runtime
         "N/A",
         inspect.Parameter.empty,

--- a/libs/langgraph/tests/test_runnable.py
+++ b/libs/langgraph/tests/test_runnable.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import pytest
+from langchain_core.runnables.config import RunnableConfig
 
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.runtime import Runtime
@@ -370,3 +371,26 @@ async def test_runnable_callable_injectable_arguments_async() -> None:
         )
         == "success"
     )
+
+
+def test_config_injection() -> None:
+    def func(x: Any, config: RunnableConfig) -> list[str]:
+        return config.get("tags", [])
+
+    assert RunnableCallable(func).invoke(
+        "test", config={"tags": ["test"], "configurable": {}}
+    ) == ["test"]
+
+    def func_optional(x: Any, config: Optional[RunnableConfig]) -> list[str]:
+        return config.get("tags", []) if config else []
+
+    assert RunnableCallable(func_optional).invoke(
+        "test", config={"tags": ["test"], "configurable": {}}
+    ) == ["test"]
+
+    def func_untyped(x: Any, config) -> list[str]:
+        return config.get("tags", [])
+
+    assert RunnableCallable(func_untyped).invoke(
+        "test", config={"tags": ["test"], "configurable": {}}
+    ) == ["test"]

--- a/libs/langgraph/tests/test_runnable.py
+++ b/libs/langgraph/tests/test_runnable.py
@@ -381,7 +381,7 @@ def test_config_injection() -> None:
         "test", config={"tags": ["test"], "configurable": {}}
     ) == ["test"]
 
-    def func_optional(x: Any, config: Optional[RunnableConfig]) -> list[str]:
+    def func_optional(x: Any, config: Optional[RunnableConfig]) -> list[str]:  # noqa: UP045
         return config.get("tags", []) if config else []
 
     assert RunnableCallable(func_optional).invoke(


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langgraph/issues/5698

I would like to do a more general refactor of this logic at some point as well using typing introspection utilities. Claude code first pass: https://github.com/langchain-ai/langgraph/pull/5709