### PR TITLE
fix(prebuilt): assign `context_schema` to `config_schema` with correct condition

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -72,7 +72,7 @@ from langgraph._internal._runnable import (
     RunnableSeq,
     coerce_to_runnable,
 )
-from langgraph._internal._typing import DeprecatedKwargs
+from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.cache.base import BaseCache
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
@@ -636,7 +636,10 @@ class Pregel(
         name: str = "LangGraph",
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
-        if config_type := deprecated_kwargs.get("config_type"):
+        if (
+            config_type := deprecated_kwargs.get("config_type"),
+            MISSING,
+        ) is not MISSING:
             warnings.warn(
                 "`config_type` is deprecated and will be removed. Please use `context_schema` instead.",
                 category=LangGraphDeprecatedSinceV10,

--- a/libs/langgraph/tests/test_deprecation.py
+++ b/libs/langgraph/tests/test_deprecation.py
@@ -102,6 +102,7 @@ def test_config_schema_deprecation() -> None:
         match="`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
     ):
         builder = StateGraph(PlainState, config_schema=PlainState)
+        assert builder.context_schema == PlainState
 
     builder.add_node("test_node", lambda state: state)
     builder.set_entry_point("test_node")
@@ -111,13 +112,28 @@ def test_config_schema_deprecation() -> None:
         LangGraphDeprecatedSinceV10,
         match="`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
     ):
-        graph.config_schema()
+        assert graph.config_schema() is not None
 
     with pytest.warns(
         LangGraphDeprecatedSinceV10,
         match="`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
     ):
         graph.get_config_jsonschema()
+
+
+@pytest.mark.filterwarnings("ignore:`config_schema` is deprecated")
+def test_config_schema_deprecation_on_entrypoint() -> None:
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
+    ):
+
+        @entrypoint(config_schema=PlainState)  # type: ignore[arg-type]
+        def my_entrypoint(state: PlainState) -> PlainState:
+            return state
+
+        assert my_entrypoint.context_schema == PlainState
+        assert my_entrypoint.config_schema() is not None
 
 
 def test_config_type_deprecation_pregel(mocker: MockerFixture) -> None:
@@ -128,7 +144,7 @@ def test_config_type_deprecation_pregel(mocker: MockerFixture) -> None:
         LangGraphDeprecatedSinceV10,
         match="`config_type` is deprecated and will be removed. Please use `context_schema` instead.",
     ):
-        Pregel(
+        instance = Pregel(
             nodes={
                 "one": chain,
             },
@@ -140,6 +156,7 @@ def test_config_type_deprecation_pregel(mocker: MockerFixture) -> None:
             output_channels="output",
             config_type=PlainState,
         )
+        assert instance.context_schema == PlainState
 
 
 @pytest.mark.filterwarnings("ignore:`interrupt_id` is deprecated. Use `id` instead.")

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -459,11 +459,11 @@ def create_react_agent(
         config_schema := deprecated_kwargs.pop("config_schema", MISSING)
     ) is not MISSING:
         warn(
-            "`config_schema` is no longer supported. Use `context_schema` instead.",
+            "`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
             category=LangGraphDeprecatedSinceV10,
         )
 
-        if context_schema is not None:
+        if context_schema is None:
             context_schema = config_schema
 
     if version not in ("v1", "v2"):

--- a/libs/prebuilt/tests/test_deprecation.py
+++ b/libs/prebuilt/tests/test_deprecation.py
@@ -1,0 +1,33 @@
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.prebuilt import create_react_agent
+from langgraph.warnings import LangGraphDeprecatedSinceV10
+from tests.model import FakeToolCallingModel
+
+
+class Config(TypedDict):
+    model: str
+
+
+@pytest.mark.filterwarnings("ignore:`config_schema` is deprecated")
+@pytest.mark.filterwarnings("ignore:`get_config_jsonschema` is deprecated")
+def test_config_schema_deprecation() -> None:
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
+    ):
+        agent = create_react_agent(FakeToolCallingModel(), [], config_schema=Config)
+        assert agent.context_schema == Config
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
+    ):
+        assert agent.config_schema() is not None
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
+    ):
+        assert agent.get_config_jsonschema() is not None


### PR DESCRIPTION
Sigh. `is None` not `is not None`.