### PR TITLE
fix(langgraph): use `LangGraphDeprecatedInV06` instead of V1 equivalent

### DIFF
--- a/libs/langgraph/langgraph/constants.py
+++ b/libs/langgraph/langgraph/constants.py
@@ -7,7 +7,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINTER,
     TASKS,
 )
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 __all__ = (
     "TAG_NOSTREAM",
@@ -36,7 +36,7 @@ def __getattr__(name: str) -> Any:
         warn(
             f"Importing {name} from langgraph.constants is deprecated. "
             f"Please use 'from langgraph.types import {name}' instead.",
-            LangGraphDeprecatedSinceV10,
+            LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
 
@@ -54,7 +54,7 @@ def __getattr__(name: str) -> Any:
             f"Importing {name} from langgraph.constants is deprecated. "
             f"This constant is now private and should not be used directly. "
             "Please let the LangGraph team know if you need this value.",
-            LangGraphDeprecatedSinceV10,
+            LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
         return attr

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -10,7 +10,7 @@ from typing_extensions import deprecated
 # EmptyChannelError is re-exported from langgraph.channels.base
 from langgraph.checkpoint.base import EmptyChannelError  # noqa: F401
 from langgraph.types import Command, Interrupt
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 __all__ = (
     "EmptyChannelError",
@@ -102,7 +102,7 @@ class NodeInterrupt(GraphInterrupt):
     def __init__(self, value: Any, id: str | None = None) -> None:
         warn(
             "NodeInterrupt is deprecated. Please use `langgraph.types.interrupt` instead.",
-            LangGraphDeprecatedSinceV10,
+            LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
         if id is None:

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -41,7 +41,7 @@ from langgraph.pregel._write import ChannelWrite, ChannelWriteEntry
 from langgraph.store.base import BaseStore
 from langgraph.types import _DC_KWARGS, CachePolicy, RetryPolicy, StreamMode
 from langgraph.typing import ContextT
-from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV06
 
 __all__ = ("task", "entrypoint")
 
@@ -393,7 +393,7 @@ class entrypoint(Generic[ContextT]):
         if (config_schema := kwargs.get("config_schema", MISSING)) is not MISSING:
             warnings.warn(
                 "`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
-                category=LangGraphDeprecatedSinceV10,
+                category=LangGraphDeprecatedSinceV06,
                 stacklevel=2,
             )
             if context_schema is None:

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -81,7 +81,7 @@ from langgraph.types import (
     Send,
 )
 from langgraph.typing import ContextT, InputT, NodeInputT, OutputT, StateT
-from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV06
 
 if sys.version_info < (3, 10):
     NoneType = type(None)
@@ -196,7 +196,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         if (config_schema := kwargs.get("config_schema", MISSING)) is not MISSING:
             warnings.warn(
                 "`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
-                category=LangGraphDeprecatedSinceV10,
+                category=LangGraphDeprecatedSinceV06,
                 stacklevel=2,
             )
             if context_schema is None:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -131,7 +131,7 @@ from langgraph.types import (
     StreamMode,
 )
 from langgraph.typing import ContextT, InputT, OutputT, StateT
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 try:
     from langchain_core.tracers._streaming import _StreamingCallbackHandler
@@ -639,7 +639,7 @@ class Pregel(
         if config_type := deprecated_kwargs.get("config_type"):
             warnings.warn(
                 "`config_type` is deprecated and will be removed. Please use `context_schema` instead.",
-                category=LangGraphDeprecatedSinceV10,
+                category=LangGraphDeprecatedSinceV06,
                 stacklevel=2,
             )
 
@@ -787,7 +787,7 @@ class Pregel(
     def config_schema(self, *, include: Sequence[str] | None = None) -> type[BaseModel]:
         warnings.warn(
             "`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
-            category=LangGraphDeprecatedSinceV10,
+            category=LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
 
@@ -814,12 +814,12 @@ class Pregel(
     ) -> dict[str, Any]:
         warnings.warn(
             "`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
-            category=LangGraphDeprecatedSinceV10,
+            category=LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
 
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=LangGraphDeprecatedSinceV10)
+            warnings.filterwarnings("ignore", category=LangGraphDeprecatedSinceV06)
             schema = self.config_schema(include=include)
         return schema.model_json_schema()
 
@@ -2506,7 +2506,7 @@ class Pregel(
             if deprecated_checkpoint_during is not None:
                 warnings.warn(
                     "`checkpoint_during` is deprecated and will be removed. Please use `durability` instead.",
-                    category=LangGraphDeprecatedSinceV10,
+                    category=LangGraphDeprecatedSinceV06,
                 )
             # assign defaults
             (
@@ -2786,7 +2786,7 @@ class Pregel(
             if deprecated_checkpoint_during is not None:
                 warnings.warn(
                     "`checkpoint_during` is deprecated and will be removed. Please use `durability` instead.",
-                    category=LangGraphDeprecatedSinceV10,
+                    category=LangGraphDeprecatedSinceV06,
                 )
             # assign defaults
             (

--- a/libs/langgraph/langgraph/pregel/types.py
+++ b/libs/langgraph/langgraph/pregel/types.py
@@ -28,11 +28,11 @@ __all__ = [
 
 from warnings import warn
 
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 warn(
     "Importing from langgraph.pregel.types is deprecated. "
     "Please use 'from langgraph.types import ...' instead.",
-    LangGraphDeprecatedSinceV10,
+    LangGraphDeprecatedSinceV06,
     stacklevel=2,
 )

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -27,7 +27,7 @@ from langgraph._internal._fields import get_cached_annotated_keys, get_update_as
 from langgraph._internal._retry import default_retry_on
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.checkpoint.base import BaseCheckpointSaver, CheckpointMetadata
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 if TYPE_CHECKING:
     from langgraph.pregel.protocol import PregelProtocol
@@ -198,7 +198,7 @@ class Interrupt:
     def interrupt_id(self) -> str:
         warn(
             "`interrupt_id` is deprecated. Use `id` instead.",
-            LangGraphDeprecatedSinceV10,
+            LangGraphDeprecatedSinceV06,
             stacklevel=2,
         )
         return self.id

--- a/libs/langgraph/langgraph/warnings.py
+++ b/libs/langgraph/langgraph/warnings.py
@@ -54,6 +54,13 @@ class LangGraphDeprecatedSinceV05(LangGraphDeprecationWarning):
         super().__init__(message, *args, since=(0, 5), expected_removal=(2, 0))
 
 
+class LangGraphDeprecatedSinceV06(LangGraphDeprecationWarning):
+    """A specific `LangGraphDeprecationWarning` subclass defining functionality deprecated since LangGraph v0.6.0"""
+
+    def __init__(self, message: str, *args: object) -> None:
+        super().__init__(message, *args, since=(1, 0), expected_removal=(2, 0))
+
+
 class LangGraphDeprecatedSinceV10(LangGraphDeprecationWarning):
     """A specific `LangGraphDeprecationWarning` subclass defining functionality deprecated since LangGraph v1.0.0"""
 

--- a/libs/langgraph/tests/test_deprecation.py
+++ b/libs/langgraph/tests/test_deprecation.py
@@ -8,7 +8,7 @@ from langgraph.func import entrypoint, task
 from langgraph.graph import StateGraph
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.types import Interrupt, RetryPolicy
-from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV06
 
 
 class PlainState(TypedDict): ...
@@ -74,13 +74,13 @@ def test_add_node_input_schema() -> None:
 
 def test_constants_deprecation() -> None:
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="Importing Send from langgraph.constants is deprecated. Please use 'from langgraph.types import Send' instead.",
     ):
         from langgraph.constants import Send  # noqa: F401
 
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="Importing Interrupt from langgraph.constants is deprecated. Please use 'from langgraph.types import Interrupt' instead.",
     ):
         from langgraph.constants import Interrupt  # noqa: F401
@@ -88,7 +88,7 @@ def test_constants_deprecation() -> None:
 
 def test_pregel_types_deprecation() -> None:
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="Importing from langgraph.pregel.types is deprecated. Please use 'from langgraph.types import ...' instead.",
     ):
         from langgraph.pregel.types import StateSnapshot  # noqa: F401
@@ -98,7 +98,7 @@ def test_pregel_types_deprecation() -> None:
 @pytest.mark.filterwarnings("ignore:`get_config_jsonschema` is deprecated")
 def test_config_schema_deprecation() -> None:
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
     ):
         builder = StateGraph(PlainState, config_schema=PlainState)
@@ -108,13 +108,13 @@ def test_config_schema_deprecation() -> None:
     graph = builder.compile()
 
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
     ):
         graph.config_schema()
 
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
     ):
         graph.get_config_jsonschema()
@@ -125,7 +125,7 @@ def test_config_type_deprecation_pregel(mocker: MockerFixture) -> None:
     chain = NodeBuilder().subscribe_only("input").do(add_one).write_to("output")
 
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="`config_type` is deprecated and will be removed. Please use `context_schema` instead.",
     ):
         Pregel(
@@ -147,7 +147,7 @@ def test_interrupt_attributes_deprecation() -> None:
     interrupt = Interrupt(value="question", id="abc")
 
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="`interrupt_id` is deprecated. Use `id` instead.",
     ):
         interrupt.interrupt_id
@@ -156,7 +156,7 @@ def test_interrupt_attributes_deprecation() -> None:
 @pytest.mark.filterwarnings("ignore:NodeInterrupt is deprecated.")
 def test_node_interrupt_deprecation() -> None:
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="NodeInterrupt is deprecated. Please use `langgraph.types.interrupt` instead.",
     ):
         NodeInterrupt(value="test")
@@ -164,7 +164,7 @@ def test_node_interrupt_deprecation() -> None:
 
 def test_deprecated_import() -> None:
     with pytest.warns(
-        LangGraphDeprecatedSinceV10,
+        LangGraphDeprecatedSinceV06,
         match="Importing PREVIOUS from langgraph.constants is deprecated. This constant is now private and should not be used directly.",
     ):
         from langgraph.constants import PREVIOUS  # noqa: F401

--- a/libs/langgraph/tests/test_interrupt_migration.py
+++ b/libs/langgraph/tests/test_interrupt_migration.py
@@ -4,13 +4,13 @@ import pytest
 
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.types import Interrupt
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 
-@pytest.mark.filterwarnings("ignore:LangGraphDeprecatedSinceV10")
+@pytest.mark.filterwarnings("ignore:LangGraphDeprecatedSinceV06")
 def test_interrupt_legacy_ns() -> None:
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=LangGraphDeprecatedSinceV10)
+        warnings.filterwarnings("ignore", category=LangGraphDeprecatedSinceV06)
 
         old_interrupt = Interrupt(
             value="abc", resumable=True, when="during", ns=["a:b", "c:d"]

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -49,7 +49,7 @@ from langgraph.runtime import Runtime
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer, Send
 from langgraph.typing import ContextT
-from langgraph.warnings import LangGraphDeprecatedSinceV10
+from langgraph.warnings import LangGraphDeprecatedSinceV06
 
 StructuredResponse = Union[dict, BaseModel]
 StructuredResponseSchema = Union[dict, type[BaseModel]]
@@ -460,7 +460,7 @@ def create_react_agent(
     ) is not MISSING:
         warn(
             "`config_schema` is no longer supported. Use `context_schema` instead.",
-            category=LangGraphDeprecatedSinceV10,
+            category=LangGraphDeprecatedSinceV06,
         )
 
         if context_schema is not None:

--- a/libs/prebuilt/tests/test_deprecation.py
+++ b/libs/prebuilt/tests/test_deprecation.py
@@ -1,0 +1,33 @@
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.prebuilt import create_react_agent
+from langgraph.warnings import LangGraphDeprecatedSinceV06
+from tests.model import FakeToolCallingModel
+
+
+@pytest.mark.filterwarnings("ignore:`config_schema` is deprecated")
+@pytest.mark.filterwarnings("ignore:`get_config_jsonschema` is deprecated")
+class Config(TypedDict):
+    model: str
+
+
+def test_config_schema_deprecation() -> None:
+    with pytest.warns(
+        LangGraphDeprecatedSinceV06,
+        match="`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
+    ):
+        agent = create_react_agent(FakeToolCallingModel(), [], config_schema=Config)
+        assert agent.context_schema == Config
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV06,
+        match="`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
+    ):
+        assert agent.config_schema() is not None
+
+    with pytest.warns(
+        LangGraphDeprecatedSinceV06,
+        match="`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
+    ):
+        assert agent.get_config_jsonschema() is not None


### PR DESCRIPTION
We ended up doing a v0.6 release, so this should be changed. Fine to change in a patch, will leave v1 dep warning available as well.