### PR TITLE
fix(langgraph): fix up deprecation warnings

### DIFF
--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -91,7 +91,7 @@ class GraphInterrupt(GraphBubbleUp):
 
 @deprecated(
     "NodeInterrupt is deprecated. Please use `langgraph.types.interrupt` instead.",
-    stacklevel=2,
+    category=None,
 )
 class NodeInterrupt(GraphInterrupt):
     """Raised by a node to interrupt execution.

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -637,8 +637,7 @@ class Pregel(
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         if (
-            config_type := deprecated_kwargs.get("config_type"),
-            MISSING,
+            config_type := deprecated_kwargs.get("config_type", MISSING)
         ) is not MISSING:
             warnings.warn(
                 "`config_type` is deprecated and will be removed. Please use `context_schema` instead.",
@@ -785,7 +784,8 @@ class Pregel(
         return self
 
     @deprecated(
-        "`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead."
+        "`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
+        category=None,
     )
     def config_schema(self, *, include: Sequence[str] | None = None) -> type[BaseModel]:
         warnings.warn(
@@ -810,7 +810,8 @@ class Pregel(
         return create_model(self.get_name("Config"), field_definitions=fields)
 
     @deprecated(
-        "`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead."
+        "`get_config_jsonschema` is deprecated. Use `get_context_jsonschema` instead.",
+        category=None,
     )
     def get_config_jsonschema(
         self, *, include: Sequence[str] | None = None

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -191,10 +191,7 @@ class Interrupt:
         return cls(value=value, id=xxh3_128_hexdigest(ns.encode()))
 
     @property
-    @deprecated(
-        "`interrupt_id` is deprecated. Use `id` instead.",
-        stacklevel=2,
-    )
+    @deprecated("`interrupt_id` is deprecated. Use `id` instead.", category=None)
     def interrupt_id(self) -> str:
         warn(
             "`interrupt_id` is deprecated. Use `id` instead.",

--- a/libs/langgraph/tests/test_deprecation.py
+++ b/libs/langgraph/tests/test_deprecation.py
@@ -94,8 +94,6 @@ def test_pregel_types_deprecation() -> None:
         from langgraph.pregel.types import StateSnapshot  # noqa: F401
 
 
-@pytest.mark.filterwarnings("ignore:`config_schema` is deprecated")
-@pytest.mark.filterwarnings("ignore:`get_config_jsonschema` is deprecated")
 def test_config_schema_deprecation() -> None:
     with pytest.warns(
         LangGraphDeprecatedSinceV10,
@@ -121,7 +119,6 @@ def test_config_schema_deprecation() -> None:
         graph.get_config_jsonschema()
 
 
-@pytest.mark.filterwarnings("ignore:`config_schema` is deprecated")
 def test_config_schema_deprecation_on_entrypoint() -> None:
     with pytest.warns(
         LangGraphDeprecatedSinceV10,
@@ -132,6 +129,10 @@ def test_config_schema_deprecation_on_entrypoint() -> None:
         def my_entrypoint(state: PlainState) -> PlainState:
             return state
 
+    with pytest.warns(
+        LangGraphDeprecatedSinceV10,
+        match="`config_schema` is deprecated. Use `get_context_jsonschema` for the relevant schema instead.",
+    ):
         assert my_entrypoint.context_schema == PlainState
         assert my_entrypoint.config_schema() is not None
 
@@ -159,7 +160,6 @@ def test_config_type_deprecation_pregel(mocker: MockerFixture) -> None:
         assert instance.context_schema == PlainState
 
 
-@pytest.mark.filterwarnings("ignore:`interrupt_id` is deprecated. Use `id` instead.")
 def test_interrupt_attributes_deprecation() -> None:
     interrupt = Interrupt(value="question", id="abc")
 
@@ -170,7 +170,6 @@ def test_interrupt_attributes_deprecation() -> None:
         interrupt.interrupt_id
 
 
-@pytest.mark.filterwarnings("ignore:NodeInterrupt is deprecated.")
 def test_node_interrupt_deprecation() -> None:
     with pytest.warns(
         LangGraphDeprecatedSinceV10,


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langgraph/issues/5795

* Must use `category=None` on decorator so that we get type checking support but no dupe warning
* Fixed tuple on `config_type` warning causing false warning