### PR TITLE
fix(prebuilt): Allow functions with no parameters to be used as tools in ToolNode

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -445,6 +445,8 @@ class ToolNode(RunnableCallable):
         if invalid_tool_message := self._validate_tool_call(call):
             return invalid_tool_message
         try:
+            if call.get("args") is None:
+                call["args"] = {}
             call_args = {**call, **{"type": "tool_call"}}
             response = self.tools_by_name[call["name"]].invoke(call_args, config)
 
@@ -502,6 +504,8 @@ class ToolNode(RunnableCallable):
             return invalid_tool_message
 
         try:
+            if call.get("args") is None:
+                call["args"] = {}
             input = {**call, **{"type": "tool_call"}}
             response = await self.tools_by_name[call["name"]].ainvoke(input, config)
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1156,3 +1156,39 @@ async def test_tool_node_command_remove_all_messages():
     command = result[0]
     assert isinstance(command, Command)
     assert command.update == {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)]}
+
+
+def test_run_one_with_no_args_tool():
+    @dec_tool
+    def no_args_tool() -> str:
+        """A dummy tool that returns 'pong'."""
+        return "pong"
+
+    tool_node = ToolNode([no_args_tool])
+
+    call = {"name": "no_args_tool", "id": "123", "args": None}
+    tool_msg = tool_node._run_one(call, input_type="dict", config={})
+
+    assert tool_msg.name == "no_args_tool"
+    assert tool_msg.tool_call_id == "123"
+    assert tool_msg.content == "pong"
+    assert tool_msg.status != "error"
+
+
+async def test_arun_one_with_no_args_tool():
+    @dec_tool
+    async def no_args_tool() -> str:
+        """An async dummy tool that returns 'pong'."""
+        return "pong"
+
+    tool_node = ToolNode([no_args_tool])
+
+    call = {"name": "no_args_tool", "id": "123", "args": None}
+    tool_msg: ToolMessage = await tool_node._arun_one(
+        call, input_type="dict", config={}
+    )
+
+    assert tool_msg.name == "no_args_tool"
+    assert tool_msg.tool_call_id == "123"
+    assert tool_msg.content == "pong"
+    assert tool_msg.status != "error"


### PR DESCRIPTION
Description:
Allows functions with no parameters to be used as tools in ToolNode.
Previously, if the args field in a ToolCall was missing or None, tool execution would fail.
This change ensures that args defaults to {} when not provided, enabling support for no-arg tools.

Issue:
Closes https://github.com/langchain-ai/langgraph/issues/5722

Dependencies:
None