### PR TITLE
docs: fix typos and improve clarity in setup guides

### DIFF
--- a/docs/docs/cloud/deployment/setup.md
+++ b/docs/docs/cloud/deployment/setup.md
@@ -18,7 +18,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── requirements.txt # package dependencies
 │   ├── __init__.py
@@ -137,7 +137,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── requirements.txt # package dependencies
 │   ├── __init__.py
@@ -174,7 +174,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── requirements.txt # package dependencies
 │   ├── __init__.py

--- a/docs/docs/cloud/deployment/setup_javascript.md
+++ b/docs/docs/cloud/deployment/setup_javascript.md
@@ -11,7 +11,7 @@ my-app/
 ├── src # all project code lies within here
 │   ├── utils # optional utilities for your graph
 │   │   ├── tools.ts # tools for your graph
-│   │   ├── nodes.ts # node functions for you graph
+│   │   ├── nodes.ts # node functions for your graph
 │   │   └── state.ts # state definition of your graph
 │   └── agent.ts # code for constructing your graph
 ├── package.json # package dependencies
@@ -162,7 +162,7 @@ my-app/
 ├── src # all project code lies within here
 │   ├── utils # optional utilities for your graph
 │   │   ├── tools.ts # tools for your graph
-│   │   ├── nodes.ts # node functions for you graph
+│   │   ├── nodes.ts # node functions for your graph
 │   │   └── state.ts # state definition of your graph
 │   └── agent.ts # code for constructing your graph
 ├── package.json # package dependencies

--- a/docs/docs/cloud/deployment/setup_pyproject.md
+++ b/docs/docs/cloud/deployment/setup_pyproject.md
@@ -18,7 +18,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── __init__.py
 │   └── agent.py # code for constructing your graph
@@ -150,7 +150,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── __init__.py
 │   └── agent.py # code for constructing your graph
@@ -187,7 +187,7 @@ my-app/
 │   ├── utils # utilities for your graph
 │   │   ├── __init__.py
 │   │   ├── tools.py # tools for your graph
-│   │   ├── nodes.py # node functions for you graph
+│   │   ├── nodes.py # node functions for your graph
 │   │   └── state.py # state definition of your graph
 │   ├── __init__.py
 │   └── agent.py # code for constructing your graph

--- a/docs/docs/cloud/how-tos/configuration_cloud.md
+++ b/docs/docs/cloud/how-tos/configuration_cloud.md
@@ -272,7 +272,7 @@ For example, to update your assistant's system prompt:
 
     ```bash
     curl --request PATCH \
-    --url <DEPOLYMENT_URL>/assistants/<ASSISTANT_ID> \
+    --url <DEPLOYMENT_URL>/assistants/<ASSISTANT_ID> \
     --header 'Content-Type: application/json' \
     --data '{
     "config": {"model_name": "openai", "system_prompt": "You are an unhelpful assistant!"}

--- a/docs/docs/concepts/langgraph_data_plane.md
+++ b/docs/docs/concepts/langgraph_data_plane.md
@@ -69,7 +69,7 @@ The data region for a deployment is implied by the data region of the LangSmith 
 
 For CPU utilization, the autoscaler targets 75% utilization. This means the autoscaler will scale the number of containers up or down to ensure that CPU utilization is at or near 75%. For memory utilization, the autoscaler targets 75% utilization as well.
 
-For number of pending runs, the autoscaler targets 10 pending runs. For example, if the current number of containers is 1, but the number of pending runs in 20, the autoscaler will scale up the deployment to 2 containers (20 pending runs / 2 containers = 10 pending runs per container).
+For number of pending runs, the autoscaler targets 10 pending runs. For example, if the current number of containers is 1, but the number of pending runs is 20, the autoscaler will scale up the deployment to 2 containers (20 pending runs / 2 containers = 10 pending runs per container).
 
 Each metric is computed independently and the autoscaler will determine the scaling action based on the metric that results in the largest number of containers.
 


### PR DESCRIPTION
This pull request makes minor corrections to documentation files to fix typos and improve clarity. The main changes are updates to comments and example commands in several setup and configuration docs.

Documentation corrections:

* Fixed a typo in the comment for `nodes.py` and `nodes.ts` in various setup documentation files, changing "node functions for you graph" to "node functions for your graph". 
* Corrected a typo in an example `curl` command, changing `<DEPOLYMENT_URL>` to `<DEPLOYMENT_URL>` in the configuration documentation.
* Improved clarity in the autoscaler explanation by changing "the number of pending runs in 20" to "the number of pending runs is 20" in the concepts documentation.