### PR TITLE
chore(prebuilt): breaking do not support prebound tools on model

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
+++ b/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Awaitable, Callable, TypeVar, Union
 
 from langgraph._internal._typing import StateLike

--- a/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
+++ b/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
@@ -1,0 +1,25 @@
+from typing import Awaitable, Callable, TypeVar, Union
+
+from langgraph._internal._typing import StateLike
+
+try:
+    from typing import ParamSpec  # 3.10+
+except ImportError:
+    from typing_extensions import ParamSpec  # type: ignore
+
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.messages import BaseMessage
+from langchain_core.runnables import Runnable
+
+P = ParamSpec("P")
+R = TypeVar("R")
+T = TypeVar("T")
+
+MaybeAwaitable = Union[T, Awaitable[T]]
+SyncOrAsync = Callable[P, MaybeAwaitable[R]]
+
+# PreConfiguredChatModel is used to support chat models that have beeen pre-configured
+# using .bind().
+# For example, chat_model.bind(api_key="...") will return a PreConfiguredChatModel
+PreConfiguredChatModel = Runnable[LanguageModelInput, BaseMessage]
+ContextT = TypeVar("ContextT", bound=StateLike)

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Awaitable,
     Callable,
-    Generic,
     Literal,
     Optional,
     Sequence,
@@ -203,7 +202,7 @@ def _validate_chat_history(
     raise ValueError(error_message)
 
 
-class _AgentBuilder(Generic[ContextT]):
+class _AgentBuilder:
     """Internal builder class for constructing React agents with intuitive method-to-node mapping."""
 
     def __init__(

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import inspect
 from typing import (
     Any,

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import inspect
 from typing import (
     Any,


### PR DESCRIPTION
Do not support prebound tools on the model. There's reason users should be prebinding tools to the model!

This is a breaking change that might affect some users, but the work-around is simple -- provide tools into the create_react_agent api.