### PR TITLE
fix(docs): correct LangGraph guides link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ While LangGraph can be used standalone, it also integrates seamlessly with any L
 
 ## Additional resources
 
-- [Guides](https://langchain-ai.github.io/langgraph/how-tos/): Quick, actionable code snippets for topics such as streaming, adding memory & persistence, and design patterns (e.g. branching, subgraphs, etc.).
+- [Guides](https://langchain-ai.github.io/langgraph/guides/): Quick, actionable code snippets for topics such as streaming, adding memory & persistence, and design patterns (e.g. branching, subgraphs, etc.).
 - [Reference](https://langchain-ai.github.io/langgraph/reference/graphs/): Detailed reference on core classes, methods, how to use the graph and checkpointing APIs, and higher-level prebuilt components.
 - [Examples](https://langchain-ai.github.io/langgraph/examples/): Guided examples on getting started with LangGraph.
 - [LangChain Forum](https://forum.langchain.com/): Connect with the community and share all of your technical questions, ideas, and feedback.


### PR DESCRIPTION
**Description:**  
Replaced the broken LangGraph documentation link (previously returned 404) with the correct link:  
`https://langchain-ai.github.io/langgraph/guides/`.  

**Issue:**  
N/A  

**Dependencies:**  
None
