### PR TITLE
fix(checkpoint): Fixed semantic search failure after converting non-ASCII characters to Unicode encoding. #5946

### DIFF
--- a/libs/checkpoint/langgraph/store/base/embed.py
+++ b/libs/checkpoint/langgraph/store/base/embed.py
@@ -238,7 +238,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
         - Nested paths in multi-field: "{field1,nested.field2}"
     """
     if not path or path == "$":
-        return [json.dumps(obj, sort_keys=True)]
+        return [json.dumps(obj, sort_keys=True, ensure_ascii=False)]
 
     tokens = tokenize_path(path) if isinstance(path, str) else path
 
@@ -249,7 +249,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
             elif obj is None:
                 return []
             elif isinstance(obj, (list, dict)):
-                return [json.dumps(obj, sort_keys=True)]
+                return [json.dumps(obj, sort_keys=True, ensure_ascii=False)]
             return []
 
         token = tokens[pos]
@@ -295,7 +295,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
                         if isinstance(current_obj, (str, int, float, bool)):
                             results.append(str(current_obj))
                         elif isinstance(current_obj, (list, dict)):
-                            results.append(json.dumps(current_obj, sort_keys=True))
+                            results.append(json.dumps(current_obj, sort_keys=True, ensure_ascii=False))
 
         # Handle wildcard
         elif token == "*":


### PR DESCRIPTION
Description: Fix non-ASCII character handling in semantic search and add comprehensive test coverage

This PR addresses an issue where non-ASCII characters (Chinese, Japanese, Korean, etc.) were not properly handled during semantic search operations due to ASCII encoding in the text extraction process.

**Root Cause:**
The `get_text_at_path()` function in `langgraph/store/base/embed.py` was using `json.dumps(obj, sort_keys=True)` which defaults to `ensure_ascii=True`. This caused non-ASCII characters to be escaped as Unicode sequences (e.g., "这是中文" became "\u8fd9\u662f\u4e2d\u6587"), leading to poor semantic search accuracy for multilingual content.

**Fix:**
Modified the `json.dumps()` calls in `get_text_at_path()` to include `ensure_ascii=False`, preserving the original Unicode characters during text extraction for embedding generation.

**Changes:**
- Updated `json.dumps(obj, sort_keys=True)` to `json.dumps(obj, sort_keys=True, ensure_ascii=False)` in `get_text_at_path()` function
- Added comprehensive test `test_Non_ASCII_semantic_search()` to validate semantic search accuracy across multiple languages

**Test Coverage:**
The new test validates:
- English text semantic search: "This is English"
- Chinese text semantic search: "这是中文" 
- Japanese text semantic search: "これは日本語です"
- Ensures similarity scores >0.999 for exact matches across all languages
- Uses OpenAI's text-embedding-3-small model for realistic testing

**Impact:**
This fix ensures that multilingual applications using LangGraph's semantic search functionality will now correctly handle non-ASCII characters, providing accurate search results for global content without degradation in similarity scoring.

**Dependencies:**
- langchain-openai for embeddings testing
- python-dotenv for environment configuration
- Requires OPENAI_API_KEY environment variable for test execution

**Testing:**
All tests pass with similarity scores >0.999 for exact matches across all tested languages, confirming the fix resolves the Unicode handling issue.

**Issue**: #5946 