### PR TITLE
chore(prebuilt): remove support for models that used `bind_X`

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
+++ b/libs/prebuilt/langgraph/prebuilt/_internal/_typing.py
@@ -2,26 +2,9 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, TypeVar, Union
 
-from langgraph._internal._typing import StateLike
-
-try:
-    from typing import ParamSpec  # 3.10+
-except ImportError:
-    from typing_extensions import ParamSpec  # type: ignore
-
-from langchain_core.language_models import LanguageModelInput
-from langchain_core.messages import BaseMessage
-from langchain_core.runnables import Runnable
+from typing_extensions import ParamSpec
 
 P = ParamSpec("P")
 R = TypeVar("R")
-T = TypeVar("T")
 
-MaybeAwaitable = Union[T, Awaitable[T]]
-SyncOrAsync = Callable[P, MaybeAwaitable[R]]
-
-# PreConfiguredChatModel is used to support chat models that have been pre-configured
-# using .bind().
-# For example, chat_model.bind(api_key="...") will return a PreConfiguredChatModel
-PreConfiguredChatModel = Runnable[LanguageModelInput, BaseMessage]
-ContextT = TypeVar("ContextT", bound=StateLike)
+SyncOrAsync = Callable[P, Union[R, Awaitable[R]]]

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -231,6 +231,12 @@ class _AgentBuilder:
         self.store = store
         self._use_individual_tool_nodes = use_individual_tool_nodes
 
+        if isinstance(model, Runnable) and not isinstance(model, BaseChatModel):
+            raise ValueError(
+                "Expected `model` to be a BaseChatModel or a string, got {type(model)}."
+                "The `model` parameter should not have pre-bound tools, simply pass the model and tools separately."
+            )
+
         self._setup_tools()
         self._setup_state_schema()
         self._setup_structured_output_tools()

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -399,11 +399,11 @@ class _AgentBuilder:
                     tool_choice = "any"
 
                 if tool_choice:
-                    model = cast(BaseChatModel, model).bind_tools(
+                    model = cast(BaseChatModel, model).bind_tools(  # type: ignore[assignment]
                         all_tools, tool_choice=tool_choice
                     )
                 else:
-                    model = cast(BaseChatModel, model).bind_tools(all_tools)
+                    model = cast(BaseChatModel, model).bind_tools(all_tools)  # type: ignore[assignment]
             # Extract just the model part for direct invocation
             self._static_model: Optional[Runnable] = model  # type: ignore[assignment]
         else:

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -303,24 +303,6 @@ def test_model_with_tools(tool_style: str, version: str, include_builtin: bool) 
         )
 
 
-def test_support_preconfigured_models_but_not_for_tools() -> None:
-    """Support (at least temporarily) some model pre-configuration.
-
-    This is a temporary workaround to support pre-configured models
-    for things like temperature or api keys (done via .bind).
-
-    We do not want users to pre-bind tools to the models.
-    """
-    model = FakeToolCallingModel()
-
-    @dec_tool
-    def tool1(some_val: int) -> str:
-        """Tool 1 docstring."""
-        return f"Tool 1: {some_val}"
-
-    create_react_agent(model.bind(temperature=3), [tool1])
-
-
 def test__validate_messages():
     # empty input
     _validate_chat_history([])

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -35,7 +35,6 @@ from langgraph.prebuilt.chat_agent_executor import (
     AgentState,
     AgentStatePydantic,
     StateSchemaType,
-    _get_model,
     _validate_chat_history,
 )
 from langgraph.prebuilt.tool_node import (
@@ -1227,30 +1226,6 @@ def test_tool_node_node_interrupt(
             id=AnyStr(),
         ),
     )
-
-
-def test_get_model() -> None:
-    model = FakeToolCallingModel(tool_calls=[])
-    assert _get_model(model) == model
-
-    @dec_tool
-    def some_tool(some_val: int) -> str:
-        """Tool docstring."""
-        return "meow"
-
-    model_with_tools = model.bind_tools([some_tool])
-    assert _get_model(model_with_tools) == model
-
-    seq = model | RunnableLambda(lambda message: message)
-    assert _get_model(seq) == model
-
-    seq_with_tools = model.bind_tools([some_tool]) | RunnableLambda(
-        lambda message: message
-    )
-    assert _get_model(seq_with_tools) == model
-
-    with pytest.raises(TypeError):
-        _get_model(RunnableLambda(lambda message: message))
 
 
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)


### PR DESCRIPTION
Remove support for models w/ `.bind` used to streamline public API + recommendations
Also cleaning up `typing.py` file as requested :)