### PR TITLE
fix(docs): Fixed async usage in MCP agent

### DIFF
--- a/docs/docs/agents/mcp.md
+++ b/docs/docs/agents/mcp.md
@@ -42,36 +42,41 @@ The `langchain-mcp-adapters` package enables agents to use tools defined across 
     # highlight-next-line
     from langchain_mcp_adapters.client import MultiServerMCPClient
     from langgraph.prebuilt import create_react_agent
+    import asyncio
 
-    # highlight-next-line
-    client = MultiServerMCPClient(
-        {
-            "math": {
-                "command": "python",
-                # Replace with absolute path to your math_server.py file
-                "args": ["/path/to/math_server.py"],
-                "transport": "stdio",
-            },
-            "weather": {
-                # Ensure you start your weather server on port 8000
-                "url": "http://localhost:8000/mcp",
-                "transport": "streamable_http",
-            }
-        }
-    )
-    # highlight-next-line
-    tools = await client.get_tools()
-    agent = create_react_agent(
-        "anthropic:claude-3-7-sonnet-latest",
-        # highlight-next-line
-        tools
-    )
-    math_response = await agent.ainvoke(
-        {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
-    )
-    weather_response = await agent.ainvoke(
-        {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
-    )
+    async def main():
+
+      # highlight-next-line
+      client = MultiServerMCPClient(
+          {
+              "math": {
+                  "command": "python",
+                  # Replace with absolute path to your math_server.py file
+                  "args": ["/path/to/math_server.py"],
+                  "transport": "stdio",
+              },
+              "weather": {
+                  # Ensure you start your weather server on port 8000
+                  "url": "http://localhost:8000/mcp",
+                  "transport": "streamable_http",
+              }
+          }
+      )
+      # highlight-next-line
+      tools = await client.get_tools()
+      agent = create_react_agent(
+          "anthropic:claude-3-7-sonnet-latest",
+          # highlight-next-line
+          tools
+      )
+      math_response = await agent.ainvoke(
+          {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
+      )
+      weather_response = await agent.ainvoke(
+          {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
+      )
+      
+    asyncio.run(main())
     ```
 
 === "In a workflow"
@@ -81,69 +86,72 @@ The `langchain-mcp-adapters` package enables agents to use tools defined across 
     from langchain.chat_models import init_chat_model
     from langgraph.graph import StateGraph, MessagesState, START, END
     from langgraph.prebuilt import ToolNode
+    import asyncio
 
-    # Initialize the model
-    model = init_chat_model("anthropic:claude-3-5-sonnet-latest")
-
-    # Set up MCP client
-    client = MultiServerMCPClient(
-        {
-            "math": {
-                "command": "python",
-                # Make sure to update to the full absolute path to your math_server.py file
-                "args": ["./examples/math_server.py"],
-                "transport": "stdio",
-            },
-            "weather": {
-                # make sure you start your weather server on port 8000
-                "url": "http://localhost:8000/mcp/",
-                "transport": "streamable_http",
-            }
-        }
-    )
-    tools = await client.get_tools()
-
-    # Bind tools to model
-    model_with_tools = model.bind_tools(tools)
-
-    # Create ToolNode
-    tool_node = ToolNode(tools)
-
-    def should_continue(state: MessagesState):
-        messages = state["messages"]
-        last_message = messages[-1]
-        if last_message.tool_calls:
-            return "tools"
-        return END
-
-    # Define call_model function
-    async def call_model(state: MessagesState):
-        messages = state["messages"]
-        response = await model_with_tools.ainvoke(messages)
-        return {"messages": [response]}
-
-    # Build the graph
-    builder = StateGraph(MessagesState)
-    builder.add_node("call_model", call_model)
-    builder.add_node("tools", tool_node)
-
-    builder.add_edge(START, "call_model")
-    builder.add_conditional_edges(
-        "call_model",
-        should_continue,
-    )
-    builder.add_edge("tools", "call_model")
-
-    # Compile the graph
-    graph = builder.compile()
-
-    # Test the graph
-    math_response = await graph.ainvoke(
-        {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
-    )
-    weather_response = await graph.ainvoke(
-        {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
-    )
+    async def main():
+      # Initialize the model
+      model = init_chat_model("anthropic:claude-3-5-sonnet-latest")
+  
+      # Set up MCP client
+      client = MultiServerMCPClient(
+          {
+              "math": {
+                  "command": "python",
+                  # Make sure to update to the full absolute path to your math_server.py file
+                  "args": ["./examples/math_server.py"],
+                  "transport": "stdio",
+              },
+              "weather": {
+                  # make sure you start your weather server on port 8000
+                  "url": "http://localhost:8000/mcp/",
+                  "transport": "streamable_http",
+              }
+          }
+      )
+      tools = await client.get_tools()
+  
+      # Bind tools to model
+      model_with_tools = model.bind_tools(tools)
+  
+      # Create ToolNode
+      tool_node = ToolNode(tools)
+  
+      def should_continue(state: MessagesState):
+          messages = state["messages"]
+          last_message = messages[-1]
+          if last_message.tool_calls:
+              return "tools"
+          return END
+  
+      # Define call_model function
+      async def call_model(state: MessagesState):
+          messages = state["messages"]
+          response = await model_with_tools.ainvoke(messages)
+          return {"messages": [response]}
+  
+      # Build the graph
+      builder = StateGraph(MessagesState)
+      builder.add_node("call_model", call_model)
+      builder.add_node("tools", tool_node)
+  
+      builder.add_edge(START, "call_model")
+      builder.add_conditional_edges(
+          "call_model",
+          should_continue,
+      )
+      builder.add_edge("tools", "call_model")
+  
+      # Compile the graph
+      graph = builder.compile()
+  
+      # Test the graph
+      math_response = await graph.ainvoke(
+          {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
+      )
+      weather_response = await graph.ainvoke(
+          {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
+      )
+    asyncio.run(main())
     ```
 
 :::


### PR DESCRIPTION
Wrapped the tutorial code in `async def main()` with `asyncio.run()` since top-level `await` is not valid in Python scripts.
This makes the tutorial fully copy-paste runnable as intended and prevents `SyntaxError: 'await' outside async function`.

## Problem
The MCP client code was using `await` outside of an async function, causing a `SyntaxError: 'await' outside async function` when trying to run the script. Without proper async function wrapping, the code would throw this error and not be executable.

## Changes
wrap async/await code in proper async function

- Add asyncio import for async execution
- Wrap main code in async def main() function  
- Add asyncio.run(main()) to execute async code
- Makes code copy-paste ready and immediately runnable