### PR TITLE
docs(examples/rag/langgraph_agentic_rag): Fix infinite loop in document relevance grading and query rewriting

### DIFF
--- a/examples/rag/langgraph_agentic_rag.ipynb
+++ b/examples/rag/langgraph_agentic_rag.ipynb
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "0e378706-47d5-425a-8ba0-57b9acffbd0c",
    "metadata": {},
    "outputs": [],
@@ -165,7 +165,8 @@
     "class AgentState(TypedDict):\n",
     "    # The add_messages function defines how an update should be processed\n",
     "    # Default is to replace. add_messages says \"append\"\n",
-    "    messages: Annotated[Sequence[BaseMessage], add_messages]"
+    "    messages: Annotated[Sequence[BaseMessage], add_messages]\n",
+    "    rewrite_count: int = 0  # Default value"
    ]
   },
   {
@@ -191,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "278d1d83-dda6-4de4-bf8b-be9965c227fa",
    "metadata": {},
    "outputs": [
@@ -200,11 +201,11 @@
      "output_type": "stream",
      "text": [
       "********************Prompt[rlm/rag-prompt]********************\n",
-      "================================\u001B[1m Human Message \u001B[0m=================================\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
       "\n",
       "You are an assistant for question-answering tasks. Use the following pieces of retrieved context to answer the question. If you don't know the answer, just say that you don't know. Use three sentences maximum and keep the answer concise.\n",
-      "Question: \u001B[33;1m\u001B[1;3m{question}\u001B[0m \n",
-      "Context: \u001B[33;1m\u001B[1;3m{context}\u001B[0m \n",
+      "Question: \u001b[33;1m\u001b[1;3m{question}\u001b[0m \n",
+      "Context: \u001b[33;1m\u001b[1;3m{context}\u001b[0m \n",
       "Answer:\n"
      ]
     }
@@ -234,6 +235,13 @@
     "    Returns:\n",
     "        str: A decision for whether the documents are relevant or not\n",
     "    \"\"\"\n",
+    "    \n",
+    "    rewrite_count = state.get(\"rewrite_count\", 0)\n",
+    "    \n",
+    "    # Prevent infinite loops - max 2 rewrites\n",
+    "    if rewrite_count >= 2:\n",
+    "        print(\"---MAX REWRITES REACHED, FORCING GENERATION---\")\n",
+    "        return \"generate\"\n",
     "\n",
     "    print(\"---CHECK RELEVANCE---\")\n",
     "\n",
@@ -315,6 +323,9 @@
     "    Returns:\n",
     "        dict: The updated state with re-phrased question\n",
     "    \"\"\"\n",
+    "    \n",
+    "    current_count = state.get(\"rewrite_count\", 0)\n",
+    "    print(f\"---REWRITE ATTEMPT {current_count + 1}---\")\n",
     "\n",
     "    print(\"---TRANSFORM QUERY---\")\n",
     "    messages = state[\"messages\"]\n",
@@ -335,7 +346,7 @@
     "    # Grader\n",
     "    model = ChatOpenAI(temperature=0, model=\"gpt-4-0125-preview\", streaming=True)\n",
     "    response = model.invoke(msg)\n",
-    "    return {\"messages\": [response]}\n",
+    "    return {\"messages\": [response], \"rewrite_count\": current_count + 1}\n",
     "\n",
     "\n",
     "def generate(state):\n",


### PR DESCRIPTION
## Problem
The agentic RAG system could get stuck in infinite loops when:
1. Retrieved documents are graded as "not relevant" 
2. START → agent → retrieve → grade_documents → rewrite → agent → retrieve → grade_documents → rewrite → ...
3. Query gets rewritten
4. Agent retrieves again with rewritten query
5. Documents still graded as "not relevant"
6. Process repeats indefinitely 

## Solution
Implemented retry limit mechanism with guaranteed termination:

- **Added `rewrite_count` tracking** to prevent infinite cycles
- **Max 2 rewrites allowed** before forcing generation
- **Early termination** in `grade_documents()` when limit reached
- **Fallback strategy** ensures user always gets a response

## Changes Made

### Core Logic Updates
- **`grade_documents()`**: Added rewrite count check at function start
- **`rewrite()`**: Added counter increment and proper variable ordering
- **Flow guarantee**: System terminates within 3 total attempts maximum

### Technical Details
```python
# Before: Potential infinite loop
retrieve → grade → rewrite → retrieve → grade → rewrite → ...

# After: Guaranteed termination  
retrieve → grade → rewrite → retrieve → grade → rewrite → retrieve → grade → FORCE GENERATE 