### PR TITLE
fix(langgraph): filter output fields from cache key computation

### DIFF
--- a/libs/langgraph/tests/test_algo.py
+++ b/libs/langgraph/tests/test_algo.py
@@ -1,5 +1,9 @@
 from langgraph._internal._constants import PULL, PUSH
-from langgraph.pregel._algo import prepare_next_tasks, task_path_str
+from langgraph.pregel._algo import (
+    _filter_cache_input,
+    prepare_next_tasks,
+    task_path_str,
+)
 from langgraph.pregel._checkpoint import channels_from_checkpoint, empty_checkpoint
 
 
@@ -65,3 +69,78 @@ def test_tuple_str() -> None:
         f"~{PUSH}, ~{PUSH}, 0000000002, 0000000001",
         f"~{PUSH}, ~{PUSH}, ~{PUSH}, 0000000002, 0000000001, 0000000003",
     ]
+
+
+def test_filter_cache_input() -> None:
+    """Test the _filter_cache_input function for cache key filtering."""
+    from langgraph.pregel._checkpoint import empty_checkpoint
+    
+    checkpoint = empty_checkpoint()
+    checkpoint["channel_values"] = {"some": "values"}  # Simulate non-empty checkpoint
+    
+    # Test 1: Filter out result fields for non-result nodes
+    input_state = {
+        "input": "test_data",
+        "result": "processed_data",
+        "output": "some_output",
+        "data": "keep_this"
+    }
+    
+    filtered = _filter_cache_input(input_state, "processor_node", checkpoint)
+    
+    # Should keep input and data, but filter out result and output
+    assert "input" in filtered
+    assert "data" in filtered
+    assert "result" not in filtered
+    assert "output" not in filtered
+    
+    # Test 2: Keep result fields for result-related nodes
+    result_node_filtered = _filter_cache_input(input_state, "result_generator", checkpoint)
+    
+    # Should keep result field since node name contains "result"
+    assert "input" in result_node_filtered
+    assert "data" in result_node_filtered
+    assert "result" in result_node_filtered  # Kept because node handles results
+    assert "output" not in result_node_filtered
+    
+    # Test 3: Keep common state fields
+    common_state = {
+        "input": "test",
+        "query": "search",
+        "text": "content",
+        "message": "hello",
+        "state": "active",
+        "result": "processed"
+    }
+    
+    filtered_common = _filter_cache_input(common_state, "simple_node", checkpoint)
+    
+    # Should keep all common fields except result
+    assert "input" in filtered_common
+    assert "query" in filtered_common
+    assert "text" in filtered_common
+    assert "message" in filtered_common
+    assert "state" in filtered_common
+    assert "result" not in filtered_common
+    
+    # Test 4: Non-dict input should be returned as-is
+    non_dict_input = "simple_string"
+    assert _filter_cache_input(non_dict_input, "node", checkpoint) == non_dict_input
+    
+    # Test 5: Empty checkpoint should return original
+    empty_cp = empty_checkpoint()
+    assert _filter_cache_input(input_state, "node", empty_cp) == input_state
+    
+    # Test 6: If all fields are filtered out, return original
+    all_output_state = {
+        "result": "data",
+        "output": "data", 
+        "response": "data",
+        "answer": "data",
+        "generated": "data"
+    }
+    
+    filtered_all = _filter_cache_input(all_output_state, "simple_node", checkpoint)
+    
+    # Should return original since all fields would be filtered
+    assert filtered_all == all_output_state


### PR DESCRIPTION
InMemoryCache was not working with InMemorySaver because cache keys included accumulated state from previous executions. Add _filter_cache_input function to exclude likely output fields from cache key generation.

Thank you for contributing to LangGraph! Follow these steps to mark your pull request as ready for review. **If any of these steps are not completed, your PR will not be considered for review.**

- [ ] **PR title**: Follows the format: {TYPE}({SCOPE}): {DESCRIPTION}
  - Examples:
    - feat(core): add multi-tenant support
    - fix(cli): resolve flag parsing error
    - docs(openai): update API usage examples
  - Allowed `{TYPE}` values:
    - feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, release
  - Allowed `{SCOPE}` values (optional):
    - langgraph, docs, cli, checkpoint, checkpoint-postgres, checkpoint-sqlite, prebuilt, scheduler-kafka, sdk-py
  - Once you've written the title, please delete this checklist item; do not include it in the PR.

- [ ] **PR message**: ***Delete this entire checklist*** and replace with
  - **Description:** a description of the change. Include a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) if applicable.
  - **Issue:** the issue # it fixes, if applicable
  - **Dependencies:** any dependencies required for this change
  - **Twitter handle:** if your PR gets announced, and you'd like a mention, we'll gladly shout you out!

- [ ] **Add tests and docs**: If you're adding a new integration, you must include:
  1. A test for the integration, preferably unit tests that do not rely on network access,
  2. An example notebook showing its use. It lives in `docs/docs/integrations` directory.

- [ ] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. We will not consider a PR unless these three are passing in CI. See [contribution guidelines](https://github.com/langchain-ai/langgraph/blob/main/CONTRIBUTING.md) for more.

Additional guidelines:

- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to `pyproject.toml` files (even optional ones) unless they are **required** for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
