### PR TITLE
Wrong Reference to Image in Create and control loops

### DIFF
--- a/docs/docs/how-tos/graph-api.md
+++ b/docs/docs/how-tos/graph-api.md
@@ -2333,7 +2333,7 @@ from IPython.display import Image, display
 display(Image(graph.get_graph().draw_mermaid_png()))
 ```
 
-![Simple loop graph](assets/graph_api_image_3.png)
+![Simple loop graph](assets/graph_api_image_7.png)
 :::
 
 :::js


### PR DESCRIPTION
docs (graph-api): Wrong Reference to Image in "Create and control loops" section.