### PR TITLE
docs: Fix Example Code Snippet in HITL

### DIFF
--- a/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
+++ b/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
@@ -366,8 +366,8 @@ result = graph.invoke(
 
 # Resume with mapping of interrupt IDs to values
 resume_map = {
-    i.interrupt_id: f"human input for prompt {i.value}"
-    for i in parent.get_state(thread_config).interrupts
+    i.id: f"edited text for {i.value['text_to_revise']}"
+    for i in graph.get_state(config).interrupts
 }
 print(graph.invoke(Command(resume=resume_map), config=config))
 # > {'text_1': 'edited text for original text 1', 'text_2': 'edited text for original text 2'}


### PR DESCRIPTION
Description: Fixing the example code snippet at this [url](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/add-human-in-the-loop/#resume-multiple-interrupts-with-one-invocation).

Fixes: 
- i.interrupt_id -> i.id, since interrupt_id is deprecrated
- f"human input for prompt {i.value}" -> f"edited text for {i.value['text_to_revise']}", to match the output statement
- parent.get_state -> graph.get_state, no variable named parent
- get_state(thread_config) -> get_state(config), no variable named thread_config