### PR TITLE
docs(readme): Correct broken link to LangGraph guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ While LangGraph can be used standalone, it also integrates seamlessly with any L
 
 ## Additional resources
 
-- [Guides](https://langchain-ai.github.io/langgraph/how-tos/): Quick, actionable code snippets for topics such as streaming, adding memory & persistence, and design patterns (e.g. branching, subgraphs, etc.).
+- [Guides](https://langchain-ai.github.io/langgraph/guides/): Quick, actionable code snippets for topics such as streaming, adding memory & persistence, and design patterns (e.g. branching, subgraphs, etc.).
 - [Reference](https://langchain-ai.github.io/langgraph/reference/graphs/): Detailed reference on core classes, methods, how to use the graph and checkpointing APIs, and higher-level prebuilt components.
 - [Examples](https://langchain-ai.github.io/langgraph/examples/): Guided examples on getting started with LangGraph.
 - [LangChain Forum](https://forum.langchain.com/): Connect with the community and share all of your technical questions, ideas, and feedback.


### PR DESCRIPTION
**Description:**
This PR fixes a broken link (404) to the LangGraph guides in the main `README.md` file.

The issue was previously addressed in two separate pull requests, #5876 and #5926, which were ultimately closed without being merged. This PR is based on the latest `main` branch and provides the correct link to finally resolve the issue.

- Previous attempt 1: https://github.com/langchain-ai/langgraph/pull/5876
- Previous attempt 2: https://github.com/langchain-ai/langgraph/pull/5926

**Issue:**
N/A

**Dependencies:**
None