### PR TITLE
fix(langgraph): resolve TypeError in edge sorting by handling None values

### DIFF
--- a/libs/langgraph/langgraph/pregel/_draw.py
+++ b/libs/langgraph/langgraph/pregel/_draw.py
@@ -203,7 +203,9 @@ def draw_graph(
         for task in start_tasks.values():
             add_edge(graph, START, task.name)
     # add discovered edges
-    for src, dest, is_conditional, label in sorted(edges):
+    for src, dest, is_conditional, label in sorted(
+        edges, key=lambda edge: tuple(field or "" for field in edge)
+    ):
         add_edge(
             graph,
             src,


### PR DESCRIPTION
This PR fixes the issue with rendering the graph when opening LangGraph Studio using `langgraph-cli`.
```
File ".venv/lib/python3.13/site-packages/langgraph/pregel/_draw.py", line 206, in draw_graph
    for src, dest, is_conditional, label in sorted(edges):
                                            ~~~~~~^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```