### PR TITLE
fix(state): correct typo "runtie" to "runtime" in StateGraph

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -155,7 +155,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         graph = StateGraph(state_schema=State, context_schema=Context)
 
         def node(state: State, runtime: Runtime[Context]) -> dict:
-            r = runtie.context.get("r", 1.0)
+            r = runtime.context.get("r", 1.0)
             x = state["x"][-1]
             next_value = x * r * (1 - x)
             return {"x": next_value}


### PR DESCRIPTION
**Description:** Fix a typo where "runtie" was incorrectly used instead of "runtime" in line 158 of the StateGraph class in state.py. This resolves the example error caused by the misspelled variable name.

**Dependencies:** None