### PR TITLE
chore(docs): Update OpenAPI spec from LangGraph API v0.4.9

### DIFF
--- a/docs/docs/cloud/reference/api/openapi.json
+++ b/docs/docs/cloud/reference/api/openapi.json
@@ -5015,6 +5015,12 @@
       },
       "ThreadSearchRequest": {
         "properties": {
+          "ids": {
+            "type": "array",
+            "items": {"type": "string", "format": "uuid"},
+            "title": "Ids",
+            "description": "List of thread IDs to include. Others are excluded."
+          },
           "metadata": {
             "type": "object",
             "title": "Metadata",


### PR DESCRIPTION
This PR updates the OpenAPI specification with changes detected from the LangGraph API server.

**Changes detected as of LangGraph API version 0.4.9**

This update was automatically generated by the sync workflow in the langgraph-api repository.