### PR TITLE
docs(docs): fix incorrect return type in should_continue example

### DIFF
--- a/docs/docs/tutorials/workflows.md
+++ b/docs/docs/tutorials/workflows.md
@@ -1948,7 +1948,7 @@ const llmWithTools = llm.bindTools(tools);
 
 
     # Conditional edge function to route to the tool node or end based upon whether the LLM made a tool call
-    def should_continue(state: MessagesState) -> Literal["environment", END]:
+    def should_continue(state: MessagesState) -> Literal["Action", END]:
         """Decide if we should continue the loop or stop based upon whether the LLM made a tool call"""
 
         messages = state["messages"]


### PR DESCRIPTION
Description:
The documentation for the should_continue function contained an incorrect return type annotation.
It was shown as Literal["environment", END], but the actual logic returns "Action" or END.

This PR updates the example to use Literal["Action", END] so that the documentation matches the intended behavior of the function.

Issue:
N/A

Dependencies:
None
