### PR TITLE
wip: testing state extension via annotations

### DIFF
--- a/libs/langgraph/langgraph/agent/middleware/poc_middleware.py
+++ b/libs/langgraph/langgraph/agent/middleware/poc_middleware.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, field
+from typing import Annotated, Any, Dict, List, cast
+
+from langchain_core.messages import AIMessage
+from typing_extensions import Annotated
+from typing import ClassVar
+from operator import add
+
+from langgraph.agent import create_agent
+from langgraph.agent.types import AgentJump, AgentMiddleware, AgentState, AgentUpdate, ModelRequest
+
+class AcceptInput:
+    ...
+
+class ExposeOutput:
+    ...
+
+# other ideas
+# state_extensions: ClassVar[dict[str, type | type[Annotated]]] = {
+#         "int1": Annotated[int, add],
+#         "int2": Annotated[int, add, AcceptInput],
+#         "int3": Annotated[int, add, ExposeOutput],
+#         "int4": Annotated[int, add, AcceptInput, ExposeOutput],
+# }
+
+class State(AgentState):
+    int1: Annotated[int, add]
+    int2: Annotated[int, add, AcceptInput]
+    int3: Annotated[int, add, ExposeOutput]
+    int4: Annotated[int, add, AcceptInput, ExposeOutput]
+
+class StateModMidleware(AgentMiddleware[State]):
+    """Terminates after a specific tool is called N times."""
+
+    state_schema: type[State] = State
+
+    def __init__(self):
+        pass
+
+    def before_model(self, state: State) -> AgentUpdate | AgentJump | None:
+        return {"int1": 1, "int2": 1, "int3": 1, "int4": 1}
+
+    def modify_model_request(self, request: ModelRequest, state: State) -> ModelRequest:
+        return request
+
+agent = create_agent(
+    model="gpt-4o",
+    tools=[],
+    system_prompt="You are a helpful assistant.",
+    middleware=[StateModMidleware()],
+)
+

--- a/libs/langgraph/langgraph/agent/middleware/tool_calls.py
+++ b/libs/langgraph/langgraph/agent/middleware/tool_calls.py
@@ -14,14 +14,6 @@ class ToolCallLimitMiddleware(AgentMiddleware):
     class State(AgentMiddleware.State):
         important: Annotated[dict[str, int], Input, Output] = field(default_factory=dict)
 
-    @dataclass
-    class InputState(AgentMiddleware.State):
-        important: dict[str, int]
-
-    @dataclass
-    class OutputState(AgentMiddleware.State):
-        important: dict[str, int]
-
     def __init__(self, tool_limits: dict[str, int]):
         self.tool_limits = tool_limits
 

--- a/libs/langgraph/langgraph/agent/types.py
+++ b/libs/langgraph/langgraph/agent/types.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypeVar, Generic, ClassVar
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AnyMessage
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Required
 
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.graph.message import Messages, add_messages
@@ -28,27 +28,29 @@ class ModelRequest:
     response_format: ResponseFormat | None
 
 
-@dataclass
-class AgentState:
+class AgentState(TypedDict, total=False):
+    # TODO: figure out Required/NotRequired wrapping annotated and still registering reducer properly
     messages: Annotated[list[AnyMessage], add_messages]
-    model_request: Annotated[ModelRequest | None, EphemeralValue] = None
-    jump_to: Annotated[JumpTo | None, EphemeralValue] = None
-    response: dict | None = None
+    model_request: Annotated[ModelRequest | None, EphemeralValue]
+    jump_to: Annotated[JumpTo | None, EphemeralValue]
+    response: dict
 
+StateT = TypeVar("StateT", bound=AgentState, default=AgentState, contravariant=True)
 
-class AgentMiddleware:
-    class State(AgentState):
+class AgentMiddleware(Generic[StateT]):
+
+    # TODO: I thought this should be a ClassVar[type[StateT]] but inherently class vars can't use type vars
+    # bc they're instance dependent
+    state_schema: type[StateT]
+    tools: list[BaseTool] = []
+
+    def before_model(self, state: StateT) -> AgentUpdate | AgentJump | None:
         pass
 
-    tools: list[BaseTool]
-
-    def before_model(self, state: State) -> AgentUpdate | AgentJump | None:
-        pass
-
-    def modify_model_request(self, request: ModelRequest, state: State) -> ModelRequest:
+    def modify_model_request(self, request: ModelRequest, state: StateT) -> ModelRequest:
         return request
 
-    def after_model(self, state: State) -> AgentUpdate | AgentJump | None:
+    def after_model(self, state: StateT) -> AgentUpdate | AgentJump | None:
         pass
 
 

--- a/test_poc.py
+++ b/test_poc.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass, field
+from typing import Annotated, Any, Dict, List, cast
+
+from langchain_core.messages import AIMessage, HumanMessage
+from typing_extensions import Annotated
+from typing import ClassVar
+from operator import add
+
+from langgraph.agent import create_agent
+from langgraph.agent.types import AgentJump, AgentMiddleware, AgentState, AgentUpdate, ModelRequest
+
+class AcceptInput:
+    ...
+
+class ExposeOutput:
+    ...
+
+# other ideas
+# state_extensions: ClassVar[dict[str, type | type[Annotated]]] = {
+#         "int1": Annotated[int, add],
+#         "int2": Annotated[int, add, AcceptInput],
+#         "int3": Annotated[int, add, ExposeOutput],
+#         "int4": Annotated[int, add, AcceptInput, ExposeOutput],
+# }
+
+class State(AgentState):
+    int1: Annotated[int, add]
+    int2: Annotated[int, AcceptInput, add]
+    int3: Annotated[int, ExposeOutput, add]
+    int4: Annotated[int, AcceptInput, ExposeOutput, add]
+
+class StateModMidleware(AgentMiddleware[State]):
+    """Terminates after a specific tool is called N times."""
+
+    state_schema: type[State] = State
+
+    def __init__(self):
+        pass
+
+    def before_model(self, state: State) -> AgentUpdate | AgentJump | None:
+        return {"int1": 1, "int2": 1, "int3": 1, "int4": 1}
+
+    def modify_model_request(self, request: ModelRequest, state: State) -> ModelRequest:
+        return request
+
+agent = create_agent(
+    model="gpt-4o",
+    tools=[],
+    system_prompt="You are a helpful assistant.",
+    # TODO: figure out invariance here
+    middleware=[StateModMidleware()],
+)
+agent = agent.compile()
+
+result = agent.invoke({"messages": [HumanMessage("What is 2+2?")]})
+print(result)


### PR DESCRIPTION
still need to migrate to direct `Pregel` usage so that I can take advantage of input / output channels parsed from state extension annotations

moved to a typed dict here bc for dataclass subclasses:
* you need to annotate sublclass w/ @dataclass
* required values can't follow optional values