### PR TITLE
fix(docs): Fix indentation of info block in graph-api.md

### DIFF
--- a/docs/docs/how-tos/graph-api.md
+++ b/docs/docs/how-tos/graph-api.md
@@ -1422,8 +1422,8 @@ const builder = new StateGraph(State)
 :::
 
 ??? info "Why split application steps into a sequence with LangGraph?"
-LangGraph makes it easy to add an underlying persistence layer to your application.
-This allows state to be checkpointed in between the execution of nodes, so your LangGraph nodes govern:
+    LangGraph makes it easy to add an underlying persistence layer to your application.
+    This allows state to be checkpointed in between the execution of nodes, so your LangGraph nodes govern:
 
     - How state updates are [checkpointed](../concepts/persistence.md)
     - How interruptions are resumed in [human-in-the-loop](../concepts/human_in_the_loop.md) workflows


### PR DESCRIPTION
The "Why split application steps into a sequence with LangGraph?" info block in `graph-api.md` is broken.

Before:
<img width="889" height="529" alt="image" src="https://github.com/user-attachments/assets/7c60e4f0-7de2-4ffa-8493-ad958e4af211" />


After:
<img width="895" height="494" alt="image" src="https://github.com/user-attachments/assets/3aefe0ca-1cb8-4d03-b1ed-7c3475204c88" />
