### PR TITLE
chore: update emphemeral local

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -56,7 +56,6 @@ from langgraph._internal._constants import (
 from langgraph._internal._scratchpad import PregelScratchpad
 from langgraph._internal._typing import EMPTY_SEQ, MISSING
 from langgraph.channels.base import BaseChannel
-from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.topic import Topic
 from langgraph.checkpoint.base import (
     BaseCheckpointSaver,


### PR DESCRIPTION
basically - for conditional edges, we use this to merge the updates from state with the state object (before the actual update really occurs in the tick.after)

otherwise - an emphemeral value will actually last through the logic in the conditional edge of the node after
