### PR TITLE
fix(checkpoint): preserve non-ascii text in InMemoryStore embeddings

### DIFF
--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -861,3 +861,52 @@ def test_store_ttl(store):
     # Now has been (TTL_SECONDS-2)*2 > TTL_SECONDS + TTL_SECONDS/2
     res = store.search(ns, query="bar", refresh_ttl=False)
     assert len(res) == 0
+
+
+@pytest.mark.parametrize(
+    "vector_type,distance_type",
+    [
+        ("vector", "cosine"),
+        ("vector", "inner_product"),
+        ("halfvec", "cosine"),
+        ("halfvec", "inner_product"),
+    ],
+)
+def test_non_ascii(
+    request: Any,
+    fake_embeddings: CharacterEmbeddings,
+    vector_type: str,
+    distance_type: str,
+) -> None:
+    """Test support for non-ascii characters"""
+    with _create_vector_store(
+        vector_type,
+        distance_type,
+        fake_embeddings
+    ) as store:
+    
+        store.put(("user_123", "memories"), "1", {"text": "这是中文"})  # Chinese
+        store.put(
+            ("user_123", "memories"), "2", {"text": "これは日本語です"}
+        )  # Japanese
+        store.put(("user_123", "memories"), "3", {"text": "이건 한국어야"})  # Korean
+        store.put(("user_123", "memories"), "4", {"text": "Это русский"})  # Russian
+        store.put(("user_123", "memories"), "5", {"text": "यह रूसी है"})  # Hindi
+
+        result1 = store.search(("user_123", "memories"), query="这是中文")
+        result2 = store.search(("user_123", "memories"), query="これは日本語です")
+        result3 = store.search(("user_123", "memories"), query="이건 한국어야")
+        result4 = store.search(("user_123", "memories"), query="Это русский")
+        result5 = store.search(("user_123", "memories"), query="यह रूसी है")
+
+        print(result1)
+        print(result2)
+        print(result3)
+        print(result4)
+        print(result5)
+
+        assert result1[0].key == "1"
+        assert result2[0].key == "2"
+        assert result3[0].key == "3"
+        assert result4[0].key == "4"
+        assert result5[0].key == "5"

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -899,12 +899,6 @@ def test_non_ascii(
         result4 = store.search(("user_123", "memories"), query="Это русский")
         result5 = store.search(("user_123", "memories"), query="यह रूसी है")
 
-        print(result1)
-        print(result2)
-        print(result3)
-        print(result4)
-        print(result5)
-
         assert result1[0].key == "1"
         assert result2[0].key == "2"
         assert result3[0].key == "3"

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -1067,3 +1067,31 @@ def test_sql_injection_vulnerability(store: SqliteStore) -> None:
 
     with pytest.raises(ValueError, match="Invalid filter key"):
         store.search(("docs",), filter={malicious_key: "dummy"})
+
+
+@pytest.mark.parametrize("distance_type", VECTOR_TYPES)
+def test_non_ascii(
+    fake_embeddings: CharacterEmbeddings,
+    distance_type: str,
+) -> None:
+    """Test support for non-ascii characters"""
+    with create_vector_store(fake_embeddings, distance_type=distance_type) as store:
+        store.put(("user_123", "memories"), "1", {"text": "这是中文"})  # Chinese
+        store.put(
+            ("user_123", "memories"), "2", {"text": "これは日本語です"}
+        )  # Japanese
+        store.put(("user_123", "memories"), "3", {"text": "이건 한국어야"})  # Korean
+        store.put(("user_123", "memories"), "4", {"text": "Это русский"})  # Russian
+        store.put(("user_123", "memories"), "5", {"text": "यह रूसी है"})  # Hindi
+
+        result1 = store.search(("user_123", "memories"), query="这是中文")
+        result2 = store.search(("user_123", "memories"), query="これは日本語です")
+        result3 = store.search(("user_123", "memories"), query="이건 한국어야")
+        result4 = store.search(("user_123", "memories"), query="Это русский")
+        result5 = store.search(("user_123", "memories"), query="यह रूसी है")
+
+        assert result1[0].key == "1"
+        assert result2[0].key == "2"
+        assert result3[0].key == "3"
+        assert result4[0].key == "4"
+        assert result5[0].key == "5"

--- a/libs/checkpoint/langgraph/store/base/embed.py
+++ b/libs/checkpoint/langgraph/store/base/embed.py
@@ -238,7 +238,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
         - Nested paths in multi-field: "{field1,nested.field2}"
     """
     if not path or path == "$":
-        return [json.dumps(obj, sort_keys=True)]
+        return [json.dumps(obj, sort_keys=True, ensure_ascii=False)]
 
     tokens = tokenize_path(path) if isinstance(path, str) else path
 

--- a/libs/checkpoint/langgraph/store/base/embed.py
+++ b/libs/checkpoint/langgraph/store/base/embed.py
@@ -295,7 +295,11 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
                         if isinstance(current_obj, (str, int, float, bool)):
                             results.append(str(current_obj))
                         elif isinstance(current_obj, (list, dict)):
-                            results.append(json.dumps(current_obj, sort_keys=True, ensure_ascii=False))
+                            results.append(
+                                json.dumps(
+                                    current_obj, sort_keys=True, ensure_ascii=False
+                                )
+                            )
 
         # Handle wildcard
         elif token == "*":

--- a/libs/checkpoint/langgraph/store/base/embed.py
+++ b/libs/checkpoint/langgraph/store/base/embed.py
@@ -249,7 +249,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
             elif obj is None:
                 return []
             elif isinstance(obj, (list, dict)):
-                return [json.dumps(obj, sort_keys=True)]
+                return [json.dumps(obj, sort_keys=True, ensure_ascii=False)]
             return []
 
         token = tokens[pos]
@@ -295,7 +295,7 @@ def get_text_at_path(obj: Any, path: str | list[str]) -> list[str]:
                         if isinstance(current_obj, (str, int, float, bool)):
                             results.append(str(current_obj))
                         elif isinstance(current_obj, (list, dict)):
-                            results.append(json.dumps(current_obj, sort_keys=True))
+                            results.append(json.dumps(current_obj, sort_keys=True, ensure_ascii=False))
 
         # Handle wildcard
         elif token == "*":

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1024,21 +1024,24 @@ async def test_embed_with_path(fake_embeddings: CharacterEmbeddings) -> None:
 
 
 def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
+    """Test support for non-ascii characters"""
     store = InMemoryStore(
         index={"dims": fake_embeddings.dims, "embed": fake_embeddings}
     )
     store.put(("user_123", "memories"), "1", {"text": "这是中文"})  # Chinese
     store.put(("user_123", "memories"), "2", {"text": "これは日本語です"})  # Japanese
     store.put(("user_123", "memories"), "3", {"text": "이건 한국어야"})  # Korean
+    store.put(("user_123", "memories"), "4", {"text": "Это русский"})  # Russian
+    store.put(("user_123", "memories"), "5", {"text": "यह रूसी है"})  # Hindi
 
     result1 = store.search(("user_123", "memories"), query="这是中文")
-    assert result1[0].key == "1"
-    assert result1[0].score >= 0.15
-
     result2 = store.search(("user_123", "memories"), query="これは日本語です")
-    assert result2[0].key == "2"
-    assert result2[0].score >= 0.15
-
     result3 = store.search(("user_123", "memories"), query="이건 한국어야")
+    result4 = store.search(("user_123", "memories"), query="Это русский")
+    result5 = store.search(("user_123", "memories"), query="यह रूसी है")
+
+    assert result1[0].key == "1"
+    assert result2[0].key == "2"
     assert result3[0].key == "3"
-    assert result3[0].score >= 0.15
+    assert result4[0].key == "4"
+    assert result5[0].key == "5"

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1021,3 +1021,24 @@ async def test_embed_with_path(fake_embeddings: CharacterEmbeddings) -> None:
     assert len(results) == 3
     doc5_result = next(r for r in results if r.key == "doc5")
     assert doc5_result.score is None
+
+
+def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
+    store = InMemoryStore(
+        index={"dims": fake_embeddings.dims, "embed": fake_embeddings}
+    )
+    store.put(("user_123", "memories"), "1", {"text": "这是中文"})  # Chinese
+    store.put(("user_123", "memories"), "2", {"text": "これは日本語です"})  # Japanese
+    store.put(("user_123", "memories"), "3", {"text": "이건 한국어야"})  # Korean
+
+    result1 = store.search(("user_123", "memories"), query="这是中文")
+    assert result1[0].key == "1"
+    assert result1[0].score >= 0.15
+
+    result2 = store.search(("user_123", "memories"), query="これは日本語です")
+    assert result2[0].key == "2"
+    assert result2[0].score >= 0.15
+
+    result3 = store.search(("user_123", "memories"), query="이건 한국어야")
+    assert result3[0].key == "3"
+    assert result3[0].score >= 0.15


### PR DESCRIPTION
### Description
* Set `ensure_ascii=False` for all `json.dumps` calls in `get_text_at_path`. Preserves non-ASCII text instead of embedding `\uXXXX` escapes. 

**Before**
```python
store.put(("user_123", "memories"), "1", {"text": "这是中文"})
# embeds {"text": "\\u8fd9\\u662f\\u4e2d\\u6587"}
```

**After**
```python
store.put(("user_123", "memories"), "1", {"text": "这是中文"})
# embeds {"text": "这是中文"}
```

### Tests & Docs

* Add unit test `test_non_ascii` that writes three records (Chinese, Japanese, Korean) to an `InMemoryStore`, searches with the same strings, and asserts the correct top hit with a score >= 0.15 for each.

### Issue
Fixes #5946
