### PR TITLE
fix(langgraph): fix graph rendering for defer=True 

### DIFF
--- a/libs/langgraph/langgraph/pregel/_draw.py
+++ b/libs/langgraph/langgraph/pregel/_draw.py
@@ -6,10 +6,10 @@ from typing import Any, cast
 
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.runnables.graph import Graph, Node
-from langgraph.checkpoint.base import BaseCheckpointSaver
 
 from langgraph._internal._constants import CONF, CONFIG_KEY_SEND, INPUT
 from langgraph.channels.base import BaseChannel
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.constants import END, START
 from langgraph.managed.base import ManagedValueSpec
 from langgraph.pregel._algo import (

--- a/libs/langgraph/langgraph/pregel/_draw.py
+++ b/libs/langgraph/langgraph/pregel/_draw.py
@@ -175,7 +175,6 @@ def draw_graph(
             for trigger in task.triggers:
                 for src, cond, label in sorted(trigger_to_sources[trigger]):
                     edges.add((src, task.name, cond, label))
-                    sources[src].discard((trigger, cond, label))
 
     # assemble the graph
     graph = Graph()

--- a/libs/langgraph/tests/__snapshots__/test_pregel.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel.ambr
@@ -307,6 +307,99 @@
   
   '''
 # ---
+# name: test_get_graph_nonterminal_last_step_source
+  '''
+  {
+    "edges": [
+      {
+        "source": "__start__",
+        "target": "human"
+      },
+      {
+        "conditional": true,
+        "source": "chatbot",
+        "target": "human"
+      },
+      {
+        "conditional": true,
+        "source": "chatbot",
+        "target": "tools"
+      },
+      {
+        "conditional": true,
+        "source": "human",
+        "target": "__end__"
+      },
+      {
+        "conditional": true,
+        "source": "human",
+        "target": "chatbot"
+      },
+      {
+        "source": "tools",
+        "target": "chatbot"
+      }
+    ],
+    "nodes": [
+      {
+        "data": {
+          "id": [
+            "langgraph",
+            "_internal",
+            "_runnable",
+            "RunnableCallable"
+          ],
+          "name": "__start__"
+        },
+        "id": "__start__",
+        "type": "runnable"
+      },
+      {
+        "data": {
+          "id": [
+            "langgraph",
+            "_internal",
+            "_runnable",
+            "RunnableCallable"
+          ],
+          "name": "chatbot"
+        },
+        "id": "chatbot",
+        "type": "runnable"
+      },
+      {
+        "data": {
+          "id": [
+            "langgraph",
+            "_internal",
+            "_runnable",
+            "RunnableCallable"
+          ],
+          "name": "tools"
+        },
+        "id": "tools",
+        "type": "runnable"
+      },
+      {
+        "data": {
+          "id": [
+            "langgraph",
+            "_internal",
+            "_runnable",
+            "RunnableCallable"
+          ],
+          "name": "human"
+        },
+        "id": "human",
+        "type": "runnable"
+      },
+      {
+        "id": "__end__"
+      }
+    ]
+  }
+  '''
+# ---
 # name: test_get_graph_root_channel
   '''
   {
@@ -428,12 +521,12 @@
   '''
   graph TD;
   	__start__ --> rewrite_query;
-  	analyzer_one -.-> qa;
   	retriever_one --> analyzer_one;
   	retriever_one --> qa;
   	retriever_two --> qa;
   	rewrite_query --> retriever_one;
   	rewrite_query --> retriever_two;
+  	analyzer_one --> __end__;
   	qa --> __end__;
   
   '''
@@ -442,12 +535,12 @@
   '''
   graph TD;
   	__start__ --> rewrite_query;
-  	analyzer_one -.-> qa;
   	retriever_one --> analyzer_one;
   	retriever_one --> qa;
   	retriever_two --> qa;
   	rewrite_query --> retriever_one;
   	rewrite_query --> retriever_two;
+  	analyzer_one --> __end__;
   	qa --> __end__;
   
   '''
@@ -793,99 +886,6 @@
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
   
-  '''
-# ---
-# name: test_get_graph_nonterminal_last_step_source
-  '''
-  {
-    "edges": [
-      {
-        "source": "__start__",
-        "target": "human"
-      },
-      {
-        "conditional": true,
-        "source": "chatbot",
-        "target": "human"
-      },
-      {
-        "conditional": true,
-        "source": "chatbot",
-        "target": "tools"
-      },
-      {
-        "conditional": true,
-        "source": "human",
-        "target": "__end__"
-      },
-      {
-        "conditional": true,
-        "source": "human",
-        "target": "chatbot"
-      },
-      {
-        "source": "tools",
-        "target": "chatbot"
-      }
-    ],
-    "nodes": [
-      {
-        "data": {
-          "id": [
-            "langgraph",
-            "_internal",
-            "_runnable",
-            "RunnableCallable"
-          ],
-          "name": "__start__"
-        },
-        "id": "__start__",
-        "type": "runnable"
-      },
-      {
-        "data": {
-          "id": [
-            "langgraph",
-            "_internal",
-            "_runnable",
-            "RunnableCallable"
-          ],
-          "name": "chatbot"
-        },
-        "id": "chatbot",
-        "type": "runnable"
-      },
-      {
-        "data": {
-          "id": [
-            "langgraph",
-            "_internal",
-            "_runnable",
-            "RunnableCallable"
-          ],
-          "name": "tools"
-        },
-        "id": "tools",
-        "type": "runnable"
-      },
-      {
-        "data": {
-          "id": [
-            "langgraph",
-            "_internal",
-            "_runnable",
-            "RunnableCallable"
-          ],
-          "name": "human"
-        },
-        "id": "human",
-        "type": "runnable"
-      },
-      {
-        "id": "__end__"
-      }
-    ]
-  }
   '''
 # ---
 # name: test_repeat_condition

--- a/libs/langgraph/tests/__snapshots__/test_pregel.ambr
+++ b/libs/langgraph/tests/__snapshots__/test_pregel.ambr
@@ -520,15 +520,15 @@
 # name: test_in_one_fan_out_state_graph_defer_node[memory-False]
   '''
   graph TD;
-  	__start__ --> rewrite_query;
-  	retriever_one --> analyzer_one;
-  	retriever_one --> qa;
-  	retriever_two --> qa;
-  	rewrite_query --> retriever_one;
-  	rewrite_query --> retriever_two;
-  	analyzer_one --> __end__;
-  	qa --> __end__;
-  
+    __start__ --> rewrite_query;
+    retriever_one --> analyzer_one;
+    retriever_one --> qa;
+    retriever_two --> qa;
+    rewrite_query --> retriever_one;
+    rewrite_query --> retriever_two;
+    analyzer_one --> __end__;
+    qa --> __end__;
+
   '''
 # ---
 # name: test_in_one_fan_out_state_graph_defer_node[memory-True]

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8383,6 +8383,7 @@ def test_get_graph_nonterminal_last_step_source(snapshot: SnapshotAssertion) -> 
 
     assert json.dumps(graph_json, indent=2, sort_keys=True) == snapshot
 
+
 def test_null_resume_disallowed_with_multiple_interrupts(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
### Description

Some graphs with `defer=True` nodes rendered incorrectly. E.g.:
* edge C2 -> E1 is missing and edge C2 -> END should not appear in #5772
* edge E3 -> END is missing and edge E -> END should not appear in #5182
* extra edge #5369

Fix:
* Record the destinations declared by get_static_writes for each node. Build step_sources as a union of the runtime writes and the static writes (instead of just runtime writes). 

<details>

<summary>Code for example</summary>

```python
from typing import Literal, TypedDict

from langgraph.graph import StateGraph
from langgraph.types import Command


class State(TypedDict):
    results: list[str]
    skip_flag: bool

def node_A(state: State) -> Command[Literal["B1", "C1", "C2", "D"]]:
    if state["skip_flag"]:
        return Command(goto=["B1", "C2"])

    return Command(goto=["B1", "C1", "D"])

def node_B1(state: State) -> Command[Literal["B2"]]:
    return Command(goto="B2")

def node_B2(state: State) -> Command[Literal["E1"]]:
    return Command(goto="E1")

def node_C1(state: State) -> Command[Literal["C2"]]:
    return Command(goto="C2")

def node_C2(state: State) -> Command[Literal["E1"]]:
    return Command(goto="E1")

def node_D(state: State) -> Command[Literal["C2"]]:
    return Command(goto="C2")

def node_E1(state: State) -> Command[Literal["E2"]]:
    return Command(goto="E2")

def node_E2(state: State) -> Command[Literal["__end__"]]:
    return Command(goto="__end__")

builder = StateGraph(State)
builder.add_node("A", node_A)
builder.add_node("B1", node_B1)
builder.add_node("B2", node_B2)
builder.add_node("C1", node_C1)
builder.add_node("C2", node_C2)
builder.add_node("D", node_D)
builder.add_node("E1", node_E1, defer=True)
builder.add_node("E2", node_E2)

builder.set_entry_point("A")

graph = builder.compile()
mermaid = graph.get_graph().draw_mermaid()
```

</details>

| Before    | After |
| -------- | ------- |
| <img height="400" alt="defer_before" src="https://github.com/user-attachments/assets/825b09fc-3fb8-461a-9928-20c8d9cfc533" /> | <img height="400" alt="defer_after" src="https://github.com/user-attachments/assets/e66349a4-0668-445b-b787-d2d14d401d31" /> | 

Before:
* For deferred joins (NamedBarrierValueAfterFinish), a writer from an upstream node may not produce a runtime task.writes entry until the barrier opens. draw_graph() builds edges from task.writes, so one side of the join (here C2) never gets recorded as a source, and C2 is seen as a sink, so there is an implicit edge: C2 -> END edge added.

After:
* C2's write to the join channel is recorded even if the barrier hasn’t opened. When E1 finally schedules, we correctly find both sources B2 and C2 for the same trigger and emit edges: B2 -> E1 and C2 -> E1.

With C2 -> E1 present, C2 is no longer a terminus, so the unexpected edge: C2 -> END is not added.

### Test
* Regenerated cassette for `test_in_one_fan_out_state_graph_defer_node()` (two cassettes because it is parametrized, but the graphs are identical for both). The previously generated cassettes were wrong, the new ones are correct:

<details>

<summary>Code for test</summary>

```python
use_waiting_edge = True

def sorted_add(
    x: list[str], y: Union[list[str], list[tuple[str, str]]]
) -> list[str]:
    if isinstance(y[0], tuple):
        for rem, _ in y:
            x.remove(rem)
        y = [t[1] for t in y]
    return sorted(operator.add(x, y))

class State(TypedDict, total=False):
    query: str
    answer: str
    docs: Annotated[list[str], sorted_add]

workflow = StateGraph(State)

@workflow.add_node
def rewrite_query(data: State) -> State:
    return {"query": f"query: {data['query']}"}

def analyzer_one(data: State) -> State:
    return {"query": f"analyzed: {data['query']}"}

def retriever_one(data: State) -> State:
    return {"docs": ["doc1", "doc2"]}

def retriever_two(data: State) -> State:
    time.sleep(0.1)  # to ensure stream order
    return {"docs": ["doc3", "doc4"]}

def qa(data: State) -> State:
    return {"answer": ",".join(data["docs"])}

workflow.add_node(analyzer_one)
workflow.add_node(retriever_one)
workflow.add_node(retriever_two)
workflow.add_node(qa, defer=True)

workflow.set_entry_point("rewrite_query")
workflow.add_edge("rewrite_query", "retriever_one")
workflow.add_edge("retriever_one", "analyzer_one")
workflow.add_edge("rewrite_query", "retriever_two")
if use_waiting_edge:
    workflow.add_edge(["retriever_one", "retriever_two"], "qa")
else:
    workflow.add_edge("retriever_one", "qa")
    workflow.add_edge("retriever_two", "qa")
workflow.set_finish_point("qa")

app = workflow.compile()
mermaid = app.get_graph().draw_mermaid()
```

</details>

| Before    | After |
| -------- | ------- |
| <img height="400" alt="defer_before" src="https://github.com/user-attachments/assets/3cf716ad-ff30-4974-b4a4-a3b9410e52ed" /> | <img height="400" alt="[defer_after" src="https://github.com/user-attachments/assets/15463287-914a-4bbc-88f5-a60f68691f04" /> | 

