### PR TITLE
fix(agent): handle the finish_reason='length' in the create_react_agent to make the response auto continue

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -798,7 +798,7 @@ def create_react_agent(
                 and last_message.response_metadata.get("finish_reason") == "length"
             ):
                 # if the model stops due to `length`, it can invoke the model again to continue generating automatically
-                return "agent"
+                return entrypoint
             else:
                 return END
         # Otherwise if there is, we continue
@@ -840,7 +840,7 @@ def create_react_agent(
     # This means that this node is the first one called
     workflow.set_entry_point(entrypoint)
 
-    agent_paths = ["agent"]  # call agent again to continue model invocation
+    agent_paths = [entrypoint]  # call model again to continue model invocation
     post_model_hook_paths = [entrypoint, "tools"]
 
     # Add a post model hook node if post_model_hook is provided


### PR DESCRIPTION


  - **Description:** 
 When using `create_react_agent` with LLM, especially the Kimi K2 API https://moonshotai.github.io/Kimi-K2/ , it stops generation when it is not finished (the `max_tokens` and `max_completion_tokens` are not set). 

For example, in https://smith.langchain.com/public/d400070d-2223-42ab-bb00-c28036cce02d/r , in the final response, it stops generating (though did not set any `max_tokens` parameter in the model initialization). The agent's final response is cut off. I have to type and send `continue` manualy, to make it finish the generation in https://smith.langchain.com/public/b5972eab-ad48-4fd5-91d1-e816ae649b9d/r

So I use this PR to make it handle the `finish_reason` in `should_continue`, to make it automatically continue to generate until finish.

This PR fixes the issue by updating the agent's should_continue logic to handle the model's finish_reason. Now, the agent will automatically continue generating until the response is truly finished, ensuring a complete answer without manual intervention.

The updated effects is shown in https://smith.langchain.com/public/cf7a85f3-52bf-4bbe-bd08-749329c41124/r , the model is automatically re-invoked untill the generation finishes.
