### PR TITLE
docs: Update broken link in persistence_postgres.ipynb

### DIFF
--- a/examples/persistence_postgres.ipynb
+++ b/examples/persistence_postgres.ipynb
@@ -5,7 +5,7 @@
    "id": "18526f23",
    "metadata": {},
    "source": [
-    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/how-tos/persistence_postgres.ipynb"
+    "This file has been moved to https://github.com/langchain-ai/langgraph/blob/main/docs/docs/how-tos/memory/add-memory.md"
    ]
   }
  ],


### PR DESCRIPTION
* Updated the relocation notice in `examples/persistence_postgres.ipynb` to reference the correct new documentation at `add-memory.md` instead of the previous notebook link.
