### PR TITLE
fix(prebuilt): ignore nested warnings as a result of subclassing

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from typing import (
     Any,
     Awaitable,
@@ -12,7 +13,6 @@ from typing import (
     cast,
     get_type_hints,
 )
-from warnings import warn
 
 from langchain_core.language_models import (
     BaseChatModel,
@@ -78,24 +78,38 @@ class AgentStatePydantic(BaseModel):
     remaining_steps: RemainingSteps = 25
 
 
-@deprecated(
-    "AgentStateWithStructuredResponse has been moved to langchain.agents. Please update your import to 'from langchain.agents import AgentStateWithStructuredResponse'.",
-    category=LangGraphDeprecatedSinceV10,
-)
-class AgentStateWithStructuredResponse(AgentState):
-    """The state of the agent with a structured response."""
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=LangGraphDeprecatedSinceV10,
+        message="AgentState has been moved to langchain.agents.*",
+    )
 
-    structured_response: StructuredResponse
+    @deprecated(
+        "AgentStateWithStructuredResponse has been moved to langchain.agents. Please update your import to 'from langchain.agents import AgentStateWithStructuredResponse'.",
+        category=LangGraphDeprecatedSinceV10,
+    )
+    class AgentStateWithStructuredResponse(AgentState):
+        """The state of the agent with a structured response."""
+
+        structured_response: StructuredResponse
 
 
-@deprecated(
-    "AgentStateWithStructuredResponsePydantic has been moved to langchain.agents. Please update your import to 'from langchain.agents import AgentStateWithStructuredResponsePydantic'.",
-    category=LangGraphDeprecatedSinceV10,
-)
-class AgentStateWithStructuredResponsePydantic(AgentStatePydantic):
-    """The state of the agent with a structured response."""
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=LangGraphDeprecatedSinceV10,
+        message="AgentStatePydantic has been moved to langchain.agents.*",
+    )
 
-    structured_response: StructuredResponse
+    @deprecated(
+        "AgentStateWithStructuredResponsePydantic has been moved to langchain.agents. Please update your import to 'from langchain.agents import AgentStateWithStructuredResponsePydantic'.",
+        category=LangGraphDeprecatedSinceV10,
+    )
+    class AgentStateWithStructuredResponsePydantic(AgentStatePydantic):
+        """The state of the agent with a structured response."""
+
+        structured_response: StructuredResponse
 
 
 StateSchema = TypeVar("StateSchema", bound=Union[AgentState, AgentStatePydantic])
@@ -480,7 +494,7 @@ def create_react_agent(
     if (
         config_schema := deprecated_kwargs.pop("config_schema", MISSING)
     ) is not MISSING:
-        warn(
+        warnings.warn(
             "`config_schema` is deprecated and will be removed. Please use `context_schema` instead.",
             category=LangGraphDeprecatedSinceV10,
         )


### PR DESCRIPTION
Raised by @jacoblee93, the following was raising a cryptic deprecation warning:

```py
import pytest
from langchain_core.language_models import FakeListChatModel
from langchain.agents import create_agent

@pytest.fixture
def test_llm():
    return FakeListChatModel(responses=["Hello from test agent!"])

@pytest.fixture
def simple_agent(test_llm):
    return create_agent(
      model=test_llm,
      tools=[],
      prompt="You are a helpful assistant."
    )

def test_basic_agent_execution(simple_agent):
    result = simple_agent.invoke({"messages": [{"role": "user", "content": "hi"}]})
    assert len(result["messages"]) == 2
    assert result["messages"][1].content == "Hello from test agent!"
```

```
<frozen abc>:106
  <frozen abc>:106: LangGraphDeprecatedSinceV10: AgentStatePydantic has been moved to langchain.agents. Please update your import to 'from langchain.agents import AgentStatePydantic'. Deprecated in LangGraph V1.0 to be removed in V2.0.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This fixes that issue.

I don't actually think we should re-expose these new states in `langchain.agents` given that middleware agents don't use them. Need to make a call on that.