### PR TITLE
revert(langgraph): restore logic to surface interrupts for stream_mod…

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -904,7 +904,11 @@ class PregelLoop:
                         )
                     }
                 ]
-                self._emit("updates", lambda: iter(interrupts))
+                stream_modes = self.stream.modes if self.stream else []
+                if "updates" in stream_modes:
+                    self._emit("updates", lambda: iter(interrupts))
+                elif "values" in stream_modes:
+                    self._emit("values", lambda: iter(interrupts))
             elif writes[0][0] != ERROR:
                 self._emit(
                     "updates",


### PR DESCRIPTION
### Description

Revert change in #5201 that prevented the surfacing of interrupts when `stream_mode="values"`. [Comment highlighting affected lines](https://github.com/langchain-ai/langgraph/pull/5201#discussion_r2344884841)

Resolves #5409 

### Test

Add test to verify interrupts are properly surfaced when `stream_mode="values"` (`test_interrupt_stream_mode_values`)