### PR TITLE
docs: Add missing merge parameter documentation in push_ui_message

### DIFF
--- a/libs/langgraph/langgraph/graph/ui.py
+++ b/libs/langgraph/langgraph/graph/ui.py
@@ -82,6 +82,8 @@ def push_ui_message(
         message: Optional message object to associate with the UI message.
         state_key: Key in the graph state where the UI messages are stored.
             Defaults to "ui".
+        merge: Whether to merge props with existing UI message (True) or replace
+            them (False). Defaults to False.
 
     Returns:
         The created UI message.


### PR DESCRIPTION
  **Description:**
  This PR adds missing documentation for the `merge` parameter in the `push_ui_message` function. The parameter was    present in the function signature but lacked documentation in the docstring, which could confuse API users.

  Changes made:
  - Added clear documentation for the `merge` parameter
  - Explains the behavior difference between `merge=True`
  (merges props) and `merge=False` (replaces props)
  - Includes default value information

  **Issue:**
  N/A - Documentation improvement

  **Dependencies:**
  None