### PR TITLE
fix(checkpoint): use tolerant float comparison to fix test failing on x86_64 architecture

### DIFF
--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -950,8 +950,8 @@ async def test_embed_with_path(fake_embeddings: CharacterEmbeddings) -> None:
     assert results[0].key != results[1].key
     ascore = results[0].score
     bscore = results[1].score
-    assert ascore == bscore
     assert ascore is not None and bscore is not None
+    assert ascore == pytest.approx(bscore, abs=1e-5)
 
     results = await store.asearch(("test",), query="uuu")
     assert len(results) == 2


### PR DESCRIPTION
### Description

`test_embed_with_path` was failing on x86_64 architecture due to numeric precision differences. `pytest.approx` was already used later on in this test for float comparison, so this PR just updates a missed assertion.

Fixes https://github.com/langchain-ai/langgraph/issues/5845