### PR TITLE
fix(langgraph): selective interrupt task scheduling

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -356,9 +356,7 @@ class PregelLoop:
                 )
         # output writes
         if hasattr(self, "tasks"):
-            print("OUTPUT WRITES CALL POS 0")
             self.output_writes(task_id, writes)
-            print("^^^")
 
     def _put_pending_writes(self) -> None:
         if self.checkpointer_put_writes is None:
@@ -449,8 +447,6 @@ class PregelLoop:
             True if more iterations are needed.
         """
 
-        print(f"----!!!! TICK: {self.step}")
-
         # check if iteration limit is reached
         if self.step > self.stop:
             self.status = "out_of_steps"
@@ -492,7 +488,6 @@ class PregelLoop:
                     task_ids_to_block.add(task_id)
 
         self.task_ids_to_block = task_ids_to_block
-        print("FIRST GO: self.task_ids_to_block: ", self.task_ids_to_block)
 
         # produce debug output
         if self._checkpointer_put_after_previous is not None:
@@ -522,9 +517,7 @@ class PregelLoop:
 
         # if there are pending writes from a previous loop, apply them
         if self.skip_done_tasks and self.checkpoint_pending_writes:
-            print(">>Wrapper")
             self._match_writes(self.tasks)
-            print(">>Wrapper done")
 
         # before execution, check if we should interrupt
         if self.interrupt_before and should_interrupt(
@@ -539,9 +532,7 @@ class PregelLoop:
         # print output for any tasks we applied previous writes to
         for task in self.tasks.values():
             if task.writes:
-                print("OUTPUT WRITES CALL POS 1")
                 self.output_writes(task.id, task.writes, cached=True)
-                print("^^^")
 
         subtractor = set()
         for task_id in self.task_ids_to_block:
@@ -549,19 +540,14 @@ class PregelLoop:
                 subtractor.add(task_id)
         self.task_ids_to_block = self.task_ids_to_block - subtractor
 
-        print("SECOND GO: self.task_ids_to_block: ", self.task_ids_to_block)
-
         for task_id, write_type, value in self.checkpoint_pending_writes:
             if task_id in self.task_ids_to_block:
-                print("OUTPUT WRITES CALL POS 2")
                 self.output_writes(task_id, [(write_type, value)])
-                print("^^^")
 
         return True
 
     def after_tick(self) -> None:
         if self.task_ids_to_block:
-            print(f"THIRD GO: self.task_ids_to_block: {self.task_ids_to_block}")
             raise GraphInterrupt(
                 tuple(
                     value[0]
@@ -956,7 +942,6 @@ class PregelLoop:
                         )
                     }
                 ]
-                print("Outputting interrupts: ", interrupts)
                 stream_modes = self.stream.modes if self.stream else []
                 if "updates" in stream_modes:
                     self._emit("updates", lambda: iter(interrupts))
@@ -1074,9 +1059,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
     ) -> PregelExecutableTask | None:
         if pushed := super().accept_push(task, write_idx, call):
             for task in self.match_cached_writes():
-                print("OUTPUT WRITES CALL POS 3")
                 self.output_writes(task.id, task.writes, cached=True)
-                print("^^^")
         return pushed
 
     def put_writes(self, task_id: str, writes: WritesT) -> None:
@@ -1252,9 +1235,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
     ) -> PregelExecutableTask | None:
         if pushed := super().accept_push(task, write_idx, call):
             for task in await self.amatch_cached_writes():
-                print("OUTPUT WRITES CALL POS 4")
                 self.output_writes(task.id, task.writes, cached=True)
-                print("^^^")
         return pushed
 
     def put_writes(self, task_id: str, writes: WritesT) -> None:

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -134,7 +134,7 @@ def DuplexStream(*streams: StreamProtocol) -> StreamProtocol:
                 stream(value)
 
     return StreamProtocol(__call__, {mode for s in streams for mode in s.modes})
-        
+
 
 class PregelLoop:
     config: RunnableConfig
@@ -652,8 +652,7 @@ class PregelLoop:
         return hanging_interrupts
 
     def _merge_interrupts(
-        self,
-        task_id: str, value: Sequence[Interrupt]
+        self, task_id: str, value: Sequence[Interrupt]
     ) -> Sequence[Interrupt]:
         """Normalize interrupt value to list and merge with existing interrupts.
 

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -567,7 +567,7 @@ class PregelLoop:
         if self.skipped_task_ids:
             # raise early GraphInterrupt for skipped tasks.
             # since we know len(resumes) != len(interrupts) for these tasks, we
-            # can prevent unecessary node re-execution by raising preemptively
+            # can prevent unnecessary node re-execution by raising preemptively
             interrupts = []
             for task_id, channel, value in self.checkpoint_pending_writes:
                 if channel == INTERRUPT and task_id in self.skipped_task_ids:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2995,7 +2995,11 @@ class Pregel(
                         for task in await loop.amatch_cached_writes():
                             loop.output_writes(task.id, task.writes, cached=True)
                         async for _ in runner.atick(
-                            [t for t in loop.tasks.values() if not t.writes],
+                            [
+                                t
+                                for t in loop.tasks.values()
+                                if not t.writes and t.id not in loop.task_ids_to_block
+                            ],
                             timeout=self.step_timeout,
                             get_waiter=get_waiter,
                             schedule_task=loop.aaccept_push,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2998,7 +2998,7 @@ class Pregel(
                             [
                                 t
                                 for t in loop.tasks.values()
-                                if not t.writes and t.id not in loop.task_ids_to_block
+                                if not t.writes and t.id not in loop.skipped_task_ids
                             ],
                             timeout=self.step_timeout,
                             get_waiter=get_waiter,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2672,7 +2672,11 @@ class Pregel(
                     for task in loop.match_cached_writes():
                         loop.output_writes(task.id, task.writes, cached=True)
                     for _ in runner.tick(
-                        [t for t in loop.tasks.values() if not t.writes],
+                        [
+                            t
+                            for t in loop.tasks.values()
+                            if not t.writes and t.id not in loop.task_ids_to_block
+                        ],
                         timeout=self.step_timeout,
                         get_waiter=get_waiter,
                         schedule_task=loop.accept_push,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2675,7 +2675,7 @@ class Pregel(
                         [
                             t
                             for t in loop.tasks.values()
-                            if not t.writes and t.id not in loop.task_ids_to_block
+                            if not t.writes and t.id not in loop.skipped_task_ids
                         ],
                         timeout=self.step_timeout,
                         get_waiter=get_waiter,

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -173,3 +173,90 @@ def test_interrupt_with_send_payloads(sync_checkpointer: BaseCheckpointSaver) ->
     # Map node runs 3 times initially (item1 completes, 2 dangerous_items interrupt),
     # then 2 times on resume
     assert node_counter["map_node"] == 5
+
+
+def test_interrupt_with_send_payloads_sequential_resume(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Test interruption in map node with Send payloads and sequential resume."""
+
+    # Global counter to track node executions
+    node_counter = {"entry": 0, "map_node": 0}
+
+    class State(TypedDict):
+        items: list[str]
+        processed: Annotated[list[str], operator.add]
+
+    def entry_node(state: State):
+        node_counter["entry"] += 1
+        return {}  # No state updates in entry node
+
+    def send_to_map(state: State):
+        return [Send("map_node", {"item": item}) for item in state["items"]]
+
+    def map_node(state: State):
+        node_counter["map_node"] += 1
+        if "dangerous" in state["item"]:
+            value = interrupt({"processing": state["item"]})
+            return {"processed": [f"processed_{value}"]}
+        else:
+            return {"processed": [f"processed_{state['item']}_auto"]}
+
+    builder = StateGraph(State)
+    builder.add_node("entry", entry_node)
+    builder.add_node("map_node", map_node)
+    builder.add_edge(START, "entry")
+    builder.add_conditional_edges("entry", send_to_map, ["map_node"])
+    builder.add_edge("map_node", END)
+
+    graph = builder.compile(checkpointer=sync_checkpointer)
+
+    config = {"configurable": {"thread_id": "test_interrupt_send_sequential"}}
+
+    # Run until interrupts
+    result = graph.invoke(
+        {"items": ["item1", "dangerous_item1", "dangerous_item2"]}, config=config
+    )
+
+    # Verify we have interrupts
+    interrupts = result.get("__interrupt__", [])
+    assert len(interrupts) == 2
+    assert "dangerous_item" in interrupts[0].value["processing"]
+
+    # Resume first interrupt only
+    first_interrupt = interrupts[0]
+    first_resume_map = {
+        first_interrupt.interrupt_id: f"human_input_{first_interrupt.value['processing']}"
+    }
+
+    partial_result = graph.invoke(Command(resume=first_resume_map), config=config)
+
+    # Verify we still have one pending interrupt
+    remaining_interrupts = partial_result.get("__interrupt__", [])
+    assert len(remaining_interrupts) == 1
+
+    # Resume second interrupt
+    second_interrupt = remaining_interrupts[0]
+    second_resume_map = {
+        second_interrupt.interrupt_id: f"human_input_{second_interrupt.value['processing']}"
+    }
+
+    final_result = graph.invoke(Command(resume=second_resume_map), config=config)
+
+    # Verify final result contains processed items
+    assert "processed" in final_result
+    processed_items = final_result["processed"]
+    assert len(processed_items) == 3
+    assert "processed_item1_auto" in processed_items  # item1 processed automatically
+    assert any(
+        "processed_human_input_dangerous_item1" in item for item in processed_items
+    )  # dangerous_item1 processed after interrupt
+    assert any(
+        "processed_human_input_dangerous_item2" in item for item in processed_items
+    )  # dangerous_item2 processed after interrupt
+
+    # Verify node execution counts
+    assert node_counter["entry"] == 1  # Entry node runs once
+    # Map node runs 3 times initially (item1 completes, 2 dangerous_items interrupt),
+    # then 1 time on first resume, then 1 time on second resume
+    assert node_counter["map_node"] == 5

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,9 +1,10 @@
 import pytest
 from langgraph.checkpoint.base import BaseCheckpointSaver
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Annotated
+import operator
 
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Durability
+from langgraph.types import Send, interrupt, Command, Durability
 
 pytestmark = pytest.mark.anyio
 
@@ -90,3 +91,55 @@ async def test_interruption_without_state_updates_async(
     assert (await graph.aget_state(thread)).next == ()
     n_checkpoints = len([c async for c in graph.aget_state_history(thread)])
     assert n_checkpoints == (5 if durability != "exit" else 3)
+
+
+def test_interrupt_with_send_payloads(sync_checkpointer: BaseCheckpointSaver) -> None:
+    """Test interruption in map node with Send payloads and human-in-the-loop resume."""
+    
+    class State(TypedDict):
+        items: list[str]
+        processed: Annotated[list[str], operator.add]
+    
+    def entry_node(state: State):
+        return {"items": ["item1", "item2"]}
+    
+    def send_to_map(state: State):
+        return [Send("map_node", {"item": item}) for item in state["items"]]
+    
+    def map_node(state: State):
+        value = interrupt({"processing": state["item"]})
+        return {"processed": [f"processed_{value}"]}
+    
+    builder = StateGraph(State)
+    builder.add_node("entry", entry_node)
+    builder.add_node("map_node", map_node)
+    builder.add_edge(START, "entry")
+    builder.add_conditional_edges("entry", send_to_map, ["map_node"])
+    builder.add_edge("map_node", END)
+    
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    
+    config = {"configurable": {"thread_id": "test_interrupt_send"}}
+    
+    # Run until interrupts
+    result = graph.invoke({"items": [], "processed": []}, config=config)
+    
+    # Verify we have interrupts
+    interrupts = result.get("__interrupt__", [])
+    assert len(interrupts) == 2
+    assert all(i.resumable for i in interrupts)
+    
+    # Resume with mapping of interrupt IDs to values
+    resume_map = {
+        i.interrupt_id: f"human_input_{i.value['processing']}"
+        for i in interrupts
+    }
+    
+    final_result = graph.invoke(Command(resume=resume_map), config=config)
+    
+    # Verify final result contains processed items
+    assert "processed" in final_result
+    processed_items = final_result["processed"]
+    assert len(processed_items) == 2
+    assert "processed_human_input_item1" in processed_items
+    assert "processed_human_input_item2" in processed_items

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -6,9 +6,10 @@ import operator
 
 =======
 import operator
+from typing import Annotated
 
 import pytest
-from typing_extensions import Annotated, TypedDict
+from typing_extensions import TypedDict
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 >>>>>>> 0ce981a0 (Test with multiple interrupts)

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,10 +1,19 @@
+<<<<<<< HEAD
 import pytest
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict, Annotated
 import operator
 
+=======
+import operator
+
+import pytest
+from typing_extensions import Annotated, TypedDict
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+>>>>>>> 0ce981a0 (Test with multiple interrupts)
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Send, interrupt, Command, Durability
+from langgraph.types import Command, Durability, Send, interrupt
 
 pytestmark = pytest.mark.anyio
 
@@ -95,51 +104,65 @@ async def test_interruption_without_state_updates_async(
 
 def test_interrupt_with_send_payloads(sync_checkpointer: BaseCheckpointSaver) -> None:
     """Test interruption in map node with Send payloads and human-in-the-loop resume."""
-    
+
+    # Global counter to track node executions
+    node_counter = {"entry": 0, "map_node": 0}
+
     class State(TypedDict):
         items: list[str]
         processed: Annotated[list[str], operator.add]
-    
+
     def entry_node(state: State):
-        return {"items": ["item1", "item2"]}
-    
+        node_counter["entry"] += 1
+        return {}  # No state updates in entry node
+
     def send_to_map(state: State):
         return [Send("map_node", {"item": item}) for item in state["items"]]
-    
+
     def map_node(state: State):
-        value = interrupt({"processing": state["item"]})
-        return {"processed": [f"processed_{value}"]}
-    
+        node_counter["map_node"] += 1
+        if "dangerous" in state["item"]:
+            value = interrupt({"processing": state["item"]})
+            return {"processed": [f"processed_{value}"]}
+        else:
+            return {"processed": [f"processed_{state['item']}_auto"]}
+
     builder = StateGraph(State)
     builder.add_node("entry", entry_node)
     builder.add_node("map_node", map_node)
     builder.add_edge(START, "entry")
     builder.add_conditional_edges("entry", send_to_map, ["map_node"])
     builder.add_edge("map_node", END)
-    
+
     graph = builder.compile(checkpointer=sync_checkpointer)
-    
+
     config = {"configurable": {"thread_id": "test_interrupt_send"}}
-    
+
     # Run until interrupts
-    result = graph.invoke({"items": [], "processed": []}, config=config)
-    
-    # Verify we have interrupts
+    result = graph.invoke({"items": ["item1", "dangerous_item"]}, config=config)
+
+    # Verify we have interrupts (only one for dangerous_item)
     interrupts = result.get("__interrupt__", [])
-    assert len(interrupts) == 2
-    assert all(i.resumable for i in interrupts)
-    
+    assert len(interrupts) == 1
+    assert "dangerous_item" in interrupts[0].value["processing"]
+
     # Resume with mapping of interrupt IDs to values
     resume_map = {
-        i.interrupt_id: f"human_input_{i.value['processing']}"
-        for i in interrupts
+        i.interrupt_id: f"human_input_{i.value['processing']}" for i in interrupts
     }
-    
+
     final_result = graph.invoke(Command(resume=resume_map), config=config)
-    
+
     # Verify final result contains processed items
     assert "processed" in final_result
     processed_items = final_result["processed"]
     assert len(processed_items) == 2
-    assert "processed_human_input_item1" in processed_items
-    assert "processed_human_input_item2" in processed_items
+    assert "processed_item1_auto" in processed_items  # item1 processed automatically
+    assert (
+        "processed_human_input_dangerous_item" in processed_items
+    )  # dangerous_item processed after interrupt
+
+    # Verify node execution counts
+    assert node_counter["entry"] == 1  # Entry node runs once
+    # Map node runs twice initially (item1 completes, dangerous_item interrupts), then once on resume
+    assert node_counter["map_node"] == 3

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -330,6 +330,7 @@ def test_interrupt_with_send_payloads_sequential_resume(
     assert node_counter["map_node"] == 5
 
 
+@NEEDS_CONTEXTVARS
 async def test_interrupt_with_send_payloads_sequential_resume_async(
     async_checkpointer: BaseCheckpointSaver,
 ) -> None:

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,18 +1,10 @@
-<<<<<<< HEAD
-import pytest
-from langgraph.checkpoint.base import BaseCheckpointSaver
-from typing_extensions import TypedDict, Annotated
-import operator
-
-=======
 import operator
 from typing import Annotated
 
 import pytest
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict
 
-from langgraph.checkpoint.base import BaseCheckpointSaver
->>>>>>> 0ce981a0 (Test with multiple interrupts)
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import Command, Durability, Send, interrupt
 
@@ -226,7 +218,7 @@ def test_interrupt_with_send_payloads_sequential_resume(
     # Resume first interrupt only
     first_interrupt = interrupts[0]
     first_resume_map = {
-        first_interrupt.interrupt_id: f"human_input_{first_interrupt.value['processing']}"
+        first_interrupt.id: f"human_input_{first_interrupt.value['processing']}"
     }
 
     partial_result = graph.invoke(Command(resume=first_resume_map), config=config)
@@ -238,10 +230,174 @@ def test_interrupt_with_send_payloads_sequential_resume(
     # Resume second interrupt
     second_interrupt = remaining_interrupts[0]
     second_resume_map = {
-        second_interrupt.interrupt_id: f"human_input_{second_interrupt.value['processing']}"
+        second_interrupt.id: f"human_input_{second_interrupt.value['processing']}"
     }
 
     final_result = graph.invoke(Command(resume=second_resume_map), config=config)
+
+    # Verify final result contains processed items
+    assert "processed" in final_result
+    processed_items = final_result["processed"]
+    assert len(processed_items) == 3
+    assert "processed_item1_auto" in processed_items  # item1 processed automatically
+    assert any(
+        "processed_human_input_dangerous_item1" in item for item in processed_items
+    )  # dangerous_item1 processed after interrupt
+    assert any(
+        "processed_human_input_dangerous_item2" in item for item in processed_items
+    )  # dangerous_item2 processed after interrupt
+
+    # Verify node execution counts
+    assert node_counter["entry"] == 1  # Entry node runs once
+    # Map node runs 3 times initially (item1 completes, 2 dangerous_items interrupt),
+    # then 1 time on first resume, then 1 time on second resume
+    assert node_counter["map_node"] == 5
+
+
+async def test_interrupt_with_send_payloads_async(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Test interruption in map node with Send payloads and human-in-the-loop resume."""
+
+    # Global counter to track node executions
+    node_counter = {"entry": 0, "map_node": 0}
+
+    class State(TypedDict):
+        items: list[str]
+        processed: Annotated[list[str], operator.add]
+
+    def entry_node(state: State):
+        node_counter["entry"] += 1
+        return {}  # No state updates in entry node
+
+    def send_to_map(state: State):
+        return [Send("map_node", {"item": item}) for item in state["items"]]
+
+    def map_node(state: State):
+        node_counter["map_node"] += 1
+        if "dangerous" in state["item"]:
+            value = interrupt({"processing": state["item"]})
+            return {"processed": [f"processed_{value}"]}
+        else:
+            return {"processed": [f"processed_{state['item']}_auto"]}
+
+    builder = StateGraph(State)
+    builder.add_node("entry", entry_node)
+    builder.add_node("map_node", map_node)
+    builder.add_edge(START, "entry")
+    builder.add_conditional_edges("entry", send_to_map, ["map_node"])
+    builder.add_edge("map_node", END)
+
+    graph = builder.compile(checkpointer=async_checkpointer)
+
+    config = {"configurable": {"thread_id": "test_interrupt_send"}}
+
+    # Run until interrupts
+    result = await graph.ainvoke(
+        {"items": ["item1", "dangerous_item1", "dangerous_item2"]}, config=config
+    )
+
+    # Verify we have interrupts (only one for dangerous_item)
+    interrupts = result.get("__interrupt__", [])
+    assert len(interrupts) == 2
+    assert "dangerous_item" in interrupts[0].value["processing"]
+
+    # Resume with mapping of interrupt IDs to values
+    resume_map = {
+        i.interrupt_id: f"human_input_{i.value['processing']}" for i in interrupts
+    }
+
+    final_result = await graph.ainvoke(Command(resume=resume_map), config=config)
+
+    # Verify final result contains processed items
+    assert "processed" in final_result
+    processed_items = final_result["processed"]
+    assert len(processed_items) == 3
+    assert "processed_item1_auto" in processed_items  # item1 processed automatically
+    assert any(
+        "processed_human_input_dangerous_item1" in item for item in processed_items
+    )  # dangerous_item1 processed after interrupt
+    assert any(
+        "processed_human_input_dangerous_item2" in item for item in processed_items
+    )  # dangerous_item2 processed after interrupt
+
+    # Verify node execution counts
+    assert node_counter["entry"] == 1  # Entry node runs once
+    # Map node runs 3 times initially (item1 completes, 2 dangerous_items interrupt),
+    # then 2 times on resume
+    assert node_counter["map_node"] == 5
+
+
+@pytest.mark.xfail(reason="Duplicate interrupts written, still debugging this")
+async def test_interrupt_with_send_payloads_sequential_resume_async(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Test interruption in map node with Send payloads and sequential resume."""
+
+    # Global counter to track node executions
+    node_counter = {"entry": 0, "map_node": 0}
+
+    class State(TypedDict):
+        items: list[str]
+        processed: Annotated[list[str], operator.add]
+
+    def entry_node(state: State):
+        node_counter["entry"] += 1
+        return {}  # No state updates in entry node
+
+    def send_to_map(state: State):
+        return [Send("map_node", {"item": item}) for item in state["items"]]
+
+    def map_node(state: State):
+        node_counter["map_node"] += 1
+        if "dangerous" in state["item"]:
+            value = interrupt({"processing": state["item"]})
+            return {"processed": [f"processed_{value}"]}
+        else:
+            return {"processed": [f"processed_{state['item']}_auto"]}
+
+    builder = StateGraph(State)
+    builder.add_node("entry", entry_node)
+    builder.add_node("map_node", map_node)
+    builder.add_edge(START, "entry")
+    builder.add_conditional_edges("entry", send_to_map, ["map_node"])
+    builder.add_edge("map_node", END)
+
+    graph = builder.compile(checkpointer=async_checkpointer)
+
+    config = {"configurable": {"thread_id": "test_interrupt_send_sequential"}}
+
+    # Run until interrupts
+    result = await graph.ainvoke(
+        {"items": ["item1", "dangerous_item1", "dangerous_item2"]}, config=config
+    )
+
+    # Verify we have interrupts
+    interrupts = result.get("__interrupt__", [])
+    assert len(interrupts) == 2
+    assert "dangerous_item" in interrupts[0].value["processing"]
+
+    # Resume first interrupt only
+    first_interrupt = interrupts[0]
+    first_resume_map = {
+        first_interrupt.id: f"human_input_{first_interrupt.value['processing']}"
+    }
+
+    partial_result = await graph.ainvoke(
+        Command(resume=first_resume_map), config=config
+    )
+
+    # Verify we still have one pending interrupt
+    remaining_interrupts = partial_result.get("__interrupt__", [])
+    assert len(remaining_interrupts) == 1
+
+    # Resume second interrupt
+    second_interrupt = remaining_interrupts[0]
+    second_resume_map = {
+        second_interrupt.id: f"human_input_{second_interrupt.value['processing']}"
+    }
+
+    final_result = await graph.ainvoke(Command(resume=second_resume_map), config=config)
 
     # Verify final result contains processed items
     assert "processed" in final_result

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -171,6 +171,7 @@ def test_interrupt_with_send_payloads(sync_checkpointer: BaseCheckpointSaver) ->
     assert node_counter["map_node"] == 5
 
 
+@NEEDS_CONTEXTVARS
 async def test_interrupt_with_send_payloads_async(
     async_checkpointer: BaseCheckpointSaver, durability: Durability
 ) -> None:

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -328,9 +328,9 @@ async def test_interrupt_with_send_payloads_async(
     assert node_counter["map_node"] == 5
 
 
-@pytest.mark.xfail(reason="Duplicate interrupts written, still debugging this")
+# @pytest.mark.xfail(reason="Duplicate interrupts written, still debugging this")
 async def test_interrupt_with_send_payloads_sequential_resume_async(
-    async_checkpointer: BaseCheckpointSaver, durability: Durability
+    async_checkpointer: BaseCheckpointSaver,
 ) -> None:
     """Test interruption in map node with Send payloads and sequential resume."""
 

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -467,7 +467,8 @@ def test_node_with_multiple_interrupts_requires_full_resume(
     # invoke with an interrupt map that DOES NOT match double_interrupt_node.
     # this should not execute the node because the optimization kicks in
     partial = graph.invoke(
-        Command(resume={"00000000000000000000000000000000": "nothing_burger"}), config=config
+        Command(resume={"00000000000000000000000000000000": "nothing_burger"}),
+        config=config,
     )
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
@@ -475,18 +476,14 @@ def test_node_with_multiple_interrupts_requires_full_resume(
     assert node_counter == 2
 
     # invoke with None resume. this should execute the node
-    partial = graph.invoke(
-        None, config=config
-    )
+    partial = graph.invoke(None, config=config)
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
     assert remaining_interrupts[0].value == "second"
     assert node_counter == 3
 
     # invoke with nonspecific resume. this should execute the node
-    partial = graph.invoke(
-        Command(resume="human_second"), config=config
-    )
+    partial = graph.invoke(Command(resume="human_second"), config=config)
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
     print("REMAINING INTERRUPTS: ", remaining_interrupts)
@@ -495,9 +492,7 @@ def test_node_with_multiple_interrupts_requires_full_resume(
 
     # finally, invoke with an interrupt map that matches double_interrupt_node.
     # this should execute the node and all interrupts should be resolved
-    final_result = graph.invoke(
-        Command(resume="human_third"), config=config
-    )
+    final_result = graph.invoke(Command(resume="human_third"), config=config)
     assert "input" in final_result
     assert final_result["input"] == "human_first-human_second-human_third"
     assert node_counter == 5
@@ -510,7 +505,7 @@ async def test_node_with_multiple_interrupts_requires_full_resume_async(
 
     Ensures that a node is not re-executed until valid resume values have been provided to all
     discovered interrupts"""
-    
+
     node_counter = 0
 
     class State(TypedDict):
@@ -553,7 +548,8 @@ async def test_node_with_multiple_interrupts_requires_full_resume_async(
     # invoke with an interrupt map that DOES NOT match double_interrupt_node.
     # this should not execute the node because the optimization kicks in
     partial = await graph.ainvoke(
-        Command(resume={"00000000000000000000000000000000": "nothing_burger"}), config=config
+        Command(resume={"00000000000000000000000000000000": "nothing_burger"}),
+        config=config,
     )
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
@@ -561,18 +557,14 @@ async def test_node_with_multiple_interrupts_requires_full_resume_async(
     assert node_counter == 2
 
     # invoke with None resume. this should execute the node
-    partial = await graph.ainvoke(
-        None, config=config
-    )
+    partial = await graph.ainvoke(None, config=config)
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
     assert remaining_interrupts[0].value == "second"
     assert node_counter == 3
 
     # invoke with nonspecific resume. this should execute the node
-    partial = await graph.ainvoke(
-        Command(resume="human_second"), config=config
-    )
+    partial = await graph.ainvoke(Command(resume="human_second"), config=config)
     remaining_interrupts = partial.get("__interrupt__", [])
     assert len(remaining_interrupts) == 1
     print("REMAINING INTERRUPTS: ", remaining_interrupts)
@@ -581,9 +573,7 @@ async def test_node_with_multiple_interrupts_requires_full_resume_async(
 
     # finally, invoke with an interrupt map that matches double_interrupt_node.
     # this should execute the node and all interrupts should be resolved
-    final_result = await graph.ainvoke(
-        Command(resume="human_third"), config=config
-    )
+    final_result = await graph.ainvoke(Command(resume="human_third"), config=config)
     assert "input" in final_result
     assert final_result["input"] == "human_first-human_second-human_third"
     assert node_counter == 5


### PR DESCRIPTION
### Description

Prevents interrupt tasks from executing when the resume value has not yet been specified.

Implemented for sync and async Pregel loop

If a task execution is skipped, the skipped interrupt is still included in the graph result for consistency:
``` python
result = graph.invoke(...)
interrupts = result.get("__interrupt__", [])   # [interrupt_1, interrupt_2]

partial_result = graph.invoke(Command(resume=interrupt_1_resume_map), ...)
remaining_interrupts = partial_result.get("__interrupt__", [])  # [interrupt_2]
```

### Tests

- `test_interrupt_with_send_payloads`: test for a single resume map that resumes all interrupts at once
- `test_interrupt_with_send_payloads_sequential_resume`: test for two resume maps delivered in sequence
- `test_node_with_multiple_interrupts_requires_full_resume` test optimization for multiple interrupts within a single node

Solves https://github.com/langchain-ai/langgraph/issues/6208


