### PR TITLE
fix(async): cleanup orphaned waiter task in AsyncPregelLoop

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent
 import concurrent.futures
+import contextlib
 import queue
 import warnings
 import weakref
@@ -2922,9 +2923,33 @@ class Pregel(
                     or "messages" in stream_modes
                     or "custom" in stream_modes
                 ):
+                    # Keep a single waiter task alive; ensure cleanup on exit.
+                    waiter: asyncio.Task[None] | None = None
 
                     def get_waiter() -> asyncio.Task[None]:
-                        return aioloop.create_task(stream.wait())
+                        nonlocal waiter
+                        if waiter is None or waiter.done():
+                            waiter = aioloop.create_task(stream.wait())
+                            def _clear(t: asyncio.Task[None]) -> None:
+                                nonlocal waiter
+                                if waiter is t:
+                                    waiter = None
+                            waiter.add_done_callback(_clear)
+                        return waiter
+
+                    async def _cleanup_waiter() -> None:
+                        """Wake pending waiter and/or cancel+await to avoid pending tasks."""
+                        nonlocal waiter
+                        # Try to wake via semaphore like SyncPregelLoop
+                        with contextlib.suppress(Exception):
+                            if hasattr(stream, "_count"):
+                                stream._count.release()
+                        t = waiter
+                        waiter = None
+                        if t is not None and not t.done():
+                            t.cancel()
+                            with contextlib.suppress(asyncio.CancelledError):
+                                await t
 
                 else:
                     get_waiter = None  # type: ignore[assignment]
@@ -2933,28 +2958,34 @@ class Pregel(
                 # channel updates from step N are only visible in step N+1
                 # channels are guaranteed to be immutable for the duration of the step,
                 # with channel updates applied only at the transition between steps
-                while loop.tick():
-                    for task in await loop.amatch_cached_writes():
-                        loop.output_writes(task.id, task.writes, cached=True)
-                    async for _ in runner.atick(
-                        [t for t in loop.tasks.values() if not t.writes],
-                        timeout=self.step_timeout,
-                        get_waiter=get_waiter,
-                        schedule_task=loop.aaccept_push,
-                    ):
-                        # emit output
-                        for o in _output(
-                            stream_mode,
-                            print_mode,
-                            subgraphs,
-                            stream.get_nowait,
-                            asyncio.QueueEmpty,
+                try:
+                    while loop.tick():
+                        for task in await loop.amatch_cached_writes():
+                            loop.output_writes(task.id, task.writes, cached=True)
+                        async for _ in runner.atick(
+                            [t for t in loop.tasks.values() if not t.writes],
+                            timeout=self.step_timeout,
+                            get_waiter=get_waiter,
+                            schedule_task=loop.aaccept_push,
                         ):
-                            yield o
-                    loop.after_tick()
-                    # wait for checkpoint
-                    if durability_ == "sync":
-                        await cast(asyncio.Future, loop._put_checkpoint_fut)
+                            # emit output
+                            for o in _output(
+                                stream_mode,
+                                print_mode,
+                                subgraphs,
+                                stream.get_nowait,
+                                asyncio.QueueEmpty,
+                            ):
+                                yield o
+                        loop.after_tick()
+                        # wait for checkpoint
+                        if durability_ == "sync":
+                            await cast(asyncio.Future, loop._put_checkpoint_fut)
+                finally:
+                    # ensure waiter doesn't remain pending on cancel/shutdown
+                    if "_cleanup_waiter" in locals():
+                        await _cleanup_waiter()
+
             # emit output
             for o in _output(
                 stream_mode,


### PR DESCRIPTION
### Summary

This PR fixes an issue where `AsyncPregelLoop` could leave behind an orphaned `stream.wait()` task, resulting in warnings like:

```
Task was destroyed but it is pending!
```

### Related Discussion
This PR is in response to: [langchain-ai/langgraph#6163](https://github.com/langchain-ai/langgraph/discussions/6163)


### Problem

* In the async path, `get_waiter()` was creating a new `asyncio.Task` via

  ```python
  aioloop.create_task(stream.wait())
  ```

  but never tracked or cleaned it up.
* On cancellation or shutdown, these tasks remained pending and produced warnings.

### Solution

* Changed `get_waiter()` to:

  * Maintain a **single waiter task** (similar to the sync path).
  * Auto-clear the reference when the task finishes.
* Added `_cleanup_waiter()`:

  * On exit, attempt to wake the waiter (`stream._count.release()` if available).
  * Otherwise, cancel and `await` the pending task to ensure proper cleanup.
* Wrapped the `while loop.tick():` block in a `try/finally` to guarantee `_cleanup_waiter()` runs on exit.
* Added missing `import contextlib`.

### Impact

* Prevents orphaned `stream.wait()` tasks.
* Removes noisy `"Task was destroyed but it is pending!"` warnings.
* Behavior of async streaming remains unchanged, only lifecycle management improved.

### Test Plan

* Reproduced the issue by running async streaming with cancellation.
* Verified warnings no longer appear after the fix.
* Ran existing test suite (all passing).

### Notes

* Sync and Async implementations now follow the same principle: *only one waiter at a time, always cleaned up on exit*.
* Backwards-compatible; no API changes.
