### PR TITLE
feat(cli): add configuration for server customization ordering

### DIFF
--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -18,6 +18,7 @@ DEFAULT_IMAGE_DISTRO = "debian"
 
 
 Distros = Literal["debian", "wolfi", "bullseye", "bookworm"]
+MiddlewareOrders = Literal["custom_auth_first", "custom_middleware_first"]
 
 
 class TTLConfig(TypedDict, total=False):
@@ -359,6 +360,18 @@ class HttpConfig(TypedDict, total=False):
     agent's behavior or permissions on a request's headers."""
     logging_headers: Optional[ConfigurableHeaderConfig]
     """Optional. Defines which headers are excluded from logging."""
+    middleware_order: Optional[MiddlewareOrders]
+    """Optional. Defines the order in which to apply server customizations.
+
+    Choices:
+      - "custom_auth_first": Custom authentication hooks are evaluated
+      before custom middleware.
+      - "custom_middleware_first": Custom middleware is evaluated
+      before custom authentication hooks.
+
+    Default is `custom_middleware_first`.
+    """
+
 
 
 class Config(TypedDict, total=False):

--- a/libs/cli/schemas/schema.json
+++ b/libs/cli/schemas/schema.json
@@ -587,6 +587,20 @@
             }
           ],
           "description": "Optional. Defines which headers are excluded from logging."
+        },
+        "middleware_order": {
+          "anyOf": [
+            {
+              "enum": [
+                "custom_auth_first",
+                "custom_middleware_first"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional. Defines the order in which to apply server customizations.\n"
         }
       },
       "required": []

--- a/libs/cli/schemas/schema.v0.json
+++ b/libs/cli/schemas/schema.v0.json
@@ -587,6 +587,20 @@
             }
           ],
           "description": "Optional. Defines which headers are excluded from logging."
+        },
+        "middleware_order": {
+          "anyOf": [
+            {
+              "enum": [
+                "custom_auth_first",
+                "custom_middleware_first"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional. Defines the order in which to apply server customizations.\n"
         }
       },
       "required": []


### PR DESCRIPTION
This adds a configuration option in `HttpConfig` that allows LangGraph Platform users to apply custom authentication hooks before (other) custom middleware. Currently, the order is fixed (custom middleware is always evaluated before custom auth).