### PR TITLE
docs(threads): fix grammar in use_threads.md

### DIFF
--- a/docs/docs/cloud/how-tos/use_threads.md
+++ b/docs/docs/cloud/how-tos/use_threads.md
@@ -4,7 +4,7 @@ In this guide, we will show how to create, view, and inspect [threads](../../con
 
 ## Create a thread
 
-To run your graph and the state persisted, you must first create a thread.
+To run your graph and persist the state, you must first create a thread.
 
 ### Empty thread
 


### PR DESCRIPTION
Description: There is a grammatical error in the doc use_threads.md. This PR fixes it.
