### PR TITLE
fix(docs): Fix duplicate docs

### DIFF
--- a/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
+++ b/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
@@ -1722,6 +1722,8 @@ You can use [LangGraph Studio](../../concepts/langgraph_studio.md) to debug your
 
 LangGraph Studio is free with [locally deployed applications](../../tutorials/langgraph-platform/local-server.md) using `langgraph dev`.
 
+:::
+
 ## Considerations
 
 When using human-in-the-loop, there are some considerations to keep in mind.


### PR DESCRIPTION
In this page of the doc: [human interrupt](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/add-human-in-the-loop/#validate-human-input)
At the part `### Debug with interrupts` is duplicated

I made this PR to remove the duplicated part