### PR TITLE
docs(add-human-in-the-loop): sync example with agent-chat-ui isAgentInboxInterruptSchema

### DIFF
--- a/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
+++ b/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
@@ -1101,6 +1101,7 @@ def add_human_in_the_loop(
             "allow_accept": True,
             "allow_edit": True,
             "allow_respond": True,
+            "allow_ignore": True,
         }
 
     @create_tool(  # (1)!
@@ -1130,6 +1131,9 @@ def add_human_in_the_loop(
         elif response["type"] == "response":
             user_feedback = response["args"]
             tool_response = user_feedback
+        # ignore the tool call
+        elif response["type"] == "ignore":
+            tool_response = "Tool call ignored by user."
         else:
             raise ValueError(f"Unsupported interrupt response type: {response['type']}")
 


### PR DESCRIPTION
**Description:**  
Update the `add-human-in-the-loop.md` documentation to match the trigger mechanism used in `agent-chat-ui`, specifically the `isAgentInboxInterruptSchema` method.  
Refer to: https://github.com/langchain-ai/agent-chat-ui/blob/main/src/lib/agent-inbox-interrupt.ts#L17C2-L17C43  

This fixes a mismatch between the official example code and the front-end trigger mechanism in `agent-chat-ui`.

**Issue:**  
N/A

**Dependencies:**  
None
