### PR TITLE
test(checkpoint): add network timeout test for Redis cache

### DIFF
--- a/libs/checkpoint/tests/test_redis_cache.py
+++ b/libs/checkpoint/tests/test_redis_cache.py
@@ -331,8 +331,8 @@ class TestRedisCache:
         values = {keys[0]: ({"data": "test"}, None)}
 
         # should handle timeout gracefully during set
-        cache.set(values) # should not raise exception
+        cache.set(values)  # should not raise exception
 
         # should handle timeout gracefully during get
         result = cache.get(keys)
-        assert result == {} # should return empty dict on timeout
+        assert result == {}  # should return empty dict on timeout


### PR DESCRIPTION
## Description
Add `test_network_timeout_scenarios` to verify Redis cache handles socket timeouts gracefully by returning empty dict instead of crashing during network issues.

This test improves error handling coverage by simulating network timeout conditions using very short socket timeouts (1ms) and verifying both `set()` and `get()` operations fail gracefully rather than raising exceptions.

## Issue
Addresses gap in network error handling test coverage for Redis cache implementation.

## Dependencies
None - uses existing test infrastructure and Redis client configuration options.

## Twitter handle
Ali_F_Ismail