### PR TITLE
docs(langgraph): clarify FastAPI dependency requirements for custom middleware

### DIFF
--- a/docs/docs/how-tos/http/custom_middleware.md
+++ b/docs/docs/how-tos/http/custom_middleware.md
@@ -2,6 +2,10 @@
 
 When deploying agents to LangGraph Platform, you can add custom middleware to your server to handle concerns like logging request metrics, injecting or checking headers, and enforcing security policies without modifying core server logic. This works the same way as [adding custom routes](./custom_routes.md). You just need to provide your own [`Starlette`](https://www.starlette.io/applications/) app (including [`FastAPI`](https://fastapi.tiangolo.com/), [`FastHTML`](https://fastht.ml/) and other compatible apps).
 
+???+ note "Note:"
+
+    `FastAPI`, `FastHTML`, and other web frameworks are not included with LangGraph Platform and must be installed separately.
+
 Adding middleware lets you intercept and modify requests and responses globally across your deployment, whether they're hitting your custom endpoints or the built-in LangGraph Platform APIs.
 
 Below is an example using FastAPI.


### PR DESCRIPTION
Clarify that FastAPI, FastHTML, and other web framework dependencies must be installed separately and are not included with LangGraph Platform.
