### PR TITLE
fix(langgraph): `CheckpointTask.state` can be a `StateSnapshot`

### DIFF
--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -48,7 +48,7 @@ class CheckpointTask(TypedDict):
     name: str
     error: str | None
     interrupts: list[dict]
-    state: RunnableConfig | None
+    state: StateSnapshot |RunnableConfig | None
 
 
 class CheckpointPayload(TypedDict):

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -48,7 +48,7 @@ class CheckpointTask(TypedDict):
     name: str
     error: str | None
     interrupts: list[dict]
-    state: StateSnapshot |RunnableConfig | None
+    state: StateSnapshot | RunnableConfig | None
 
 
 class CheckpointPayload(TypedDict):


### PR DESCRIPTION
This adds `StateSnapshot` to the union type annotation of `CheckpointTask.state`. 

The annotation was previously incomplete: `map_debug_checkpoint()` generates `CheckpointPayload` objects from `PregelTask` objects, and the `state` field in `PregelTask`  is of type `None | RunnableConfig | StateSnapshot`. 

