### PR TITLE
feat(prebuilt): allow passing tool_bind_kwargs through create_react_agent

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -275,6 +275,7 @@ def create_react_agent(
     interrupt_after: Optional[list[str]] = None,
     debug: bool = False,
     version: Literal["v1", "v2"] = "v2",
+    tool_bind_kwargs: Optional[dict[str, Any]] = None,
     name: Optional[str] = None,
     **deprecated_kwargs: Any,
 ) -> CompiledStateGraph:
@@ -422,6 +423,9 @@ def create_react_agent(
         name: An optional name for the CompiledStateGraph.
             This name will be automatically used when adding ReAct agent graph to another graph as a subgraph node -
             particularly useful for building multi-agent systems.
+        tool_bind_kwargs: Additional keyword arguments to forward to
+            `model.bind_tools()` when tools are automatically bound. Has no
+            effect when the model instance is already configured with tools.
 
     !!! warning "`config_schema` Deprecated"
         The `config_schema` parameter is deprecated in v0.6.0 and support will be removed in v2.0.0.
@@ -539,8 +543,10 @@ def create_react_agent(
             _should_bind_tools(model, tool_classes, num_builtin=len(llm_builtin_tools))  # type: ignore[arg-type]
             and len(tool_classes + llm_builtin_tools) > 0
         ):
+            bind_kwargs = dict(tool_bind_kwargs or {})
             model = cast(BaseChatModel, model).bind_tools(
-                tool_classes + llm_builtin_tools  # type: ignore[operator]
+                tool_classes + llm_builtin_tools,  # type: ignore[operator]
+                **bind_kwargs,
             )
 
         static_model: Optional[Runnable] = _get_prompt_runnable(prompt) | model  # type: ignore[operator]

--- a/libs/prebuilt/tests/model.py
+++ b/libs/prebuilt/tests/model.py
@@ -30,6 +30,7 @@ class FakeToolCallingModel(BaseChatModel):
     structured_response: Optional[StructuredResponse] = None
     index: int = 0
     tool_style: Literal["openai", "anthropic"] = "openai"
+    last_bind_kwargs: Optional[Dict[str, Any]] = None
 
     def _generate(
         self,
@@ -68,6 +69,7 @@ class FakeToolCallingModel(BaseChatModel):
         tools: Sequence[Union[Dict[str, Any], Type[BaseModel], Callable, BaseTool]],
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, BaseMessage]:
+        self.last_bind_kwargs = dict(kwargs)
         if len(tools) == 0:
             raise ValueError("Must provide at least one tool")
 

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -183,6 +183,36 @@ def test_runnable_prompt():
     assert response == expected_response
 
 
+def test_tool_bind_kwargs_strict_true():
+    model = FakeToolCallingModel()
+
+    @dec_tool
+    def some_tool() -> str:
+        """Return a static value."""
+        return "bar"
+
+    create_react_agent(
+        model,
+        [some_tool],
+        tool_bind_kwargs={"strict": True},
+    )
+
+    assert model.last_bind_kwargs == {"strict": True}
+
+
+def test_tool_bind_kwargs_defaults_to_model_behavior():
+    model = FakeToolCallingModel()
+
+    @dec_tool
+    def some_tool() -> str:
+        """Return a static value."""
+        return "bar"
+
+    create_react_agent(model, [some_tool])
+
+    assert model.last_bind_kwargs == {}
+
+
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
 def test_prompt_with_store(version: str):
     def add(a: int, b: int):


### PR DESCRIPTION
Forward tool_bind_kwargs during automatic bind_tools() in create_react_agent, document the new parameter, and add coverage that ensures kwargs (including strict) are passed through unchanged. Relates to langchain-ai/langchain#27423