### PR TITLE
fix(langgraph): handle multiple annotations w/ `BaseChannel` detection

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1360,10 +1360,14 @@ def _get_channel(
 def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
-        if len(meta) >= 1 and isinstance(meta[-1], BaseChannel):
-            return meta[-1]
-        elif len(meta) >= 1 and isclass(meta[-1]) and issubclass(meta[-1], BaseChannel):
-            return meta[-1](typ.__origin__ if hasattr(typ, "__origin__") else typ)
+        # Search through all annotated medata to find channel annotations
+        for item in meta:
+            if isinstance(item, BaseChannel):
+                return item
+            elif isclass(item) and issubclass(item, BaseChannel):
+                # ex, Annotated[int, EphemeralValue, SomeOtherAnnotation]
+                # would return EphemeralValue(int)
+                return item(typ.__origin__ if hasattr(typ, "__origin__") else typ)
     return None
 
 

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -338,27 +338,6 @@ def test_private_input_schema_conditional_edge():
     assert graph.invoke({"foo": 0}) == {"foo": 2, "bar": "meow"}
 
 
-def test_is_field_channel_basic_detection():
-    """Test basic channel detection with single channel annotations."""
-    # Test with EphemeralValue class
-    typ = Annotated[int, EphemeralValue]
-    result = _is_field_channel(typ)
-    assert isinstance(result, EphemeralValue)
-    assert result.typ is int
-
-    # Test with LastValue class
-    typ = Annotated[str, LastValue]
-    result = _is_field_channel(typ)
-    assert isinstance(result, LastValue)
-    assert result.typ is str
-
-    # Test with UntrackedValue class
-    typ = Annotated[list, UntrackedValue]
-    result = _is_field_channel(typ)
-    assert isinstance(result, UntrackedValue)
-    assert result.typ is list
-
-
 def test_is_field_channel() -> None:
     """Test channel detection across all scenarios."""
     # Basic detection

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -12,7 +12,12 @@ from typing_extensions import NotRequired, Required, TypedDict
 
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.ephemeral_value import EphemeralValue
-from langgraph.graph.state import _is_field_channel
+from langgraph.graph.state import (
+    StateGraph,
+    _get_node_name,
+    _is_field_channel,
+    _warn_invalid_state_schema,
+)
 
 
 class State(BaseModel):


### PR DESCRIPTION
This PR ensures that even if a type has multiple annotations, we can still detect the `BaseChannel` subclasses attached.

```py
class State(TypedDict):
    # recognized as EphemeralValue(int)
    foo: Annotated[int, EphemeralValue]

    # now recognized as EphemeralValue(int)
    bar: Annotated[int, EphemeralValue, OtherMetadata]

    # now recognized as EphemeralValue(int)
    baz: Annotated[int, SomeMetadata, EphemeralValue, OtherMetadata]
```