### PR TITLE
Fix incorrect escape sequence in regular expression in `base.py`.

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -567,7 +567,7 @@ class BasePostgresStore(Generic[C]):
                                 (SELECT STRING_AGG(part, '.' ORDER BY idx)
                                  FROM (
                                      SELECT part, ROW_NUMBER() OVER () AS idx
-                                     FROM UNNEST(REGEXP_SPLIT_TO_ARRAY(prefix, '\.')) AS part
+                                     FROM UNNEST(REGEXP_SPLIT_TO_ARRAY(prefix, '\\.')) AS part
                                      LIMIT %s::integer
                                  ) subquery
                                 )


### PR DESCRIPTION
# fix(checkpoint-postgres): correct escape sequence in Postgres regex split

### Description
Fixes an incorrect escape sequence in the `REGEXP_SPLIT_TO_ARRAY` call used to parse namespace prefixes in  
`libs/checkpoint-postgres/langgraph/store/postgres/base.py`.  

The regex now uses a properly escaped dot (`'\\.'`) so that splitting occurs only on literal periods rather than any character, ensuring accurate namespace aggregation in `_get_batch_list_namespaces_queries`.

---

### Issue

N/A (no linked issue).  

---

### Dependencies

 None

---

### Notes
- Changes the regex from `'\.'` to `'\\.'` inside SQL string literal to prevent unintended splitting behavior.  
- Backwards-compatible; no public API changes.  
- No new dependencies introduced.  

---