### PR TITLE
Fix Command goto routing to execute exclusively (#6248)

### DIFF
--- a/libs/langgraph/tests/test_command_goto_exclusive.py
+++ b/libs/langgraph/tests/test_command_goto_exclusive.py
@@ -1,0 +1,67 @@
+import asyncio
+from typing import TypedDict
+
+import pytest
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.types import Command
+
+
+class State(TypedDict):
+    foo: str
+
+
+async def node_y(state: State) -> dict:
+    await asyncio.sleep(0.1)
+    return {"foo": "Y done"}
+
+
+async def node_x(state: State) -> dict:
+    await asyncio.sleep(0.1)
+    return {"foo": "X done"}
+
+
+@pytest.mark.asyncio
+async def test_command_goto_executes_exclusively():
+    """Test that Command(goto=...) executes ONLY the specified node, not racing with normal flow."""
+    builder = StateGraph(State)
+    builder.add_node("Y", node_y)
+    builder.add_node("X", node_x)
+    builder.add_edge(START, "Y")
+    builder.add_edge("Y", END)
+    builder.add_edge("X", END)
+    graph = builder.compile()
+    
+    # Test that goto X executes ONLY X, never Y
+    results = []
+    async for chunk in graph.astream(Command(goto="X"), stream_mode="updates"):
+        results.append(chunk)
+    
+    # Should only see X executing, never Y
+    assert len(results) == 1
+    assert "X" in results[0]
+    assert results[0]["X"]["foo"] == "X done"
+    assert "Y" not in results[0]  # Y should not execute at all
+
+
+@pytest.mark.asyncio
+async def test_normal_execution_still_works():
+    """Test that normal execution without goto still works as expected."""
+    builder = StateGraph(State)
+    builder.add_node("Y", node_y)
+    builder.add_node("X", node_x)
+    builder.add_edge(START, "Y")
+    builder.add_edge("Y", END)
+    builder.add_edge("X", END)
+    graph = builder.compile()
+    
+    # Test normal execution (should only execute Y due to START -> Y edge)
+    results = []
+    async for chunk in graph.astream({"foo": "start"}, stream_mode="updates"):
+        results.append(chunk)
+    
+    # Should only see Y executing in normal flow
+    assert len(results) == 1
+    assert "Y" in results[0]
+    assert results[0]["Y"]["foo"] == "Y done"
+    assert "X" not in results[0]  # X should not execute without explicit trigger


### PR DESCRIPTION
## Description

Fixes #6248 

This PR resolves an issue where `Command(goto="...")` was executing the goto target node alongside nodes from normal graph flow, instead of executing exclusively.

## Problem

When using `Command(goto="X")` with `astream()`, both the specified node (X) and nodes from the normal graph flow (e.g., START→Y) were executing concurrently, creating a race condition. The first node to complete would determine the execution path, which is non-deterministic and unexpected behavior.

## Solution

Modified the `prepare_next_tasks` function in `libs/langgraph/langgraph/pregel/_algo.py` to:

1. **Track PUSH tasks**: Added `has_push_tasks` flag when PUSH tasks (from Command goto) are present
2. **Exclusive execution**: Only prepare PULL tasks (normal node triggers) when `has_push_tasks` is False
3. **Maintain compatibility**: Normal graph execution without goto commands remains unchanged

## Changes

- **Modified** `prepare_next_tasks()` in `_algo.py` to ensure goto commands override normal flow
- **Added** test cases to verify exclusive execution and backward compatibility

## Testing

- [x] Added test case `test_command_goto_executes_exclusively()` 
- [x] Added test case `test_normal_execution_still_works()`
- [x] Verified fix resolves the race condition described in #6248
- [x] Confirmed backward compatibility with existing functionality

## Behavior Changes

- **Before**: `Command(goto="X")` executed both X and normal flow nodes concurrently
- **After**: `Command(goto="X")` executes ONLY the specified node X

This change makes goto commands behave predictably and as expected by users.
