### PR TITLE
docs(langgraph): fixing human_in_the_loop demo code

### DIFF
--- a/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
+++ b/docs/docs/how-tos/human_in_the_loop/add-human-in-the-loop.md
@@ -1707,7 +1707,7 @@ To debug and test a graph, use [static interrupts](../../concepts/human_in_the_l
 
     # This will run until the breakpoint
     # You can get the state of the graph at this point
-    print(graph.get_state(config))
+    print(graph.get_state(thread))
 
     # You can continue the graph execution by passing in `None` for the input
     for event in graph.stream(None, thread, stream_mode="values"):
@@ -1865,7 +1865,7 @@ To debug and test a graph, use [static interrupts](../../concepts/human_in_the_l
 
     # This will run until the breakpoint
     # You can get the state of the graph at this point
-    print(graph.get_state(config))
+    print(graph.get_state(thread))
 
     # You can continue the graph execution by passing in `None` for the input
     for event in graph.stream(None, thread, stream_mode="values"):


### PR DESCRIPTION
docs(langgraph): fixing human_in_the_loop demo code
 - **Description:**  In the demo code,term 'config' is undefined. Based on the context, the correct term here should be 'thread' in code : `print(graph.get_state(config))`





```python
# Thread
thread = {"configurable": {"thread_id": "1"}}

# Run the graph until the first interruption
for event in graph.stream(initial_input, thread, stream_mode="values"):
    print(event)

# This will run until the breakpoint
# You can get the state of the graph at this point
print(graph.get_state(config))

# You can continue the graph execution by passing in `None` for the input
for event in graph.stream(None, thread, stream_mode="values"):
    print(event)
```

