### PR TITLE
add overwrite command

### DIFF
--- a/libs/langgraph/langgraph/pregel/__init__.py
+++ b/libs/langgraph/langgraph/pregel/__init__.py
@@ -1,3 +1,4 @@
+from langgraph.pregel._write import Overwrite, overwrite
 from langgraph.pregel.main import NodeBuilder, Pregel
 
-__all__ = ("Pregel", "NodeBuilder")
+__all__ = ("Pregel", "NodeBuilder", "overwrite", "Overwrite")

--- a/libs/langgraph/langgraph/pregel/_write.py
+++ b/libs/langgraph/langgraph/pregel/_write.py
@@ -26,6 +26,32 @@ SKIP_WRITE = object()
 PASSTHROUGH = object()
 
 
+class _Overwrite:
+    """Marker wrapper indicating a direct channel overwrite.
+
+    Use via `overwrite(channel, value)` or `Overwrite(value)`.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: Any):
+        self.value = value
+
+
+def Overwrite(value: Any) -> _Overwrite:
+    """Wrap a value to force overwrite a channel, bypassing reducers."""
+    return _Overwrite(value)
+
+
+def overwrite(channel: str, value: Any) -> ChannelWriteEntry:
+    """Convenience factory for a write that overwrites the target channel.
+
+    Example:
+        NodeBuilder().write_to(overwrite("foo", 123))
+    """
+    return ChannelWriteEntry(channel, Overwrite(value))
+
+
 class ChannelWriteEntry(NamedTuple):
     channel: str
     """Channel name to write to."""


### PR DESCRIPTION
writen by codex: prompt:

right now, the way pregel in langgraph works is that there are reducers for each state channel. that is a custom function. thats nice, but sometimes i just want to bypass the reducer and overwrite the state channel directly. add some method for doing so. it should work for any state channel regardless of reducer. come up with a nice devx for specifying this. happy to brainstorm!
