### PR TITLE
fix: rename away from LangGraph Platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Below is a high-level overview:
 - **langgraph** – core framework for building stateful, multi-actor agents.
 - **prebuilt** – high-level APIs for creating and running agents and tools.
 - **sdk-js** – JS/TS SDK for interacting with the LangGraph REST API.
-- **sdk-py** – Python SDK for the LangGraph Platform API.
+- **sdk-py** – Python SDK for the LangGraph Server API.
 
 ### Dependency map
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ LangGraph provides low-level supporting infrastructure for *any* long-running, s
 While LangGraph can be used standalone, it also integrates seamlessly with any LangChain product, giving developers a full suite of tools for building agents. To improve your LLM application development, pair LangGraph with:
 
 - [LangSmith](http://www.langchain.com/langsmith) — Helpful for agent evals and observability. Debug poor-performing LLM app runs, evaluate agent trajectories, gain visibility in production, and improve performance over time.
-- [LangGraph Platform](https://langchain-ai.github.io/langgraph/concepts/langgraph_platform/) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/).
+- [LangSmith Deployment](https://langchain-ai.github.io/langgraph/concepts/langgraph_platform/) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/).
 - [LangChain](https://python.langchain.com/docs/introduction/) – Provides integrations and composable components to streamline LLM application development.
 
 > [!NOTE]

--- a/docs/docs/tutorials/auth/getting_started.md
+++ b/docs/docs/tutorials/auth/getting_started.md
@@ -68,7 +68,7 @@ The server will start and open the studio in your browser:
 > - 📚 API Docs: http://127.0.0.1:2024/docs
 >
 > This in-memory server is designed for development and testing.
-> For production use, please use LangGraph Platform.
+> For production use, please use LangSmith Deployment.
 ```
 
 If you were to self-host this on the public internet, anyone could access it!

--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -39,7 +39,7 @@ class InMemorySaver(
         Only use `InMemorySaver` for debugging or testing purposes.
         For production use cases we recommend installing [langgraph-checkpoint-postgres](https://pypi.org/project/langgraph-checkpoint-postgres/) and using `PostgresSaver` / `AsyncPostgresSaver`.
 
-        If you are using the LangGraph Platform, no checkpointer needs to be specified. The correct managed checkpointer will be used automatically.
+        If you are using LangSmith Deployment, no checkpointer needs to be specified. The correct managed checkpointer will be used automatically.
 
     Args:
         serde: The serializer to use for serializing and deserializing checkpoints. Defaults to None.

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -216,7 +216,7 @@ def up(
 ):
     click.secho("Starting LangGraph API server...", fg="green")
     click.secho(
-        """For local dev, requires env var LANGSMITH_API_KEY with access to LangGraph Platform.
+        """For local dev, requires env var LANGSMITH_API_KEY with access to LangSmith Deployment.
 For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KEY.""",
     )
     with Runner() as runner, Progress(message="Pulling...") as set:
@@ -584,7 +584,7 @@ def dockerfile(
                         "\n",
                         "# LANGSMITH_API_KEY=your-api-key",
                         "\n",
-                        "# Or if you have a LangGraph Platform license key, "
+                        "# Or if you have a LangSmith Deployment license key, "
                         "then uncomment the following line: ",
                         "\n",
                         "# LANGGRAPH_CLOUD_LICENSE_KEY=your-license-key",

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -713,7 +713,7 @@ ENV LANGSERVE_GRAPHS='{{"agent": "/deps/outer-graphs/src/agent.py:graph"}}'
     assert additional_contexts == {}
 
 
-# node.js build used for LangGraph Platform
+# node.js build used for LangSmith Deployment
 def test_config_to_docker_nodejs():
     graphs = {"agent": "./graphs/agent.js:graph"}
     actual_docker_stdin, additional_contexts = config_to_docker(

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -63,7 +63,7 @@ LangGraph provides low-level supporting infrastructure for *any* long-running, s
 While LangGraph can be used standalone, it also integrates seamlessly with any LangChain product, giving developers a full suite of tools for building agents. To improve your LLM application development, pair LangGraph with:
 
 - [LangSmith](http://www.langchain.com/langsmith) — Helpful for agent evals and observability. Debug poor-performing LLM app runs, evaluate agent trajectories, gain visibility in production, and improve performance over time.
-- [LangGraph Platform](https://langchain-ai.github.io/langgraph/concepts/langgraph_platform/) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/).
+- [LangSmith Deployment](https://langchain-ai.github.io/langgraph/concepts/langgraph_platform/) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://langchain-ai.github.io/langgraph/concepts/langgraph_studio/).
 - [LangChain](https://python.langchain.com/docs/introduction/) – Provides integrations and composable components to streamline LLM application development.
 
 > [!NOTE]

--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -110,7 +110,7 @@ class RemoteGraph(PregelProtocol):
     APIs that implement the LangGraph Server API specification.
 
     For example, the `RemoteGraph` class can be used to call APIs from deployments
-    on LangGraph Platform.
+    on LangSmith Deployment.
 
     `RemoteGraph` behaves the same way as a `Graph` and can be used directly as
     a node in another `Graph`.

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -864,7 +864,7 @@ async def test_ainvoke():
 
 
 @pytest.mark.skip(
-    "Unskip this test to manually test the LangGraph Platform integration"
+    "Unskip this test to manually test the LangSmith Deployment integration"
 )
 @pytest.mark.anyio
 async def test_langgraph_cloud_integration():

--- a/libs/sdk-py/README.md
+++ b/libs/sdk-py/README.md
@@ -1,6 +1,6 @@
 # LangGraph Python SDK
 
-This repository contains the Python SDK for interacting with the LangGraph Platform REST API.
+This repository contains the Python SDK for interacting with the LangSmith Deployment REST API.
 
 ## Quick Start
 

--- a/libs/sdk-py/langgraph_sdk/client.py
+++ b/libs/sdk-py/langgraph_sdk/client.py
@@ -160,7 +160,7 @@ def get_client(
 ) -> LangGraphClient:
     """Create and configure a LangGraphClient.
 
-    The client provides programmatic access to a LangGraph Platform deployment. It supports
+    The client provides programmatic access to LangSmith Deployment. It supports
     both remote servers and local in-process connections (when running inside a LangGraph server).
 
     Args:


### PR DESCRIPTION
some of these changes were obvious, and some were less obvious. In a few spots, it felt like a judgement call if we should be saying LangSmith Deployment of LangGraph Server. But hopefully either works.