### PR TITLE
chore(docs): Update OpenAPI spec from LangGraph API v0.4.42

### DIFF
--- a/docs/docs/cloud/reference/api/openapi.json
+++ b/docs/docs/cloud/reference/api/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "LangGraph Platform",
+    "title": "LangSmith Deployment",
     "version": "0.1.0"
   },
   "tags": [


### PR DESCRIPTION
This PR updates the OpenAPI specification with changes detected from the LangGraph API server.

**Changes detected as of LangGraph API version 0.4.42**

This update was automatically generated by the sync workflow in the langgraph-api repository.