### PR TITLE
fix(sdk-py): remove `body` param (`Auth.authenticate`)

### DIFF
--- a/libs/sdk-py/langgraph_sdk/auth/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/auth/__init__.py
@@ -194,7 +194,6 @@ class Auth:
         by name:
 
             - request (Request): The raw ASGI request object
-            - body (dict | None): The parsed request body, if a valid JSON body is present in `request` (otherwise, `None`).
             - path (str): The request path, e.g., "/threads/abcd-1234-abcd-1234/runs/abcd-1234-abcd-1234/stream"
             - method (str): The HTTP method, e.g., "GET"
             - path_params (dict[str, str]): URL path parameters, e.g., {"thread_id": "abcd-1234-abcd-1234", "run_id": "abcd-1234-abcd-1234"}


### PR DESCRIPTION
Requests are not guaranteed to contain a body, and a request's body is not guaranteed to be valid JSON. This updates the type signature for authentication handlers to account for these scenarios.