### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ While LangGraph can be used standalone, it also integrates seamlessly with any L
 - [Guides](https://langchain-ai.github.io/langgraph/guides/): Quick, actionable code snippets for topics such as streaming, adding memory & persistence, and design patterns (e.g. branching, subgraphs, etc.).
 - [Reference](https://langchain-ai.github.io/langgraph/reference/graphs/): Detailed reference on core classes, methods, how to use the graph and checkpointing APIs, and higher-level prebuilt components.
 - [Examples](https://langchain-ai.github.io/langgraph/examples/): Guided examples on getting started with LangGraph.
-- [LangChain Forum](https://forum.langchain.com/): Connect with the community and share all of your technical questions, ideas, and feedback.
+- [LangChain Forum](https://forum.langchain.com/): Connect with the community and share all technical questions, ideas, and feedback.
 - [LangChain Academy](https://academy.langchain.com/courses/intro-to-langgraph): Learn the basics of LangGraph in our free, structured course.
 - [Templates](https://langchain-ai.github.io/langgraph/concepts/template_applications/): Pre-built reference apps for common agentic workflows (e.g. ReAct agent, memory, retrieval etc.) that can be cloned and adapted.
 - [Case studies](https://www.langchain.com/built-with-langgraph): Hear how industry leaders use LangGraph to ship AI applications at scale.


### PR DESCRIPTION
Hi LangGraph team,

This small PR makes a minor grammatical adjustment in the 'Additional resources' section of the README.md.

Rationale: The original phrasing 'share all of your technical questions...' is slightly informal for technical documentation. This correction removes the possessive 'of your' to make the sentence cleaner and more consistent with standard technical writing practices.

Thanks for maintaining LangGraph!