### PR TITLE
fix(checkpoint-postgres): make async PG checkpoint migration idempotent

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -81,7 +81,7 @@ MIGRATIONS = [
     """
     CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_writes_thread_id_idx ON checkpoint_writes(thread_id);
     """,
-    """ALTER TABLE checkpoint_writes ADD COLUMN task_path TEXT NOT NULL DEFAULT '';""",
+    """ALTER TABLE checkpoint_writes ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';""",
 ]
 
 SELECT_SQL = """

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -77,7 +77,7 @@ MIGRATIONS = [
     CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_writes_thread_id_idx ON checkpoint_writes(thread_id);
     """,
     """
-    ALTER TABLE checkpoint_writes ADD COLUMN task_path TEXT NOT NULL DEFAULT '';
+    ALTER TABLE checkpoint_writes ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';
     """,
 ]
 


### PR DESCRIPTION
- **Description:** The final migration for the postgres checkpointer is not currently idempotent. That presents problems when migrating from one checkpointer to another or if migrations otherwise get applied twice. This makes the final migration idempotent to avoid this problem.
- **Issue:** N/A
- **Dependencies:** N/A
- **Twitter handle:** N/A
