### PR TITLE
docs(langgraph): Fix typo in docstring of PregelLoop.tick

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -459,9 +459,6 @@ class PregelLoop:
     def tick(self) -> bool:
         """Execute a single iteration of the Pregel loop.
 
-        Args:
-            input_keys: The key(s) to read input from.
-
         Returns:
             True if more iterations are needed.
         """


### PR DESCRIPTION
This is a very small PR to correct a typo in the docstring of the `PregelLoop.tick()` method.
```python
  def tick(self) -> bool:
      """Execute a single iteration of the Pregel loop.

      Args:
          input_keys: The key(s) to read input from.

      Returns:
          True if more iterations are needed.
      """
```

Corrected to :
```python
  def tick(self) -> bool:
      """Execute a single iteration of the Pregel loop.

      Returns:
          True if more iterations are needed.
      """
```

The docstring was written in #2946 when the signature of tick was
```python
    def tick(
        self,
        *,
        input_keys: Union[str, Sequence[str]],
    ) -> bool:
```
but  it was simplified to 
```python
def tick(self) -> bool:
```
in #5080 