### PR TITLE
docs(langgraph): Fix docstring code examples of task function

### DIFF
--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -151,13 +151,13 @@ def task(
 
 
         @task
-        def add_one(a: int) -> int:
+        def add_one_task(a: int) -> int:
             return a + 1
 
 
         @entrypoint()
         def add_one(numbers: list[int]) -> list[int]:
-            futures = [add_one(n) for n in numbers]
+            futures = [add_one_task(n) for n in numbers]
             results = [f.result() for f in futures]
             return results
 
@@ -173,13 +173,13 @@ def task(
 
 
         @task
-        async def add_one(a: int) -> int:
+        async def add_one_task(a: int) -> int:
             return a + 1
 
 
         @entrypoint()
         async def add_one(numbers: list[int]) -> list[int]:
-            futures = [add_one(n) for n in numbers]
+            futures = [add_one_task(n) for n in numbers]
             return asyncio.gather(*futures)
 
 


### PR DESCRIPTION
Hi all,
I found out that the sync and async code examples of the `task` function in `libs/langgraph/langgraph/func/__init__.py` have a typo:
```
    Example: Sync Task
        ```python
        from langgraph.func import entrypoint, task


        @task
        def add_one(a: int) -> int:
            return a + 1


        @entrypoint()
        def add_one(numbers: list[int]) -> list[int]:
            futures = [add_one(n) for n in numbers]
            results = [f.result() for f in futures]
            return results


        # Call the entrypoint
        add_one.invoke([1, 2, 3])  # Returns [2, 3, 4]
        ```
```

Both task and entrypoint functions have the same name which gives an error.

This is a small PR to fix this