### PR TITLE
fix(docs): synchronize `stream` and `astream` docstrings

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2431,6 +2431,7 @@ class Pregel(
                     Will be emitted as 2-tuples `(LLM token, metadata)`.
                 - `"checkpoints"`: Emit an event when a checkpoint is created, in the same format as returned by `get_state()`.
                 - `"tasks"`: Emit events when tasks start and finish, including their results and errors.
+                - `"debug"`: Emit debug events with as much information as possible for each step.
 
                 You can pass a list as the `stream_mode` parameter to stream multiple modes at once.
                 The streamed outputs will be tuples of `(mode, data)`.
@@ -2697,6 +2698,8 @@ class Pregel(
                 - `"custom"`: Emit custom data from inside nodes or tasks using `StreamWriter`.
                 - `"messages"`: Emit LLM messages token-by-token together with metadata for any LLM invocations inside nodes or tasks.
                     Will be emitted as 2-tuples `(LLM token, metadata)`.
+                - `"checkpoints"`: Emit an event when a checkpoint is created, in the same format as returned by `get_state()`.
+                - `"tasks"`: Emit events when tasks start and finish, including their results and errors.
                 - `"debug"`: Emit debug events with as much information as possible for each step.
 
                 You can pass a list as the `stream_mode` parameter to stream multiple modes at once.


### PR DESCRIPTION
`stream` and `astream` docstrings listed different available `stream_mode` options.

Both methods support the same seven stream modes as defined in `StreamMode`

Fixed for consistency