### PR TITLE
fix: make ToolNode changes more backwards compat

### DIFF
--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -316,7 +316,10 @@ class RunnableCallable(Runnable):
                 continue
 
             # If the kwarg is accepted by the function, store the key / runtime attribute to inject
-            self.func_accepts[kw] = (runtime_key, default)
+            # Use the actual parameter default from the function signature if available,
+            # otherwise fall back to the default from KWARGS_CONFIG_KEYS
+            param_default = p.default if p.default is not inspect.Parameter.empty else default
+            self.func_accepts[kw] = (runtime_key, param_default)
 
     def __repr__(self) -> str:
         repr_args = {

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -84,6 +84,7 @@ from langchain_core.tools.base import (
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.errors import GraphBubbleUp
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langgraph.runtime import DEFAULT_RUNTIME
 from langgraph.store.base import BaseStore  # noqa: TC002
 from langgraph.types import Command, Send, StreamWriter
 from pydantic import BaseModel, ValidationError
@@ -702,7 +703,7 @@ class ToolNode(RunnableCallable):
         self,
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
-        runtime: Runtime,
+        runtime: Runtime = DEFAULT_RUNTIME,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
         config_list = get_config_list(config, len(tool_calls))
@@ -734,7 +735,7 @@ class ToolNode(RunnableCallable):
         self,
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
-        runtime: Runtime,
+        runtime: Runtime = DEFAULT_RUNTIME,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
         config_list = get_config_list(config, len(tool_calls))


### PR DESCRIPTION
* Allows for direct invocation w/o mocked runtime
* Old overrides are still compat w/ new signatures bc of defaults