### PR TITLE
Fix lint for APIConnectionError

### DIFF
--- a/libs/sdk-py/langgraph_sdk/errors.py
+++ b/libs/sdk-py/langgraph_sdk/errors.py
@@ -84,11 +84,17 @@ class APIStatusError(APIError):
         self.request_id = response.headers.get("x-request-id")
 
 
-class APIConnectionError(APIError):
+class APIConnectionError(httpx.RequestError, LangGraphError):
+    message: str
+    request: httpx.Request
+
     def __init__(
         self, *, message: str = "Connection error.", request: httpx.Request
     ) -> None:
-        super().__init__(message, request, body=None)
+        httpx.RequestError.__init__(self, message, request=request)
+        LangGraphError.__init__(self)
+        self.message = message
+        self.request = request
 
 
 class APITimeoutError(APIConnectionError):


### PR DESCRIPTION
Getting familiar with the project; `make lint` in the pre-PR [steps](https://github.com/langchain-ai/langgraph/blob/main/AGENTS.md) run locally fails on `APIConnectionError`:

  ```
  error[invalid-argument-type]: Argument to bound method `__init__` is incorrect
  --> langgraph_sdk/errors.py:91:35
   |
89 |         self, *, message: str = "Connection error.", request: httpx.Request
90 |     ) -> None:
91 |         super().__init__(message, request, body=None)
   |                                   ^^^^^^^ Expected `Response`, found `Request`
   ...
   ```

Updates `APIConnectionError` with a potential fix to pass the lint.

(Claude explaining an outdated `ty` version, now updated in the pipeline, is responsible for this not failing CI):
```
  Timeline:

  1. Sept 24, 2025: PR #6173 introduced the bug
    - The APIConnectionError class was created with the type error
    - CI passed because ty (the type checker) didn't catch this error at that time
  2. ~Oct 29, 2025: ty was updated to version 0.0.1-alpha.25
    - This new version has improved type checking and now detects the invalid-argument-type error
  3. Nov 7, 2025: PR #6388 touched sdk-py files
    - Lint ran with the new version of ty
    - It FAILED with the exact same error you're seeing:
  error[invalid-argument-type]: Argument to bound method `__init__` is incorrect
    --> langgraph_sdk/errors.py:91:35
    - The PR was merged anyway (likely with admin override) because:
        - The PR only changed auth/__init__.py, not errors.py
      - The error was in pre-existing code, not the new changes
  4. Since Nov 7: No changes to sdk-py
    - All CI runs skip the sdk-py lint job due to the changed-files filter
    - From the most recent main CI run: "Analysing package code with our lint": "skipped"

  ```