### PR TITLE
fix(langgraph): allow providing both context and configurable in RemoteGraph, fixes #6342

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -395,6 +395,11 @@ class RemoteGraph(PregelProtocol):
 
         return sanitized
 
+    def _validate_context(self, context: Any):
+        if not isinstance(context, dict):
+            raise ValueError("Context must be a dictionary.")
+        return context
+
     def get_state(
         self,
         config: RunnableConfig,
@@ -687,6 +692,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: dict[str, Any] | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -726,12 +732,20 @@ class RemoteGraph(PregelProtocol):
         else:
             command = None
 
+        context = self._validate_context(context)
+        if context:
+            context.update(sanitized_config["configurable"])
+            sanitized_config.pop("configurable", None)
+
         for chunk in sync_client.runs.stream(
-            thread_id=sanitized_config["configurable"].get("thread_id"),
+            thread_id=context.get("thread_id")
+            if context
+            else sanitized_config["configurable"].get("thread_id"),
             assistant_id=self.assistant_id,
             input=input,
             command=command,
             config=sanitized_config,
+            context=context,
             stream_mode=stream_modes,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
@@ -796,6 +810,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: dict[str, Any] | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -813,6 +828,8 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Static context to add to the assistant.
+                !!! version-added "Added in version 0.6.0"
             stream_mode: Stream mode(s) to use.
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
@@ -835,12 +852,20 @@ class RemoteGraph(PregelProtocol):
         else:
             command = None
 
+        context = self._validate_context(context)
+        if context:
+            context.update(sanitized_config["configurable"])
+            sanitized_config.pop("configurable", None)
+
         async for chunk in client.runs.stream(
-            thread_id=sanitized_config["configurable"].get("thread_id"),
+            thread_id=context.get("thread_id")
+            if context
+            else sanitized_config["configurable"].get("thread_id"),
             assistant_id=self.assistant_id,
             input=input,
             command=command,
             config=sanitized_config,
+            context=context,
             stream_mode=stream_modes,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
@@ -921,6 +946,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: dict[str, Any] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -932,6 +958,8 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Static context to add to the assistant.
+                !!! version-added "Added in version 0.6.0"
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
             headers: Additional headers to pass to the request.
@@ -943,6 +971,7 @@ class RemoteGraph(PregelProtocol):
         for chunk in self.stream(
             input,
             config=config,
+            context=context,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
             headers=headers,
@@ -962,6 +991,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: dict[str, Any] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -973,6 +1003,8 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Static context to add to the assistant.
+                !!! version-added "Added in version 0.6.0"
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
             headers: Additional headers to pass to the request.
@@ -984,6 +1016,7 @@ class RemoteGraph(PregelProtocol):
         async for chunk in self.astream(
             input,
             config=config,
+            context=context,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
             headers=headers,


### PR DESCRIPTION
## **Description:**

Fixes https://github.com/langchain-ai/langgraph/issues/6342

This PR fixes a 400 error in `RemoteGraph` when using both `context` and `configurable` together. It merges any `configurable` fields into `context` internally and removes the `configurable` key, allowing checkpointing and middleware to work under the context-first architecture introduced in LangGraph 1.0.

### Summary of Issue

This PR resolves an issue where using both `context` and `configurable` together in `RemoteGraph` caused a `400 Bad Request` error:

```python
Cannot specify both configurable and context. Prefer setting context alone.
Context was introduced in LangGraph 0.6.0 and is the long term planned replacement for configurable.
```

The `400 error` here isn’t about using both config and context, it’s specifically about using both configurable and context together. In other words, this line in the error:

```python
Cannot specify both configurable and context.
```

refers to the configurable field inside config, not the entire config argument. You can safely pass both config and context as long as config doesn’t contain a configurable key.
So, instead of doing this:

```python
config = {"configurable": {"thread_id": thread_id}}
context = {"user_id": "123"}
```

You can move those fields up into your context:

```python
context = {"user_id": "123", "thread_id": thread_id}
```

and omit the configurable block entirely.

However, with this approach, checkpointing still doesn’t work, since the thread id being sent to the langgraph api comes from the config[”configurable”], not the context.

---

###  **Fix Summary**

- Added an explicit `context` parameter to `RemoteGraph.stream()`, `.astream()`, `.invoke()`, and `.ainvoke()`.
- Unified `configurable` fields into `context` internally to prevent 400 errors from the API.
- Ensures checkpointing continues to work when using `context`.
- Aligns RemoteGraph API with LangGraph 1.0’s context-first architecture.

---

###  **Correct Usage**

Previously, this would fail because you can’t specify both configurable and context:

```python
config = {"configurable": {"thread_id": "123"}}
context = {"user_id": "abc"}
remote_graph.ainvoke(input, config=config, context=context)
```

Now, you can simply do:

```python
context = {"user_id": "abc", "thread_id": "123"}
config = {
    "run_name": "joke_generation",
    "tags": ["humor", "demo"],
} # remove configurable key from config

remote_graph.ainvoke(input, config=config, context=context)
```

Works because `config` **does not contain a `configurable` key**.

Everything that used to go inside `configurable` can now be placed directly in `context`.

---

###  **Backward Compatibility**

While it’s still technically possible to pass both `configurable` and `context` together, it’s **not recommended**. Internally, the `configurable` block is merged into `context` and removed to prevent API errors. This ensures existing workflows do not break while promoting the **context-first** model introduced in LangGraph 0.6.0.

---

###  **Implementation Highlights**

```python
if context:
    context.update(sanitized_config["configurable"])
    sanitized_config.pop("configurable", None)

async for chunk in client.runs.stream(
    thread_id=context.get("thread_id")
    if context
    else sanitized_config["configurable"].get("thread_id"),
    assistant_id=self.assistant_id,
    input=input,
    command=command,
    config=sanitized_config,
    context=context,
    stream_mode=stream_modes,
    interrupt_before=interrupt_before,
    interrupt_after=interrupt_after,
    stream_subgraphs=subgraphs or stream is not None,
    if_not_exists="create",
    headers=(
        _merge_tracing_headers(headers) if self.distributed_tracing else headers
    ),
    params=params,
    **kwargs,
):
    ...
```

- Merges `configurable` fields into `context` before sending the request.
- Removes `configurable` from `config` to prevent API rejection.
- Supports checkpointing and middleware under the unified context interface.

X handle - https://x.com/bolexyro