### PR TITLE
feat: Add Goto type for atomic cross-graph handoffs

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -66,6 +66,7 @@ from langgraph.constants import TAG_HIDDEN
 from langgraph.errors import (
     EmptyInputError,
     GraphInterrupt,
+    InvalidUpdateError,
 )
 from langgraph.managed.base import (
     ManagedValueMapping,
@@ -657,11 +658,15 @@ class PregelLoop:
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)
             # group writes by task ID
-            for tid, c, v in map_command(cmd=self.input):
+            for tid, target_graph, c, v in map_command(cmd=self.input):
                 if not (c == RESUME and resume_is_map):
+                    # For now, just ignore the target_graph - cross-graph handling
+                    # is done by _control_branch which raises ParentCommand
                     writes[tid].append((c, v))
+
             if not writes and not resume_is_map:
                 raise EmptyInputError("Received empty Command input")
+
             # save writes
             for tid, ws in writes.items():
                 self.put_writes(tid, ws)

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -52,6 +52,7 @@ __all__ = (
     "PregelExecutableTask",
     "StateSnapshot",
     "Send",
+    "Goto",
     "Command",
     "Durability",
     "interrupt",
@@ -346,6 +347,77 @@ N = TypeVar("N", bound=Hashable)
 
 
 @dataclass(**_DC_KWARGS)
+class Goto(Generic[N]):
+    """A navigation command with state updates for the target graph.
+
+    The `Goto` class enables atomic cross-graph handoffs by allowing a node to:
+    1. Navigate to a different graph
+    2. Apply state updates to the target graph using its reducers
+    3. Execute the target node
+
+    This eliminates the need for shim nodes and maintains message history integrity.
+
+    Attributes:
+        graph: The target graph to navigate to. Can be:
+            - `None`: current graph
+            - `Command.PARENT`: parent graph
+            - String: specific graph namespace
+        node: The node to execute in the target graph. Can be:
+            - String: node name
+            - `Send` object: node with custom input
+            - Sequence of node names or `Send` objects
+        update: State updates to apply to the TARGET graph before executing the node.
+            Applied using the target graph's reducers.
+
+    !!! example
+
+        ```python
+        from langgraph.types import Command, Goto
+        from langchain_core.messages import ToolMessage, AIMessage
+
+        def my_tool_node(state):
+            # Update current graph, then handoff to parent with parent update
+            return Command(
+                update={"messages": [ToolMessage(content="result", tool_call_id="1")]},
+                goto=Goto(
+                    graph=Command.PARENT,
+                    node="agent",
+                    update={"messages": [AIMessage(content="Routing back to agent")]}
+                )
+            )
+        ```
+
+    !!! version-added "Added in version 0.6.0"
+    """
+
+    graph: str | None = None
+    node: Send | Sequence[Send | N] | N = ()
+    update: Any | None = None
+
+    def __repr__(self) -> str:
+        contents = ", ".join(
+            f"{key}={value!r}" for key, value in asdict(self).items() if value
+        )
+        return f"Goto({contents})"
+
+    def _update_as_tuples(self) -> Sequence[tuple[str, Any]]:
+        """Convert update to a sequence of (channel, value) tuples."""
+        if isinstance(self.update, dict):
+            return list(self.update.items())
+        elif isinstance(self.update, (list, tuple)) and all(
+            isinstance(t, tuple) and len(t) == 2 and isinstance(t[0], str)
+            for t in self.update
+        ):
+            return self.update
+        elif keys := get_cached_annotated_keys(type(self.update)):
+            return get_update_as_tuples(self.update, keys)
+        elif self.update is not None:
+            return [("__root__", self.update)]
+        else:
+            return []
+
+
+@dataclass(**_DC_KWARGS)
 class Command(Generic[N], ToolOutputMixin):
     """One or more commands to update the graph's state and send messages to nodes.
 
@@ -354,7 +426,8 @@ class Command(Generic[N], ToolOutputMixin):
 
             - `None`: the current graph
             - `Command.PARENT`: closest parent graph
-        update: Update to apply to the graph's state.
+        update: Update to apply to the CURRENT graph's state before any navigation.
+            Applied using the current graph's reducers.
         resume: Value to resume execution with. To be used together with [`interrupt()`][langgraph.types.interrupt].
             Can be one of the following:
 
@@ -366,12 +439,35 @@ class Command(Generic[N], ToolOutputMixin):
             - Sequence of node names to navigate to next
             - `Send` object (to execute a node with the input provided)
             - Sequence of `Send` objects
+            - `Goto` object (to navigate to a different graph with atomic state updates)
+            - Sequence of `Goto` objects
+
+    !!! example "Atomic Cross-Graph Handoff"
+
+        ```python
+        from langgraph.types import Command, Goto
+        from langchain_core.messages import ToolMessage, AIMessage
+
+        def tool_node(state):
+            # Atomically: update current graph + navigate to parent + update parent
+            return Command(
+                update={"messages": [ToolMessage(content="result", tool_call_id="1")]},
+                goto=Goto(
+                    graph=Command.PARENT,
+                    node="agent",
+                    update={"messages": [AIMessage(content="Routing back")]}
+                )
+            )
+        ```
+
+    !!! version-changed "Changed in version 0.6.0"
+        Added support for `Goto` objects in the `goto` field for atomic cross-graph handoffs.
     """
 
     graph: str | None = None
     update: Any | None = None
     resume: dict[str, Any] | Any | None = None
-    goto: Send | Sequence[Send | N] | N = ()
+    goto: Send | Sequence[Send | N] | N | Goto[N] | Sequence[Goto[N]] = ()
 
     def __repr__(self) -> str:
         # get all non-None values


### PR DESCRIPTION
## **Description:** 
In Response to #6455.
Implements atomic cross-graph state updates and navigation by introducing a new `Goto` type. This enables nodes to update their local graph state, navigate to a different graph (parent/child/sibling), apply updates to the target graph, and execute the target node - all in a single atomic operation without requiring shim nodes.

## **Problem:**
Currently, performing a single atomic handoff from a subgraph to another graph that updates both source and target graph states requires hacky workarounds with shim nodes, which is error-prone and difficult to enforce consistently.

## **Solution:**
The `Goto` type allows developers to write:
```python
return Command(
    update={"messages": [ToolMessage(content="result", tool_call_id="1")]},
    goto=Goto(
        graph=Command.PARENT,
        node="agent",
        update={"messages": [AIMessage(content="Routing back")]}
    )
)
```
## Changes:

- Add Goto dataclass to types.py with graph, node, and update fields
- Extend Command.goto to accept Goto objects
- Modify map_command() in _io.py to handle Goto navigation
- Update _control_branch() in state.py to raise ParentCommand for cross-graph Gotos
- Update _loop.py to process 4-tuple format from map_command()
- Maintain full backward compatibility with existing Command usage

**Status:** Work in progress - Core infrastructure (70%) implemented, currently debugging cross-graph update propagation. Seeking feedback on approach before finalizing implementation. 
**Issue:** Closes #6358 
**Dependencies:** None 
**Twitter handle:** 0xaaryan
