### PR TITLE
docs: add missing docstrings to PregelNode and ChannelRead

### DIFF
--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -59,11 +59,13 @@ class ChannelRead(RunnableCallable):
         return super().get_name(suffix, name=name)
 
     def _read(self, _: Any, config: RunnableConfig) -> Any:
+        """Read from the channel."""
         return self.do_read(
             config, select=self.channel, fresh=self.fresh, mapper=self.mapper
         )
 
     async def _aread(self, _: Any, config: RunnableConfig) -> Any:
+        """Read from the channel asynchronously."""
         return self.do_read(
             config, select=self.channel, fresh=self.fresh, mapper=self.mapper
         )
@@ -229,6 +231,7 @@ class PregelNode:
         config: RunnableConfig | None = None,
         **kwargs: Any | None,
     ) -> Any:
+        """Invoke the node."""
         self_config: RunnableConfig = {"metadata": self.metadata, "tags": self.tags}
         return self.bound.invoke(
             input,
@@ -242,6 +245,7 @@ class PregelNode:
         config: RunnableConfig | None = None,
         **kwargs: Any | None,
     ) -> Any:
+        """Invoke the node asynchronously."""
         self_config: RunnableConfig = {"metadata": self.metadata, "tags": self.tags}
         return await self.bound.ainvoke(
             input,
@@ -255,6 +259,7 @@ class PregelNode:
         config: RunnableConfig | None = None,
         **kwargs: Any | None,
     ) -> Iterator[Any]:
+        """Stream output from the node."""
         self_config: RunnableConfig = {"metadata": self.metadata, "tags": self.tags}
         yield from self.bound.stream(
             input,
@@ -268,6 +273,7 @@ class PregelNode:
         config: RunnableConfig | None = None,
         **kwargs: Any | None,
     ) -> AsyncIterator[Any]:
+        """Stream output from the node asynchronously."""
         self_config: RunnableConfig = {"metadata": self.metadata, "tags": self.tags}
         async for item in self.bound.astream(
             input,


### PR DESCRIPTION
Description: Added missing docstrings to internal methods in PregelNode and ChannelRead (_read, _aread, invoke, ainvoke, stream, astream) to improve code readability and developer experience
Issue: N/A 
Dependencies: None 
Twitter handle: @sebuzdugan

 - Add tests and docs: Documentation added.
 - Lint and test: Changes are docstrings only.