### PR TITLE
feat(sdk-py): add sentinel to skip auto loading api key on sdk client create

### DIFF
--- a/.github/scripts/check_sdk_methods.py
+++ b/.github/scripts/check_sdk_methods.py
@@ -18,10 +18,8 @@ def get_class_methods(node: ast.ClassDef) -> List[str]:
 
 def find_classes(tree: ast.AST) -> List[Tuple[str, List[str]]]:
     classes = []
-    # Classes to exclude from sync/async parity checks (e.g., sentinel types, utility classes)
-    excluded_classes = {"_SkipAutoLoad"}
     for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name not in excluded_classes:
+        if isinstance(node, ast.ClassDef):
             methods = get_class_methods(node)
             classes.append((node.name, methods))
     return classes

--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -1,6 +1,6 @@
 from langgraph_sdk.auth import Auth
-from langgraph_sdk.client import SKIP_AUTO_LOAD, get_client, get_sync_client
+from langgraph_sdk.client import get_client, get_sync_client
 
 __version__ = "0.2.10"
 
-__all__ = ["SKIP_AUTO_LOAD", "Auth", "get_client", "get_sync_client"]
+__all__ = ["Auth", "get_client", "get_sync_client"]

--- a/libs/sdk-py/tests/test_skip_auto_load_api_key.py
+++ b/libs/sdk-py/tests/test_skip_auto_load_api_key.py
@@ -1,12 +1,12 @@
-"""Tests for SKIP_AUTO_LOAD sentinel value."""
+"""Tests for api_key parameter behavior."""
 
 import pytest
 
-from langgraph_sdk import SKIP_AUTO_LOAD, get_client, get_sync_client
+from langgraph_sdk import get_client, get_sync_client
 
 
 class TestSkipAutoLoadApiKey:
-    """Test the SKIP_AUTO_LOAD sentinel value."""
+    """Test the api_key parameter's auto-loading behavior."""
 
     @pytest.mark.asyncio
     async def test_get_client_loads_from_env_by_default(self, monkeypatch):
@@ -20,10 +20,10 @@ class TestSkipAutoLoadApiKey:
 
     @pytest.mark.asyncio
     async def test_get_client_skips_env_when_sentinel_used(self, monkeypatch):
-        """Test that API key is not loaded from environment when SKIP_AUTO_LOAD is used."""
+        """Test that API key is not loaded from environment when None is explicitly passed."""
         monkeypatch.setenv("LANGGRAPH_API_KEY", "test-key-from-env")
 
-        client = get_client(url="http://localhost:8123", api_key=SKIP_AUTO_LOAD)
+        client = get_client(url="http://localhost:8123", api_key=None)
         assert "x-api-key" not in client.http.client.headers
         await client.aclose()
 
@@ -40,17 +40,6 @@ class TestSkipAutoLoadApiKey:
         assert client.http.client.headers["x-api-key"] == "explicit-key"
         await client.aclose()
 
-    @pytest.mark.asyncio
-    async def test_get_client_no_key_when_skip_and_no_env(self, monkeypatch):
-        """Test that no API key is set when SKIP_AUTO_LOAD is used."""
-        # Clear any API key environment variables
-        for prefix in ["LANGGRAPH", "LANGSMITH", "LANGCHAIN"]:
-            monkeypatch.delenv(f"{prefix}_API_KEY", raising=False)
-
-        client = get_client(url="http://localhost:8123", api_key=SKIP_AUTO_LOAD)
-        assert "x-api-key" not in client.http.client.headers
-        await client.aclose()
-
     def test_get_sync_client_loads_from_env_by_default(self, monkeypatch):
         """Test that sync client loads API key from environment by default."""
         monkeypatch.setenv("LANGGRAPH_API_KEY", "test-key-from-env")
@@ -61,10 +50,10 @@ class TestSkipAutoLoadApiKey:
         client.close()
 
     def test_get_sync_client_skips_env_when_sentinel_used(self, monkeypatch):
-        """Test that sync client doesn't load from environment when SKIP_AUTO_LOAD is used."""
+        """Test that sync client doesn't load from environment when None is explicitly passed."""
         monkeypatch.setenv("LANGGRAPH_API_KEY", "test-key-from-env")
 
-        client = get_sync_client(url="http://localhost:8123", api_key=SKIP_AUTO_LOAD)
+        client = get_sync_client(url="http://localhost:8123", api_key=None)
         assert "x-api-key" not in client.http.client.headers
         client.close()
 
@@ -79,7 +68,3 @@ class TestSkipAutoLoadApiKey:
         assert "x-api-key" in client.http.client.headers
         assert client.http.client.headers["x-api-key"] == "explicit-key"
         client.close()
-
-    def test_sentinel_repr(self):
-        """Test that SKIP_AUTO_LOAD has a useful repr."""
-        assert repr(SKIP_AUTO_LOAD) == "SKIP_AUTO_LOAD"


### PR DESCRIPTION
**Description:** There are times a user might want to create the client, but conditionally set the API key. For example, consider a complex auth situation where the system has user callers using jwts and system callers using API keys. This allows explicitly disabling the auto-loading behavior of API keys in the client today, so no key is set.
**Issue:** N/A
**Dependencies:** None
**Twitter handle:** N/A
