### PR TITLE
fix(checkpoint): return self in InMemorySaver context manager

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -97,7 +97,8 @@ class InMemorySaver(
             self.stack.enter_context(self.blobs)  # type: ignore[arg-type]
 
     def __enter__(self) -> InMemorySaver:
-        return self.stack.__enter__()
+        self.stack.__enter__()
+        return self
 
     def __exit__(
         self,
@@ -108,7 +109,8 @@ class InMemorySaver(
         return self.stack.__exit__(exc_type, exc_value, traceback)
 
     async def __aenter__(self) -> InMemorySaver:
-        return self.stack.__enter__()
+        self.stack.__enter__()
+        return self
 
     async def __aexit__(
         self,

--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -192,3 +192,14 @@ def test_memory_saver() -> None:
     from langgraph.checkpoint.memory import InMemorySaver
 
     assert isinstance(InMemorySaver(), InMemorySaver)
+
+
+async def test_memory_saver_context_manager_returns_self() -> None:
+    checkpointer = InMemorySaver()
+    async with checkpointer as saver:
+        assert saver is checkpointer
+        assert hasattr(saver, "get_next_version")
+
+    with checkpointer as saver:
+        assert saver is checkpointer
+        assert hasattr(saver, "get_next_version")


### PR DESCRIPTION
**Description:**
This PR fixes a bug where `InMemorySaver` returned the internal `ExitStack` object instead of `self` when used as a context manager (`with` or `async with`). This caused `AttributeError` when trying to access methods like `get_next_version` on the context object.

The fix ensures `__enter__` and `__aenter__` return `self`, complying with the type hint and the expected interface.

**Issue:** Fixes #6478

**Dependencies:** None

**Twitter handle:** @SidharthRajmoh2