### PR TITLE
fix(langgraph): validate node output against schema before checkpoint save

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -194,13 +194,13 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     output_schema: type[OutputT]
 
     def __init__(
-            self,
-            state_schema: type[StateT],
-            context_schema: type[ContextT] | None = None,
-            *,
-            input_schema: type[InputT] | None = None,
-            output_schema: type[OutputT] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        state_schema: type[StateT],
+        context_schema: type[ContextT] | None = None,
+        *,
+        input_schema: type[InputT] | None = None,
+        output_schema: type[OutputT] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         if (config_schema := kwargs.get("config_schema", MISSING)) is not MISSING:
             warnings.warn(
@@ -287,16 +287,16 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
     @overload
     def add_node(
-            self,
-            node: StateNode[NodeInputT, ContextT],
-            *,
-            defer: bool = False,
-            metadata: dict[str, Any] | None = None,
-            input_schema: None = None,
-            retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-            cache_policy: CachePolicy | None = None,
-            destinations: dict[str, str] | tuple[str, ...] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        node: StateNode[NodeInputT, ContextT],
+        *,
+        defer: bool = False,
+        metadata: dict[str, Any] | None = None,
+        input_schema: None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema.
         Will take the name of the function/runnable as the node name.
@@ -305,16 +305,16 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
     @overload
     def add_node(
-            self,
-            node: StateNode[NodeInputT, ContextT],
-            *,
-            defer: bool = False,
-            metadata: dict[str, Any] | None = None,
-            input_schema: type[NodeInputT],
-            retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-            cache_policy: CachePolicy | None = None,
-            destinations: dict[str, str] | tuple[str, ...] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        node: StateNode[NodeInputT, ContextT],
+        *,
+        defer: bool = False,
+        metadata: dict[str, Any] | None = None,
+        input_schema: type[NodeInputT],
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is specified.
         Will take the name of the function/runnable as the node name.
@@ -323,50 +323,50 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
     @overload
     def add_node(
-            self,
-            node: str,
-            action: StateNode[NodeInputT, ContextT],
-            *,
-            defer: bool = False,
-            metadata: dict[str, Any] | None = None,
-            input_schema: None = None,
-            retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-            cache_policy: CachePolicy | None = None,
-            destinations: dict[str, str] | tuple[str, ...] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        node: str,
+        action: StateNode[NodeInputT, ContextT],
+        *,
+        defer: bool = False,
+        metadata: dict[str, Any] | None = None,
+        input_schema: None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema."""
         ...
 
     @overload
     def add_node(
-            self,
-            node: str | StateNode[NodeInputT, ContextT],
-            action: StateNode[NodeInputT, ContextT] | None = None,
-            *,
-            defer: bool = False,
-            metadata: dict[str, Any] | None = None,
-            input_schema: type[NodeInputT],
-            retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-            cache_policy: CachePolicy | None = None,
-            destinations: dict[str, str] | tuple[str, ...] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        node: str | StateNode[NodeInputT, ContextT],
+        action: StateNode[NodeInputT, ContextT] | None = None,
+        *,
+        defer: bool = False,
+        metadata: dict[str, Any] | None = None,
+        input_schema: type[NodeInputT],
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is specified."""
         ...
 
     def add_node(
-            self,
-            node: str | StateNode[NodeInputT, ContextT],
-            action: StateNode[NodeInputT, ContextT] | None = None,
-            *,
-            defer: bool = False,
-            metadata: dict[str, Any] | None = None,
-            input_schema: type[NodeInputT] | None = None,
-            retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-            cache_policy: CachePolicy | None = None,
-            destinations: dict[str, str] | tuple[str, ...] | None = None,
-            **kwargs: Unpack[DeprecatedKwargs],
+        self,
+        node: str | StateNode[NodeInputT, ContextT],
+        action: StateNode[NodeInputT, ContextT] | None = None,
+        *,
+        defer: bool = False,
+        metadata: dict[str, Any] | None = None,
+        input_schema: type[NodeInputT] | None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`.
 
@@ -488,12 +488,12 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         ends: tuple[str, ...] | dict[str, str] = EMPTY_SEQ
         try:
             if (
-                    isfunction(action)
-                    or ismethod(action)
-                    or ismethod(getattr(action, "__call__", None))
+                isfunction(action)
+                or ismethod(action)
+                or ismethod(getattr(action, "__call__", None))
             ) and (
-                    hints := get_type_hints(getattr(action, "__call__"))
-                             or get_type_hints(action)
+                hints := get_type_hints(getattr(action, "__call__"))
+                or get_type_hints(action)
             ):
                 if input_schema is None:
                     first_parameter_name = next(
@@ -521,10 +521,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
                     # Check if it's a Command type
                     if (
-                            rtn_origin is Command
-                            and (rargs := get_args(rtn))
-                            and get_origin(rargs[0]) is Literal
-                            and (vals := get_args(rargs[0]))
+                        rtn_origin is Command
+                        and (rargs := get_args(rtn))
+                        and get_origin(rargs[0]) is Literal
+                        and (vals := get_args(rargs[0]))
                     ):
                         ends = vals
         except (NameError, TypeError, StopIteration):
@@ -601,7 +601,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
             # run this validation only for non-StateGraph graphs
             if not hasattr(self, "channels") and start_key in set(
-                    start for start, _ in self.edges
+                start for start, _ in self.edges
             ):
                 raise ValueError(
                     f"Already found path for node '{start_key}'.\n"
@@ -625,12 +625,12 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         return self
 
     def add_conditional_edges(
-            self,
-            source: str,
-            path: Callable[..., Hashable | Sequence[Hashable]]
-                  | Callable[..., Awaitable[Hashable | Sequence[Hashable]]]
-                  | Runnable[Any, Hashable | Sequence[Hashable]],
-            path_map: dict[Hashable, str] | list[str] | None = None,
+        self,
+        source: str,
+        path: Callable[..., Hashable | Sequence[Hashable]]
+        | Callable[..., Awaitable[Hashable | Sequence[Hashable]]]
+        | Runnable[Any, Hashable | Sequence[Hashable]],
+        path_map: dict[Hashable, str] | list[str] | None = None,
     ) -> Self:
         """Add a conditional edge from the starting node to any number of destination nodes.
 
@@ -675,11 +675,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         return self
 
     def add_sequence(
-            self,
-            nodes: Sequence[
-                StateNode[NodeInputT, ContextT]
-                | tuple[str, StateNode[NodeInputT, ContextT]]
-                ],
+        self,
+        nodes: Sequence[
+            StateNode[NodeInputT, ContextT]
+            | tuple[str, StateNode[NodeInputT, ContextT]]
+        ],
     ) -> Self:
         """Add a sequence of nodes that will be executed in the provided order.
 
@@ -735,11 +735,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         return self.add_edge(START, key)
 
     def set_conditional_entry_point(
-            self,
-            path: Callable[..., Hashable | Sequence[Hashable]]
-                  | Callable[..., Awaitable[Hashable | Sequence[Hashable]]]
-                  | Runnable[Any, Hashable | Sequence[Hashable]],
-            path_map: dict[Hashable, str] | list[str] | None = None,
+        self,
+        path: Callable[..., Hashable | Sequence[Hashable]]
+        | Callable[..., Awaitable[Hashable | Sequence[Hashable]]]
+        | Runnable[Any, Hashable | Sequence[Hashable]],
+        path_map: dict[Hashable, str] | list[str] | None = None,
     ) -> Self:
         """Sets a conditional entry point in the graph.
 
@@ -821,15 +821,15 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         return self
 
     def compile(
-            self,
-            checkpointer: Checkpointer = None,
-            *,
-            cache: BaseCache | None = None,
-            store: BaseStore | None = None,
-            interrupt_before: All | list[str] | None = None,
-            interrupt_after: All | list[str] | None = None,
-            debug: bool = False,
-            name: str | None = None,
+        self,
+        checkpointer: Checkpointer = None,
+        *,
+        cache: BaseCache | None = None,
+        store: BaseStore | None = None,
+        interrupt_before: All | list[str] | None = None,
+        interrupt_after: All | list[str] | None = None,
+        debug: bool = False,
+        name: str | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -870,7 +870,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         output_channels = (
             "__root__"
             if len(self.schemas[self.output_schema]) == 1
-               and "__root__" in self.schemas[self.output_schema]
+            and "__root__" in self.schemas[self.output_schema]
             else [
                 key
                 for key, val in self.schemas[self.output_schema].items()
@@ -934,18 +934,18 @@ class CompiledStateGraph(
     schema_to_mapper: dict[type[Any], Callable[[Any], Any] | None]
 
     def __init__(
-            self,
-            *,
-            builder: StateGraph[StateT, ContextT, InputT, OutputT],
-            schema_to_mapper: dict[type[Any], Callable[[Any], Any] | None],
-            **kwargs: Any,
+        self,
+        *,
+        builder: StateGraph[StateT, ContextT, InputT, OutputT],
+        schema_to_mapper: dict[type[Any], Callable[[Any], Any] | None],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.builder = builder
         self.schema_to_mapper = schema_to_mapper
 
     def get_input_jsonschema(
-            self, config: RunnableConfig | None = None
+        self, config: RunnableConfig | None = None
     ) -> dict[str, Any]:
         return _get_json_schema(
             typ=self.builder.input_schema,
@@ -955,7 +955,7 @@ class CompiledStateGraph(
         )
 
     def get_output_jsonschema(
-            self, config: RunnableConfig | None = None
+        self, config: RunnableConfig | None = None
     ) -> dict[str, Any]:
         return _get_json_schema(
             typ=self.builder.output_schema,
@@ -976,7 +976,7 @@ class CompiledStateGraph(
                 k for k, v in self.builder.managed.items()
             ]
 
-        def __get_updates(
+        def _get_updates(
             input: None | dict | Any,
         ) -> Sequence[tuple[str, Any]] | None:
             if input is None:
@@ -1003,7 +1003,7 @@ class CompiledStateGraph(
                             (k, v) for k, v in i._update_as_tuples() if k in output_keys
                         )
                     else:
-                        updates.extend(__get_updates(i) or ())
+                        updates.extend(_get_updates(i) or ())
                 return updates
             elif (t := type(input)) and get_cached_annotated_keys(t):
                 return get_update_as_tuples(input, output_keys)
@@ -1013,24 +1013,6 @@ class CompiledStateGraph(
                     error_code=ErrorCode.INVALID_GRAPH_NODE_RETURN_VALUE,
                 )
                 raise InvalidUpdateError(msg)
-
-        def _get_updates(
-                input: None | dict | Any,
-        ) -> Sequence[tuple[str, Any]] | None:
-            updates = __get_updates(input)
-
-            if key in self.nodes and self.nodes[key].mapper is not None:
-                try:
-                    # Apply same validation as node input
-                    self.nodes[key].mapper({k: v for k, v in updates})
-                except Exception as exc:
-                    msg = create_error_message(
-                        message=f"Node '{key}' returned invalid state: {exc}",
-                        error_code=ErrorCode.INVALID_GRAPH_NODE_RETURN_VALUE
-                    )
-                    raise InvalidUpdateError(msg) from exc
-
-            return updates
 
         # state updaters
         write_entries: tuple[ChannelWriteEntry | ChannelWriteTupleEntry, ...] = (
@@ -1075,6 +1057,8 @@ class CompiledStateGraph(
                 channels=("__root__" if is_single_input else input_channels),
                 # coerce state dict to schema class (eg. pydantic model)
                 mapper=mapper,
+                # validate output state before checkpoint (same as input mapper)
+                mapper_output=mapper,
                 # publish to state keys
                 writers=[ChannelWrite(write_entries)],
                 metadata=node.metadata,
@@ -1112,10 +1096,10 @@ class CompiledStateGraph(
                 )
 
     def attach_branch(
-            self, start: str, name: str, branch: BranchSpec, *, with_reader: bool = True
+        self, start: str, name: str, branch: BranchSpec, *, with_reader: bool = True
     ) -> None:
         def get_writes(
-                packets: Sequence[str | Send], static: bool = False
+            packets: Sequence[str | Send], static: bool = False
         ) -> Sequence[ChannelWriteEntry | Send]:
             writes = [
                 (
@@ -1267,7 +1251,7 @@ class CompiledStateGraph(
 
 
 def _pick_mapper(
-        state_keys: Sequence[str], schema: type[Any]
+    state_keys: Sequence[str], schema: type[Any]
 ) -> Callable[[Any], Any] | None:
     if state_keys == ["__root__"]:
         return None
@@ -1310,7 +1294,7 @@ def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
 
 
 def _control_static(
-        ends: tuple[str, ...] | dict[str, str],
+    ends: tuple[str, ...] | dict[str, str],
 ) -> Sequence[tuple[str, Any, str | None]]:
     if isinstance(ends, dict):
         return [
@@ -1329,9 +1313,9 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
             return ()
         return input._update_as_tuples()
     elif (
-            isinstance(input, (list, tuple))
-            and input
-            and any(isinstance(i, Command) for i in input)
+        isinstance(input, (list, tuple))
+        and input
+        and any(isinstance(i, Command) for i in input)
     ):
         updates: list[tuple[str, Any]] = []
         for i in input:
@@ -1347,7 +1331,7 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
 
 
 def _get_channels(
-        schema: type[dict],
+    schema: type[dict],
 ) -> tuple[dict[str, BaseChannel], dict[str, ManagedValueSpec], dict[str, Any]]:
     if not hasattr(schema, "__annotations__"):
         return (
@@ -1371,23 +1355,23 @@ def _get_channels(
 
 @overload
 def _get_channel(
-        name: str, annotation: Any, *, allow_managed: Literal[False]
+    name: str, annotation: Any, *, allow_managed: Literal[False]
 ) -> BaseChannel: ...
 
 
 @overload
 def _get_channel(
-        name: str, annotation: Any, *, allow_managed: Literal[True] = True
+    name: str, annotation: Any, *, allow_managed: Literal[True] = True
 ) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
-        name: str, annotation: Any, *, allow_managed: bool = True
+    name: str, annotation: Any, *, allow_managed: bool = True
 ) -> BaseChannel | ManagedValueSpec:
     # Strip out Required and NotRequired wrappers
     if hasattr(annotation, "__origin__") and annotation.__origin__ in (
-            Required,
-            NotRequired,
+        Required,
+        NotRequired,
     ):
         annotation = annotation.__args__[0]
     if manager := _is_field_managed_value(name, annotation):
@@ -1428,11 +1412,11 @@ def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
             sig = signature(meta[-1])
             params = list(sig.parameters.values())
             if (
-                    sum(
-                        p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
-                        for p in params
-                    )
-                    == 2
+                sum(
+                    p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+                    for p in params
+                )
+                == 2
             ):
                 return BinaryOperatorAggregate(typ, meta[-1])
             else:
@@ -1452,9 +1436,9 @@ def _is_field_managed_value(name: str, typ: type[Any]) -> ManagedValueSpec | Non
 
     # Handle Required, NotRequired, etc wrapped types by extracting the inner type
     if (
-            get_origin(typ) is not None
-            and (args := get_args(typ))
-            and (inner_type := args[0])
+        get_origin(typ) is not None
+        and (args := get_args(typ))
+        and (inner_type := args[0])
     ):
         return _is_field_managed_value(name, inner_type)
 
@@ -1462,10 +1446,10 @@ def _is_field_managed_value(name: str, typ: type[Any]) -> ManagedValueSpec | Non
 
 
 def _get_json_schema(
-        typ: type,
-        schemas: dict,
-        channels: dict,
-        name: str,
+    typ: type,
+    schemas: dict,
+    channels: dict,
+    name: str,
 ) -> dict[str, Any]:
     if isclass(typ) and issubclass(typ, BaseModel):
         return typ.model_json_schema()

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -109,6 +109,13 @@ class PregelNode:
     mapper: Callable[[Any], Any] | None
     """A function to transform the input before passing it to `bound`."""
 
+    mapper_output: Callable[[Any], Any] | None
+    """A function to validate the output state before saving to checkpoint.
+
+    If validation fails, InvalidUpdateError is raised and the checkpoint
+    is not saved, preventing permanently corrupted checkpoints.
+    """
+
     writers: list[Runnable]
     """A list of writers that will be executed after `bound`, responsible for
     taking the output of `bound` and writing it to the appropriate channels."""
@@ -138,6 +145,7 @@ class PregelNode:
         channels: str | list[str],
         triggers: Sequence[str],
         mapper: Callable[[Any], Any] | None = None,
+        mapper_output: Callable[[Any], Any] | None = None,
         writers: list[Runnable] | None = None,
         tags: list[str] | None = None,
         metadata: Mapping[str, Any] | None = None,
@@ -149,6 +157,7 @@ class PregelNode:
         self.channels = channels
         self.triggers = list(triggers)
         self.mapper = mapper
+        self.mapper_output = mapper_output
         self.writers = writers or []
         self.bound = bound if bound is not None else DEFAULT_BOUND
         self.cache_policy = cache_policy

--- a/libs/langgraph/tests/test_output_validation.py
+++ b/libs/langgraph/tests/test_output_validation.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 from pydantic import BaseModel
 
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import InvalidUpdateError
 from langgraph.graph import END, START, StateGraph
 
@@ -25,15 +26,15 @@ def test_node_output_validation_invalid():
     graph.add_edge(START, "bad")
     graph.add_edge("bad", END)
 
-    app = graph.compile()
+    app = graph.compile(checkpointer=MemorySaver())
 
     # Should raise InvalidUpdateError when node returns invalid output
     with pytest.raises(InvalidUpdateError) as exc_info:
-        app.invoke(State(items=["hello"]))
+        app.invoke(State(items=["hello"]), {"configurable": {"thread_id": "1"}})
 
     # Error message should mention the node name
     assert "bad" in str(exc_info.value).lower()
-    assert "invalid state" in str(exc_info.value).lower()
+    assert "invalid output state" in str(exc_info.value).lower()
 
 
 def test_node_output_validation_valid():
@@ -48,10 +49,10 @@ def test_node_output_validation_valid():
     graph.add_edge(START, "good")
     graph.add_edge("good", END)
 
-    app = graph.compile()
+    app = graph.compile(checkpointer=MemorySaver())
 
     # Should succeed
-    result = app.invoke(State(items=["hello"]))
+    result = app.invoke(State(items=["hello"]), {"configurable": {"thread_id": "1"}})
     assert result["items"] == ["hello", "world"]
 
 
@@ -76,11 +77,11 @@ def test_node_output_validation_with_multiple_nodes():
     graph.add_edge("invalid", "node3")
     graph.add_edge("node3", END)
 
-    app = graph.compile()
+    app = graph.compile(checkpointer=MemorySaver())
 
     # Should fail at invalid_node
     with pytest.raises(InvalidUpdateError) as exc_info:
-        app.invoke(State())
+        app.invoke(State(), {"configurable": {"thread_id": "1"}})
 
     # Error should mention the invalid node
     assert "invalid" in str(exc_info.value).lower()
@@ -99,8 +100,152 @@ def test_node_output_validation_pydantic_model_return():
     graph.add_edge(START, "bad_pydantic")
     graph.add_edge("bad_pydantic", END)
 
-    app = graph.compile()
+    app = graph.compile(checkpointer=MemorySaver())
 
     # Should catch the validation error
     with pytest.raises(Exception):  # Could be ValidationError or InvalidUpdateError
-        app.invoke(State(items=["hello"]))
+        app.invoke(State(items=["hello"]), {"configurable": {"thread_id": "1"}})
+
+
+def test_node_output_validation_with_reducer_single_object():
+    """Test validation with reducer that accepts single object and appends to list.
+
+    This is a common pattern like `add_messages` where:
+    - State has `Annotated[list[Item], add_items]`
+    - Node returns a single `Item` (not a list)
+    - Reducer appends it to the list
+
+    The validation should catch when the single object is invalid.
+    """
+    from typing import Annotated, Union
+
+    class Message(BaseModel):
+        content: str
+        role: str
+
+    def add_messages(
+        left: List[Message], right: Union[Message, List[Message]]
+    ) -> List[Message]:
+        """Reducer that accepts single Message or list of Messages."""
+        if isinstance(right, list):
+            return left + right
+        return left + [right]
+
+    class ChatState(BaseModel):
+        messages: Annotated[List[Message], add_messages] = []
+
+    def valid_node(state: ChatState) -> dict:
+        """Node that returns a single valid Message."""
+        return {"messages": Message(content="hello", role="user")}
+
+    def invalid_node(state: ChatState) -> dict:
+        """Node that returns invalid data for Message field."""
+        # Returning None where Message is expected
+        return {"messages": None}
+
+    # Test valid case
+    graph = StateGraph(ChatState)
+    graph.add_node("valid", valid_node)
+    graph.add_edge(START, "valid")
+    graph.add_edge("valid", END)
+    app = graph.compile(checkpointer=MemorySaver())
+
+    result = app.invoke(ChatState(), {"configurable": {"thread_id": "1"}})
+    assert len(result["messages"]) == 1
+    assert result["messages"][0].content == "hello"
+
+    # Test invalid case - None instead of Message
+    graph2 = StateGraph(ChatState)
+    graph2.add_node("invalid", invalid_node)
+    graph2.add_edge(START, "invalid")
+    graph2.add_edge("invalid", END)
+    app2 = graph2.compile(checkpointer=MemorySaver())
+
+    with pytest.raises(InvalidUpdateError) as exc_info:
+        app2.invoke(ChatState(), {"configurable": {"thread_id": "1"}})
+
+    assert "invalid" in str(exc_info.value).lower()
+
+
+def test_node_output_validation_with_reducer_wrong_type():
+    """Test validation when reducer receives completely wrong type.
+
+    Node returns a string where list[Message] is expected after reduction.
+    """
+    from typing import Annotated, Union
+
+    class Item(BaseModel):
+        value: int
+
+    def add_items(left: List[Item], right: Union[Item, List[Item]]) -> List[Item]:
+        if isinstance(right, list):
+            return left + right
+        return left + [right]
+
+    class ItemState(BaseModel):
+        items: Annotated[List[Item], add_items] = []
+
+    def wrong_type_node(state: ItemState) -> dict:
+        """Node that returns wrong type - string instead of Item."""
+        return {"items": "not an item"}
+
+    graph = StateGraph(ItemState)
+    graph.add_node("wrong", wrong_type_node)
+    graph.add_edge(START, "wrong")
+    graph.add_edge("wrong", END)
+    app = graph.compile(checkpointer=MemorySaver())
+
+    with pytest.raises(InvalidUpdateError) as exc_info:
+        app.invoke(ItemState(), {"configurable": {"thread_id": "1"}})
+
+    assert "wrong" in str(exc_info.value).lower()
+
+
+def test_pregel_node_mapper_output_single_channel():
+    """Test that PregelNode.mapper_output is properly set for single channel state.
+
+    Single channel states (e.g., List[str], str) have mapper=None by design,
+    so mapper_output should also be None (no validation for single channel).
+    This is consistent with the existing behavior where single channels skip
+    validation.
+    """
+    # Single channel state with List[str]
+    graph = StateGraph(List[str])
+    graph.add_node("node1", lambda x: x)
+    graph.add_edge(START, "node1")
+    graph.add_edge("node1", END)
+
+    # Access the compiled graph's nodes
+    compiled = graph.compile()
+    pregel_nodes = compiled.nodes
+
+    # For single channel state, mapper_output should be None (same as mapper)
+    node1 = pregel_nodes["node1"]
+    assert node1.mapper is None
+    assert node1.mapper_output is None
+
+
+def test_pregel_node_mapper_output_multi_channel():
+    """Test that PregelNode.mapper_output is properly set for multi-channel state.
+
+    Multi-channel states (e.g., Pydantic models) have mapper set to validate input,
+    so mapper_output should be the same to validate output.
+    """
+
+    class MultiState(BaseModel):
+        items: List[str] = []
+        count: int = 0
+
+    graph = StateGraph(MultiState)
+    graph.add_node("node1", lambda x: {"items": x.items})
+    graph.add_edge(START, "node1")
+    graph.add_edge("node1", END)
+
+    compiled = graph.compile()
+    pregel_nodes = compiled.nodes
+
+    # For multi-channel state, mapper_output should be set (same as mapper)
+    node1 = pregel_nodes["node1"]
+    assert node1.mapper is not None
+    assert node1.mapper_output is not None
+    assert node1.mapper_output == node1.mapper


### PR DESCRIPTION
## Description

Fixes #6491

This PR adds output state validation before checkpoint save, preventing permanently corrupted checkpoints caused by invalid node outputs.

### Problem

Previously, nodes could return invalid state (e.g., `None` in `List[str]`) that violated Pydantic schema validation. This invalid state was saved to checkpoints without validation, causing **permanent corruption** - any attempt to read the checkpoint via `get_state_history()` would fail with `ValidationError`.

### Solution

Added `PregelNode.mapper_output` field and `PregelLoop._validate_output_state()` method to validate output state before checkpoint save.

### Design Decisions

#### Alternative approaches considered

| Approach | Pros | Cons |
|----------|------|------|
| **Validate in `_get_updates()`** | Close to node output | Complex due to reducers (e.g., `add_messages` accepts single `BaseMessage` for `List[BaseMessage]` field) and required fields; degrades code quality significantly |
| **Validate in `Channel.update()`** | Low-level, catches all writes | Only validates individual fields, not full state; requires modifying all channel types; reducer results also need validation |
| **Validate before checkpoint save (chosen)** | Validates complete state; single validation point | Slightly later in the pipeline |

#### Why `mapper_output` instead of reusing `mapper`?

I considered reusing the existing `mapper` field for output validation, but chose to add a separate `mapper_output` field for these reasons:

1. **Separation of concerns**: `mapper` is for input transformation, `mapper_output` is for output validation - different responsibilities
2. **Pregel independence**: Pregel is a generalized abstraction where input/output schemas may differ. Using `mapper` for output validation would couple Pregel to LangGraph's assumption that input/output schemas are identical
3. **Explicit intent**: Code readers can clearly understand each field's purpose without confusion

For LangGraph's `StateGraph`, `mapper_output` is set to the same function as `mapper` since input/output schemas are identical.

### Changes

- `pregel/_read.py`: Added `mapper_output` field to `PregelNode`
- `pregel/_loop.py`: Added `_validate_output_state()` method, called before checkpoint save
- `graph/state.py`: Set `mapper_output=mapper` when creating `PregelNode`
- `tests/test_output_validation.py`: Added comprehensive tests including reducer patterns and single-channel states

### Tests

All existing tests pass: `946 passed, 4 skipped`

Issue: #6491

Dependencies: None

Twitter handle: None