### PR TITLE
fix(prebuilt): handle functools.partial in ToolNode injection detection

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -40,6 +40,7 @@ Typical Usage:
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import json
 from collections.abc import Awaitable, Callable
@@ -1798,6 +1799,10 @@ def _get_all_injected_args(tool: BaseTool) -> _InjectedArgs:
     schema_annotations = get_all_basemodel_annotations(full_schema)
 
     func = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
+    # Unwrap functools.partial to get the underlying function, since
+    # get_type_hints() doesn't support partial objects (e.g., retriever tools)
+    while isinstance(func, functools.partial):
+        func = func.func
     func_annotations = get_type_hints(func, include_extras=True) if func else {}
 
     # Combine both annotation sources, preferring schema annotations


### PR DESCRIPTION
## Summary

Fixes #6477

This PR fixes a regression in `langgraph-prebuilt==1.0.5` where `create_react_agent` fails when passing a list of `BaseTool` instances created with `create_retriever_tool()`.

## Problem

The `_get_all_injected_args()` function uses `get_type_hints()` to extract type annotations from a tool's `func`/`coroutine` attributes. However, `get_type_hints()` doesn't support `functools.partial` objects:

```
TypeError: functools.partial(<function _get_relevant_documents at 0x...>) is not a module, class, method, or function.
```

Tools created by `create_retriever_tool()` use `functools.partial` objects, causing this error.

## Solution

Unwrap `functools.partial` objects to get the underlying function before calling `get_type_hints()`:

```python
func = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
# Unwrap functools.partial to get the underlying function
while isinstance(func, functools.partial):
    func = func.func
func_annotations = get_type_hints(func, include_extras=True) if func else {}
```

## Changes

- **libs/prebuilt/langgraph/prebuilt/tool_node.py**: Added `functools` import and partial unwrapping logic in `_get_all_injected_args()`
- **libs/prebuilt/tests/test_tool_node.py**: Added regression test `test_tool_node_with_functools_partial`

## Test Plan

- [x] Added test case that reproduces the issue with `functools.partial`
- [x] Verified existing injection tests still pass
- [x] Test passes locally: `pytest tests/test_tool_node.py::test_tool_node_with_functools_partial -v`