### PR TITLE
fix: Enable token-level streaming for Functional API with stream_mode="messages"

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -70,6 +70,7 @@ from langgraph.managed.base import ManagedValueMapping
 from langgraph.pregel._call import get_runnable_for_task, identifier
 from langgraph.pregel._io import read_channels
 from langgraph.pregel._log import logger
+from langgraph.pregel._messages import StreamMessagesHandler
 from langgraph.pregel._read import INPUT_CACHE_KEY_TYPE, PregelNode
 from langgraph.runtime import DEFAULT_RUNTIME, ExecutionInfo, Runtime
 from langgraph.types import (
@@ -831,6 +832,23 @@ def prepare_push_task_functional(
                 run_id=str(rid) if (rid := config.get("run_id")) else None,
             ),
         )
+        # Use original callback selection to preserve step-tag behaviour.
+        # When call.callbacks is truthy the 'or' would skip manager.get_child(),
+        # losing StreamMessagesHandler.  Inject it explicitly as a handler list so
+        # it is added to the copy of call.callbacks without changing its tags
+        # (merge_configs treats a list value as add_handler calls, not a tag merge).
+        callbacks: Callbacks = call.callbacks or (
+            manager.get_child(f"graph:step:{step}") if manager else None
+        )
+        if manager and call.callbacks:
+            streaming_handlers: list[StreamMessagesHandler] = [
+                h for h in manager.handlers if isinstance(h, StreamMessagesHandler)
+            ]
+            if streaming_handlers:
+                callbacks = merge_configs(
+                    cast(RunnableConfig, {"callbacks": callbacks}),
+                    cast(RunnableConfig, {"callbacks": streaming_handlers}),
+                ).get("callbacks")
         return PregelExecutableTask(
             name,
             call.input,
@@ -839,8 +857,7 @@ def prepare_push_task_functional(
             patch_config(
                 merge_configs(config, {"metadata": metadata}),
                 run_name=name,
-                callbacks=call.callbacks
-                or (manager.get_child(f"graph:step:{step}") if manager else None),
+                callbacks=callbacks,
                 configurable={
                     CONFIG_KEY_TASK_ID: task_id,
                     # deque.extend is thread-safe

--- a/libs/langgraph/tests/test_functional_api_streaming.py
+++ b/libs/langgraph/tests/test_functional_api_streaming.py
@@ -1,0 +1,115 @@
+"""
+Test case for GitHub Issue #6373: Functional API stream_mode='messages' fix
+
+This test verifies that token-level streaming works correctly in the Functional API
+when using stream_mode='messages'. Previously, callbacks from inside @task were not
+propagating correctly, causing only a single complete message to be returned instead
+of streaming tokens progressively.
+
+The fix ensures that StreamMessagesHandler is properly merged with task callbacks
+instead of being skipped when call.callbacks is truthy.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+from langgraph.func import entrypoint, task
+from tests.fake_chat import FakeChatModel
+
+
+def test_functional_api_stream_mode_messages() -> None:
+    """Test that stream_mode='messages' works with @task decorator.
+
+    This tests the fix for GitHub Issue #6373 where the Functional API
+    did not stream responses token-by-token. The issue was that
+    StreamMessagesHandler was being skipped due to incorrect callback
+    merging logic in prepare_push_task_functional().
+    """
+    # Create a fake chat model that streams tokens
+    model = FakeChatModel(
+        messages=[AIMessage(content="Hello world this is a streaming test response")]
+    )
+
+    @task
+    def call_llm(messages: list[BaseMessage]) -> AIMessage:
+        """LLM call inside a @task decorator."""
+        return model.invoke(messages)
+
+    @entrypoint()
+    def functional_agent(messages: list[BaseMessage]) -> list[BaseMessage]:
+        """Functional API agent that uses @task for LLM calls."""
+        response = call_llm(messages).result()
+        return [response]
+
+    messages = [HumanMessage(content="Hi there!")]
+
+    # Stream with stream_mode="messages" and subgraphs=True
+    # subgraphs=True is required to receive messages from nested tasks
+    collected_chunks = []
+    for ns, (msg, metadata) in functional_agent.stream(
+        messages, stream_mode="messages", subgraphs=True
+    ):
+        if hasattr(msg, "content") and msg.content:
+            collected_chunks.append(msg.content)
+
+    # With the fix, we should get multiple chunks (token-level streaming)
+    # Without the fix, we would only get 1 chunk (complete message)
+    assert len(collected_chunks) > 1, (
+        f"Expected multiple streaming chunks, but got {len(collected_chunks)}. "
+        "This indicates StreamMessagesHandler is not propagating to @task callbacks."
+    )
+
+    # Verify the complete response is reconstructed from chunks
+    full_response = "".join(collected_chunks)
+    assert "Hello" in full_response
+    assert "streaming" in full_response
+
+
+def test_functional_api_stream_mode_messages_with_user_callbacks() -> None:
+    """Test that user-provided callbacks don't break message streaming.
+
+    This specifically tests the scenario where users pass their own callbacks
+    via config. Previously, if call.callbacks was truthy (even an empty
+    CallbackManager), the StreamMessagesHandler from the manager was skipped.
+    """
+    from langchain_core.callbacks import BaseCallbackHandler
+
+    # Create a fake chat model that streams tokens
+    model = FakeChatModel(messages=[AIMessage(content="Token by token streaming test")])
+
+    # Track if user callback receives events
+    user_callback_events = []
+
+    class UserCallback(BaseCallbackHandler):
+        def on_llm_new_token(self, token: str, **kwargs) -> None:
+            user_callback_events.append(token)
+
+    @task
+    def call_llm(messages: list[BaseMessage]) -> AIMessage:
+        return model.invoke(messages)
+
+    @entrypoint()
+    def functional_agent(messages: list[BaseMessage]) -> list[BaseMessage]:
+        response = call_llm(messages).result()
+        return [response]
+
+    messages = [HumanMessage(content="Test")]
+
+    # Stream with user-provided callback
+    collected_chunks = []
+    for ns, (msg, metadata) in functional_agent.stream(
+        messages,
+        stream_mode="messages",
+        subgraphs=True,
+        config={"callbacks": [UserCallback()]},
+    ):
+        if hasattr(msg, "content") and msg.content:
+            collected_chunks.append(msg.content)
+
+    # Both user callbacks and StreamMessagesHandler should work
+    assert len(collected_chunks) > 1, "Message streaming failed with user callbacks"
+    assert len(user_callback_events) > 0, "User callback did not receive any events"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #6373

The Functional API (\`@task\`, \`@entrypoint\`) now correctly streams tokens when using \`stream_mode=\"messages\"\`. Previously it returned a single complete \`AIMessage\` instead of streaming token-by-token.

**Root Cause:** In \`prepare_push_task_functional()\` in \`_algo.py\`, the callback assignment used \`callbacks=call.callbacks or manager.get_child(...)\`. The \`or\` short-circuits when \`call.callbacks\` is truthy (even a non-empty \`CallbackManager\`), causing \`StreamMessagesHandler\` to be skipped entirely. Without \`StreamMessagesHandler\` in the callback chain, the LLM output is buffered into a single \`AIMessage\` instead of streaming token-by-token.

**Solution:** Keep the original \`or\` logic to preserve existing step-tag behaviour on task events, but explicitly inject any \`StreamMessagesHandler\` instances from the manager as a handler list when \`call.callbacks\` would otherwise short-circuit them away. Passing handlers as a list to \`merge_configs\` uses \`add_handler\` internally, so \`StreamMessagesHandler\` is added to a copy of \`call.callbacks\` without inheriting the manager's \`graph:step:N\` tag — which would have broken \`test_imp_exception\` and changed event metadata for all tasks.

**Note:** Users should use \`subgraphs=True\` when streaming with the Functional API:
\`\`\`python
for ns, (msg, metadata) in agent.stream(input, stream_mode="messages", subgraphs=True):
    ...
\`\`\`

Added \`tests/test_functional_api_streaming.py\` with tests for token-level streaming with the \`@task\` decorator and streaming with user-provided callbacks.