### PR TITLE
fix: replace bare except with specific exceptions in async queue

### DIFF
--- a/libs/langgraph/langgraph/_internal/_queue.py
+++ b/libs/langgraph/langgraph/_internal/_queue.py
@@ -25,7 +25,7 @@ class AsyncQueue(asyncio.Queue):
             self._getters.append(getter)
             try:
                 await getter
-            except:
+            except (asyncio.CancelledError, Exception):
                 getter.cancel()  # Just in case getter is not done yet.
                 try:
                     # Clean self._getters from canceled getters.


### PR DESCRIPTION
## Problem

The bare `except:` block in `AsyncQueue.wait()` (line 28) catches all exceptions, including critical system exceptions like `KeyboardInterrupt` and `SystemExit`. This can mask important signals that should propagate.

## Solution

Replace bare `except:` with specific exception types:
- `asyncio.CancelledError`: Expected cancellation during await
- `Exception`: Application-level exceptions

## Why This Matters

- Follows Python best practices (PEP 8)
- Prevents accidentally suppressing system-level exceptions
- Improves debuggability by allowing critical exceptions to propagate
- Aligns with async/await best practices

## Testing

The change maintains existing behavior for expected exceptions while allowing system exceptions to propagate correctly.