### PR TITLE
fix(checkpoint-sqlite): AttributeError: 'Connection' object has no attribute 'is_alive'

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -281,8 +281,6 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         async with self.lock:
             if self.is_setup:
                 return
-            if not self.conn.is_alive():
-                await self.conn
             async with self.conn.executescript(
                 """
                 PRAGMA journal_mode=WAL;

--- a/libs/checkpoint-sqlite/pyproject.toml
+++ b/libs/checkpoint-sqlite/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 license-files = ['LICENSE']
 dependencies = [
     "langgraph-checkpoint>=3,<4.0.0",
-    "aiosqlite>=0.20",
+    "aiosqlite>=0.22",
     "sqlite-vec>=0.1.6",
 ]
 

--- a/libs/checkpoint-sqlite/uv.lock
+++ b/libs/checkpoint-sqlite/uv.lock
@@ -1,17 +1,14 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
 name = "aiosqlite"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/0d/449c024bdabd0678ae07d804e60ed3b9786facd3add66f51eee67a0fccea/aiosqlite-0.22.0.tar.gz", hash = "sha256:7e9e52d72b319fcdeac727668975056c49720c995176dc57370935e5ba162bb9", size = 14707, upload-time = "2025-12-13T18:32:45.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/39/b2181148075272edfbbd6d87e6cd78cc71dca243446fa3b381fd4116950b/aiosqlite-0.22.0-py3-none-any.whl", hash = "sha256:96007fac2ce70eda3ca1bba7a3008c435258a592b8fbf2ee3eeaa36d33971a09", size = 17263, upload-time = "2025-12-13T18:32:44.619Z" },
 ]
 
 [[package]]
@@ -329,7 +326,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "aiosqlite", specifier = ">=0.22" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "sqlite-vec", specifier = ">=0.1.6" },
 ]


### PR DESCRIPTION
## Description

`aiosqlite` released a new version [0.22.0](https://github.com/omnilib/aiosqlite/releases/tag/v0.22.0) which comes with [breaking-changes](https://github.com/omnilib/aiosqlite/commit/1cd60adcab12347577150a6fa6c7d92b7b86d989#diff-3716bdfa73f4bf05a8cbf62e271bc61298991ae6a7a6cab1d293a23342b86a4cL47-R48)

The class `Connection` no longer inherits from `Thread`, so `AsyncSqliteSaver` [will fail with](https://github.com/langchain-ai/langgraph/blob/main/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py#L284C1-L285C32): 
```
AttributeError: 'Connection' object has no attribute 'is_alive'
```

Fixes: https://github.com/langchain-ai/langgraph/issues/6583

References:
https://github.com/UiPath/uipath-langchain-python/issues/344
https://github.com/omnilib/aiosqlite/issues/368