### PR TITLE
Fix the parameter passing of seed in state 

### DIFF
--- a/docs/docs/tutorials/tot/tot.ipynb
+++ b/docs/docs/tutorials/tot/tot.ipynb
@@ -394,7 +394,7 @@
     "    if solved or state[\"depth\"] >= ctx[\"max_depth\"]:\n",
     "        return \"__end__\"\n",
     "    return [\n",
-    "        Send(\"expand\", {**state, \"somevalseed\": candidate})\n",
+    "        Send(\"expand\", {**state, \"seed\": candidate})\n",
     "        for candidate in state[\"candidates\"]\n",
     "    ]\n",
     "\n",


### PR DESCRIPTION
fix(langgraph): correct parameter name in state transition

Description: Fixed an issue where the second expansion couldn't retrieve the previous candidate's value due to an incorrect parameter name in the state transition. The parameter was incorrectly passed as somevalseed instead of seed.

Changes:

Updated parameter name from somevalseed to seed in the state transition
Ensures proper passing of candidate values between expansion steps
Impact:

Fixes the candidate value retrieval in sequential expansions
Improves the reliability of the search algorithm
Testing:

Verified that the issue is resolved by running the test suite
Confirmed that candidate values are now correctly passed between expansion steps
Note: This is a small but critical fix that ensures the proper functioning of the search algorithm's state management