### PR TITLE
fix: RemoteGraph.astream(subgraphs=True) namespace handling to match in-memory Pregel graphs

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -778,11 +778,13 @@ class RemoteGraph(PregelProtocol):
 
             # emit chunk
             if subgraphs:
-                if NS_SEP in chunk.event:
-                    mode, ns_ = chunk.event.split(NS_SEP, 1)
-                    ns = tuple(ns_.split(NS_SEP))
-                else:
-                    mode, ns = chunk.event, ()
+                # When streaming subgraphs, we want namespaces to reflect both:
+                # 1) The remote graph's own namespace hierarchy.
+                # 2) Any caller namespace (e.g., when RemoteGraph is used as a subgraph).
+                #
+                # We've already parsed `mode` / `ns` from `chunk.event` and
+                # prefixed `ns` with `caller_ns` above, so we should not
+                # recompute them here based on `chunk.event` again.
                 if req_single:
                     yield ns, chunk.data
                 else:
@@ -888,11 +890,9 @@ class RemoteGraph(PregelProtocol):
 
             # emit chunk
             if subgraphs:
-                if NS_SEP in chunk.event:
-                    mode, ns_ = chunk.event.split(NS_SEP, 1)
-                    ns = tuple(ns_.split(NS_SEP))
-                else:
-                    mode, ns = chunk.event, ()
+                # As in astream_events above, reuse the already-prefixed `ns`
+                # so that namespaces match in-memory Pregel graphs when this
+                # RemoteGraph is used as a subgraph.
                 if req_single:
                     yield ns, chunk.data
                 else:

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -1222,8 +1222,7 @@ async def test_remote_graph_stream_messages_tuple(
     coerced_events = [get_message_dict(e) for e in events]
     coerced_inmem_events = [get_message_dict(e) for e in inmem_events]
     assert coerced_events == coerced_inmem_events
-    # TODO: Fix the namespace matching in the next api release.
-    # assert namespaces == inmem_namespaces
+    assert namespaces == inmem_namespaces
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #6604

## Summary

This PR fixes a subtle bug in `RemoteGraph.astream` where namespaces emitted with `subgraphs=True` could diverge from the namespaces produced by an equivalent in-memory `Pregel` graph.

In particular, `RemoteGraph.astream`:

- Parsed `mode` / `ns` from `chunk.event`.
- Correctly prefixed `ns` with the caller namespace (`CONFIG_KEY_CHECKPOINT_NS`) when the remote graph was used as a subgraph.
- Then **re-parsed** `mode` / `ns` from `chunk.event` again inside the `if subgraphs:` branch, overwriting the caller-prefixed `ns`.

This broke namespace-based comparisons and observability for remote subgraphs, and was the reason for the TODO in `test_remote_graph_stream_messages_tuple`.

## Changes

- **`libs/langgraph/langgraph/pregel/remote.py`**
  - In both streaming loops, reuse the already-parsed and caller-prefixed `ns` when `subgraphs=True` instead of recomputing it from `chunk.event`.
  - Keep event parsing and caller namespace prefixing in a single place to ensure consistent namespace semantics between remote and in-memory graphs.

- **`libs/langgraph/tests/test_remote_graph.py`**
  - Re-enable the assertion in `test_remote_graph_stream_messages_tuple` that checks `namespaces == inmem_namespaces`, now that the remote behavior matches the in-memory `Pregel` behavior.

## Rationale

When `RemoteGraph` is used as a subgraph, callers depend on namespaces to:

- Reflect the **caller’s namespace prefix**, and
- Preserve the **remote graph’s internal hierarchy**,

so that traces and streaming events line up with what an in-memory `Pregel` graph would produce. Recomputing `ns` from `chunk.event` after prefixing dropped the caller namespace and caused mismatches.

The updated implementation keeps the original, prefixed `ns`, which:

- Aligns `RemoteGraph.astream(..., subgraphs=True)` with in-memory `Pregel` semantics.
- Allows `test_remote_graph_stream_messages_tuple` to fully assert both event equality and namespace equality.

## Testing

- `make test` (langgraph)
- Verified that `test_remote_graph_stream_messages_tuple` now passes with the `namespaces == inmem_namespaces` assertion enabled.