### PR TITLE
release(sdk-py): bump to 0.3.1

### DIFF
--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -3,6 +3,6 @@ from langgraph_sdk.client import get_client, get_sync_client
 from langgraph_sdk.encryption import Encryption
 from langgraph_sdk.encryption.types import EncryptionContext
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = ["Auth", "Encryption", "EncryptionContext", "get_client", "get_sync_client"]


### PR DESCRIPTION
bumping sdk-py for custom encryption cleanup changes (#6595) - these are breaking changes on this beta, unreleased and unused feature.