### PR TITLE
docs: clarify relationship between LangGraph and LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ LangGraph provides low-level supporting infrastructure for *any* long-running, s
 
 ## LangGraph’s ecosystem
 
-While LangGraph can be used standalone, it also integrates seamlessly with any LangChain product, giving developers a full suite of tools for building agents. To improve your LLM application development, pair LangGraph with:
+While LangGraph can be used standalone, it also integrates seamlessly with any LangChain product, giving developers a full suite of tools for building agents.
+
+LangGraph focuses on **workflow orchestration and state management**, making it ideal for building long-running, multi-step, and stateful agent systems.  
+LangChain, on the other hand, provides **higher-level building blocks** such as prompts, tools, models, and agent abstractions that can be orchestrated using LangGraph.
+
+To improve your LLM application development, pair LangGraph with:
 
 - [LangSmith](http://www.langchain.com/langsmith) — Helpful for agent evals and observability. Debug poor-performing LLM app runs, evaluate agent trajectories, gain visibility in production, and improve performance over time.
-- [LangSmith Deployment](https://docs.langchain.com/langsmith/deployments) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://docs.langchain.com/oss/python/langgraph/studio).
+- [LangSmith Deployment](https://docs.langchain.com/langsmith/deployments) — Deploy and scale agents effortlessly with a purpose-built deployment platform for long-running, stateful workflows. Discover, reuse, configure, and share agents across teams — and iterate quickly with visual prototyping in [LangGraph Studio](https://docs.langchain.com/oss/python/langgraph/studio).
 - [LangChain](https://docs.langchain.com/oss/python/langchain/overview) – Provides integrations and composable components to streamline LLM application development.
+
 
 > [!NOTE]
 > Looking for the JS version of LangGraph? See the [JS repo](https://github.com/langchain-ai/langgraphjs) and the [JS docs](https://docs.langchain.com/oss/javascript/langgraph/overview).


### PR DESCRIPTION
This PR clarifies the distinction between LangGraph and LangChain in the README
by explaining their respective roles and how they complement each other.
