### PR TITLE
fix(checkpoint-postgres): ensure thread_id is always converted to string when loading checkpoints

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -442,10 +442,15 @@ class PostgresSaver(BasePostgresSaver):
             including its configuration, metadata, parent checkpoint (if any),
             and pending writes.
         """
+        # Ensure thread_id is a string (psycopg3 may return bytes/memoryview in some cases)
+        thread_id = value["thread_id"]
+        if isinstance(thread_id, (bytes, memoryview)):
+            thread_id = bytes(thread_id).decode("utf-8")
+
         return CheckpointTuple(
             {
                 "configurable": {
-                    "thread_id": value["thread_id"],
+                    "thread_id": thread_id,
                     "checkpoint_ns": value["checkpoint_ns"],
                     "checkpoint_id": value["checkpoint_id"],
                 }
@@ -461,7 +466,7 @@ class PostgresSaver(BasePostgresSaver):
             (
                 {
                     "configurable": {
-                        "thread_id": value["thread_id"],
+                        "thread_id": thread_id,
                         "checkpoint_ns": value["checkpoint_ns"],
                         "checkpoint_id": value["parent_checkpoint_id"],
                     }

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -403,10 +403,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
             including its configuration, metadata, parent checkpoint (if any),
             and pending writes.
         """
+        # Ensure thread_id is a string (psycopg3 may return bytes/memoryview in some cases)
+        thread_id = value["thread_id"]
+        if isinstance(thread_id, (bytes, memoryview)):
+            thread_id = bytes(thread_id).decode("utf-8")
+
         return CheckpointTuple(
             {
                 "configurable": {
-                    "thread_id": value["thread_id"],
+                    "thread_id": thread_id,
                     "checkpoint_ns": value["checkpoint_ns"],
                     "checkpoint_id": value["checkpoint_id"],
                 }
@@ -422,7 +427,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             (
                 {
                     "configurable": {
-                        "thread_id": value["thread_id"],
+                        "thread_id": thread_id,
                         "checkpoint_ns": value["checkpoint_ns"],
                         "checkpoint_id": value["parent_checkpoint_id"],
                     }

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -279,6 +279,11 @@ class ShallowPostgresSaver(BasePostgresSaver):
         with self._cursor() as cur:
             cur.execute(query, params, binary=True)
             for value in cur:
+                # Ensure thread_id is a string (psycopg3 may return bytes/memoryview in some cases)
+                thread_id = value["thread_id"]
+                if isinstance(thread_id, (bytes, memoryview)):
+                    thread_id = bytes(thread_id).decode("utf-8")
+
                 checkpoint: Checkpoint = {
                     **value["checkpoint"],
                     "channel_values": self._load_blobs(value["channel_values"]),
@@ -292,7 +297,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
                 yield CheckpointTuple(
                     config={
                         "configurable": {
-                            "thread_id": value["thread_id"],
+                            "thread_id": thread_id,
                             "checkpoint_ns": value["checkpoint_ns"],
                             "checkpoint_id": checkpoint["id"],
                         }
@@ -645,6 +650,11 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         async with self._cursor() as cur:
             await cur.execute(query, params, binary=True)
             async for value in cur:
+                # Ensure thread_id is a string (psycopg3 may return bytes/memoryview in some cases)
+                thread_id = value["thread_id"]
+                if isinstance(thread_id, (bytes, memoryview)):
+                    thread_id = bytes(thread_id).decode("utf-8")
+
                 checkpoint: Checkpoint = {
                     **value["checkpoint"],
                     "channel_values": self._load_blobs(value["channel_values"]),
@@ -658,7 +668,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 yield CheckpointTuple(
                     config={
                         "configurable": {
-                            "thread_id": value["thread_id"],
+                            "thread_id": thread_id,
                             "checkpoint_ns": value["checkpoint_ns"],
                             "checkpoint_id": checkpoint["id"],
                         }

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -371,3 +371,42 @@ async def test_get_checkpoint_no_channel_values(
 
         checkpoint = await saver.aget_tuple(config)
         assert checkpoint.checkpoint["channel_values"] == {}
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+async def test_thread_id_bytes_conversion(
+    monkeypatch, saver_name: str, test_data
+) -> None:
+    """Test that thread_id is correctly converted from bytes to string.
+
+    This tests the fix for issue #6623 where thread_id could be stored in
+    mixed formats (string vs bytes) when using PostgreSQL checkpointer
+    with interrupt/resume operations.
+    """
+    async with _saver(saver_name) as saver:
+        config = {
+            "configurable": {
+                "thread_id": "thread-bytes-test",
+                "checkpoint_ns": "",
+            },
+        }
+        chkpnt: Checkpoint = create_checkpoint(empty_checkpoint(), {}, 1)
+        await saver.aput(config, chkpnt, {}, {})
+
+        load_checkpoint_tuple = saver._load_checkpoint_tuple
+
+        async def patched_load_checkpoint_tuple(value):
+            # Simulate psycopg3 returning bytes for thread_id
+            # (this can happen in certain edge cases with binary mode)
+            value = dict(value)
+            value["thread_id"] = b"thread-bytes-test"
+            return await load_checkpoint_tuple(value)
+
+        monkeypatch.setattr(
+            saver, "_load_checkpoint_tuple", patched_load_checkpoint_tuple
+        )
+
+        checkpoint = await saver.aget_tuple(config)
+        # Verify that thread_id is converted to string, not left as bytes
+        assert checkpoint.config["configurable"]["thread_id"] == "thread-bytes-test"
+        assert isinstance(checkpoint.config["configurable"]["thread_id"], str)


### PR DESCRIPTION
Fix #6623 

## Description
Resovles issue where `thread_id` could be stored in mixed formats (plain string vs hex-encoded bytes) in the `checkpoint_writes` table when using PostgreSQL checkpointer with interrupt/resume operations. 

When loading checkpoint tuples from PostgreSQL, `psycopg3` may return `bytes` or `memoryview` for TEXT columns in certain edge cases (particularly in binary mode). This bytes value was then used in subsequent `put_writes` calls, causing it to be stored as a hex-encoded bytea representation (e.g., `617070726f76616c2d313233`) instead of the plain string (`approval-123`). This led to partial graph state being missing because the JOIN condition in the SELECT query couldn't match the different formats.

The fix adds conversion logic to ensure `thread_id` is always a Python string when loaded from the database:
```python
  thread_id = value["thread_id"]
  if isinstance(thread_id, (bytes, memoryview)):
      thread_id = bytes(thread_id).decode("utf-8")
```
**Issue:** Fixes #6623
