### PR TITLE
feat(langgraph): support Pydantic state with aliased fields (input)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1332,6 +1332,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
         # Compute alias map for input schema (Pydantic models with aliased fields)
         input_alias_map = _get_pydantic_alias_map(self.input_schema) or None
+        # Reverse map (field_name -> alias) for output sites — only populated
+        # when the output schema sets `serialize_by_alias=True`.
+        output_alias_map = _get_pydantic_output_alias_map(self.output_schema) or None
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
@@ -1345,6 +1348,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             },
             input_channels=START,
             input_alias_map=input_alias_map,
+            output_alias_map=output_alias_map,
             stream_mode="updates",
             output_channels=output_channels,
             stream_channels=stream_channels,
@@ -1846,6 +1850,46 @@ def _get_pydantic_alias_map(schema: type[Any]) -> dict[str, str]:
             alias_map[alias] = field_name
 
     return alias_map
+
+
+def _get_pydantic_output_alias_map(schema: type[Any]) -> dict[str, str]:
+    """Reverse alias map (field_name -> alias) for output serialization.
+
+    Returns a non-empty mapping only when the schema's `model_config` sets
+    `serialize_by_alias=True` — mirroring Pydantic's own opt-in for
+    alias-keyed serialization on `.model_dump()`. When this returns a
+    non-empty dict, output sites (stream values, stream updates, state
+    snapshots) translate channel keys (field names) into the corresponding
+    aliases so the wire format matches the user-declared aliases.
+
+    Args:
+        schema: The schema class (Pydantic model or other type).
+
+    Returns:
+        A dict mapping field_name -> alias for fields that have an
+        alias, when the schema opts into alias-by-default serialization.
+        Empty dict otherwise.
+    """
+    if not (isclass(schema) and issubclass(schema, BaseModel)):
+        return {}
+
+    # model_config is a TypedDict in Pydantic v2 (dict-like); tolerate either form.
+    config = getattr(schema, "model_config", None) or {}
+    serialize_by_alias = (
+        config.get("serialize_by_alias", False)
+        if hasattr(config, "get")
+        else getattr(config, "serialize_by_alias", False)
+    )
+    if not serialize_by_alias:
+        return {}
+
+    out_map: dict[str, str] = {}
+    for field_name, field_info in schema.model_fields.items():
+        alias = field_info.alias
+        if alias is not None and alias != field_name:
+            out_map[field_name] = alias
+
+    return out_map
 
 
 def _get_channels(

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1330,6 +1330,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
 
+        # Compute alias map for input schema (Pydantic models with aliased fields)
+        input_alias_map = _get_pydantic_alias_map(self.input_schema) or None
+
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
             schema_to_mapper={},
@@ -1341,6 +1344,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 START: EphemeralValue(self.input_schema),
             },
             input_channels=START,
+            input_alias_map=input_alias_map,
             stream_mode="updates",
             output_channels=output_channels,
             stream_channels=stream_channels,
@@ -1435,10 +1439,13 @@ class CompiledStateGraph(
                 for k, v in self.builder.schemas[self.builder.input_schema].items()
                 if not is_managed_value(v)
             ]
+            # Get alias map for input schema to translate alias keys to field names
+            alias_map = _get_pydantic_alias_map(self.builder.input_schema)
         else:
             output_keys = list(self.builder.channels) + [
                 k for k, v in self.builder.managed.items()
             ]
+            alias_map = {}
 
         def _get_updates(
             input: None | dict | Any,
@@ -1446,7 +1453,12 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
-                return [(k, v) for k, v in input.items() if k in output_keys]
+                # Translate alias keys to field names using alias_map
+                return [
+                    (alias_map.get(k, k), v)
+                    for k, v in input.items()
+                    if alias_map.get(k, k) in output_keys
+                ]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:
                     return None
@@ -1729,6 +1741,17 @@ _S = TypeVar("_S")
 
 
 def _coerce_state(schema: type[_S], input: dict[str, Any]) -> _S:
+    # Pydantic rejects field names for aliased fields (it expects the alias).
+    # Channels are keyed by field name, so translate where needed.
+    if isclass(schema) and issubclass(schema, BaseModel):
+        if any(fi.alias for fi in schema.model_fields.values()):
+            return schema(
+                **{
+                    (fi.alias or k): input[k]
+                    for k, fi in schema.model_fields.items()
+                    if k in input
+                }
+            )
     return schema(**input)
 
 
@@ -1796,6 +1819,33 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
         return updates
     elif input is not None:
         return [("__root__", input)]
+
+
+def _get_pydantic_alias_map(schema: type[Any]) -> dict[str, str]:
+    """Extract a mapping of alias -> field_name for Pydantic models.
+
+    For Pydantic models with aliased fields, this returns a dict mapping
+    the alias name to the actual field name. This allows input data using
+    aliases to be properly mapped to channels.
+
+    Args:
+        schema: The schema class (Pydantic model or other type)
+
+    Returns:
+        A dict mapping alias -> field_name for fields that have aliases.
+        Empty dict for non-Pydantic schemas or schemas without aliases.
+    """
+    if not (isclass(schema) and issubclass(schema, BaseModel)):
+        return {}
+
+    alias_map: dict[str, str] = {}
+    for field_name, field_info in schema.model_fields.items():
+        # Get the alias if it exists
+        alias = field_info.alias
+        if alias is not None and alias != field_name:
+            alias_map[alias] = field_name
+
+    return alias_map
 
 
 def _get_channels(

--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -109,12 +109,32 @@ def map_input(
                 logger.warning(f"Input channel {k} not found in {input_channels}")
 
 
+def _rekey_with_aliases(value: Any, output_alias_map: dict[str, str] | None) -> Any:
+    """Translate top-level keys in a dict from field names to aliases.
+
+    No-op when `output_alias_map` is falsy or the value is not a dict.
+    Used by the output-side handlers below so the wire format matches
+    the user's declared aliases when `serialize_by_alias=True` is set
+    on a Pydantic output schema.
+    """
+    if not output_alias_map or not isinstance(value, dict):
+        return value
+    return {output_alias_map.get(k, k): v for k, v in value.items()}
+
+
 def map_output_values(
     output_channels: str | Sequence[str],
     pending_writes: Literal[True] | Sequence[tuple[str, Any]],
     channels: Mapping[str, BaseChannel],
+    *,
+    output_alias_map: dict[str, str] | None = None,
 ) -> Iterator[dict[str, Any] | Any]:
-    """Map pending writes (a sequence of tuples (channel, value)) to output chunk."""
+    """Map pending writes (a sequence of tuples (channel, value)) to output chunk.
+
+    When `output_alias_map` is provided (Pydantic output schema with
+    `serialize_by_alias=True`), the yielded dict's keys are translated
+    from channel/field names to aliases.
+    """
     if isinstance(output_channels, str):
         if pending_writes is True or any(
             chan == output_channels for chan, _ in pending_writes
@@ -124,15 +144,23 @@ def map_output_values(
         if pending_writes is True or {
             c for c, _ in pending_writes if c in output_channels
         }:
-            yield read_channels(channels, output_channels)
+            yield _rekey_with_aliases(
+                read_channels(channels, output_channels), output_alias_map
+            )
 
 
 def map_output_updates(
     output_channels: str | Sequence[str],
     tasks: list[tuple[PregelExecutableTask, Sequence[tuple[str, Any]]]],
     cached: bool = False,
+    *,
+    output_alias_map: dict[str, str] | None = None,
 ) -> Iterator[dict[str, Any | dict[str, Any]]]:
-    """Map pending writes (a sequence of tuples (channel, value)) to output chunk."""
+    """Map pending writes (a sequence of tuples (channel, value)) to output chunk.
+
+    When `output_alias_map` is provided, channel-keyed dicts inside each
+    node's update are rekeyed with aliases for user-facing output.
+    """
     output_tasks = [
         (t, ww)
         for t, ww in tasks
@@ -153,11 +181,17 @@ def map_output_updates(
             )
         elif any(chan in output_channels for chan, _ in writes):
             counts = Counter(chan for chan, _ in writes)
+
+            def _rekey_chan(chan: str) -> str:
+                if output_alias_map:
+                    return output_alias_map.get(chan, chan)
+                return chan
+
             if any(counts[chan] > 1 for chan in output_channels):
                 updated.extend(
                     (
                         task.name,
-                        {chan: value},
+                        {_rekey_chan(chan): value},
                     )
                     for chan, value in writes
                     if chan in output_channels
@@ -167,7 +201,7 @@ def map_output_updates(
                     (
                         task.name,
                         {
-                            chan: value
+                            _rekey_chan(chan): value
                             for chan, value in writes
                             if chan in output_channels
                         },

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -109,6 +109,7 @@ from langgraph.pregel._executor import (
     Submit,
 )
 from langgraph.pregel._io import (
+    _rekey_with_aliases,
     map_command,
     map_input,
     map_output_updates,
@@ -166,6 +167,7 @@ class PregelLoop:
     specs: Mapping[str, BaseChannel | ManagedValueSpec]
     input_keys: str | Sequence[str]
     input_alias_map: dict[str, str] | None
+    output_alias_map: dict[str, str] | None
     output_keys: str | Sequence[str]
     stream_keys: str | Sequence[str]
     is_replaying: bool
@@ -277,6 +279,7 @@ class PregelLoop:
         specs: Mapping[str, BaseChannel | ManagedValueSpec],
         input_keys: str | Sequence[str],
         input_alias_map: dict[str, str] | None,
+        output_alias_map: dict[str, str] | None,
         output_keys: str | Sequence[str],
         stream_keys: str | Sequence[str],
         trigger_to_nodes: Mapping[str, Sequence[str]],
@@ -301,6 +304,7 @@ class PregelLoop:
         self.specs = specs
         self.input_keys = input_keys
         self.input_alias_map = input_alias_map
+        self.output_alias_map = output_alias_map
         self.output_keys = output_keys
         self.stream_keys = stream_keys
         self.interrupt_after = interrupt_after
@@ -685,7 +689,12 @@ class PregelLoop:
             else self.output_keys
         ):
             self._emit(
-                "values", map_output_values, self.output_keys, writes, self.channels
+                "values",
+                map_output_values,
+                self.output_keys,
+                writes,
+                self.channels,
+                output_alias_map=self.output_alias_map,
             )
         # capture delta-channel writes for exit-mode accumulator before clearing
         if self._exit_delta_writes is not None:
@@ -953,7 +962,12 @@ class PregelLoop:
                 self._put_checkpoint({"source": "fork"})
             # produce values output
             self._emit(
-                "values", map_output_values, self.output_keys, True, self.channels
+                "values",
+                map_output_values,
+                self.output_keys,
+                True,
+                self.channels,
+                output_alias_map=self.output_alias_map,
             )
         # map inputs to channel updates
         elif input_writes := deque(
@@ -1334,6 +1348,7 @@ class PregelLoop:
                         self.output_keys,
                         [w for t in self.tasks.values() for w in t.writes],
                         self.channels,
+                        output_alias_map=self.output_alias_map,
                     )
             # emit INTERRUPT if exception is empty (otherwise emitted by put_writes)
             if not interrupt.args or not interrupt.args[0]:
@@ -1343,12 +1358,18 @@ class PregelLoop:
                     lambda: iter([{INTERRUPT: interrupt_payload}]),
                 )
             # save final output
-            self.output = read_channels(self.channels, self.output_keys)
+            self.output = _rekey_with_aliases(
+                read_channels(self.channels, self.output_keys),
+                self.output_alias_map,
+            )
             # suppress interrupt
             return True
         elif exc_type is None:
             # save final output
-            self.output = read_channels(self.channels, self.output_keys)
+            self.output = _rekey_with_aliases(
+                read_channels(self.channels, self.output_keys),
+                self.output_alias_map,
+            )
 
     def _emit(
         self,
@@ -1414,7 +1435,10 @@ class PregelLoop:
                 if "updates" in stream_modes:
                     self._emit("updates", lambda: iter(interrupts))
                 if "values" in stream_modes:
-                    current_values = read_channels(self.channels, self.output_keys)
+                    current_values = _rekey_with_aliases(
+                        read_channels(self.channels, self.output_keys),
+                        self.output_alias_map,
+                    )
                     # self.output_keys is a sequence, stream chunk contains entire state and interrupts
                     if isinstance(current_values, dict):
                         current_values[INTERRUPT] = interrupts[0][INTERRUPT]
@@ -1429,6 +1453,7 @@ class PregelLoop:
                     self.output_keys,
                     [(task, writes)],
                     cached,
+                    output_alias_map=self.output_alias_map,
                 )
             if not cached:
                 self._emit(
@@ -1458,6 +1483,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         interrupt_before: All | Sequence[str] = EMPTY_SEQ,
         input_keys: str | Sequence[str] = EMPTY_SEQ,
         input_alias_map: dict[str, str] | None = None,
+        output_alias_map: dict[str, str] | None = None,
         output_keys: str | Sequence[str] = EMPTY_SEQ,
         stream_keys: str | Sequence[str] = EMPTY_SEQ,
         migrate_checkpoint: Callable[[Checkpoint], None] | None = None,
@@ -1476,6 +1502,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             specs=specs,
             input_keys=input_keys,
             input_alias_map=input_alias_map,
+            output_alias_map=output_alias_map,
             output_keys=output_keys,
             stream_keys=stream_keys,
             interrupt_after=interrupt_after,
@@ -1712,6 +1739,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         manager: None | AsyncParentRunManager | ParentRunManager = None,
         input_keys: str | Sequence[str] = EMPTY_SEQ,
         input_alias_map: dict[str, str] | None = None,
+        output_alias_map: dict[str, str] | None = None,
         output_keys: str | Sequence[str] = EMPTY_SEQ,
         stream_keys: str | Sequence[str] = EMPTY_SEQ,
         migrate_checkpoint: Callable[[Checkpoint], None] | None = None,
@@ -1730,6 +1758,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             specs=specs,
             input_keys=input_keys,
             input_alias_map=input_alias_map,
+            output_alias_map=output_alias_map,
             output_keys=output_keys,
             stream_keys=stream_keys,
             interrupt_after=interrupt_after,

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -165,6 +165,7 @@ class PregelLoop:
     nodes: Mapping[str, PregelNode]
     specs: Mapping[str, BaseChannel | ManagedValueSpec]
     input_keys: str | Sequence[str]
+    input_alias_map: dict[str, str] | None
     output_keys: str | Sequence[str]
     stream_keys: str | Sequence[str]
     is_replaying: bool
@@ -275,6 +276,7 @@ class PregelLoop:
         nodes: Mapping[str, PregelNode],
         specs: Mapping[str, BaseChannel | ManagedValueSpec],
         input_keys: str | Sequence[str],
+        input_alias_map: dict[str, str] | None,
         output_keys: str | Sequence[str],
         stream_keys: str | Sequence[str],
         trigger_to_nodes: Mapping[str, Sequence[str]],
@@ -298,6 +300,7 @@ class PregelLoop:
         self.nodes = nodes
         self.specs = specs
         self.input_keys = input_keys
+        self.input_alias_map = input_alias_map
         self.output_keys = output_keys
         self.stream_keys = stream_keys
         self.interrupt_after = interrupt_after
@@ -953,7 +956,9 @@ class PregelLoop:
                 "values", map_output_values, self.output_keys, True, self.channels
             )
         # map inputs to channel updates
-        elif input_writes := deque(map_input(input_keys, self.input)):
+        elif input_writes := deque(
+            map_input(input_keys, self.input, alias_map=self.input_alias_map)
+        ):
             # discard any unfinished tasks from previous checkpoint
             discard_tasks = prepare_next_tasks(
                 self.checkpoint,
@@ -1452,6 +1457,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         interrupt_after: All | Sequence[str] = EMPTY_SEQ,
         interrupt_before: All | Sequence[str] = EMPTY_SEQ,
         input_keys: str | Sequence[str] = EMPTY_SEQ,
+        input_alias_map: dict[str, str] | None = None,
         output_keys: str | Sequence[str] = EMPTY_SEQ,
         stream_keys: str | Sequence[str] = EMPTY_SEQ,
         migrate_checkpoint: Callable[[Checkpoint], None] | None = None,
@@ -1469,6 +1475,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             nodes=nodes,
             specs=specs,
             input_keys=input_keys,
+            input_alias_map=input_alias_map,
             output_keys=output_keys,
             stream_keys=stream_keys,
             interrupt_after=interrupt_after,
@@ -1704,6 +1711,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         interrupt_before: All | Sequence[str] = EMPTY_SEQ,
         manager: None | AsyncParentRunManager | ParentRunManager = None,
         input_keys: str | Sequence[str] = EMPTY_SEQ,
+        input_alias_map: dict[str, str] | None = None,
         output_keys: str | Sequence[str] = EMPTY_SEQ,
         stream_keys: str | Sequence[str] = EMPTY_SEQ,
         migrate_checkpoint: Callable[[Checkpoint], None] | None = None,
@@ -1721,6 +1729,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             nodes=nodes,
             specs=specs,
             input_keys=input_keys,
+            input_alias_map=input_alias_map,
             output_keys=output_keys,
             stream_keys=stream_keys,
             interrupt_after=interrupt_after,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -723,7 +723,23 @@ class Pregel(
     input_channels: str | Sequence[str]
 
     input_alias_map: dict[str, str] | None = None
-    """Mapping of alias -> field_name for Pydantic models with aliased fields."""
+    """Mapping of alias -> field_name for Pydantic models with aliased fields.
+
+    Only the input boundary uses this — keys in `invoke({...})` /
+    `astream({...})` / `Command(update={...})` are translated alias →
+    field_name before they reach a channel.
+    """
+
+    output_alias_map: dict[str, str] | None = None
+    """Mapping of field_name -> alias for output serialization.
+
+    Populated only when the output schema is a Pydantic model with
+    `model_config = ConfigDict(serialize_by_alias=True)`. When set,
+    output sites (`stream` values/updates modes, `StateSnapshot.values`,
+    `invoke` return) emit keys using aliases rather than channel
+    (field) names, matching what Pydantic's own `.model_dump()` does
+    for the schema.
+    """
 
     step_timeout: float | None = None
     """Maximum time to wait for a step to complete, in seconds."""
@@ -770,6 +786,7 @@ class Pregel(
         interrupt_before_nodes: All | Sequence[str] = (),
         input_channels: str | Sequence[str],
         input_alias_map: dict[str, str] | None = None,
+        output_alias_map: dict[str, str] | None = None,
         step_timeout: float | None = None,
         debug: bool | None = None,
         checkpointer: Checkpointer = None,
@@ -817,6 +834,7 @@ class Pregel(
         self.interrupt_before_nodes = interrupt_before_nodes
         self.input_channels = input_channels
         self.input_alias_map = input_alias_map
+        self.output_alias_map = output_alias_map
         self.step_timeout = step_timeout
         self.debug = debug if debug is not None else get_debug()
         self.checkpointer = checkpointer
@@ -1145,6 +1163,20 @@ class Pregel(
                 checkpoint["channel_versions"].values()
             )
 
+    def _apply_output_aliases(self, values: Any) -> Any:
+        """Translate top-level channel keys to aliases for user-facing output.
+
+        Only applies when `self.output_alias_map` is set (i.e. the output
+        schema is a Pydantic model with `serialize_by_alias=True`). For
+        non-dict values (e.g. single-channel output where ``output_keys``
+        is a string), the value is returned unchanged. Nested values are
+        not touched — Pydantic's own model_dump handles deeper alias
+        propagation when consumers re-serialize.
+        """
+        if not self.output_alias_map or not isinstance(values, dict):
+            return values
+        return {self.output_alias_map.get(k, k): v for k, v in values.items()}
+
     def _prepare_state_snapshot(
         self,
         config: RunnableConfig,
@@ -1258,7 +1290,9 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._apply_output_aliases(
+                read_channels(channels, self.stream_channels_asis)
+            ),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,
@@ -1382,7 +1416,9 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._apply_output_aliases(
+                read_channels(channels, self.stream_channels_asis)
+            ),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,
@@ -2890,6 +2926,7 @@ class Pregel(
                 output_keys=output_keys,
                 input_keys=self.input_channels,
                 input_alias_map=self.input_alias_map,
+                output_alias_map=self.output_alias_map,
                 stream_keys=self.stream_channels_asis,
                 interrupt_before=interrupt_before_,
                 interrupt_after=interrupt_after_,
@@ -3343,6 +3380,7 @@ class Pregel(
                 output_keys=output_keys,
                 input_keys=self.input_channels,
                 input_alias_map=self.input_alias_map,
+                output_alias_map=self.output_alias_map,
                 stream_keys=self.stream_channels_asis,
                 interrupt_before=interrupt_before_,
                 interrupt_after=interrupt_after_,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -722,6 +722,9 @@ class Pregel(
 
     input_channels: str | Sequence[str]
 
+    input_alias_map: dict[str, str] | None = None
+    """Mapping of alias -> field_name for Pydantic models with aliased fields."""
+
     step_timeout: float | None = None
     """Maximum time to wait for a step to complete, in seconds."""
 
@@ -766,6 +769,7 @@ class Pregel(
         interrupt_after_nodes: All | Sequence[str] = (),
         interrupt_before_nodes: All | Sequence[str] = (),
         input_channels: str | Sequence[str],
+        input_alias_map: dict[str, str] | None = None,
         step_timeout: float | None = None,
         debug: bool | None = None,
         checkpointer: Checkpointer = None,
@@ -812,6 +816,7 @@ class Pregel(
         self.interrupt_after_nodes = interrupt_after_nodes
         self.interrupt_before_nodes = interrupt_before_nodes
         self.input_channels = input_channels
+        self.input_alias_map = input_alias_map
         self.step_timeout = step_timeout
         self.debug = debug if debug is not None else get_debug()
         self.checkpointer = checkpointer
@@ -1748,7 +1753,11 @@ class Pregel(
                         "Cannot apply multiple updates when updating as input"
                     )
 
-                if input_writes := deque(map_input(self.input_channels, values)):
+                if input_writes := deque(
+                    map_input(
+                        self.input_channels, values, alias_map=self.input_alias_map
+                    )
+                ):
                     apply_writes(
                         checkpoint,
                         channels,
@@ -2196,7 +2205,11 @@ class Pregel(
                         "Cannot apply multiple updates when updating as input"
                     )
 
-                if input_writes := deque(map_input(self.input_channels, values)):
+                if input_writes := deque(
+                    map_input(
+                        self.input_channels, values, alias_map=self.input_alias_map
+                    )
+                ):
                     apply_writes(
                         checkpoint,
                         channels,
@@ -2876,6 +2889,7 @@ class Pregel(
                 specs=self.channels,
                 output_keys=output_keys,
                 input_keys=self.input_channels,
+                input_alias_map=self.input_alias_map,
                 stream_keys=self.stream_channels_asis,
                 interrupt_before=interrupt_before_,
                 interrupt_after=interrupt_after_,
@@ -3328,6 +3342,7 @@ class Pregel(
                 specs=self.channels,
                 output_keys=output_keys,
                 input_keys=self.input_channels,
+                input_alias_map=self.input_alias_map,
                 stream_keys=self.stream_channels_asis,
                 interrupt_before=interrupt_before_,
                 interrupt_after=interrupt_after_,

--- a/libs/langgraph/tests/test_pydantic.py
+++ b/libs/langgraph/tests/test_pydantic.py
@@ -13,8 +13,10 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from pydantic import (
     BaseModel,
     ByteSize,
+    ConfigDict,
     Field,
     SecretStr,
+    alias_generators,
     confloat,
     conint,
     conlist,
@@ -561,3 +563,37 @@ async def test_pydantic_aliased_fields_async():
     result = await graph.ainvoke({"q": "hello"})
     assert result["query"] == "hello"
     assert result["result"] == "processed: hello"
+
+
+def test_pydantic_alias_generator_to_camel():
+    """alias_generator=to_camel is the canonical pattern for JSON APIs.
+
+    Without the fix for #2555, Pydantic rejects the camelCase input because
+    the state schema has snake_case field names. This confirms the most
+    common real-world use case works end-to-end.
+    """
+
+    class State(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=alias_generators.to_camel,
+            populate_by_name=True,
+        )
+        user_id: str
+        display_name: str
+        retry_count: int = 0
+
+    def node_fn(state: State) -> dict:
+        assert state.user_id == "u-1"
+        assert state.display_name == "Alice"
+        return {"retry_count": state.retry_count + 1}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node_fn)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    result = graph.invoke({"userId": "u-1", "displayName": "Alice"})
+    assert result["user_id"] == "u-1"
+    assert result["display_name"] == "Alice"
+    assert result["retry_count"] == 1

--- a/libs/langgraph/tests/test_pydantic.py
+++ b/libs/langgraph/tests/test_pydantic.py
@@ -8,6 +8,7 @@ import uuid
 from enum import Enum
 from typing import Annotated, Literal, Optional
 
+import pytest
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from pydantic import (
     BaseModel,
@@ -360,3 +361,203 @@ def test_interrupt_functional_pydantic(sync_checkpointer: BaseCheckpointSaver) -
     res = graph.invoke(Command(resume="bar"), config)
     assert res == {"a": "foobar", "b": "bar"}
     assert called_count == 1
+
+
+def test_pydantic_aliased_fields():
+    """Test that Pydantic state with aliased fields works correctly.
+
+    When using Field(alias=...), the graph should accept input using either
+    the alias or the field name.
+
+    This addresses GitHub issue #2555.
+    """
+
+    class State(BaseModel):
+        foo: str = Field(alias="bar")
+        other: str = Field(default="default")
+
+    def node_fn(state: State) -> dict:
+        # The state should have the correct value
+        assert state.foo == "hello"
+        assert state.other == "default"
+        return {"other": "updated"}
+
+    builder = StateGraph(State)
+    builder.add_node("process", node_fn)
+    builder.add_edge(START, "process")
+    builder.add_edge("process", END)
+    graph = builder.compile()
+
+    # Test with alias key
+    result = graph.invoke({"bar": "hello"})
+    assert result["foo"] == "hello"
+    assert result["other"] == "updated"
+
+
+def test_pydantic_multiple_aliased_fields():
+    """Test multiple aliased fields work correctly."""
+
+    class State(BaseModel):
+        first_name: str = Field(alias="firstName")
+        last_name: str = Field(alias="lastName")
+        age: int = Field(alias="userAge")
+
+    def node_fn(state: State) -> dict:
+        assert state.first_name == "John"
+        assert state.last_name == "Doe"
+        assert state.age == 30
+        return {"age": 31}
+
+    builder = StateGraph(State)
+    builder.add_node("process", node_fn)
+    builder.add_edge(START, "process")
+    builder.add_edge("process", END)
+    graph = builder.compile()
+
+    # Test with alias keys (camelCase)
+    result = graph.invoke({"firstName": "John", "lastName": "Doe", "userAge": 30})
+    assert result["first_name"] == "John"
+    assert result["last_name"] == "Doe"
+    assert result["age"] == 31
+
+
+def test_pydantic_mixed_alias_and_fieldname():
+    """Test mixing aliased and non-aliased fields."""
+
+    class State(BaseModel):
+        aliased_field: str = Field(alias="aliasedField")
+        normal_field: str
+
+    def node_fn(state: State) -> dict:
+        assert state.aliased_field == "alias_value"
+        assert state.normal_field == "normal_value"
+        return {}
+
+    builder = StateGraph(State)
+    builder.add_node("process", node_fn)
+    builder.add_edge(START, "process")
+    builder.add_edge("process", END)
+    graph = builder.compile()
+
+    # Test with alias for aliased field and field name for normal field
+    result = graph.invoke(
+        {"aliasedField": "alias_value", "normal_field": "normal_value"}
+    )
+    assert result["aliased_field"] == "alias_value"
+    assert result["normal_field"] == "normal_value"
+
+
+def test_pydantic_alias_with_reducer():
+    """Test aliased fields work with reducers."""
+
+    def concat_reducer(a: list[str], b: str | list[str]) -> list[str]:
+        if isinstance(b, list):
+            return a + b
+        return a + [b]
+
+    class State(BaseModel):
+        messages: Annotated[list[str], concat_reducer] = Field(
+            default_factory=list, alias="msgs"
+        )
+
+    def node_fn(state: State) -> dict:
+        return {"messages": "processed"}
+
+    builder = StateGraph(State)
+    builder.add_node("process", node_fn)
+    builder.add_edge(START, "process")
+    builder.add_edge("process", END)
+    graph = builder.compile()
+
+    # Test with alias key and list initial value
+    result = graph.invoke({"msgs": ["hello"]})
+    assert result["messages"] == ["hello", "processed"]
+
+
+def test_pydantic_aliased_fields_multinode_with_checkpointer():
+    """Integration test: aliased fields with multiple nodes and checkpointing."""
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    class State(BaseModel):
+        user_name: str = Field(alias="userName")
+        step_count: int = Field(default=0, alias="stepCount")
+        processed_by: Annotated[list[str], lambda a, b: a + [b]] = Field(
+            default_factory=list, alias="processedBy"
+        )
+
+    def node_a(state: State) -> dict:
+        assert state.user_name == "Alice"
+        return {"step_count": state.step_count + 1, "processed_by": "node_a"}
+
+    def node_b(state: State) -> dict:
+        assert state.user_name == "Alice"
+        assert state.step_count == 1
+        assert "node_a" in state.processed_by
+        return {"step_count": state.step_count + 1, "processed_by": "node_b"}
+
+    def node_c(state: State) -> dict:
+        assert state.step_count == 2
+        assert state.processed_by == ["node_a", "node_b"]
+        return {"step_count": state.step_count + 1, "processed_by": "node_c"}
+
+    builder = StateGraph(State)
+    builder.add_node("node_a", node_a)
+    builder.add_node("node_b", node_b)
+    builder.add_node("node_c", node_c)
+    builder.add_edge(START, "node_a")
+    builder.add_edge("node_a", "node_b")
+    builder.add_edge("node_b", "node_c")
+    builder.add_edge("node_c", END)
+
+    # Test without checkpointer - full run
+    graph = builder.compile()
+    result = graph.invoke({"userName": "Alice"})
+    assert result["user_name"] == "Alice"
+    assert result["step_count"] == 3
+    assert result["processed_by"] == ["node_a", "node_b", "node_c"]
+
+    # Test with checkpointer and interrupt
+    checkpointer = InMemorySaver()
+    graph_with_cp = builder.compile(
+        checkpointer=checkpointer, interrupt_after=["node_a"]
+    )
+
+    config = {"configurable": {"thread_id": "test-1"}}
+
+    # First invocation - should stop after node_a
+    result1 = graph_with_cp.invoke({"userName": "Alice"}, config)
+    assert result1["step_count"] == 1
+    assert result1["processed_by"] == ["node_a"]
+
+    # Check state
+    state = graph_with_cp.get_state(config)
+    assert state.next == ("node_b",)
+
+    # Resume - should complete
+    result2 = graph_with_cp.invoke(None, config)
+    assert result2["step_count"] == 3
+    assert result2["processed_by"] == ["node_a", "node_b", "node_c"]
+
+
+@pytest.mark.anyio
+async def test_pydantic_aliased_fields_async():
+    """Integration test: aliased fields with async graph."""
+
+    class State(BaseModel):
+        query: str = Field(alias="q")
+        result: str = Field(default="", alias="res")
+
+    async def process(state: State) -> dict:
+        assert state.query == "hello"
+        return {"result": f"processed: {state.query}"}
+
+    builder = StateGraph(State)
+    builder.add_node("process", process)
+    builder.add_edge(START, "process")
+    builder.add_edge("process", END)
+    graph = builder.compile()
+
+    # Test async invoke with alias
+    result = await graph.ainvoke({"q": "hello"})
+    assert result["query"] == "hello"
+    assert result["result"] == "processed: hello"

--- a/libs/langgraph/tests/test_pydantic.py
+++ b/libs/langgraph/tests/test_pydantic.py
@@ -597,3 +597,144 @@ def test_pydantic_alias_generator_to_camel():
     assert result["user_id"] == "u-1"
     assert result["display_name"] == "Alice"
     assert result["retry_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Output-side alias support (serialize_by_alias=True)
+# ---------------------------------------------------------------------------
+
+
+def test_output_keys_use_alias_when_serialize_by_alias_set():
+    """`invoke` return + `stream` chunks use alias keys when the output schema
+    sets ``model_config = ConfigDict(serialize_by_alias=True)``."""
+
+    class State(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=alias_generators.to_camel,
+            populate_by_name=True,
+            serialize_by_alias=True,
+        )
+        user_id: str
+        display_name: str
+
+    def node(state: State) -> dict:
+        return {"display_name": state.display_name + "!"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile()
+    )
+
+    # invoke: top-level keys are aliases (camelCase), not field names.
+    result = graph.invoke({"userId": "u-1", "displayName": "Alice"})
+    assert "userId" in result and "displayName" in result
+    assert "user_id" not in result and "display_name" not in result
+    assert result["userId"] == "u-1"
+    assert result["displayName"] == "Alice!"
+
+    # stream(values): same keys on each yielded chunk.
+    chunks = list(
+        graph.stream({"userId": "u-1", "displayName": "Alice"}, stream_mode="values")
+    )
+    assert chunks, "expected at least one values chunk"
+    for chunk in chunks:
+        # Every dict-shaped chunk should use aliases.
+        if isinstance(chunk, dict) and chunk:
+            assert "userId" in chunk or "displayName" in chunk
+            assert "user_id" not in chunk
+            assert "display_name" not in chunk
+
+
+def test_output_keys_unchanged_without_serialize_by_alias():
+    """Without serialize_by_alias=True, output keys remain field names —
+    no behaviour change vs current main."""
+
+    class State(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=alias_generators.to_camel,
+            populate_by_name=True,
+            # serialize_by_alias intentionally absent
+        )
+        user_id: str
+
+    def node(state: State) -> dict:
+        return {"user_id": state.user_id + "-x"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile()
+    )
+    result = graph.invoke({"userId": "u-1"})
+    # Output keyed by field name, not alias.
+    assert "user_id" in result
+    assert "userId" not in result
+    assert result["user_id"] == "u-1-x"
+
+
+def test_stream_updates_use_alias_when_serialize_by_alias_set():
+    """`stream_mode='updates'` chunks key channel updates by alias."""
+
+    class State(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=alias_generators.to_camel,
+            populate_by_name=True,
+            serialize_by_alias=True,
+        )
+        user_id: str
+        display_name: str = ""
+
+    def node(state: State) -> dict:
+        return {"display_name": "Bob"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile()
+    )
+
+    update_chunks = list(graph.stream({"userId": "u-1"}, stream_mode="updates"))
+    # One update from node "n"; its dict should be keyed by alias.
+    payloads = [v for chunk in update_chunks for v in chunk.values()]
+    assert any(isinstance(p, dict) and "displayName" in p for p in payloads)
+    assert not any(isinstance(p, dict) and "display_name" in p for p in payloads)
+
+
+def test_get_state_snapshot_values_use_alias_when_serialize_by_alias_set():
+    """`StateSnapshot.values` uses alias keys when serialize_by_alias=True."""
+
+    class State(BaseModel):
+        model_config = ConfigDict(
+            alias_generator=alias_generators.to_camel,
+            populate_by_name=True,
+            serialize_by_alias=True,
+        )
+        user_id: str
+        display_name: str
+
+    def node(state: State) -> dict:
+        return {"display_name": state.display_name + "!"}
+
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    graph = (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=InMemorySaver())
+    )
+
+    config = {"configurable": {"thread_id": "t-1"}}
+    graph.invoke({"userId": "u-1", "displayName": "Alice"}, config=config)
+    snap = graph.get_state(config)
+
+    assert "userId" in snap.values and "displayName" in snap.values
+    assert "user_id" not in snap.values and "display_name" not in snap.values


### PR DESCRIPTION
## Summary

Fixes #2555 — Pydantic `Field(alias=...)` and `alias_generator` are now respected on **both sides** of a LangGraph state schema: input and output.

### Before

```python
class State(BaseModel):
    foo: str = Field(alias='bar')

graph = StateGraph(State).compile()
graph.invoke({'bar': 'hello'})   # ValidationError (alias rejected)
graph.invoke({'foo': 'hello'})   # ValidationError (field name rejected on aliased field)
```

```python
class State(BaseModel):
    model_config = ConfigDict(
        alias_generator=alias_generators.to_camel,
        serialize_by_alias=True,
    )
    user_id: str
    display_name: str

graph.invoke({"userId": "u-1", "displayName": "Alice"})
# -> {"user_id": ..., "display_name": ...}    # output uses field names even though
                                              # schema says serialize_by_alias=True
```

### After

Both inputs and outputs respect the schema's alias intent.

---

## Input side

Channels are keyed by field name, but Pydantic rejects field-name kwargs for aliased fields. The fix translates between the two boundaries:

1. **`_get_pydantic_alias_map(schema)`** extracts `{alias: field_name}` from a Pydantic schema.
2. **`map_input` / `_get_updates`** translate user-supplied alias keys → channel (field) names before they reach a channel.
3. **`_coerce_state`** translates channel field names → aliases when constructing the Pydantic model (so Pydantic validation accepts them).

`alias_generator` is supported by construction: Pydantic populates `field_info.alias` at model-build time, so the same code path picks up generated aliases.

## Output side (new in `36d7ddec`)

Strictly opt-in via `model_config = ConfigDict(serialize_by_alias=True)` — mirroring Pydantic's own opt-in for alias-keyed `.model_dump()`. Graphs with aliased fields but without that flag are **unchanged** (no breakage).

When enabled, alias-keyed output flows through:

| Surface | Site |
|---|---|
| `invoke()` / `astream()` final return | `PregelLoop.output` (via `_rekey_with_aliases`) → `on_chain_end` |
| `stream(stream_mode='values')` | `map_output_values(output_alias_map=…)` |
| `stream(stream_mode='updates')` | `map_output_updates(output_alias_map=…)` |
| `get_state().values`, snapshot serialization | `Pregel._apply_output_aliases(...)` at both `StateSnapshot` construction sites |

The mechanism is a single tiny helper `_rekey_with_aliases(dict, map)` reused across the output surface, plus a `Pregel.output_alias_map` plumbed through `PregelLoop` from `StateGraph.compile`.

---

## Test plan

`libs/langgraph/tests/test_pydantic.py` (+4 new for the output side; +7 from the input commit):

**Input:**
- `test_pydantic_aliased_fields` — basic `Field(alias=...)`
- `test_pydantic_multiple_aliased_fields` — several explicit aliases
- `test_pydantic_alias_generator_to_camel` — canonical `alias_generator=to_camel`
- `test_pydantic_mixed_alias_and_fieldname` — mix of aliased and non-aliased
- `test_pydantic_alias_with_reducer` — aliased fields with reducer annotations
- `test_pydantic_aliased_fields_multinode_with_checkpointer` — multi-node + checkpointing + interrupt/resume
- `test_pydantic_aliased_fields_async` — async path

**Output (new):**
- `test_output_keys_use_alias_when_serialize_by_alias_set` — `invoke` + `stream(values)` emit alias keys
- `test_output_keys_unchanged_without_serialize_by_alias` — opt-in behaviour, no regression for non-opted-in graphs
- `test_stream_updates_use_alias_when_serialize_by_alias_set` — `stream(updates)` rekeys per-node update dicts
- `test_get_state_snapshot_values_use_alias_when_serialize_by_alias_set` — `StateSnapshot.values` uses aliases

```
tests/test_pydantic.py + tests/test_state.py: 33 passed (29 input + 4 output)
tests/test_pregel.py + tests/test_pregel_async.py (excluding redis/postgres variants): 890 passed, 0 regressions
make format / make lint / mypy:                                                       clean
```

The one failure in the broader suite (`test_in_one_fan_out_state_graph_waiting_edge_multiple[redis-True]`) reproduces on `origin/main` with identical content, so it's a pre-existing redis-cache flake, not introduced here.
