### PR TITLE
fix(prebuilt): remove self-loop edge in graph visualization when using post_model_hook

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -874,7 +874,7 @@ def create_react_agent(
     workflow.set_entry_point(entrypoint)
 
     agent_paths = []
-    post_model_hook_paths = [entrypoint, "tools"]
+    post_model_hook_paths = ["tools"]
 
     # Add a post model hook node if post_model_hook is provided
     if post_model_hook is not None:
@@ -937,8 +937,6 @@ def create_react_agent(
                     )
                     for call in pending_tool_calls
                 ]
-            elif isinstance(messages[-1], ToolMessage):
-                return entrypoint
             elif response_format is not None:
                 return "generate_structured_response"
             else:

--- a/libs/prebuilt/tests/__snapshots__/test_react_agent_graph.ambr
+++ b/libs/prebuilt/tests/__snapshots__/test_react_agent_graph.ambr
@@ -52,7 +52,6 @@
   	__start__ --> agent;
   	agent --> post_model_hook;
   	post_model_hook -.-> __end__;
-  	post_model_hook -.-> agent;
   	post_model_hook -.-> tools;
   	tools --> agent;
   
@@ -74,7 +73,6 @@
   	__start__ --> pre_model_hook;
   	agent --> post_model_hook;
   	post_model_hook -.-> __end__;
-  	post_model_hook -.-> pre_model_hook;
   	post_model_hook -.-> tools;
   	pre_model_hook --> agent;
   	tools --> pre_model_hook;
@@ -138,7 +136,6 @@
   graph TD;
   	__start__ --> agent;
   	agent --> post_model_hook;
-  	post_model_hook -.-> agent;
   	post_model_hook -.-> generate_structured_response;
   	post_model_hook -.-> tools;
   	tools --> agent;
@@ -163,7 +160,6 @@
   	__start__ --> pre_model_hook;
   	agent --> post_model_hook;
   	post_model_hook -.-> generate_structured_response;
-  	post_model_hook -.-> pre_model_hook;
   	post_model_hook -.-> tools;
   	pre_model_hook --> agent;
   	tools --> pre_model_hook;


### PR DESCRIPTION
Fix for #6516 

## Description
Fix graph visualization showing a confusing self-loop arrow from `post_model_hook` back to `agent` (or `pre_model_hook`) when using `response_format` with `post_model_hook`.

The issue was caused by:
  1. Including `entrypoint` in `post_model_hook_paths` initialization
  2. An unreachable condition in `post_model_hook_router` that returned `entrypoint` when the last message was a `ToolMessage`

  This condition never triggers because after tools execute, they route to the agent which produces an `AIMessage` before reaching `post_model_hook_router`.

## Issue
Fixes #6516

## Dependencies
 None