### PR TITLE
fix(prebuilt): strip trailing AI messages to support regeneration

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -637,6 +637,18 @@ def create_react_agent(
         if messages is None:
             raise ValueError(error_msg)
 
+        # Remove trailing AI messages (without tool calls) to support regeneration.
+        # This handles the case where the graph is re-invoked with an AI message
+        # that should be regenerated (e.g., when the agent is used as a subgraph
+        # or when regenerate is triggered in LangGraph Studio).
+        messages = list(messages)
+        while (
+            messages
+            and isinstance(messages[-1], AIMessage)
+            and not messages[-1].tool_calls
+        ):
+            messages.pop()
+
         _validate_chat_history(messages)
         # we're passing messages under `messages` key, as this is expected by the prompt
         if isinstance(state_schema, type) and issubclass(state_schema, BaseModel):


### PR DESCRIPTION
Closes #6618 

## Description

  When `create_react_agent` is used as a subgraph or when "regenerate response" is triggered in LangSmith Studio, the input state may contain trailing AI messages that should be regenerated. Previously, these messages were passed directly to the LLM, causing unexpected behavior where the LLM would not generate a new response.

  This fix strips trailing AI messages (without tool calls) from the input before invoking the LLM, ensuring:
  - Regeneration works correctly in LangSmith Studio
  - Subgraph usage handles edge cases gracefully
  - AI messages with pending tool calls are preserved (they require corresponding ToolMessages first)

  ## Issue

  Fixes #6618

  ## Dependencies

  None

  ## Test Plan

  - [x] Added `test_regeneration_strips_trailing_ai_message` - verifies trailing AI messages are stripped before LLM invocation
  - [x] Added `test_regeneration_only_strips_trailing_ai_messages` - verifies only trailing messages are stripped, not earlier AI messages in the conversation
  - [x] All 85 existing tests pass
  - [x] `make format`, `make lint`, and `make test` pass