### PR TITLE
fix(langgraph): allow ToolNode to be invoked programmatically without config

### DIFF
--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -54,6 +54,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_RUNTIME,
 )
 from langgraph._internal._typing import MISSING
+from langgraph.runtime import DEFAULT_RUNTIME
 from langgraph.types import StreamWriter
 
 try:
@@ -354,14 +355,14 @@ class RunnableCallable(Runnable):
             kw_value: Any = MISSING
             if kw == "config":
                 kw_value = config
+            elif kw == "runtime":
+                # Use config runtime if available, otherwise use default runtime
+                kw_value = runtime if runtime else DEFAULT_RUNTIME
             elif runtime:
-                if kw == "runtime":
-                    kw_value = runtime
-                else:
-                    try:
-                        kw_value = getattr(runtime, runtime_key)
-                    except AttributeError:
-                        pass
+                try:
+                    kw_value = getattr(runtime, runtime_key)
+                except AttributeError:
+                    pass
 
             if kw_value is MISSING:
                 if default is inspect.Parameter.empty:
@@ -426,14 +427,14 @@ class RunnableCallable(Runnable):
             kw_value: Any = MISSING
             if kw == "config":
                 kw_value = config
+            elif kw == "runtime":
+                # Use config runtime if available, otherwise use default runtime
+                kw_value = runtime if runtime else DEFAULT_RUNTIME
             elif runtime:
-                if kw == "runtime":
-                    kw_value = runtime
-                else:
-                    try:
-                        kw_value = getattr(runtime, runtime_key)
-                    except AttributeError:
-                        pass
+                try:
+                    kw_value = getattr(runtime, runtime_key)
+                except AttributeError:
+                    pass
             if kw_value is MISSING:
                 if default is inspect.Parameter.empty:
                     raise ValueError(

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -260,6 +260,49 @@ async def test_tool_node_tool_call_input() -> None:
     ]
 
 
+async def test_tool_node_direct_invoke_without_config() -> None:
+    """Test invoking ToolNode directly without config (issue #6397).
+
+    When invoking a ToolNode programmatically outside of a graph context,
+    it should use DEFAULT_RUNTIME rather than raising an error.
+    """
+
+    @dec_tool
+    def get_instructions() -> str:
+        """Get instructions."""
+        return "Instructions."
+
+    tool_node = ToolNode(tools=[get_instructions])
+    tool_calls = [
+        {
+            "name": "get_instructions",
+            "args": {},
+            "id": "call_35db3afc-3232-4278-b5c1-4fb54ae6cbe7",
+            "type": "tool_call",
+        }
+    ]
+
+    # Invoke without config - should work without raising ValueError
+    result = tool_node.invoke(tool_calls)
+    assert result["messages"] == [
+        ToolMessage(
+            content="Instructions.",
+            tool_call_id="call_35db3afc-3232-4278-b5c1-4fb54ae6cbe7",
+            name="get_instructions",
+        ),
+    ]
+
+    # Also test async invoke
+    result = await tool_node.ainvoke(tool_calls)
+    assert result["messages"] == [
+        ToolMessage(
+            content="Instructions.",
+            tool_call_id="call_35db3afc-3232-4278-b5c1-4fb54ae6cbe7",
+            name="get_instructions",
+        ),
+    ]
+
+
 def test_tool_node_error_handling_default_invocation() -> None:
     tn = ToolNode([tool1])
     result = tn.invoke(


### PR DESCRIPTION
Closes #6397

## Description

This PR fixes an issue where invoking a `ToolNode` directly outside of a graph context (without providing a config) raised `ValueError: Missing required config key 'N/A' for 'tools'.`

This prevented users from using `ToolNode` for:
- Unit testing tools independently
- Sequential operations within a single node
- Closure-based tools that capture runtime-created objects

## Root Cause

In `RunnableCallable.invoke()` and `ainvoke()`, when the `runtime` kwarg was required by a function (like `ToolNode._func`), the code only set the value if `runtime` was available from `config["configurable"]["__pregel_runtime"]`. When invoked without a config (or with a config lacking runtime), `runtime` was `None`, causing the code to fall through to the error case since `default` was `inspect.Parameter.empty`.

## Solution

Modified the kwarg injection logic in `RunnableCallable` to use `DEFAULT_RUNTIME` (a pre-defined runtime with safe defaults) when:
1. The `runtime` kwarg is needed by the function
2. No runtime is available from config

This allows `ToolNode` and other runnables that accept a `runtime` parameter to work outside of graph context with sensible defaults (no store, no context, no-op stream writer).

## Changes Made

| File | Change |
|------|--------|
| `libs/langgraph/langgraph/_internal/_runnable.py` | Added import for `DEFAULT_RUNTIME` from `langgraph.runtime` |
| `libs/langgraph/langgraph/_internal/_runnable.py` | Updated `invoke()` to use `DEFAULT_RUNTIME` when `kw == "runtime"` and config runtime is unavailable |
| `libs/langgraph/langgraph/_internal/_runnable.py` | Updated `ainvoke()` with the same fix |
| `libs/prebuilt/tests/test_tool_node.py` | Added `test_tool_node_direct_invoke_without_config()` to verify the fix |

## Working Example

```python
from langchain_core.tools import tool
from langgraph.prebuilt import ToolNode

@tool
def get_instructions() -> str:
    """Get instructions."""
    return "Instructions."

tool_node = ToolNode(tools=[get_instructions])
tool_calls = [{'name': 'get_instructions', 'args': {}, 'id': 'call_123', 'type': 'tool_call'}]

# This now works without raising ValueError
result = tool_node.invoke(tool_calls)
```
## Issue
Closes #6397

## Dependencies
None

## Checklist

- [x] Added test: test_tool_node_direct_invoke_without_config() in libs/prebuilt/tests/test_tool_node.py
- [x] make format passes on libs/langgraph
- [x] make lint passes on libs/langgraph
- [x] make test passes on libs/langgraph (runnable tests)
- [x] make format passes on libs/prebuilt
- [x] make lint passes on libs/prebuilt
- [x] make test passes on libs/prebuilt (tool_node tests - 28 tests)
- [x] Change is backwards compatible