### PR TITLE
feat(langgraph): add field-level tracing annotations to control LangSmith trace visibility

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -186,6 +186,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     channels: dict[str, BaseChannel]
     managed: dict[str, ManagedValueSpec]
     schemas: dict[type[Any], dict[str, BaseChannel | ManagedValueSpec]]
+    type_hints: dict[type[Any], dict[str, type]]
     waiting_edges: set[tuple[tuple[str, ...], str]]
 
     compiled: bool
@@ -234,6 +235,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.edges = set()
         self.branches = defaultdict(dict)
         self.schemas = {}
+        self.type_hints = {}
         self.channels = {}
         self.managed = {}
         self.compiled = False
@@ -266,6 +268,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                     " Managed channels are not permitted in Input/Output schema."
                 )
             self.schemas[schema] = {**channels, **managed}
+            self.type_hints[schema] = type_hints
             for key, channel in channels.items():
                 if key in self.channels:
                     if self.channels[key] != channel:

--- a/libs/langgraph/langgraph/tracing.py
+++ b/libs/langgraph/langgraph/tracing.py
@@ -1,0 +1,220 @@
+"""Tracing annotations for controlling field visibility in LangSmith traces.
+
+This module provides annotations that can be used with Python's `Annotated` type
+to control how state fields are traced in LangSmith.
+
+Example:
+    ```python
+    from typing import Annotated
+    from langgraph.tracing import NotTraced, AsAttachment
+
+    class State(TypedDict):
+        query: str  # Traced normally in all nodes
+        large_pdf: Annotated[bytes, NotTraced()]  # Never traced
+        results: Annotated[list, AsAttachment()]  # Traced in root, masked in child runs
+    ```
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Literal
+
+
+class TraceLevel(str, Enum):
+    """Enum defining trace visibility levels."""
+
+    TRACED = "traced"  # Normal tracing (default)
+    NOT_TRACED = "not_traced"  # Never traced
+    ROOT_ONLY = "root_only"  # Only traced in root run
+    AS_ATTACHMENT = "as_attachment"  # Traced in root, masked in children
+
+
+@dataclass(frozen=True)
+class TraceAnnotation:
+    """Base class for tracing annotations.
+
+    This annotation can be added to state field type hints using Python's
+    `Annotated` type to control how that field is traced in LangSmith.
+    """
+
+    level: TraceLevel
+    mask_value: Any = "[MASKED]"
+
+    def should_trace(self, is_root: bool = False) -> bool:
+        """Determine if the field should be traced in the current context.
+
+        Args:
+            is_root: Whether this is the root run (not a child node).
+
+        Returns:
+            True if the field should be included in the trace.
+        """
+        if self.level == TraceLevel.TRACED:
+            return True
+        elif self.level == TraceLevel.NOT_TRACED:
+            return False
+        elif self.level == TraceLevel.ROOT_ONLY:
+            return is_root
+        elif self.level == TraceLevel.AS_ATTACHMENT:
+            return is_root
+        return True
+
+    def get_trace_value(self, value: Any, is_root: bool = False) -> Any:
+        """Get the value to use in the trace.
+
+        Args:
+            value: The actual field value.
+            is_root: Whether this is the root run.
+
+        Returns:
+            The value to include in the trace (or mask value if masked).
+        """
+        if self.should_trace(is_root):
+            return value
+        return self.mask_value
+
+
+class Traced(TraceAnnotation):
+    """Annotation to explicitly mark a field as traced (default behavior).
+
+    Example:
+        ```python
+        from typing import Annotated
+        from langgraph.tracing import Traced
+
+        class State(TypedDict):
+            query: Annotated[str, Traced()]  # Explicitly traced
+        ```
+    """
+
+    def __init__(self, mask_value: Any = "[MASKED]"):
+        super().__init__(level=TraceLevel.TRACED, mask_value=mask_value)
+
+
+class NotTraced(TraceAnnotation):
+    """Annotation to exclude a field from all tracing.
+
+    Use this for large data (PDFs, images, large dataframes) that should
+    never be sent to LangSmith.
+
+    Example:
+        ```python
+        from typing import Annotated
+        from langgraph.tracing import NotTraced
+
+        class State(TypedDict):
+            large_pdf: Annotated[bytes, NotTraced()]
+            dataframe_dicts: Annotated[dict, NotTraced(mask_value="<dataframe>")]
+        ```
+    """
+
+    def __init__(self, mask_value: Any = "[NOT TRACED]"):
+        super().__init__(level=TraceLevel.NOT_TRACED, mask_value=mask_value)
+
+
+class RootOnly(TraceAnnotation):
+    """Annotation to trace a field only in the root run.
+
+    The field will be traced when the graph is invoked, but masked in all
+    child node executions.
+
+    Example:
+        ```python
+        from typing import Annotated
+        from langgraph.tracing import RootOnly
+
+        class State(TypedDict):
+            input_document: Annotated[str, RootOnly()]
+        ```
+    """
+
+    def __init__(self, mask_value: Any = "[MASKED IN CHILD RUN]"):
+        super().__init__(level=TraceLevel.ROOT_ONLY, mask_value=mask_value)
+
+
+class AsAttachment(TraceAnnotation):
+    """Annotation to trace a field in root run, mask in child runs.
+
+    Similar to RootOnly but semantically indicates the value is an "attachment"
+    that should be visible at the top level but not repeated in every child trace.
+
+    Example:
+        ```python
+        from typing import Annotated
+        from langgraph.tracing import AsAttachment
+
+        class State(TypedDict):
+            pdf_content: Annotated[bytes, AsAttachment(mask_value="<PDF attachment>")]
+        ```
+    """
+
+    def __init__(self, mask_value: Any = "[SEE ROOT TRACE]"):
+        super().__init__(level=TraceLevel.AS_ATTACHMENT, mask_value=mask_value)
+
+
+def get_trace_annotation(typ: type[Any]) -> TraceAnnotation | None:
+    """Extract tracing annotation from a type hint.
+
+    Args:
+        typ: A type hint, possibly Annotated with a TraceAnnotation.
+
+    Returns:
+        The TraceAnnotation instance if present, otherwise None.
+    """
+    if hasattr(typ, "__metadata__"):
+        meta = typ.__metadata__
+        # Search through all annotations to find tracing annotations
+        for item in meta:
+            if isinstance(item, TraceAnnotation):
+                return item
+    return None
+
+
+def filter_state_for_tracing(
+    state: dict[str, Any],
+    type_hints: dict[str, type],
+    is_root: bool = False,
+) -> dict[str, Any]:
+    """Filter state dictionary based on tracing annotations.
+
+    Args:
+        state: The state dictionary to filter.
+        type_hints: Type hints for the state fields (from get_type_hints).
+        is_root: Whether this is the root run (not a child node).
+
+    Returns:
+        A filtered copy of the state with masked values where appropriate.
+    """
+    if not state or not type_hints:
+        return state
+
+    filtered = {}
+    for key, value in state.items():
+        if key not in type_hints:
+            # No type hint, include as-is
+            filtered[key] = value
+            continue
+
+        annotation = get_trace_annotation(type_hints[key])
+        if annotation is None:
+            # No tracing annotation, include as-is
+            filtered[key] = value
+        else:
+            # Apply tracing annotation
+            filtered[key] = annotation.get_trace_value(value, is_root)
+
+    return filtered
+
+
+__all__ = [
+    "TraceLevel",
+    "TraceAnnotation",
+    "Traced",
+    "NotTraced",
+    "RootOnly",
+    "AsAttachment",
+    "get_trace_annotation",
+    "filter_state_for_tracing",
+]

--- a/libs/langgraph/tests/test_field_tracing.py
+++ b/libs/langgraph/tests/test_field_tracing.py
@@ -1,0 +1,280 @@
+"""Tests for field-level tracing annotations."""
+
+from typing import Annotated
+
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.tracing import (
+    AsAttachment,
+    NotTraced,
+    RootOnly,
+    Traced,
+    TraceLevel,
+    filter_state_for_tracing,
+    get_trace_annotation,
+)
+
+
+class TestTraceAnnotations:
+    """Test tracing annotation classes."""
+
+    def test_traced_annotation(self):
+        """Test Traced annotation."""
+        traced = Traced()
+        assert traced.level == TraceLevel.TRACED
+        assert traced.should_trace(is_root=True)
+        assert traced.should_trace(is_root=False)
+        assert traced.get_trace_value("test", is_root=True) == "test"
+        assert traced.get_trace_value("test", is_root=False) == "test"
+
+    def test_not_traced_annotation(self):
+        """Test NotTraced annotation."""
+        not_traced = NotTraced()
+        assert not_traced.level == TraceLevel.NOT_TRACED
+        assert not not_traced.should_trace(is_root=True)
+        assert not not_traced.should_trace(is_root=False)
+        assert not_traced.get_trace_value("test", is_root=True) == "[NOT TRACED]"
+        assert not_traced.get_trace_value("test", is_root=False) == "[NOT TRACED]"
+
+    def test_not_traced_custom_mask(self):
+        """Test NotTraced with custom mask value."""
+        not_traced = NotTraced(mask_value="<hidden>")
+        assert not_traced.get_trace_value("test", is_root=True) == "<hidden>"
+        assert not_traced.get_trace_value("test", is_root=False) == "<hidden>"
+
+    def test_root_only_annotation(self):
+        """Test RootOnly annotation."""
+        root_only = RootOnly()
+        assert root_only.level == TraceLevel.ROOT_ONLY
+        assert root_only.should_trace(is_root=True)
+        assert not root_only.should_trace(is_root=False)
+        assert root_only.get_trace_value("test", is_root=True) == "test"
+        assert (
+            root_only.get_trace_value("test", is_root=False) == "[MASKED IN CHILD RUN]"
+        )
+
+    def test_as_attachment_annotation(self):
+        """Test AsAttachment annotation."""
+        as_attachment = AsAttachment()
+        assert as_attachment.level == TraceLevel.AS_ATTACHMENT
+        assert as_attachment.should_trace(is_root=True)
+        assert not as_attachment.should_trace(is_root=False)
+        assert as_attachment.get_trace_value("test", is_root=True) == "test"
+        assert (
+            as_attachment.get_trace_value("test", is_root=False) == "[SEE ROOT TRACE]"
+        )
+
+    def test_as_attachment_custom_mask(self):
+        """Test AsAttachment with custom mask value."""
+        as_attachment = AsAttachment(mask_value="<see parent>")
+        assert as_attachment.get_trace_value("test", is_root=True) == "test"
+        assert as_attachment.get_trace_value("test", is_root=False) == "<see parent>"
+
+
+class TestGetTraceAnnotation:
+    """Test get_trace_annotation helper function."""
+
+    def test_no_annotation(self):
+        """Test type without annotation."""
+        assert get_trace_annotation(str) is None
+        assert get_trace_annotation(int) is None
+
+    def test_with_traced_annotation(self):
+        """Test Annotated type with Traced."""
+        ann_type = Annotated[str, Traced()]
+        annotation = get_trace_annotation(ann_type)
+        assert annotation is not None
+        assert annotation.level == TraceLevel.TRACED
+
+    def test_with_not_traced_annotation(self):
+        """Test Annotated type with NotTraced."""
+        ann_type = Annotated[bytes, NotTraced()]
+        annotation = get_trace_annotation(ann_type)
+        assert annotation is not None
+        assert annotation.level == TraceLevel.NOT_TRACED
+
+    def test_with_root_only_annotation(self):
+        """Test Annotated type with RootOnly."""
+        ann_type = Annotated[str, RootOnly()]
+        annotation = get_trace_annotation(ann_type)
+        assert annotation is not None
+        assert annotation.level == TraceLevel.ROOT_ONLY
+
+    def test_with_as_attachment_annotation(self):
+        """Test Annotated type with AsAttachment."""
+        ann_type = Annotated[dict, AsAttachment()]
+        annotation = get_trace_annotation(ann_type)
+        assert annotation is not None
+        assert annotation.level == TraceLevel.AS_ATTACHMENT
+
+    def test_with_multiple_metadata(self):
+        """Test Annotated type with multiple metadata items."""
+        # The trace annotation should be found even with other metadata
+        ann_type = Annotated[str, "some doc", NotTraced(), "other metadata"]
+        annotation = get_trace_annotation(ann_type)
+        assert annotation is not None
+        assert annotation.level == TraceLevel.NOT_TRACED
+
+
+class TestFilterStateForTracing:
+    """Test filter_state_for_tracing function."""
+
+    def test_non_dict_state(self):
+        """Test that non-dict state is returned as-is."""
+        assert filter_state_for_tracing("string", {}, is_root=True) == "string"
+        assert filter_state_for_tracing(42, {}, is_root=False) == 42
+        assert filter_state_for_tracing(None, {}, is_root=True) is None
+
+    def test_dict_without_type_hints(self):
+        """Test dict without type hints is returned as-is."""
+        state = {"key": "value", "num": 42}
+        result = filter_state_for_tracing(state, {}, is_root=True)
+        assert result == state
+
+    def test_filter_not_traced_field(self):
+        """Test filtering NotTraced fields."""
+        type_hints = {
+            "query": str,
+            "pdf": Annotated[bytes, NotTraced()],
+        }
+        state = {"query": "test query", "pdf": b"large pdf content"}
+
+        # Root run - should still mask NotTraced
+        result = filter_state_for_tracing(state, type_hints, is_root=True)
+        assert result["query"] == "test query"
+        assert result["pdf"] == "[NOT TRACED]"
+
+        # Child run - should also mask NotTraced
+        result = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result["query"] == "test query"
+        assert result["pdf"] == "[NOT TRACED]"
+
+    def test_filter_root_only_field(self):
+        """Test filtering RootOnly fields."""
+        type_hints = {
+            "query": str,
+            "document": Annotated[str, RootOnly()],
+        }
+        state = {"query": "test query", "document": "long document"}
+
+        # Root run - should show document
+        result = filter_state_for_tracing(state, type_hints, is_root=True)
+        assert result["query"] == "test query"
+        assert result["document"] == "long document"
+
+        # Child run - should mask document
+        result = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result["query"] == "test query"
+        assert result["document"] == "[MASKED IN CHILD RUN]"
+
+    def test_filter_as_attachment_field(self):
+        """Test filtering AsAttachment fields."""
+        type_hints = {
+            "query": str,
+            "dataframe": Annotated[dict, AsAttachment(mask_value="<dataframe>")],
+        }
+        state = {
+            "query": "test query",
+            "dataframe": {"col1": [1, 2, 3], "col2": [4, 5, 6]},
+        }
+
+        # Root run - should show dataframe
+        result = filter_state_for_tracing(state, type_hints, is_root=True)
+        assert result["query"] == "test query"
+        assert result["dataframe"] == {"col1": [1, 2, 3], "col2": [4, 5, 6]}
+
+        # Child run - should mask dataframe
+        result = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result["query"] == "test query"
+        assert result["dataframe"] == "<dataframe>"
+
+    def test_mixed_annotations(self):
+        """Test state with mixed annotation types."""
+        type_hints = {
+            "query": str,
+            "pdf": Annotated[bytes, NotTraced()],
+            "context": Annotated[str, RootOnly()],
+            "results": Annotated[list, AsAttachment()],
+            "score": float,
+        }
+        state = {
+            "query": "find info",
+            "pdf": b"pdf bytes",
+            "context": "background context",
+            "results": [{"doc": 1}, {"doc": 2}],
+            "score": 0.95,
+        }
+
+        # Root run
+        result_root = filter_state_for_tracing(state, type_hints, is_root=True)
+        assert result_root["query"] == "find info"
+        assert result_root["pdf"] == "[NOT TRACED]"
+        assert result_root["context"] == "background context"
+        assert result_root["results"] == [{"doc": 1}, {"doc": 2}]
+        assert result_root["score"] == 0.95
+
+        # Child run
+        result_child = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result_child["query"] == "find info"
+        assert result_child["pdf"] == "[NOT TRACED]"
+        assert result_child["context"] == "[MASKED IN CHILD RUN]"
+        assert result_child["results"] == "[SEE ROOT TRACE]"
+        assert result_child["score"] == 0.95
+
+    def test_field_not_in_type_hints(self):
+        """Test that fields not in type hints are passed through."""
+        type_hints = {
+            "known_field": Annotated[str, NotTraced()],
+        }
+        state = {
+            "known_field": "value",
+            "unknown_field": "should pass through",
+        }
+
+        result = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result["known_field"] == "[NOT TRACED]"
+        assert result["unknown_field"] == "should pass through"
+
+
+class TestTypedDictIntegration:
+    """Test integration with TypedDict state schemas."""
+
+    def test_typed_dict_with_annotations(self):
+        """Test that TypedDict with annotations works correctly."""
+
+        class AgentState(TypedDict):
+            query: str
+            pdf_content: Annotated[bytes, NotTraced()]
+            intermediate_results: Annotated[list, RootOnly()]
+            final_answer: str
+
+        # Simulate getting type hints from TypedDict
+        from typing import get_type_hints
+
+        type_hints = get_type_hints(AgentState, include_extras=True)
+
+        state = {
+            "query": "What is in the PDF?",
+            "pdf_content": b"large pdf bytes" * 1000,
+            "intermediate_results": ["step1", "step2", "step3"],
+            "final_answer": "The answer is...",
+        }
+
+        # Root run - intermediate_results visible, pdf_content masked
+        result_root = filter_state_for_tracing(state, type_hints, is_root=True)
+        assert result_root["query"] == "What is in the PDF?"
+        assert result_root["pdf_content"] == "[NOT TRACED]"
+        assert result_root["intermediate_results"] == ["step1", "step2", "step3"]
+        assert result_root["final_answer"] == "The answer is..."
+
+        # Child run - intermediate_results masked, pdf_content masked
+        result_child = filter_state_for_tracing(state, type_hints, is_root=False)
+        assert result_child["query"] == "What is in the PDF?"
+        assert result_child["pdf_content"] == "[NOT TRACED]"
+        assert result_child["intermediate_results"] == "[MASKED IN CHILD RUN]"
+        assert result_child["final_answer"] == "The answer is..."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Description:** 
Adds field-level tracing control using Python's `Annotated` type to solve LangSmith size limit errors and trace bloat. Developers can now annotate state fields with `NotTraced()`, `AsAttachment()`, or `RootOnly()` to control whether fields appear in traces, while code retains full access to all data. Closes langchain-ai/langsmith-sdk#2034

**Issue:**  #6214, langchain-ai/langsmith-sdk#2034

**Dependencies:** None - uses existing typing features

**Twitter handle:** @0xaaryan
