### PR TITLE
fix: supress deprecation warnings

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -108,8 +108,13 @@ with warnings.catch_warnings():
         structured_response: StructuredResponse
 
 
-StateSchema = TypeVar("StateSchema", bound=AgentState | AgentStatePydantic)
-StateSchemaType = type[StateSchema]
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=LangGraphDeprecatedSinceV10,
+    )
+    StateSchema = TypeVar("StateSchema", bound=AgentState | AgentStatePydantic)
+    StateSchemaType = type[StateSchema]
 
 PROMPT_RUNNABLE_NAME = "Prompt"
 


### PR DESCRIPTION
1. Any import `from langgraph.prebuilt import X` (even `ToolNode`, `ToolRuntime`, etc.)
2. -> Loads `langgraph/prebuilt/__init__.py`
3. -> Line 3 imports `create_react_agent` from `chat_agent_executor.py`
4. -> `chat_agent_executor.py` loads completely
5. -> Line 111 evaluates: `StateSchema = TypeVar("StateSchema", bound=AgentState | AgentStatePydantic)`
6. -> Accessing `AgentStatePydantic` triggers its `@deprecated` decorator -> warning