### PR TITLE
fix: change default recursion limit

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -28,7 +28,7 @@ from langgraph._internal._constants import (
     NS_SEP,
 )
 
-DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "1000"))
+DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10000"))
 
 
 def recast_checkpoint_ns(ns: str) -> str:


### PR DESCRIPTION
25 is pretty unreasonable for most applications, bumping up to 1000 by default, burden really should be on the user to enforce this based on their application