### PR TITLE
fix: remove importlib.metadata for version access

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,5 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "1.0.6"


### PR DESCRIPTION
Fixes #5040

## Changes
- Replaced `importlib.metadata.version()` with hardcoded version string in `libs/langgraph/langgraph/version.py`

## Benchmark Results
| Approach | Time (1000 imports) |
|----------|---------------------|
| OLD (importlib.metadata) | 122.19ms |
| NEW (hardcoded) | 0.0045ms |

**~27,000x faster** — saves ~0.12ms per import