### PR TITLE
ci: add Windows build to test matrix

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -13,17 +13,32 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
-          - "3.14"
-
-    name: "test #${{ matrix.python-version }}"
+        exclude:
+          # Run full Python version matrix only on Ubuntu
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.14"
+        include:
+          # Add remaining Python versions for Ubuntu only
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: ubuntu-latest
+            python-version: "3.14"
+    runs-on: ${{ matrix.os }}
+    name: "test ${{ matrix.os }} #${{ matrix.python-version }}"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -34,7 +49,7 @@ jobs:
           cache-suffix: test-${{ inputs.working-directory }}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork && matrix.os == 'ubuntu-latest' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_RO_TOKEN }}


### PR DESCRIPTION
Fixes #5029

## Changes
Adds `windows-latest` to the OS matrix in the `_test.yml` reusable workflow.

### Test Matrix
| OS | Python Versions |
|----|-----------------|
| Ubuntu | 3.10, 3.11, 3.12, 3.13, 3.14 |
| Windows | 3.11, 3.12 |

### Notes
- Windows tests run on a subset of Python versions (3.11, 3.12) to reduce CI cost while still catching Windows-specific issues
- Docker login step is skipped on Windows (not needed for most tests)
- All existing Ubuntu tests remain unchanged

This is a minimal first step. Additional Windows-specific fixes may be needed based on test results.