### PR TITLE
fix(langgraph): support Pydantic default values with reducer functions

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -48,24 +48,41 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     ```
     """
 
-    __slots__ = ("value", "operator")
+    __slots__ = ("value", "operator", "_default")
 
-    def __init__(self, typ: type[Value], operator: Callable[[Value, Value], Value]):
+    def __init__(
+        self,
+        typ: type[Value],
+        operator: Callable[[Value, Value], Value],
+        default: Any = ...,
+    ):
         super().__init__(typ)
         self.operator = operator
-        # special forms from typing or collections.abc are not instantiable
-        # so we need to replace them with their concrete counterparts
-        typ = _strip_extras(typ)
-        if typ in (collections.abc.Sequence, collections.abc.MutableSequence):
-            typ = list
-        if typ in (collections.abc.Set, collections.abc.MutableSet):
-            typ = set
-        if typ in (collections.abc.Mapping, collections.abc.MutableMapping):
-            typ = dict
-        try:
-            self.value = typ()
-        except Exception:
-            self.value = MISSING
+        self._default = default
+
+        # If a default value is provided and it's not the special ... marker
+        if default is not ...:
+            self.value = default
+        else:
+            # special forms from typing or collections.abc are not instantiable
+            # so we need to replace them with their concrete counterparts
+            stripped_typ: Any = _strip_extras(typ)
+            if stripped_typ in (
+                collections.abc.Sequence,
+                collections.abc.MutableSequence,
+            ):
+                stripped_typ = list
+            if stripped_typ in (collections.abc.Set, collections.abc.MutableSet):
+                stripped_typ = set
+            if stripped_typ in (
+                collections.abc.Mapping,
+                collections.abc.MutableMapping,
+            ):
+                stripped_typ = dict
+            try:
+                self.value = stripped_typ()
+            except Exception:
+                self.value = MISSING
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, BinaryOperatorAggregate) and (
@@ -87,13 +104,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def copy(self) -> Self:
         """Return a copy of the channel."""
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self._default)
         empty.key = self.key
         empty.value = self.value
         return empty
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self._default)
         empty.key = self.key
         if checkpoint is not MISSING:
             empty.value = checkpoint


### PR DESCRIPTION
## Summary

Fixes #5225

When using Pydantic `Field(default=...)` or `Field(default_factory=...)` with `Annotated` reducer functions, the default value was being ignored. The `BinaryOperatorAggregate` channel was always initializing with an empty instance (e.g., `[]` for lists) instead of the specified default.

## The Problem

```python
class State(BaseModel):
    variable: Annotated[list[str], extend_list] = Field(default_factory=lambda: ["default"])

# Before this fix:
result = graph.compile().invoke({})
# variable was [] instead of ["default"]
```

## The Solution

This fix makes three minimal changes:

1. **`_fields.py`**: Adds Pydantic `BaseModel` support to `get_field_default()` to extract `default` and `default_factory` values
2. **`binop.py`**: Adds a `default` parameter to `BinaryOperatorAggregate` so it can use the provided default instead of `typ()`
3. **`state.py`**: Passes the schema through `_get_channels` → `_get_channel` → `_is_field_binop` to enable default extraction

## Example Usage After Fix

```python
from pydantic import BaseModel, Field
from typing import Annotated
import operator
from langgraph.graph import StateGraph, START, END

class State(BaseModel):
    messages: Annotated[list[str], operator.add] = Field(
        default_factory=lambda: ["initial"]
    )
    count: Annotated[int, operator.add] = Field(default=10)

def my_node(state: State) -> dict:
    return {"messages": ["new"], "count": 5}

graph = StateGraph(State)
graph.add_node("process", my_node)
graph.add_edge(START, "process")
graph.add_edge("process", END)

result = graph.compile().invoke({})
# result["messages"] == ["initial", "new"]  ✅ Now works!
# result["count"] == 15  ✅ (10 + 5)
```

## Tests Added

Added 6 comprehensive tests in `tests/test_pydantic.py`:
- `test_pydantic_default_factory_with_reducer` - Main reproduction case
- `test_pydantic_default_value_with_operator_add` - operator.add with default_factory
- `test_pydantic_static_default_with_reducer` - Static default with reducer
- `test_pydantic_mixed_defaults_with_reducers` - Mix of reducer and non-reducer fields
- `test_pydantic_reducer_without_default_still_works` - Backward compatibility
- `test_pydantic_custom_reducer_with_default` - Custom reducer function

## Backward Compatibility

- ✅ Existing code without defaults works unchanged
- ✅ Non-Pydantic state schemas (TypedDict, dataclasses) unaffected
- ✅ Regular fields without reducers work as before
- ✅ All existing tests pass