### PR TITLE
fix(checkpoint-postgres): skip acquiring the lock when using pooled connections

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
@@ -550,6 +550,10 @@ class AsyncPostgresStore(AsyncBatchedBaseStore, BasePostgresStore[_ainternal.Con
                 Will be applied regardless of whether the PostgresStore instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
+        is_pooled_conn = isinstance(self.conn, AsyncConnectionPool)
+        # when using pooled connections, connections are never shared across threads/coroutines,
+        # so we don't need to acquire the shared lock.
+        lock = asyncio.Lock() if is_pooled_conn else self.lock
         async with _ainternal.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
@@ -566,21 +570,21 @@ class AsyncPostgresStore(AsyncBatchedBaseStore, BasePostgresStore[_ainternal.Con
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     async with (
-                        self.lock,
+                        lock,
                         conn.pipeline(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
                         yield cur
                 else:
                     async with (
-                        self.lock,
+                        lock,
                         conn.transaction(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
                         yield cur
             else:
                 async with (
-                    self.lock,
+                    lock,
                     conn.cursor(binary=True, row_factory=dict_row) as cur,
                 ):
                     yield cur


### PR DESCRIPTION
When using an `AsyncConnectionPool`, connections are most likely† never shared by `_cursor()`. Calling `AsyncConnectionPool.connection()` removes the connection from the pool, so it cannot be used by any concurrent calls. As such, the lock inside `_cursor()` is redundant. 

If the pool allows more than one connection, then `_cursor()` should be allowed to be concurrently called. As far as I can tell, the only way for that to occur is between `_execute_batch()` and `sweep_ttl()`. 

In the current setup, if the `sweep_ttl()` operation is slow, then that delays all batch operations. This might be the trigger of the behaviour I was seeing in #6701.

† In theory, someone could implement `AsyncConnectionPool` to return a shared connection, but that would be redundant in langgraph.