### PR TITLE
fix: add missing edge from generate_structured_response to END

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -898,6 +898,8 @@ def create_react_agent(
                 agenerate_structured_response,
             ),
         )
+        # After generating structured response, the graph should end
+        workflow.add_edge("generate_structured_response", END)
         if post_model_hook is not None:
             post_model_hook_paths.append("generate_structured_response")
         else:


### PR DESCRIPTION
## Summary

- Adds missing edge from `generate_structured_response` node to `END` in `create_react_agent`
- Fixes infinite loop issue when using `response_format` parameter
- The graph now properly terminates after generating structured response

## Problem

When `response_format` is provided to `create_react_agent`, the `generate_structured_response` node is added to the graph but no outgoing edge to `END` is defined. This causes the graph to not terminate properly after generating the structured response, potentially leading to infinite loops until the recursion limit is hit.

## Solution

Added an explicit edge from `generate_structured_response` to `END` after the node is added to the workflow (line 901-902 in `chat_agent_executor.py`):

```python
workflow.add_edge("generate_structured_response", END)
```

This ensures the graph properly terminates after the structured response is generated.

## Test plan

- [x] All existing tests pass (`make test-fast` - 189 tests passed)
- [x] Specifically tested structured response related tests (`test_react_agent_with_structured_response`, `test_dynamic_model_with_structured_response`, `test_post_model_hook_with_structured_output`)
- [x] Lint and format checks pass

Fixes #6731