### PR TITLE
Add AgentMarket - B2A Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,5 @@ While LangGraph can be used standalone, it also integrates seamlessly with any L
 ## Acknowledgements
 
 LangGraph is inspired by [Pregel](https://research.google/pubs/pub37252/) and [Apache Beam](https://beam.apache.org/). The public interface draws inspiration from [NetworkX](https://networkx.org/documentation/latest/). LangGraph is built by LangChain Inc, the creators of LangChain, but can be used without LangChain.
+
+- [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, 28M+ energy records, enterprise-ready API.


### PR DESCRIPTION
AgentMarket.cloud - Enterprise B2A marketplace for AI agents.

- 189+ API listings
- 28M+ real energy data records
- LangChain, MCP, OpenAPI integration

https://agentmarket.cloud