### PR TITLE
Handle asyncio.CancelledError in ToolNode

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1108,6 +1108,20 @@ class ToolNode(RunnableCallable):
         # (2 and 3 can happen in a "supervisor w/ tools" multi-agent architecture)
         except GraphBubbleUp:
             raise
+        except asyncio.CancelledError:
+            # Handle CancelledError separately since it inherits from BaseException, not Exception
+            if self._handle_tool_errors:
+                content = _handle_tool_error(
+                    Exception("Tool execution was cancelled"),
+                    flag=self._handle_tool_errors,
+                )
+                return ToolMessage(
+                    content=content,
+                    name=call["name"],
+                    tool_call_id=call["id"],
+                    status="error",
+                )
+            raise
         except Exception as e:
             # Determine which exception types are handled
             handled_types: tuple[type[Exception], ...]

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2202,3 +2202,67 @@ def test_tool_node_injected_state_overwrites_llm_value() -> None:
     )
     tool_message = result["messages"][-1]
     assert tool_message.content == "PUBLIC_DATA"
+
+
+async def test_tool_node_handles_cancelled_error() -> None:
+    """Test that ToolNode handles asyncio.CancelledError raised within tools when handle_tool_errors=True.
+
+    This replicates the scenario from issue #6726 where a tool raises CancelledError
+    (e.g., from a cancelled underlying operation) and we want the ToolNode to convert
+    it to an error ToolMessage rather than letting it propagate.
+    """
+    import asyncio
+
+    @dec_tool
+    async def tool_that_cancels(query: str) -> str:
+        """A tool that simulates cancellation during execution."""
+        # Simulate a scenario where the tool's work is cancelled
+        # For example, an internal HTTP request that times out and gets cancelled
+        raise asyncio.CancelledError("Simulated cancellation")
+
+    # Test with handle_tool_errors=True
+    tool_node = ToolNode([tool_that_cancels], handle_tool_errors=True)
+
+    ai_message = AIMessage(
+        "",
+        tool_calls=[
+            {"id": "call_1", "name": "tool_that_cancels", "args": {"query": "test"}}
+        ],
+    )
+    state = {"messages": [ai_message]}
+    config = _create_config_with_runtime()
+
+    # Should not raise, should return ToolMessage with error
+    result = await tool_node.ainvoke(state, config)
+    tool_message = result["messages"][-1]
+
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.tool_call_id == "call_1"
+    assert tool_message.status == "error"
+    assert "cancel" in tool_message.content.lower()
+
+
+async def test_tool_node_raises_cancelled_error_when_not_handled() -> None:
+    """Test that ToolNode raises CancelledError when handle_tool_errors=False."""
+    import asyncio
+
+    @dec_tool
+    async def tool_that_cancels(query: str) -> str:
+        """A tool that simulates cancellation during execution."""
+        raise asyncio.CancelledError("Simulated cancellation")
+
+    # Test with handle_tool_errors=False
+    tool_node = ToolNode([tool_that_cancels], handle_tool_errors=False)
+
+    ai_message = AIMessage(
+        "",
+        tool_calls=[
+            {"id": "call_1", "name": "tool_that_cancels", "args": {"query": "test"}}
+        ],
+    )
+    state = {"messages": [ai_message]}
+    config = _create_config_with_runtime()
+
+    # Should raise CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await tool_node.ainvoke(state, config)


### PR DESCRIPTION
## Summary
Fixes #6726 - ToolNode now properly handles asyncio.CancelledError when handle_tool_errors=True.

## Problem
When a tool execution is cancelled via `asyncio.CancelledError`, the `ToolNode` does not create an error `ToolMessage` even when `handle_tool_errors=True`. This leaves the message history in an invalid state where an `AIMessage` has `tool_calls` without corresponding `ToolMessages`, causing INVALID_CHAT_HISTORY errors on subsequent LLM calls.

**Root cause**: `asyncio.CancelledError` inherits from `BaseException`, not `Exception`, so it bypasses the existing exception handler which only catches `Exception` and its subclasses.

## Solution
Added an explicit handler for `asyncio.CancelledError` in `_execute_tool_async()` that:
1. Catches `CancelledError` before the general `Exception` handler
2. When `handle_tool_errors=True`, converts it to an error `ToolMessage` with "Tool execution was cancelled" message
3. When `handle_tool_errors=False`, re-raises the `CancelledError` (preserving existing behavior)

## Test Plan
Added two comprehensive tests:
- `test_tool_node_handles_cancelled_error`: Verifies that when a tool raises CancelledError and handle_tool_errors=True, it returns an error ToolMessage instead of propagating the error
- `test_tool_node_raises_cancelled_error_when_not_handled`: Verifies that when handle_tool_errors=False, CancelledError is still raised
- All existing tests pass (30 passed)

## Changes
- `libs/prebuilt/langgraph/prebuilt/tool_node.py`: Added CancelledError handler
- `libs/prebuilt/tests/test_tool_node.py`: Added regression tests

