### PR TITLE
refactor: replace bare except with BaseException in AsyncQueue

### DIFF
--- a/libs/langgraph/langgraph/_internal/_queue.py
+++ b/libs/langgraph/langgraph/_internal/_queue.py
@@ -25,7 +25,7 @@ class AsyncQueue(asyncio.Queue):
             self._getters.append(getter)
             try:
                 await getter
-            except:
+            except BaseException:
                 getter.cancel()  # Just in case getter is not done yet.
                 try:
                     # Clean self._getters from canceled getters.


### PR DESCRIPTION
## Description
Replaced a bare `except:` with `except BaseException:` in `libs/langgraph/langgraph/_internal/_queue.py`.

## Motivation
Using a bare `except:` violates PEP 8 (E722). While functionally equivalent to `except BaseException:`, making it explicit improves code readability and satisfies static analysis tools.

This ensures that `asyncio.CancelledError` (which inherits from `BaseException`) is still caught and handled correctly by the cancellation logic in the `wait()` method, but without the ambiguity of a bare except.