### PR TITLE
fix: handle END in conditional edge path_map lookup

### DIFF
--- a/libs/langgraph/langgraph/graph/_branch.py
+++ b/libs/langgraph/langgraph/graph/_branch.py
@@ -200,7 +200,8 @@ class BranchSpec(NamedTuple):
             result = [result]
         if self.ends:
             destinations: Sequence[Send | str] = [
-                r if isinstance(r, Send) else self.ends[r] for r in result
+                r if isinstance(r, Send) else (r if r == END else self.ends[r])
+                for r in result
             ]
         else:
             destinations = cast(Sequence[Send | str], result)


### PR DESCRIPTION
## Summary
When a conditional router returns `END` (`'__end__'`) but `path_map` does not include an explicit END mapping, the code raises `KeyError('__end__')`.

## Fix
This PR treats `END` as a special case in `_branch.py`'s `_finish` method - it now passes through directly without requiring a path_map entry, matching user expectations.

## The Change
```python
# Before
destinations = [r if isinstance(r, Send) else self.ends[r] for r in result]

# After  
destinations = [r if isinstance(r, Send) else (r if r == END else self.ends[r]) for r in result]
```

Fixes #6770