### PR TITLE
perf(langgraph): remove importlib metadata version lookup (#5040)

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,6 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Keep this in sync with `libs/langgraph/pyproject.toml`.
+__version__ = "1.0.8"

--- a/libs/langgraph/tests/test_version.py
+++ b/libs/langgraph/tests/test_version.py
@@ -1,0 +1,5 @@
+from langgraph.version import __version__
+
+
+def test_version_is_non_empty() -> None:
+    assert __version__


### PR DESCRIPTION
## Problem
`langgraph.version` currently imports `importlib.metadata` at import time just to read package version.

## Reproduction
Importing `langgraph.version` triggers metadata resolution even in local editable contexts.

## Solution
Replace metadata lookup with a static version constant and keep `__version__` public API unchanged.

## Tests
- Added `libs/langgraph/tests/test_version.py` to assert `__version__` is non-empty.
- Local smoke check:
  - `python - <<` import `langgraph.version.__version__` with `PYTHONPATH=libs/langgraph`

## Backward Compatibility
No API changes. `langgraph.version.__version__` remains available.

Closes #5040