### PR TITLE
Fix async functional interrupt resume double-consumption

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -1060,14 +1060,17 @@ def _scratchpad(
     stop: int,
 ) -> PregelScratchpad:
     if len(pending_writes) > 0:
-        # find global resume value
-        for w in pending_writes:
-            if w[0] == NULL_TASK_ID and w[1] == RESUME:
-                null_resume_write = w
-                break
+        # only the root scratchpad should consume the global resume value
+        if parent_scratchpad is None:
+            for w in pending_writes:
+                if w[0] == NULL_TASK_ID and w[1] == RESUME:
+                    null_resume_write = w
+                    break
+            else:
+                # None cannot be used as a resume value, because it would be difficult to
+                # distinguish from missing when used over http
+                null_resume_write = None
         else:
-            # None cannot be used as a resume value, because it would be difficult to
-            # distinguish from missing when used over http
             null_resume_write = None
 
         # find task-specific resume value

--- a/libs/langgraph/tests/test_algo.py
+++ b/libs/langgraph/tests/test_algo.py
@@ -1,5 +1,5 @@
-from langgraph._internal._constants import PULL, PUSH
-from langgraph.pregel._algo import prepare_next_tasks, task_path_str
+from langgraph._internal._constants import PULL, PUSH, RESUME
+from langgraph.pregel._algo import _scratchpad, prepare_next_tasks, task_path_str
 from langgraph.pregel._checkpoint import channels_from_checkpoint, empty_checkpoint
 
 
@@ -65,3 +65,20 @@ def test_tuple_str() -> None:
         f"~{PUSH}, ~{PUSH}, 0000000002, 0000000001",
         f"~{PUSH}, ~{PUSH}, ~{PUSH}, 0000000002, 0000000001, 0000000003",
     ]
+
+
+def test_scratchpad_root_without_global_resume_value() -> None:
+    writes = [("task-1", RESUME, "task-resume")]
+    scratchpad = _scratchpad(
+        parent_scratchpad=None,
+        pending_writes=writes,
+        task_id="task-1",
+        namespace_hash="ns",
+        resume_map=None,
+        step=0,
+        stop=1,
+    )
+
+    assert scratchpad.resume == ["task-resume"]
+    assert scratchpad.get_null_resume() is None
+    assert scratchpad.get_null_resume(consume=True) is None


### PR DESCRIPTION
## Summary
Fixes async functional API behavior where interrupt resume values can be consumed twice across parent/child scratchpads, causing fewer resume steps than expected.

In the reported reproduction (`@entrypoint` + async `@task` + `interrupt()`), async execution could skip interrupts:
- Expected progression: `1`, `12`, `123`, `1234`, `12345`
- Actual progression: `1`, `123`, `12345`

## Root cause
`_scratchpad()` was caching `null_resume_write` in both root and child scratchpads. In async paths, this allowed duplicate consumption attempts against the same global resume write.

## Changes
- In `langgraph/pregel/_algo.py`, only root scratchpads (`parent_scratchpad is None`) capture global `NULL_TASK_ID` resume writes.
- Child scratchpads delegate `get_null_resume()` to parent, preventing double consumption.
- Added regression test in `tests/test_pregel_async.py`:
  - `test_async_functional_resume_not_double_consumed`
- Added targeted unit test in `tests/test_algo.py` to cover root scratchpad behavior when pending writes exist without a global resume value.

## Testing
- `NO_DOCKER=true uv run pytest tests/test_algo.py tests/test_pregel_async.py -k "scratchpad_root_without_global_resume_value or async_functional_resume_not_double_consumed or multiple_interrupts_functional" -q`
- `uv run ruff check langgraph/pregel/_algo.py tests/test_pregel_async.py tests/test_algo.py`
- `uv run ruff format --check langgraph/pregel/_algo.py tests/test_pregel_async.py tests/test_algo.py`

All commands passed locally.

Fixes #6660
