### PR TITLE
fix(langgraph): validate config type before invoke and stream

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -299,6 +299,9 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
     for config in configs:
         if config is None:
             continue
+        if not isinstance(config, Mapping):
+            msg = f"Expected config to be a mapping, got {type(config).__name__}"
+            raise TypeError(msg)
         for k, v in config.items():
             if _is_not_empty(v) and k in CONFIG_KEYS:
                 if k == CONF:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2483,12 +2483,14 @@ class Pregel(
                 )
             durability = "async" if checkpoint_during else "exit"
 
+        config = ensure_config(self.config, config)
+
         if stream_mode is None:
             # if being called as a node in another graph, default to values mode
             # but don't overwrite stream_mode arg if provided
             stream_mode = (
                 "values"
-                if config is not None and CONFIG_KEY_TASK_ID in config.get(CONF, {})
+                if CONFIG_KEY_TASK_ID in config.get(CONF, {})
                 else self.stream_mode
             )
         if debug or self.debug:
@@ -2496,7 +2498,6 @@ class Pregel(
 
         stream = SyncQueue()
 
-        config = ensure_config(self.config, config)
         callback_manager = get_callback_manager_for_config(config)
         run_manager = callback_manager.on_chain_start(
             None,
@@ -2757,12 +2758,14 @@ class Pregel(
                 )
             durability = "async" if checkpoint_during else "exit"
 
+        config = ensure_config(self.config, config)
+
         if stream_mode is None:
             # if being called as a node in another graph, default to values mode
             # but don't overwrite stream_mode arg if provided
             stream_mode = (
                 "values"
-                if config is not None and CONFIG_KEY_TASK_ID in config.get(CONF, {})
+                if CONFIG_KEY_TASK_ID in config.get(CONF, {})
                 else self.stream_mode
             )
         if debug or self.debug:
@@ -2775,7 +2778,6 @@ class Pregel(
             partial(aioloop.call_soon_threadsafe, stream.put_nowait),
         )
 
-        config = ensure_config(self.config, config)
         callback_manager = get_async_callback_manager_for_config(config)
         run_manager = await callback_manager.on_chain_start(
             None,

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -317,3 +317,28 @@ def test_configurable_metadata():
     metadata = merged["metadata"]
     assert metadata.keys() == expected
     assert metadata["nooverride"] == 18
+
+
+def test_ensure_config_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError, match="Expected config to be a mapping, got str"):
+        ensure_config("invalid_config")  # type: ignore[arg-type]
+
+
+def test_graph_rejects_non_mapping_config() -> None:
+    class State(TypedDict):
+        value: int
+
+    def node(state: State) -> State:
+        return state
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.set_entry_point("node")
+    builder.add_edge("node", END)
+    graph = builder.compile()
+
+    with pytest.raises(TypeError, match="Expected config to be a mapping, got str"):
+        graph.invoke({"value": 1}, config="invalid_config")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="Expected config to be a mapping, got str"):
+        list(graph.stream({"value": 1}, config="invalid_config"))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Fixes #6782.

`graph.invoke()` / `graph.stream()` currently crash with an internal `AttributeError` when `config` is not a mapping (for example, a string).

This PR adds explicit config-type validation and returns a clear user-facing `TypeError` instead.

## Changes
- Add runtime validation in `ensure_config(...)`:
  - raise `TypeError("Expected config to be a mapping, got <type>")` for non-mapping config values.
- Normalize config earlier in both sync and async stream paths:
  - call `ensure_config(self.config, config)` before checking `stream_mode` defaults.
  - this prevents pre-validation access via `config.get(...)` on invalid types.
- Add regression tests:
  - `test_ensure_config_rejects_non_mapping`
  - `test_graph_rejects_non_mapping_config` (covers both `graph.invoke` and `graph.stream`)

## Validation
Executed locally in `libs/langgraph`:
- `make format`
- `make lint`
- `NO_DOCKER=true TEST=tests/test_utils.py make test`
- `uv run python -m trace --count --coverdir /tmp/langgraph_6782_trace --module pytest tests/test_utils.py -q`

The new failure path and stream/invoke guard paths are covered by the added tests.

## AI involvement
AI assistance was limited to unit-test drafting, code-review suggestions, and formatting checks. Final implementation and code decisions were manually completed and verified.
