### PR TITLE
fix(config): validate config type in ensure_config

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -299,6 +299,12 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
     for config in configs:
         if config is None:
             continue
+        if not isinstance(config, Mapping):
+            msg = (
+                "config must be a mapping (RunnableConfig), "
+                f"got {type(config).__name__}"
+            )
+            raise TypeError(msg)
         for k, v in config.items():
             if _is_not_empty(v) and k in CONFIG_KEYS:
                 if k == CONF:

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -317,3 +317,8 @@ def test_configurable_metadata():
     metadata = merged["metadata"]
     assert metadata.keys() == expected
     assert metadata["nooverride"] == 18
+
+
+def test_ensure_config_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError, match="config must be a mapping"):
+        ensure_config("invalid_config")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
Validate `config` type in `ensure_config` and raise a clear `TypeError` when a non-mapping is passed.

## Problem
`graph.invoke()` / `graph.stream()` can fail with an internal `AttributeError` when `config` is not a mapping (e.g. a string), because `ensure_config` calls `.items()` unconditionally.

## Changes
- Add a type guard in `ensure_config` to reject non-mapping `config` values.
- Raise `TypeError` with explicit message: `config must be a mapping (RunnableConfig), got <type>`.
- Add regression test `test_ensure_config_rejects_non_mapping` in `libs/langgraph/tests/test_utils.py`.

## Validation
- `NO_DOCKER=true pytest -q libs/langgraph/tests/test_utils.py -k "ensure_config_rejects_non_mapping"`
- `NO_DOCKER=true pytest -q libs/langgraph/tests/test_utils.py -k "configurable_metadata or ensure_config_rejects_non_mapping"`

## Risk & Rollback
- Low risk: only tightens input validation for invalid `config` types.
- Rollback: revert this commit if needed.

## Related
Fixes #6782