### PR TITLE
Add Telnyx communication tools for LangGraph agents

### DIFF
--- a/examples/telnyx_tools/README.md
+++ b/examples/telnyx_tools/README.md
@@ -1,0 +1,134 @@
+# Telnyx Tools for LangGraph
+
+This example demonstrates how to integrate Telnyx telephony capabilities into LangGraph agents using LangChain-compatible tools.
+
+## Overview
+
+Telnyx is a global communications platform providing SMS, voice, and other telephony services. This integration allows LangGraph agents to:
+
+- Send SMS text messages
+- Make voice phone calls
+- Hang up active calls
+
+## Prerequisites
+
+1. **Telnyx Account**: Sign up at [telnyx.com](https://telnyx.com)
+2. **API Key**: Get your API key from the [Telnyx Portal](https://portal.telnyx.com)
+3. **Phone Number**: Purchase or port a phone number in the Telnyx Portal
+4. **Messaging Profile** (optional): Create a messaging profile for SMS
+
+## Installation
+
+```bash
+pip install langgraph langchain-openai telnyx
+```
+
+## Configuration
+
+Set the following environment variables:
+
+```bash
+export TELNYX_API_KEY='your-api-key'
+export TELNYX_FROM_NUMBER='+15551234567'  # Your Telnyx phone number
+export TELNYX_MESSAGING_PROFILE_ID='your-profile-id'  # Optional, for SMS
+```
+
+## Usage
+
+### Basic Usage with ToolNode
+
+```python
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import ToolNode, create_react_agent
+from telnyx_tools import TelnyxSendSMS, TelnyxMakeCall
+
+# Initialize tools
+tools = [
+    TelnyxSendSMS(),
+    TelnyxMakeCall(),
+]
+
+# Create agent
+model = ChatOpenAI(model="gpt-4o")
+agent = create_react_agent(model, tools)
+
+# Send an SMS
+response = agent.invoke({
+    "messages": [("user", "Send SMS to +15551234567 saying 'Hello!'")]
+})
+```
+
+### Custom Configuration
+
+You can also configure tools with explicit credentials instead of environment variables:
+
+```python
+from telnyx_tools import TelnyxSendSMS
+
+sms_tool = TelnyxSendSMS(
+    api_key="your-api-key",
+    from_number="+15551234567",
+    messaging_profile_id="your-profile-id"
+)
+```
+
+## Available Tools
+
+### TelnyxSendSMS
+
+Send SMS text messages to any phone number.
+
+**Parameters:**
+- `to` (required): Destination phone number in E.164 format (e.g., `+15551234567`)
+- `body` (required): Text message content
+- `from_` (optional): Sender phone number (uses `TELNYX_FROM_NUMBER` if not provided)
+
+### TelnyxMakeCall
+
+Initiate a voice phone call using Telnyx Call Control.
+
+**Parameters:**
+- `to` (required): Destination phone number in E.164 format
+- `from_` (optional): Caller phone number (uses `TELNYX_FROM_NUMBER` if not provided)
+- `webhook_url` (optional): URL for receiving call status events
+
+### TelnyxHangupCall
+
+Hang up an active voice call.
+
+**Parameters:**
+- `call_control_id` (required): The call control ID from a previous call
+
+## Example Agent
+
+See `agent_example.py` for a complete working example:
+
+```bash
+python agent_example.py
+```
+
+## Phone Number Format
+
+All phone numbers must be in E.164 format:
+- Start with `+`
+- Include country code
+- No spaces or dashes
+- Example: `+15551234567`
+
+## Error Handling
+
+All tools return descriptive error messages for:
+- Missing or invalid API keys
+- Missing phone numbers
+- Invalid phone number formats
+- API communication errors
+
+## Telnyx Documentation
+
+- [Telnyx API Reference](https://developers.telnyx.com/docs/api/v2/overview)
+- [Telnyx Python SDK](https://github.com/team-telnyx/telnyx-python)
+- [Call Control Documentation](https://developers.telnyx.com/docs/api/v2/call-control)
+
+## License
+
+This example is provided under the same license as LangGraph.

--- a/examples/telnyx_tools/__init__.py
+++ b/examples/telnyx_tools/__init__.py
@@ -1,0 +1,21 @@
+"""Telnyx communication tools for LangGraph agents.
+
+This module provides LangChain-compatible tools for SMS and voice operations
+using the Telnyx API. These tools can be used with LangGraph's ToolNode for
+building conversational agents with telephony capabilities.
+
+Requirements:
+    pip install telnyx
+
+Usage:
+    from langgraph.prebuilt import ToolNode, create_react_agent
+    from telnyx_tools import TelnyxSendSMS, TelnyxMakeCall
+
+    tools = [TelnyxSendSMS(), TelnyxMakeCall()]
+    agent = create_react_agent(model, tools)
+"""
+
+from telnyx_tools.sms import TelnyxSendSMS
+from telnyx_tools.voice import TelnyxMakeCall, TelnyxHangupCall
+
+__all__ = ["TelnyxSendSMS", "TelnyxMakeCall", "TelnyxHangupCall"]

--- a/examples/telnyx_tools/agent_example.py
+++ b/examples/telnyx_tools/agent_example.py
@@ -1,0 +1,107 @@
+"""Example LangGraph agent with Telnyx communication tools.
+
+This example demonstrates how to create a LangGraph agent that can send SMS
+messages and make phone calls using the Telnyx API.
+
+Prerequisites:
+    1. Set environment variables:
+        export TELNYX_API_KEY='your-api-key'
+        export TELNYX_FROM_NUMBER='+15551234567'
+        export TELNYX_MESSAGING_PROFILE_ID='your-profile-id'  # optional
+
+    2. Install dependencies:
+        pip install langgraph langchain-openai telnyx
+
+Usage:
+    python agent_example.py
+"""
+
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+# Import Telnyx tools
+from telnyx_tools import TelnyxSendSMS, TelnyxMakeCall, TelnyxHangupCall
+
+
+def create_telnyx_agent(model_name: str = "gpt-4o"):
+    """Create a LangGraph agent with Telnyx communication tools.
+
+    Args:
+        model_name: The OpenAI model to use for the agent.
+
+    Returns:
+        A compiled LangGraph agent with Telnyx tools.
+    """
+    # Initialize the model
+    model = ChatOpenAI(model=model_name, temperature=0)
+
+    # Initialize Telnyx tools
+    tools = [
+        TelnyxSendSMS(),
+        TelnyxMakeCall(),
+        TelnyxHangupCall(),
+    ]
+
+    # Create the react agent
+    agent = create_react_agent(model, tools)
+
+    return agent
+
+
+def main():
+    """Run an example interaction with the Telnyx agent."""
+    # Verify environment variables
+    if not os.environ.get("TELNYX_API_KEY"):
+        print("Warning: TELNYX_API_KEY not set. Agent will return error messages.")
+        print("Set it with: export TELNYX_API_KEY='your-api-key'")
+
+    if not os.environ.get("TELNYX_FROM_NUMBER"):
+        print("Warning: TELNYX_FROM_NUMBER not set. Agent will ask for sender number.")
+        print("Set it with: export TELNYX_FROM_NUMBER='+15551234567'")
+
+    # Create the agent
+    agent = create_telnyx_agent()
+
+    # Example 1: Send an SMS
+    print("\n" + "=" * 60)
+    print("Example 1: Sending an SMS")
+    print("=" * 60)
+
+    response = agent.invoke(
+        {
+            "messages": [
+                (
+                    "user",
+                    "Send an SMS to +15551234567 with the message 'Hello from LangGraph!'",
+                )
+            ]
+        }
+    )
+
+    for message in response["messages"]:
+        print(f"{message.__class__.__name__}: {message.content}")
+
+    # Example 2: Make a call
+    print("\n" + "=" * 60)
+    print("Example 2: Making a phone call")
+    print("=" * 60)
+
+    response = agent.invoke(
+        {
+            "messages": [
+                (
+                    "user",
+                    "Call +15551234567",
+                )
+            ]
+        }
+    )
+
+    for message in response["messages"]:
+        print(f"{message.__class__.__name__}: {message.content}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/telnyx_tools/sms.py
+++ b/examples/telnyx_tools/sms.py
@@ -1,0 +1,188 @@
+"""Telnyx SMS tool for LangGraph agents.
+
+This module provides a LangChain-compatible tool for sending SMS messages
+via the Telnyx API.
+"""
+
+from typing import Optional
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class TelnyxSMSInput(BaseModel):
+    """Input schema for Telnyx SMS tool."""
+
+    to: str = Field(
+        ...,
+        description="The destination phone number in E.164 format (e.g., '+15551234567')",
+    )
+    body: str = Field(
+        ...,
+        description="The text message content to send",
+    )
+    from_: str = Field(
+        default="",
+        description="The source phone number in E.164 format. If not provided, uses TELNYX_FROM_NUMBER environment variable.",
+    )
+
+
+class TelnyxSendSMS(BaseTool):
+    """Tool for sending SMS messages via Telnyx API.
+
+    This tool allows LangGraph agents to send text messages to phone numbers
+    using the Telnyx telecommunications platform.
+
+    Setup:
+        1. Install the telnyx package: `pip install telnyx`
+        2. Set your Telnyx API key: `export TELNYX_API_KEY='your-api-key'`
+        3. Set your Telnyx phone number: `export TELNYX_FROM_NUMBER='+15551234567'`
+        4. Optionally set a messaging profile ID: `export TELNYX_MESSAGING_PROFILE_ID='your-profile-id'`
+
+    Example:
+        ```python
+        from langgraph.prebuilt import create_react_agent
+        from langchain_openai import ChatOpenAI
+        from telnyx_tools import TelnyxSendSMS
+
+        model = ChatOpenAI(model="gpt-4")
+        tools = [TelnyxSendSMS()]
+        agent = create_react_agent(model, tools)
+
+        # Agent can now send SMS messages
+        response = agent.invoke(
+            {"messages": [("user", "Send an SMS to +15551234567 saying 'Hello from LangGraph!'")]}
+        )
+        ```
+
+    Attributes:
+        name: The name of the tool for agent use.
+        description: Description of what the tool does.
+    """
+
+    name: str = "telnyx_send_sms"
+    description: str = (
+        "Send an SMS text message to a phone number. "
+        "Use this when you need to send a text message to someone. "
+        "The 'to' parameter should be a phone number in E.164 format (e.g., '+15551234567'). "
+        "The 'body' parameter is the text content of the message."
+    )
+    args_schema: type[BaseModel] = TelnyxSMSInput
+
+    # Configuration attributes
+    api_key: Optional[str] = Field(default=None, exclude=True)
+    from_number: Optional[str] = Field(default=None, exclude=True)
+    messaging_profile_id: Optional[str] = Field(default=None, exclude=True)
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        from_number: Optional[str] = None,
+        messaging_profile_id: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initialize the Telnyx SMS tool.
+
+        Args:
+            api_key: Telnyx API key. If not provided, reads from TELNYX_API_KEY env var.
+            from_number: Default sender phone number in E.164 format. If not provided,
+                reads from TELNYX_FROM_NUMBER env var.
+            messaging_profile_id: Optional messaging profile ID. If not provided,
+                reads from TELNYX_MESSAGING_PROFILE_ID env var.
+            **kwargs: Additional arguments passed to BaseTool.
+        """
+        super().__init__(**kwargs)
+        self.api_key = api_key
+        self.from_number = from_number
+        self.messaging_profile_id = messaging_profile_id
+
+    def _run(
+        self,
+        to: str,
+        body: str,
+        from_: str = "",
+        run_manager=None,
+    ) -> str:
+        """Send an SMS message.
+
+        Args:
+            to: Destination phone number in E.164 format.
+            body: Text message content.
+            from_: Source phone number (optional, uses config if not provided).
+
+        Returns:
+            A success message with the message ID or an error message.
+        """
+        import os
+
+        try:
+            import telnyx
+        except ImportError:
+            return (
+                "Error: telnyx package not installed. "
+                "Please install it with: pip install telnyx"
+            )
+
+        # Get API key from config or environment
+        api_key = self.api_key or os.environ.get("TELNYX_API_KEY")
+        if not api_key:
+            return "Error: TELNYX_API_KEY not set. Please set the TELNYX_API_KEY environment variable."
+
+        telnyx.api_key = api_key
+
+        # Determine the sender number
+        sender = from_ or self.from_number or os.environ.get("TELNYX_FROM_NUMBER")
+        if not sender:
+            return (
+                "Error: No sender phone number provided. "
+                "Either pass the 'from_' parameter or set TELNYX_FROM_NUMBER environment variable."
+            )
+
+        # Get messaging profile ID if available
+        profile_id = (
+            self.messaging_profile_id
+            or os.environ.get("TELNYX_MESSAGING_PROFILE_ID")
+            or None
+        )
+
+        try:
+            # Build message parameters
+            message_params = {
+                "from_": sender,
+                "to": to,
+                "text": body,
+            }
+
+            if profile_id:
+                message_params["messaging_profile_id"] = profile_id
+
+            # Send the message
+            message = telnyx.Message.create(**message_params)
+
+            return (
+                f"Successfully sent SMS to {to}. "
+                f"Message ID: {message.id}. "
+                f"Status: {message.status}."
+            )
+
+        except telnyx.error.AuthenticationError:
+            return "Error: Invalid Telnyx API key. Please check your TELNYX_API_KEY."
+        except telnyx.error.InvalidRequestError as e:
+            return f"Error: Invalid request - {str(e)}"
+        except Exception as e:
+            return f"Error sending SMS: {str(e)}"
+
+    async def _arun(
+        self,
+        to: str,
+        body: str,
+        from_: str = "",
+        run_manager=None,
+    ) -> str:
+        """Async implementation - calls the sync version.
+
+        Note: Telnyx SDK is sync-only, so this wraps the sync call.
+        For production use with async LangGraph, consider using
+        asyncio.to_thread() or running in an executor.
+        """
+        return self._run(to, body, from_, run_manager)

--- a/examples/telnyx_tools/voice.py
+++ b/examples/telnyx_tools/voice.py
@@ -1,0 +1,278 @@
+"""Telnyx Voice tool for LangGraph agents.
+
+This module provides LangChain-compatible tools for making and managing
+voice calls via the Telnyx API.
+"""
+
+from typing import Optional
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class TelnyxCallInput(BaseModel):
+    """Input schema for Telnyx voice call tool."""
+
+    to: str = Field(
+        ...,
+        description="The destination phone number in E.164 format (e.g., '+15551234567')",
+    )
+    from_: str = Field(
+        default="",
+        description="The source phone number in E.164 format. If not provided, uses TELNYX_FROM_NUMBER environment variable.",
+    )
+    webhook_url: Optional[str] = Field(
+        default=None,
+        description="Optional webhook URL for call status events",
+    )
+
+
+class TelnyxHangupInput(BaseModel):
+    """Input schema for Telnyx hangup tool."""
+
+    call_control_id: str = Field(
+        ...,
+        description="The call control ID of the call to hang up",
+    )
+
+
+class TelnyxMakeCall(BaseTool):
+    """Tool for making voice calls via Telnyx API.
+
+    This tool allows LangGraph agents to initiate phone calls using the
+    Telnyx Voice API with Call Control.
+
+    Setup:
+        1. Install the telnyx package: `pip install telnyx`
+        2. Set your Telnyx API key: `export TELNYX_API_KEY='your-api-key'`
+        3. Set your Telnyx phone number: `export TELNYX_FROM_NUMBER='+15551234567'`
+        4. Configure your Telnyx Call Control application in the dashboard
+
+    Example:
+        ```python
+        from langgraph.prebuilt import create_react_agent
+        from langchain_openai import ChatOpenAI
+        from telnyx_tools import TelnyxMakeCall
+
+        model = ChatOpenAI(model="gpt-4")
+        tools = [TelnyxMakeCall()]
+        agent = create_react_agent(model, tools)
+
+        # Agent can now make phone calls
+        response = agent.invoke(
+            {"messages": [("user", "Call +15551234567 and play a greeting")]}
+        )
+        ```
+
+    Attributes:
+        name: The name of the tool for agent use.
+        description: Description of what the tool does.
+    """
+
+    name: str = "telnyx_make_call"
+    description: str = (
+        "Make a phone call to a specified number using Telnyx. "
+        "Use this when you need to call someone. "
+        "The 'to' parameter should be a phone number in E.164 format (e.g., '+15551234567'). "
+        "Returns a call_control_id that can be used to manage the call."
+    )
+    args_schema: type[BaseModel] = TelnyxCallInput
+
+    # Configuration attributes
+    api_key: Optional[str] = Field(default=None, exclude=True)
+    from_number: Optional[str] = Field(default=None, exclude=True)
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        from_number: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initialize the Telnyx voice call tool.
+
+        Args:
+            api_key: Telnyx API key. If not provided, reads from TELNYX_API_KEY env var.
+            from_number: Default caller phone number in E.164 format. If not provided,
+                reads from TELNYX_FROM_NUMBER env var.
+            **kwargs: Additional arguments passed to BaseTool.
+        """
+        super().__init__(**kwargs)
+        self.api_key = api_key
+        self.from_number = from_number
+
+    def _run(
+        self,
+        to: str,
+        from_: str = "",
+        webhook_url: Optional[str] = None,
+        run_manager=None,
+    ) -> str:
+        """Make a voice call.
+
+        Args:
+            to: Destination phone number in E.164 format.
+            from_: Source phone number (optional, uses config if not provided).
+            webhook_url: Optional webhook URL for call status events.
+
+        Returns:
+            A success message with the call control ID or an error message.
+        """
+        import os
+
+        try:
+            import telnyx
+        except ImportError:
+            return (
+                "Error: telnyx package not installed. "
+                "Please install it with: pip install telnyx"
+            )
+
+        # Get API key from config or environment
+        api_key = self.api_key or os.environ.get("TELNYX_API_KEY")
+        if not api_key:
+            return "Error: TELNYX_API_KEY not set. Please set the TELNYX_API_KEY environment variable."
+
+        telnyx.api_key = api_key
+
+        # Determine the caller number
+        caller = from_ or self.from_number or os.environ.get("TELNYX_FROM_NUMBER")
+        if not caller:
+            return (
+                "Error: No caller phone number provided. "
+                "Either pass the 'from_' parameter or set TELNYX_FROM_NUMBER environment variable."
+            )
+
+        try:
+            # Create the call
+            call_params = {
+                "from_": caller,
+                "to": to,
+            }
+
+            if webhook_url:
+                call_params["webhook_url"] = webhook_url
+
+            call = telnyx.Call.create(**call_params)
+
+            return (
+                f"Successfully initiated call to {to}. "
+                f"Call Control ID: {call.call_control_id}. "
+                f"Call will be connected shortly."
+            )
+
+        except telnyx.error.AuthenticationError:
+            return "Error: Invalid Telnyx API key. Please check your TELNYX_API_KEY."
+        except telnyx.error.InvalidRequestError as e:
+            return f"Error: Invalid request - {str(e)}"
+        except Exception as e:
+            return f"Error making call: {str(e)}"
+
+    async def _arun(
+        self,
+        to: str,
+        from_: str = "",
+        webhook_url: Optional[str] = None,
+        run_manager=None,
+    ) -> str:
+        """Async implementation - calls the sync version."""
+        return self._run(to, from_, webhook_url, run_manager)
+
+
+class TelnyxHangupCall(BaseTool):
+    """Tool for hanging up voice calls via Telnyx API.
+
+    This tool allows LangGraph agents to hang up active phone calls
+    using the Telnyx Call Control API.
+
+    Example:
+        ```python
+        from langgraph.prebuilt import create_react_agent
+        from langchain_openai import ChatOpenAI
+        from telnyx_tools import TelnyxMakeCall, TelnyxHangupCall
+
+        model = ChatOpenAI(model="gpt-4")
+        tools = [TelnyxMakeCall(), TelnyxHangupCall()]
+        agent = create_react_agent(model, tools)
+        ```
+
+    Attributes:
+        name: The name of the tool for agent use.
+        description: Description of what the tool does.
+    """
+
+    name: str = "telnyx_hangup_call"
+    description: str = (
+        "Hang up an active phone call. "
+        "Use this when you need to end a call. "
+        "Provide the call_control_id returned from a previous telnyx_make_call."
+    )
+    args_schema: type[BaseModel] = TelnyxHangupInput
+
+    # Configuration attributes
+    api_key: Optional[str] = Field(default=None, exclude=True)
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        **kwargs,
+    ):
+        """Initialize the Telnyx hangup tool.
+
+        Args:
+            api_key: Telnyx API key. If not provided, reads from TELNYX_API_KEY env var.
+            **kwargs: Additional arguments passed to BaseTool.
+        """
+        super().__init__(**kwargs)
+        self.api_key = api_key
+
+    def _run(
+        self,
+        call_control_id: str,
+        run_manager=None,
+    ) -> str:
+        """Hang up an active call.
+
+        Args:
+            call_control_id: The call control ID of the call to hang up.
+
+        Returns:
+            A success message or an error message.
+        """
+        import os
+
+        try:
+            import telnyx
+        except ImportError:
+            return (
+                "Error: telnyx package not installed. "
+                "Please install it with: pip install telnyx"
+            )
+
+        # Get API key from config or environment
+        api_key = self.api_key or os.environ.get("TELNYX_API_KEY")
+        if not api_key:
+            return "Error: TELNYX_API_KEY not set. Please set the TELNYX_API_KEY environment variable."
+
+        telnyx.api_key = api_key
+
+        try:
+            # Retrieve and hang up the call
+            call = telnyx.Call.retrieve(call_control_id)
+            call.hangup()
+
+            return f"Successfully hung up call {call_control_id}."
+
+        except telnyx.error.AuthenticationError:
+            return "Error: Invalid Telnyx API key. Please check your TELNYX_API_KEY."
+        except telnyx.error.InvalidRequestError as e:
+            return f"Error: Invalid request - {str(e)}"
+        except Exception as e:
+            return f"Error hanging up call: {str(e)}"
+
+    async def _arun(
+        self,
+        call_control_id: str,
+        run_manager=None,
+    ) -> str:
+        """Async implementation - calls the sync version."""
+        return self._run(call_control_id, run_manager)


### PR DESCRIPTION
## Summary

This PR adds Telnyx telephony tools for LangGraph agents, enabling AI agents to send SMS messages and make voice calls.

### Tools Added

- **TelnyxSendSMS**: Send SMS text messages via Telnyx API
- **TelnyxMakeCall**: Make voice calls using Telnyx Call Control
- **TelnyxHangupCall**: Hang up active voice calls

### Features

- Full LangChain BaseTool compatibility for seamless integration with ToolNode
- Pydantic input schemas for proper parameter validation
- Comprehensive error handling with user-friendly messages
- Async support via `_arun` methods
- Configurable via environment variables or constructor parameters

### Usage Example

```python
from langgraph.prebuilt import create_react_agent
from langchain_openai import ChatOpenAI
from telnyx_tools import TelnyxSendSMS, TelnyxMakeCall

model = ChatOpenAI(model="gpt-4o")
tools = [TelnyxSendSMS(), TelnyxMakeCall()]
agent = create_react_agent(model, tools)

response = agent.invoke({
    "messages": [("user", "Send SMS to +15551234567 saying 'Hello from LangGraph!'")]
})
```

### Prerequisites

Users need to set:
- `TELNYX_API_KEY`: Their Telnyx API key
- `TELNYX_FROM_NUMBER`: Their Telnyx phone number

## Testing

All tools follow the existing LangGraph tool patterns and include:
- Proper docstrings following LangChain conventions
- Error handling for missing dependencies, credentials, and API errors
- Input validation via Pydantic models

## Documentation

Includes:
- README.md with setup and usage instructions
- agent_example.py demonstrating full integration
- Inline documentation for all tool classes