### PR TITLE
fix(checkpoint): improve InMemorySaver serialization errors

### DIFF
--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -194,6 +194,23 @@ class TestMemorySaver:
         ]
         assert len(search_results_4) == 0
 
+    def test_put_writes_raises_serialization_error_with_context(self) -> None:
+        class FaultySerializer:
+            def dumps_typed(self, obj: Any) -> tuple[str, bytes]:
+                raise TypeError("cannot pickle '_thread.lock' object")
+
+            def loads_typed(self, data: tuple[str, bytes]) -> Any:
+                return data
+
+        memory_saver = InMemorySaver(serde=FaultySerializer())  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="Failed to serialize checkpoint write"):
+            memory_saver.put_writes(
+                self.config_1,
+                writes=[("foo", object())],
+                task_id="task-1",
+            )
+
 
 async def test_memory_saver() -> None:
     from langgraph.checkpoint.memory import InMemorySaver


### PR DESCRIPTION
## Summary
This PR improves `InMemorySaver` error diagnostics when checkpoint serialization fails.

- add `_serialize_or_raise(...)` helper to preserve original exception type while enriching error context
- include `thread_id`, `checkpoint_ns`, `checkpoint_id`, `task_id`, `channel`, and `value_type` in serialization failure messages
- cover the new behavior with a regression test in `libs/checkpoint/tests/test_memory.py`

## Why
In failures like #6781, runtime logs often surface low-level serialization errors (for example, non-picklable objects in middleware outputs) without enough checkpoint context to identify which write failed. This change keeps existing failure semantics (exceptions still surface) but makes root cause triage much faster.

## Validation
- `uv run ruff check langgraph/checkpoint/memory/__init__.py tests/test_memory.py`
- `uv run pytest tests/test_memory.py -q` (from `libs/checkpoint`)
- changed-line coverage for `libs/checkpoint/langgraph/checkpoint/memory/__init__.py`: 100%

Closes #6781
