### PR TITLE
fix(channels): handle None checkpoint in Topic.from_checkpoint()

### DIFF
--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -57,7 +57,7 @@ class Topic(
         """Return a copy of the channel."""
         empty = self.__class__(self.typ, self.accumulate)
         empty.key = self.key
-        empty.values = self.values.copy()
+        empty.values = self.values.copy() if self.values is not None else []
         return empty
 
     def checkpoint(self) -> list[Value]:
@@ -66,7 +66,7 @@ class Topic(
     def from_checkpoint(self, checkpoint: list[Value]) -> Self:
         empty = self.__class__(self.typ, self.accumulate)
         empty.key = self.key
-        if checkpoint is not MISSING:
+        if checkpoint is not MISSING and checkpoint is not None:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
                 empty.values = checkpoint[1]

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -56,6 +56,27 @@ def test_topic() -> None:
     assert channel.get() == ["e"]
 
 
+def test_topic_none_checkpoint() -> None:
+    """Regression test: Topic.from_checkpoint(None) should not crash on copy().
+
+    When a checkpoint contains None for a Topic channel value (e.g., after a
+    failed execution), from_checkpoint should treat it as missing and default
+    to an empty list. See https://github.com/langchain-ai/langgraph/issues/6791
+    """
+    channel = Topic(str).from_checkpoint(None)
+    with pytest.raises(EmptyChannelError):
+        channel.get()
+
+    # copy() must not raise AttributeError
+    channel_copy = channel.copy()
+    with pytest.raises(EmptyChannelError):
+        channel_copy.get()
+
+    # channel should still be usable after restore from None checkpoint
+    channel.update(["a", "b"])
+    assert channel.get() == ["a", "b"]
+
+
 def test_topic_accumulate() -> None:
     channel = Topic(str, accumulate=True).from_checkpoint(MISSING)
     assert channel.ValueType == Sequence[str]


### PR DESCRIPTION
## Summary

`Topic.from_checkpoint(None)` sets `self.values = None`, causing `Topic.copy()` to crash with `AttributeError` when the runtime reads channels during retry after a failed execution.

**Root cause**: `from_checkpoint()` only guards against `MISSING` but not `None`. When a checkpoint contains `None` for a Topic channel value (key exists but value is `None`), `values` is set to `None` instead of defaulting to an empty list.

**Fix**:
- Treat `None` as equivalent to `MISSING` in `from_checkpoint()` so `values` defaults to `[]`
- Add defensive guard in `copy()` to prevent crash if `None` leaks through another path

## Changes

- `libs/langgraph/langgraph/channels/topic.py`: 2-line fix
- `libs/langgraph/tests/test_channels.py`: regression test

## Test plan

- [x] Added `test_topic_none_checkpoint` covering the exact crash scenario
- [x] Verifies `from_checkpoint(None)` produces a valid empty channel
- [x] Verifies `copy()` works after `from_checkpoint(None)`
- [x] Verifies channel is still usable (update + get) after restore from `None`

Closes #6791