### PR TITLE
fix(typing): accept TypedDict state schemas under ty checker

### DIFF
--- a/libs/langgraph/langgraph/_internal/_typing.py
+++ b/libs/langgraph/langgraph/_internal/_typing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import Field
 from typing import Any, ClassVar, Protocol, TypeAlias
 
@@ -35,11 +36,17 @@ class DataclassLike(Protocol):
     __dataclass_fields__: ClassVar[dict[str, Field[Any]]]
 
 
-StateLike: TypeAlias = TypedDictLikeV1 | TypedDictLikeV2 | DataclassLike | BaseModel
+StateLike: TypeAlias = (
+    TypedDictLikeV1 | TypedDictLikeV2 | Mapping[str, Any] | DataclassLike | BaseModel
+)
 """Type alias for state-like types.
 
 It can either be a `TypedDict`, `dataclass`, or Pydantic `BaseModel`.
-Note: we cannot use either `TypedDict` or `dataclass` directly due to limitations in type checking.
+Note: we cannot use either `TypedDict` or `dataclass` directly due to limitations in
+type checking.
+
+`Mapping[str, Any]` keeps `TypedDict` support compatible with stricter type checkers
+like `ty` while preserving existing `Protocol`-based checks.
 """
 
 MISSING = object()

--- a/libs/langgraph/tests/test_type_checking.py
+++ b/libs/langgraph/tests/test_type_checking.py
@@ -35,6 +35,23 @@ def test_typed_dict_state() -> None:
     graph.invoke({"invalid": "lalala"})  # type: ignore[arg-type]
 
 
+def test_partial_typed_dict_state() -> None:
+    class PartialTypedDictState(TypedDict, total=False):
+        info: Annotated[list[str], add]
+        user_id: str
+
+    graph_builder = StateGraph(PartialTypedDictState)
+
+    def valid(state: PartialTypedDictState) -> Any: ...
+
+    graph_builder.add_node("valid", valid)
+    graph_builder.set_entry_point("valid")
+    graph = graph_builder.compile()
+
+    graph.invoke({"info": ["hello"]})
+    graph.invoke({"user_id": "u-1"})
+
+
 def test_dataclass_state() -> None:
     @dataclass
     class DataclassState:


### PR DESCRIPTION
## Summary
This PR fixes type-checking failures reported in #6823 when using `ty` with `TypedDict` state schemas.

### What changed
- Extended `StateLike` to include `Mapping[str, Any]` so `TypedDict`-based state schemas satisfy stricter type checkers like `ty`.
- Kept the existing protocol-based constraints (`TypedDictLikeV1`, `TypedDictLikeV2`, `DataclassLike`, `BaseModel`) intact.
- Added a regression test for `total=False` TypedDict state schemas in `tests/test_type_checking.py`.

## Why this works
`ty` does not consistently treat `TypedDict` classes as satisfying the existing protocol-only bound. Including `Mapping[str, Any]` in the state bound provides a compatible path for `TypedDict` while still rejecting unsupported schema classes.

## Validation
- `uv run ruff format langgraph/_internal/_typing.py tests/test_type_checking.py --check`
- `uv run ruff check langgraph/_internal/_typing.py tests/test_type_checking.py`
- `uv run mypy langgraph`
- `NO_DOCKER=true uv run pytest tests/test_type_checking.py`
- `uv run --with ty==0.0.17 ty check /tmp/langgraph_ty_6823_check.py`

AI assistance disclosure: AI support was limited to test/lint command orchestration and drafting review text. Final code changes and validation decisions were manually reviewed before submission.
