### PR TITLE
chore: bump orjson

### DIFF
--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 license-files = ['LICENSE']
 dependencies = [
   "langgraph-checkpoint>=2.1.2,<5.0.0",
-  "orjson>=3.10.1",
+  "orjson>=3.11.5",
   "psycopg>=3.2.0",
   "psycopg-pool>=3.2.0",
 ]

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -346,7 +346,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
     { name = "psycopg", specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
 ]

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
     { name = "psycopg", specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
 ]
@@ -1812,7 +1812,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.2" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
 ]
 
 [package.metadata.requires-dev]

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -411,7 +411,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
     { name = "psycopg", specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
 ]
@@ -585,7 +585,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.2" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
 ]
 
 [package.metadata.requires-dev]

--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = "MIT"
 license-files = ['LICENSE']
-dependencies = ["httpx>=0.25.2", "orjson>=3.10.1"]
+dependencies = ["httpx>=0.25.2", "orjson>=3.11.5"]
 
 [tool.hatch.version]
 path = "langgraph_sdk/__init__.py"

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -484,7 +484,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.25.2" },
-    { name = "orjson", specifier = ">=3.10.1" },
+    { name = "orjson", specifier = ">=3.11.5" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
The orjson.dumps function in orjson thru 3.11.4 does not limit recursion for deeply nested JSON documents.

