### PR TITLE
feat: Add messages_key parameter to stream_mode="messages"

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1042,6 +1042,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         interrupt_after: All | list[str] | None = None,
         debug: bool = False,
         name: str | None = None,
+        messages_key: str | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1074,6 +1075,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             interrupt_after: An optional list of node names to interrupt after.
             debug: A flag indicating whether to enable debug mode.
             name: The name to use for the compiled graph.
+            messages_key: Optional key to restrict `stream_mode="messages"` to a specific state field.
+                If provided, when streaming with `stream_mode="messages"`, only messages from this
+                state key will be streamed. This is useful when you have multiple message fields
+                but only want to expose one (e.g., `messages`) to the frontend while keeping others
+                (e.g., `agent_messages`) private. Can be overridden at stream time.
 
         Returns:
             CompiledStateGraph: The compiled `StateGraph`.
@@ -1134,6 +1140,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             store=store,
             cache=cache,
             name=name or "LangGraph",
+            messages_key=messages_key,
         )
 
         compiled.attach_node(START, None)

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -652,6 +652,7 @@ class Pregel(
         config: RunnableConfig | None = None,
         trigger_to_nodes: Mapping[str, Sequence[str]] | None = None,
         name: str = "LangGraph",
+        messages_key: str | None = None,
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         if (
@@ -698,6 +699,7 @@ class Pregel(
         self.config = config
         self.trigger_to_nodes = trigger_to_nodes or {}
         self.name = name
+        self.messages_key = messages_key
         if auto_validate:
             self.validate()
 
@@ -2418,6 +2420,7 @@ class Pregel(
         durability: Durability | None = None,
         subgraphs: bool = False,
         debug: bool | None = None,
+        messages_key: str | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Iterator[dict[str, Any] | Any]:
         """Stream graph steps for a single input.
@@ -2535,11 +2538,16 @@ class Pregel(
             # set up messages stream mode
             if "messages" in stream_modes:
                 ns_ = cast(str | None, config[CONF].get(CONFIG_KEY_CHECKPOINT_NS))
+                # Determine effective messages_key: stream param > compile param
+                effective_messages_key = (
+                    messages_key if messages_key is not None else self.messages_key
+                )
                 run_manager.inheritable_handlers.append(
                     StreamMessagesHandler(
                         stream.put,
                         subgraphs,
                         parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
+                        messages_key=effective_messages_key,
                     )
                 )
 
@@ -2692,6 +2700,7 @@ class Pregel(
         durability: Durability | None = None,
         subgraphs: bool = False,
         debug: bool | None = None,
+        messages_key: str | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> AsyncIterator[dict[str, Any] | Any]:
         """Asynchronously stream graph steps for a single input.
@@ -2829,11 +2838,16 @@ class Pregel(
             if "messages" in stream_modes:
                 # namespace can be None in a root level graph?
                 ns_ = cast(str | None, config[CONF].get(CONFIG_KEY_CHECKPOINT_NS))
+                # Determine effective messages_key: stream param > compile param
+                effective_messages_key = (
+                    messages_key if messages_key is not None else self.messages_key
+                )
                 run_manager.inheritable_handlers.append(
                     StreamMessagesHandler(
                         stream_put,
                         subgraphs,
                         parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
+                        messages_key=effective_messages_key,
                     )
                 )
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -6680,6 +6680,155 @@ def test_stream_mode_messages_command() -> None:
     ]
 
 
+def test_stream_mode_messages_with_messages_key() -> None:
+    """Test that messages_key restricts streaming to specific state field."""
+    from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+    class MultiMessageState(TypedDict):
+        messages: Annotated[list[BaseMessage], add_messages]
+        agent_messages: Annotated[list[BaseMessage], add_messages]
+
+    def public_node(state):
+        return {
+            "messages": [AIMessage(content="Public response")],
+            "agent_messages": [AIMessage(content="SECRET internal reasoning")],
+        }
+
+    def private_node(state):
+        return {
+            "agent_messages": [AIMessage(content="More secret stuff")],
+        }
+
+    graph = (
+        StateGraph(MultiMessageState)
+        .add_node("public", public_node)
+        .add_node("private", private_node)
+        .add_edge(START, "public")
+        .add_edge("public", "private")
+        .compile()
+    )
+
+    # Test 1: Default behavior (no messages_key) - streams all node outputs
+    chunks_all = list(
+        graph.stream(
+            {"messages": [HumanMessage(content="hi")], "agent_messages": []},
+            stream_mode="messages",
+        )
+    )
+    # Input messages are NOT streamed, only node outputs: 3 AIMessages
+    assert len(chunks_all) == 3  # 3 AIMessages from node outputs
+    contents_all = [msg.content for msg, _ in chunks_all]
+    assert "Public response" in contents_all
+    assert "SECRET internal reasoning" in contents_all
+    assert "More secret stuff" in contents_all
+
+    # Test 2: With messages_key at stream time - only streams from 'messages' key
+    chunks_filtered = list(
+        graph.stream(
+            {"messages": [HumanMessage(content="hi")], "agent_messages": []},
+            stream_mode="messages",
+            messages_key="messages",
+        )
+    )
+    assert len(chunks_filtered) == 1  # Only public AIMessage (node output only)
+    contents_filtered = [msg.content for msg, _ in chunks_filtered]
+    assert "Public response" in contents_filtered
+    assert "SECRET internal reasoning" not in contents_filtered
+    assert "More secret stuff" not in contents_filtered
+
+    # Test 3: With messages_key at compile time
+    # Create a new graph with messages_key at compile time
+    graph_with_key = (
+        StateGraph(MultiMessageState)
+        .add_node("public", public_node)
+        .add_node("private", private_node)
+        .add_edge(START, "public")
+        .add_edge("public", "private")
+        .compile(messages_key="messages")
+    )
+    chunks_compile = list(
+        graph_with_key.stream(
+            {"messages": [HumanMessage(content="hi")], "agent_messages": []},
+            stream_mode="messages",
+        )
+    )
+    # Same as Test 2: only messages from 'messages' key (node outputs only)
+    assert len(chunks_compile) == 1
+    contents_compile = [msg.content for msg, _ in chunks_compile]
+    assert "Public response" in contents_compile
+    assert "SECRET internal reasoning" not in contents_compile
+
+
+def test_stream_mode_messages_with_custom_messages_key() -> None:
+    """Test messages_key with non-default key name."""
+    from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+    class CustomState(TypedDict):
+        chat: Annotated[list[BaseMessage], add_messages]
+        internal: Annotated[list[BaseMessage], add_messages]
+
+    def my_node(state):
+        return {
+            "chat": [AIMessage(content="Hello")],
+            "internal": [AIMessage(content="Internal thought")],
+        }
+
+    graph = (
+        StateGraph(CustomState)
+        .add_node("my_node", my_node)
+        .add_edge(START, "my_node")
+        .compile(messages_key="chat")
+    )
+
+    chunks = list(
+        graph.stream(
+            {"chat": [HumanMessage(content="hi")], "internal": []},
+            stream_mode="messages",
+        )
+    )
+
+    assert len(chunks) == 1  # Only AIMessage from 'chat' (node output only)
+    contents = [msg.content for msg, _ in chunks]
+    assert "Hello" in contents
+    assert "Internal thought" not in contents
+
+
+def test_stream_mode_messages_key_override() -> None:
+    """Test that stream-time messages_key overrides compile-time setting."""
+    from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+    class MultiMessageState(TypedDict):
+        messages: Annotated[list[BaseMessage], add_messages]
+        agent_messages: Annotated[list[BaseMessage], add_messages]
+
+    def my_node(state):
+        return {
+            "messages": [AIMessage(content="Public")],
+            "agent_messages": [AIMessage(content="Private")],
+        }
+
+    # Compile with messages_key="agent_messages"
+    graph = (
+        StateGraph(MultiMessageState)
+        .add_node("my_node", my_node)
+        .add_edge(START, "my_node")
+        .compile(messages_key="agent_messages")
+    )
+
+    # Override at stream time to "messages"
+    chunks = list(
+        graph.stream(
+            {"messages": [HumanMessage(content="hi")], "agent_messages": []},
+            stream_mode="messages",
+            messages_key="messages",  # Override compile-time setting
+        )
+    )
+
+    contents = [msg.content for msg, _ in chunks]
+    assert "Public" in contents
+    assert "Private" not in contents
+
+
 def test_node_destinations() -> None:
     class State(TypedDict):
         foo: Annotated[str, operator.add]


### PR DESCRIPTION
## Summary

This PR adds a `messages_key` parameter to `stream_mode="messages"` to restrict streaming to specific state keys, preventing private/internal messages (e.g., `agent_messages`) from leaking to frontend clients.

## Changes

### 1. Core Implementation
- **`StateGraph.compile()`**: Added optional `messages_key` parameter to specify which state key to stream messages from
- **`Pregel.stream()`/`astream()`**: Added `messages_key` parameter for runtime override
- **`StreamMessagesHandler`**: Implemented filtering logic with `_find_and_emit_from_key()` method

### 2. Features
- ✅ **Compile-time filtering**: Set `messages_key` when compiling the graph
- ✅ **Runtime override**: Override compile-time setting at stream time
- ✅ **Custom key names**: Support for non-default message key names (e.g., `chat`, `messages`)
- ✅ **Backward compatible**: Default `None` preserves current behavior (streams all keys)

### 3. Test Coverage
- 6 new tests (3 sync + 3 async)
- Tests for: default behavior, compile-time, stream-time, custom keys, override
- All 64 existing stream-related tests still pass

## Example Usage

```python
from typing import Annotated
from typing_extensions import TypedDict
from langgraph.graph import StateGraph, START
from langchain_core.messages import BaseMessage
from langgraph.graph.message import add_messages

class MultiMessageState(TypedDict):
    messages: Annotated[list[BaseMessage], add_messages]
    agent_messages: Annotated[list[BaseMessage], add_messages]

def my_node(state):
    return {
        "messages": [AIMessage(content="Public response")],
        "agent_messages": [AIMessage(content="SECRET internal reasoning")],
    }

# Option 1: Set at compile time
graph = StateGraph(MultiMessageState)
    .add_node("my_node", my_node)
    .add_edge(START, "my_node")
    .compile(messages_key="messages")

# Option 2: Override at stream time
chunks = list(graph.stream(
    {"messages": [HumanMessage("hi")], "agent_messages": []},
    stream_mode="messages",
    messages_key="messages"  # Only stream from 'messages' key
))
```

## Impact

- **Security**: Prevents internal/private messages from being exposed to clients
- **Flexibility**: Allows fine-grained control over which message fields are streamed
- **Backward Compatible**: Default `None` preserves existing behavior

## Test Plan

```bash
# Run new tests
NO_DOCKER=true uv run pytest tests/test_pregel.py -k "messages_key" -xvs
NO_DOCKER=true uv run pytest tests/test_pregel_async.py -k "messages_key" -xvs

# Run all stream tests to verify no regressions
NO_DOCKER=true uv run pytest tests/test_pregel.py -k "stream" -x
NO_DOCKER=true uv run pytest tests/test_pregel_async.py -k "stream" -x
```

## Related Issues

Fixes #6798

🤖 Generated with [Claude Code](https://claude.com/claude-code)