### PR TITLE
chore: rm duplicate writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -1061,17 +1061,13 @@ def _scratchpad(
 ) -> PregelScratchpad:
     if len(pending_writes) > 0:
         # find global resume value
-        # Only the root scratchpad (no parent) owns the null resume write.
-        # Child scratchpads always delegate to their parent via
-        # get_null_resume, ensuring the value is consumed at most once.
-        if parent_scratchpad is None:
-            for w in pending_writes:
-                if w[0] == NULL_TASK_ID and w[1] == RESUME:
-                    null_resume_write = w
-                    break
-            else:
-                null_resume_write = None
+        for w in pending_writes:
+            if w[0] == NULL_TASK_ID and w[1] == RESUME:
+                null_resume_write = w
+                break
         else:
+            # None cannot be used as a resume value, because it would be difficult to
+            # distinguish from missing when used over http
             null_resume_write = None
 
         # find task-specific resume value

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -728,7 +728,6 @@ async def _acall_impl(
                     )
                 else:
                     fut.set_result(None)
-                futures()[fut] = next_task  # type: ignore[index]
             else:
                 # schedule the next task
                 fut = cast(

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5889,6 +5889,54 @@ def test_multiple_tasks_before_interrupt_resume(
     assert result == {"computed": 12, "answer": "continue"}
 
 
+def test_no_redundant_put_writes_for_cached_task(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Cached @tasks on resume must not trigger redundant put_writes."""
+    from unittest.mock import patch
+
+    from langgraph.pregel._loop import PregelLoop
+
+    @task
+    def setup(x: int) -> int:
+        return x
+
+    @task
+    def ask(question: str) -> str:
+        return interrupt(question)
+
+    @entrypoint(checkpointer=sync_checkpointer)
+    def workflow(x: int) -> dict:
+        n = setup(x).result()
+        answer = ask(f"q{n}").result()
+        return {"answer": answer}
+
+    config = {"configurable": {"thread_id": "1"}}
+    result = workflow.invoke(1, config=config)
+    assert "__interrupt__" in result
+
+    put_writes_task_ids: list[str] = []
+    orig = PregelLoop.put_writes
+
+    def spy(self, task_id, writes):
+        put_writes_task_ids.append(task_id)
+        return orig(self, task_id, writes)
+
+    with patch.object(PregelLoop, "put_writes", spy):
+        result = workflow.invoke(Command(resume="ans"), config=config)
+
+    assert result == {"answer": "ans"}
+    # Count unique non-null task IDs that got put_writes.
+    # Should be exactly 2: the ask task and the entrypoint task.
+    # If 3, the cached setup task is being redundantly re-committed.
+    non_null = set(
+        tid for tid in put_writes_task_ids if not tid.startswith("00000000")
+    )
+    assert len(non_null) == 2, (
+        f"Expected 2 task IDs in put_writes (ask + entrypoint), got {len(non_null)}"
+    )
+
+
 def test_node_before_interrupt_resume_graph_api(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
In the original proposed fix [6863](https://github.com/langchain-ai/langgraph/pull/6863), we were guarding this specific case by only checking for null resume in the scratchpad.

But I noticed the tests passed on main for the sync case, indicating an inconsistency between the two paths. 

Seems like we were making a redundant put_writes call when replaying the async tasks