### PR TITLE
feat(sdk-py): improve store auth type safety and docstrings

### DIFF
--- a/libs/sdk-py/langgraph_sdk/auth/types.py
+++ b/libs/sdk-py/langgraph_sdk/auth/types.py
@@ -402,7 +402,7 @@ class AuthContext(BaseAuthContext):
         "list_namespaces",
     ]
     """The action being performed on the resource.
-    
+
     Most resources support the following actions:
     - create: Create a new resource
     - read: Read information about a resource
@@ -411,8 +411,10 @@ class AuthContext(BaseAuthContext):
     - search: Search for resources
 
     The store supports the following actions:
-    - put: Add or update a document in the store
-    - get: Get a document from the store
+    - put: Add or update an item in the store
+    - get: Get an item from the store
+    - search: Search for items within a namespace prefix
+    - delete: Delete an item from the store
     - list_namespaces: List the namespaces in the store
     """
 
@@ -851,20 +853,34 @@ class CronsSearch(typing.TypedDict, total=False):
 
 
 class StoreGet(typing.TypedDict):
-    """Operation to retrieve a specific item by its namespace and key."""
+    """Operation to retrieve a specific item by its namespace and key.
+
+    This dict is mutable — auth handlers can modify `namespace` to enforce
+    access scoping (e.g., prepending the user's identity).
+    """
 
     namespace: tuple[str, ...]
-    """Hierarchical path that uniquely identifies the item's location."""
+    """Hierarchical path that uniquely identifies the item's location.
+
+    Auth handlers can modify this to enforce per-user scoping.
+    """
 
     key: str
     """Unique identifier for the item within its specific namespace."""
 
 
 class StoreSearch(typing.TypedDict):
-    """Operation to search for items within a specified namespace hierarchy."""
+    """Operation to search for items within a specified namespace hierarchy.
+
+    This dict is mutable — auth handlers can modify `namespace` to enforce
+    access scoping (e.g., prepending the user's identity).
+    """
 
     namespace: tuple[str, ...]
-    """Prefix filter for defining the search scope."""
+    """Prefix filter for defining the search scope.
+
+    Auth handlers can modify this to enforce per-user scoping.
+    """
 
     filter: dict[str, typing.Any] | None
     """Key-value pairs for filtering results based on exact matches or comparison operators."""
@@ -876,14 +892,22 @@ class StoreSearch(typing.TypedDict):
     """Number of matching items to skip for pagination."""
 
     query: str | None
-    """Naturalj language search query for semantic search capabilities."""
+    """Natural language search query for semantic search capabilities."""
 
 
 class StoreListNamespaces(typing.TypedDict):
-    """Operation to list and filter namespaces in the store."""
+    """Operation to list and filter namespaces in the store.
+
+    This dict is mutable — auth handlers can modify `namespace` (the prefix)
+    to enforce access scoping (e.g., prepending the user's identity).
+    """
 
     namespace: tuple[str, ...] | None
-    """Prefix filter namespaces."""
+    """Prefix filter for namespaces. Can be `None` if no prefix was provided.
+
+    Auth handlers can modify this to enforce per-user scoping. When `None`,
+    handlers should set it to `(user_id,)` to scope listing to the user's namespaces.
+    """
 
     suffix: tuple[str, ...] | None
     """Optional conditions for filtering namespaces."""
@@ -903,10 +927,17 @@ class StoreListNamespaces(typing.TypedDict):
 
 
 class StorePut(typing.TypedDict):
-    """Operation to store, update, or delete an item in the store."""
+    """Operation to store, update, or delete an item in the store.
+
+    This dict is mutable — auth handlers can modify `namespace` to enforce
+    access scoping (e.g., prepending the user's identity).
+    """
 
     namespace: tuple[str, ...]
-    """Hierarchical path that identifies the location of the item."""
+    """Hierarchical path that identifies the location of the item.
+
+    Auth handlers can modify this to enforce per-user scoping.
+    """
 
     key: str
     """Unique identifier for the item within its namespace."""
@@ -919,10 +950,17 @@ class StorePut(typing.TypedDict):
 
 
 class StoreDelete(typing.TypedDict):
-    """Operation to delete an item from the store."""
+    """Operation to delete an item from the store.
+
+    This dict is mutable — auth handlers can modify `namespace` to enforce
+    access scoping (e.g., prepending the user's identity).
+    """
 
     namespace: tuple[str, ...]
-    """Hierarchical path that uniquely identifies the item's location."""
+    """Hierarchical path that uniquely identifies the item's location.
+
+    Auth handlers can modify this to enforce per-user scoping.
+    """
 
     key: str
     """Unique identifier for the item within its specific namespace."""


### PR DESCRIPTION
## Summary
- Add `_StoreActionOn` class with action-specific decorator properties (`.put`, `.get`, `.search`, `.delete`, `.list_namespaces`) to `_StoreOn`, enabling `@auth.on.store.put` etc. which was documented but not implemented
- Update docstring examples to show namespace-rewriting pattern as the canonical store auth approach
- Fix `AuthContext.action` docstring: add missing `search` and `delete` store actions
- Fix typo in `StoreSearch.query` docstring
- Add auth-handler-aware docstrings to all store TypedDicts

## Test plan
- [x] `make format && make lint` passes in `libs/sdk-py`
- [] Verify `@auth.on.store.put` decorator works at runtime