### PR TITLE
perf: remove importlib.metadata usage for version access

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import warnings
 from collections.abc import Sequence
-from importlib.metadata import version as get_version
+# Removed importlib.metadata import to avoid performance overhead
 from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -19,7 +19,8 @@ from psycopg.types.json import Jsonb
 MetadataInput = dict[str, Any] | None
 
 try:
-    major, minor = get_version("langgraph").split(".")[:2]
+    from langgraph.version import __version__
+    major, minor = __version__.split(".")[:2]
     if int(major) == 0 and int(minor) < 5:
         warnings.warn(
             "You're using incompatible versions of langgraph and checkpoint-postgres. Please upgrade langgraph to avoid unexpected behavior.",

--- a/libs/cli/generate_schema.py
+++ b/libs/cli/generate_schema.py
@@ -214,12 +214,12 @@ def main():
     schema = generate_schema()
 
     # Add versioning to the schema
-    import importlib.metadata
-
+    # Use hardcoded version to avoid importlib.metadata overhead
     try:
-        version = importlib.metadata.version("langgraph_cli").split(".")
+        from langgraph_cli.version import __version__
+        version = __version__.split(".")
         schema_version = f"v{version[0]}"
-    except importlib.metadata.PackageNotFoundError:
+    except ImportError:
         schema_version = "v1"
 
     # Add version to schema

--- a/libs/cli/langgraph_cli/version.py
+++ b/libs/cli/langgraph_cli/version.py
@@ -1,10 +1,4 @@
 """Main entrypoint into package."""
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Import version from __init__.py to avoid importlib.metadata overhead
+from langgraph_cli import __version__

--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,7 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Hardcoded version to avoid importlib.metadata overhead
+# This should be kept in sync with pyproject.toml
+__version__ = "1.0.8"


### PR DESCRIPTION
## Summary

This PR addresses performance issue #5040 by removing `importlib.metadata` usage for internal package version access and replacing it with hardcoded version imports.

## Changes

### Core Changes
- **`langgraph/version.py`**: Replaced `importlib.metadata.version()` call with hardcoded `__version__ = "1.0.8"` (synced with pyproject.toml)
- **`checkpoint-postgres/base.py`**: Replaced `importlib.metadata.version("langgraph")` with import from `langgraph.version.__version__`
- **`cli/generate_schema.py`**: Replaced `importlib.metadata.version("langgraph_cli")` with import from `langgraph_cli.version.__version__`  
- **`cli/langgraph_cli/version.py`**: Replaced `importlib.metadata.version()` call with direct import from `langgraph_cli.__version__`

### Preserved
- **`checkpoint/store/base/embed.py`**: Left unchanged as it checks external package (langchain) versions that we don't control

## Performance Impact

- Eliminates importlib.metadata import overhead on every version access
- Reduces cold import time for LangGraph package
- Maintains same API surface (all __version__ attributes work identically)

## Testing

- All modified files pass syntax validation (python -m py_compile)
- Version imports verified working:
  - `from langgraph.version import __version__` ✓
  - `from langgraph_cli.version import __version__` ✓
  - Postgres checkpoint compatibility check ✓

## Synchronization

All hardcoded versions are kept in sync with their respective pyproject.toml files:
- langgraph: 1.0.8
- langgraph_cli: 0.4.13 (from __init__.py as per hatch.version.path)

Fixes #5040