### PR TITLE
fix: bump js-yaml to 3.14.2 to resolve CVE-2025-64718

### DIFF
--- a/libs/cli/js-examples/yarn.lock
+++ b/libs/cli/js-examples/yarn.lock
@@ -3533,9 +3533,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Security Alert Patch

Resolves 1 Dependabot security alert (medium severity).

### Package Updated

| Package | Old Version | New Version | Strategy | CVE Resolved |
|---------|-------------|-------------|----------|--------------|
| `js-yaml` | 3.14.1 | 3.14.2 | Lockfile patch (within-range bump) | CVE-2025-64718 |

### CVE Details

**CVE-2025-64718** / [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m) — `js-yaml` prototype pollution via YAML merge keys (`<<`). Affects versions < 3.14.2.

The vulnerable package is a transitive dev dependency pulled in by `@istanbuljs/load-nyc-config@1.1.0` (a Jest internal). No runtime impact.

### Fix Strategy

Lockfile-only patch in `libs/cli/js-examples/yarn.lock`. The `^3.13.1` version range already allows 3.14.2, so no manifest changes were needed. The `js-yaml@^4.1.1` entry (used by `@eslint/eslintrc`) is untouched.

### Verification

- [x] Lockfile updated — `js-yaml@^3.13.1` now resolves to `3.14.2`
- [x] `js-yaml@^4.1.1` entry unchanged (`4.1.1`)
- [x] `yarn install --frozen-lockfile` passes

🤖 Submitted by langster-patch