### PR TITLE
fix(cli): guard inmem extra on unsupported Python versions

### DIFF
--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -13,6 +13,7 @@ For development mode with hot reloading:
 ```bash
 pip install "langgraph-cli[inmem]"
 ```
+Note: `inmem` currently supports Python `3.11` to `3.13`.
 
 ## Commands
 

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -22,6 +22,27 @@ from langgraph_cli.templates import TEMPLATE_HELP_STRING, create_new
 from langgraph_cli.util import warn_non_wolfi_distro
 from langgraph_cli.version import __version__
 
+
+def _inmem_python_version_note(
+    version: tuple[int, int] | None = None,
+) -> str:
+    """Return a user-facing note when the current Python cannot run `inmem`."""
+    major, minor = version or (sys.version_info.major, sys.version_info.minor)
+    if (major, minor) < (3, 11):
+        return (
+            "\n\nNote: The in-mem server requires Python 3.11 or higher to be installed."
+            f" You are currently using Python {major}.{minor}."
+            ' Please upgrade your Python version before installing "langgraph-cli[inmem]".'
+        )
+    if (major, minor) >= (3, 14):
+        return (
+            "\n\nNote: The in-mem server currently supports Python 3.11-3.13."
+            f" You are currently using Python {major}.{minor}."
+            ' Please use Python 3.13 (or 3.12/3.11) before installing "langgraph-cli[inmem]".'
+        )
+    return ""
+
+
 OPT_DOCKER_COMPOSE = click.option(
     "--docker-compose",
     "-d",
@@ -700,13 +721,7 @@ def dev(
     try:
         from langgraph_api.cli import run_server  # type: ignore
     except ImportError:
-        py_version_msg = ""
-        if sys.version_info < (3, 11):
-            py_version_msg = (
-                "\n\nNote: The in-mem server requires Python 3.11 or higher to be installed."
-                f" You are currently using Python {sys.version_info.major}.{sys.version_info.minor}."
-                ' Please upgrade your Python version before installing "langgraph-cli[inmem]".'
-            )
+        py_version_msg = _inmem_python_version_note()
         try:
             from importlib import util
 

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
 path = "langgraph_cli/__init__.py"
 [project.optional-dependencies]
 inmem = [
-    "langgraph-api>=0.5.35,<0.8.0 ; python_version >= '3.11'",
-    "langgraph-runtime-inmem>=0.7 ; python_version >= '3.11'",
+    "langgraph-api>=0.5.35,<0.8.0 ; python_version >= '3.11' and python_version < '3.14'",
+    "langgraph-runtime-inmem>=0.7 ; python_version >= '3.11' and python_version < '3.14'",
     "python-dotenv>=0.8.0",
 ]
 

--- a/libs/cli/tests/unit_tests/test_cli.py
+++ b/libs/cli/tests/unit_tests/test_cli.py
@@ -1,0 +1,18 @@
+from langgraph_cli.cli import _inmem_python_version_note
+
+
+def test_inmem_python_version_note_for_unsupported_old_python() -> None:
+    note = _inmem_python_version_note((3, 10))
+    assert "requires Python 3.11 or higher" in note
+    assert "3.10" in note
+
+
+def test_inmem_python_version_note_for_supported_python() -> None:
+    assert _inmem_python_version_note((3, 11)) == ""
+    assert _inmem_python_version_note((3, 13)) == ""
+
+
+def test_inmem_python_version_note_for_unsupported_new_python() -> None:
+    note = _inmem_python_version_note((3, 14))
+    assert "supports Python 3.11-3.13" in note
+    assert "3.14" in note

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -974,8 +974,8 @@ dependencies = [
 
 [package.optional-dependencies]
 inmem = [
-    { name = "langgraph-api", marker = "python_full_version >= '3.11'" },
-    { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11'" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "python-dotenv" },
 ]
 
@@ -1007,8 +1007,8 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
-    { name = "langgraph-api", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.5.35,<0.8.0" },
-    { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.7" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'inmem'", specifier = ">=0.5.35,<0.8.0" },
+    { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'inmem'", specifier = ">=0.7" },
     { name = "langgraph-sdk", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "python-dotenv", marker = "extra == 'inmem'", specifier = ">=0.8.0" },
 ]


### PR DESCRIPTION
## Summary
Fixes #6505.

Installing `langgraph-cli[inmem]` on Python 3.14 currently pulls transitive dependencies that may fail to build in some environments. This change makes the failure mode deterministic and user-friendly.

## Changes
- Constrained `inmem` extra deps to Python `>=3.11,<3.14` in `libs/cli/pyproject.toml`.
- Updated `libs/cli/uv.lock` markers to match the same Python range.
- Added `_inmem_python_version_note()` in `libs/cli/langgraph_cli/cli.py` and reused it in `langgraph dev` import-error handling.
- Added unit tests for old/supported/new Python version note behavior.
- Added a short README note documenting the supported Python range for `inmem`.

## Validation
- `make format`
- `make lint`
- `uv run pytest tests/unit_tests/test_cli.py -q`

Note: `make test` currently reports 2 pre-existing failures in `tests/unit_tests/cli/test_cli.py` unrelated to this change (`test_dockerfile_command_with_docker_compose`, `test_build_generate_proper_build_context`).

## AI assistance disclosure
I used AI assistance in a limited scope for unit-test drafting, code review, and formatting checks.
