### PR TITLE
perf: remove use of importlib.metadata for version access

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 import warnings
 from collections.abc import Sequence
-from importlib.metadata import version as get_version
 from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -14,12 +13,13 @@ from langgraph.checkpoint.base import (
     get_checkpoint_id,
 )
 from langgraph.checkpoint.serde.types import TASKS
+from langgraph.version import __version__ as _langgraph_version
 from psycopg.types.json import Jsonb
 
 MetadataInput = dict[str, Any] | None
 
 try:
-    major, minor = get_version("langgraph").split(".")[:2]
+    major, minor = _langgraph_version.split(".")[:2]
     if int(major) == 0 and int(minor) < 5:
         warnings.warn(
             "You're using incompatible versions of langgraph and checkpoint-postgres. Please upgrade langgraph to avoid unexpected behavior.",

--- a/libs/checkpoint/langgraph/store/base/embed.py
+++ b/libs/checkpoint/langgraph/store/base/embed.py
@@ -83,12 +83,11 @@ def ensure_embeddings(
     if isinstance(embed, str):
         init_embeddings = _get_init_embeddings()
         if init_embeddings is None:
-            from importlib.metadata import PackageNotFoundError, version
-
             try:
-                lc_version = version("langchain")
+                from langchain import __version__ as lc_version
+
                 version_info = f"Found langchain version {lc_version}, but"
-            except PackageNotFoundError:
+            except ImportError:
                 version_info = "langchain is not installed;"
 
             raise ValueError(

--- a/libs/cli/generate_schema.py
+++ b/libs/cli/generate_schema.py
@@ -214,12 +214,12 @@ def main():
     schema = generate_schema()
 
     # Add versioning to the schema
-    import importlib.metadata
+    from langgraph_cli import __version__ as cli_version
 
     try:
-        version = importlib.metadata.version("langgraph_cli").split(".")
+        version = cli_version.split(".")
         schema_version = f"v{version[0]}"
-    except importlib.metadata.PackageNotFoundError:
+    except Exception:
         schema_version = "v1"
 
     # Add version to schema

--- a/libs/cli/langgraph_cli/version.py
+++ b/libs/cli/langgraph_cli/version.py
@@ -1,10 +1,3 @@
 """Main entrypoint into package."""
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+from langgraph_cli import __version__  # noqa: F401

--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,5 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "1.0.9"


### PR DESCRIPTION
## Summary
Fixes #5040

Removes all `importlib.metadata` usage for version lookups across the monorepo, replacing with direct `__version__` imports. This avoids the metadata scan overhead that `importlib.metadata.version()` incurs on every import.

## Changes

- **`libs/langgraph/langgraph/version.py`**: Replace `importlib.metadata.version()` with a hardcoded `__version__` string (matching `pyproject.toml`)
- **`libs/cli/langgraph_cli/version.py`**: Replace metadata lookup with a direct import from `langgraph_cli.__init__` (where the version is already defined by hatch)
- **`libs/checkpoint-postgres/.../base.py`**: Replace `importlib.metadata.version("langgraph")` with import from `langgraph.version.__version__`
- **`libs/checkpoint/langgraph/store/base/embed.py`**: Replace `importlib.metadata.version("langchain")` with `from langchain import __version__`
- **`libs/cli/generate_schema.py`**: Replace `importlib.metadata.version("langgraph_cli")` with import from `langgraph_cli.__version__`

## Test plan
- [ ] Existing tests pass with no behavioral changes
- [ ] `from langgraph.version import __version__` returns the correct version string
- [ ] `from langgraph_cli.version import __version__` returns the correct version string
- [ ] No remaining `importlib.metadata` usage: `grep -r "importlib.metadata" --include="*.py" libs/` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)