### PR TITLE
perf: remove importlib.metadata for version access

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import random
-import warnings
 from collections.abc import Sequence
-from importlib.metadata import version as get_version
 from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -17,18 +15,6 @@ from langgraph.checkpoint.serde.types import TASKS
 from psycopg.types.json import Jsonb
 
 MetadataInput = dict[str, Any] | None
-
-try:
-    major, minor = get_version("langgraph").split(".")[:2]
-    if int(major) == 0 and int(minor) < 5:
-        warnings.warn(
-            "You're using incompatible versions of langgraph and checkpoint-postgres. Please upgrade langgraph to avoid unexpected behavior.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-except Exception:
-    # skip version check if running from source
-    pass
 
 """
 To add a new migration, add a new string to the MIGRATIONS list.

--- a/libs/cli/langgraph_cli/version.py
+++ b/libs/cli/langgraph_cli/version.py
@@ -1,10 +1,3 @@
 """Main entrypoint into package."""
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+from langgraph_cli import __version__

--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,5 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "1.0.9"


### PR DESCRIPTION
## Summary

Removes `importlib.metadata` usage at import time for version access, improving import performance.

- **`langgraph/version.py`**: Replace `importlib.metadata.version()` with a hardcoded version string matching `pyproject.toml`
- **`langgraph_cli/version.py`**: Re-export `__version__` from `langgraph_cli.__init__` (which already has a static version) instead of using `importlib.metadata`
- **`checkpoint-postgres/base.py`**: Remove the obsolete version compatibility check that used `importlib.metadata` at import time. The check warned about `langgraph < 0.5`, which is no longer relevant since langgraph is at v1.x

The remaining `importlib.metadata` usages in `embed.py` and `generate_schema.py` are already lazy (inside function bodies, not at module level) and do not affect import time.

Fixes #5040

## Test plan

- [x] `from langgraph.version import __version__` returns `"1.0.9"`
- [x] `from langgraph_cli.version import __version__` returns the correct version from `__init__.py`
- [x] No `importlib.metadata` in module-level imports of changed files
- [x] Import time for `langgraph.version` reduced (no metadata scan overhead)