### PR TITLE
fix: support Pydantic default values with reducer functions

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1567,7 +1567,7 @@ def _get_channels(
 
     type_hints = get_type_hints(schema, include_extras=True)
     all_keys = {
-        name: _get_channel(name, typ)
+        name: _get_channel(name, typ, schema=schema)
         for name, typ in type_hints.items()
         if name != "__slots__"
     }
@@ -1580,18 +1580,30 @@ def _get_channels(
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[False]
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: Literal[False],
+    schema: type[Any] | None = None,
 ) -> BaseChannel: ...
 
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[True] = True
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: Literal[True] = True,
+    schema: type[Any] | None = None,
 ) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: bool = True
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: bool = True,
+    schema: type[Any] | None = None,
 ) -> BaseChannel | ManagedValueSpec:
     # Strip out Required and NotRequired wrappers
     if hasattr(annotation, "__origin__") and annotation.__origin__ in (
@@ -1607,7 +1619,7 @@ def _get_channel(
     elif channel := _is_field_channel(annotation):
         channel.key = name
         return channel
-    elif channel := _is_field_binop(annotation):
+    elif channel := _is_field_binop(annotation, name=name, schema=schema):
         channel.key = name
         return channel
 
@@ -1630,7 +1642,11 @@ def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     return None
 
 
-def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
+def _is_field_binop(
+    typ: type[Any],
+    name: str | None = None,
+    schema: type[Any] | None = None,
+) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and callable(meta[-1]):
@@ -1643,7 +1659,10 @@ def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
                 )
                 == 2
             ):
-                return BinaryOperatorAggregate(typ, meta[-1])
+                default = ...
+                if name is not None and schema is not None:
+                    default = get_field_default(name, typ, schema)
+                return BinaryOperatorAggregate(typ, meta[-1], default=default)
             else:
                 raise ValueError(
                     f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"


### PR DESCRIPTION
## Summary

Fixes #5225

When a Pydantic `BaseModel` state field has both a default value (`Field(default=...)` or `Field(default_factory=...)`) and a reducer function (`Annotated[type, reducer]`), the default value was being ignored. The channel was always initialized with the type's zero-argument constructor (e.g., `[]` for `list`, `0` for `int`).

### Root Cause

`BinaryOperatorAggregate.__init__` always initialized its value by calling `typ()` (the bare type constructor). It had no mechanism to receive or use schema-defined default values. While `_get_channels` and `_get_channel` had partial plumbing for passing the `schema` parameter, `_is_field_binop` didn't use it and `BinaryOperatorAggregate` didn't accept a `default` parameter.

### Changes

- **`_fields.py`**: Added Pydantic `BaseModel` support to `get_field_default()` to extract `Field(default=...)` and `Field(default_factory=...)` values via `model_fields`
- **`binop.py`**: Added `default` parameter to `BinaryOperatorAggregate.__init__()`. When provided, uses it instead of `typ()`. Uses `copy.deepcopy` to prevent mutable default sharing. Preserves defaults through `copy()` and `from_checkpoint()`
- **`state.py`**: Connected the schema context through `_get_channels` → `_get_channel` → `_is_field_binop` so field defaults are resolved and passed to `BinaryOperatorAggregate`

### Example

```python
from pydantic import BaseModel, Field
from typing import Annotated
import operator
from langgraph.graph import StateGraph, START, END

class State(BaseModel):
    messages: Annotated[list[str], operator.add] = Field(
        default_factory=lambda: ["welcome"]
    )
    count: Annotated[int, operator.add] = Field(default=100)

def node(state):
    return {"messages": ["hello"], "count": 5}

graph = StateGraph(State)
graph.add_node("process", node)
graph.add_edge(START, "process")
graph.add_edge("process", END)

result = graph.compile().invoke({})
# result["messages"] == ["welcome", "hello"]  ✅
# result["count"] == 105                       ✅
```

## Test plan

- [x] Unit test for `BinaryOperatorAggregate` with default values (`test_binop_with_default`)
- [x] Integration test: `default_factory` with custom reducer (exact issue scenario)
- [x] Integration test: static `Field(default=...)` with `operator.add`
- [x] Integration test: default + user-provided initial input
- [x] Integration test: mutable default safety across multiple invocations
- [x] Integration test: backward compat - no default still works
- [x] Integration test: mixed fields with/without defaults
- [x] All existing tests pass (33/33 in test_channels, test_pydantic, test_state)