### PR TITLE
fix(langgraph): handle END in conditional edge path_map lookup

### DIFF
--- a/libs/langgraph/langgraph/graph/_branch.py
+++ b/libs/langgraph/langgraph/graph/_branch.py
@@ -200,7 +200,8 @@ class BranchSpec(NamedTuple):
             result = [result]
         if self.ends:
             destinations: Sequence[Send | str] = [
-                r if isinstance(r, Send) else self.ends[r] for r in result
+                r if isinstance(r, Send) or r == END else self.ends[r]
+                for r in result
             ]
         else:
             destinations = cast(Sequence[Send | str], result)


### PR DESCRIPTION
## Summary

- Fix `KeyError('__end__')` when a conditional router returns `END` but `path_map` does not include an explicit `END` mapping
- Treat `END` as a pass-through value in `BranchSpec._finish()`, consistent with the behavior when no `path_map` is provided
- Add regression test covering both the termination and normal-flow paths

## Details

In `_branch.py`, the `_finish` method looks up each routing result in `self.ends` (the resolved `path_map`). When the router returns `END` (`"__end__"`) and `path_map` doesn't explicitly include it, the lookup raises `KeyError`. Since `END` is a special terminal node, it should always be treated as a valid destination regardless of `path_map` contents.

**Before:**
```python
destinations = [r if isinstance(r, Send) else self.ends[r] for r in result]
```

**After:**
```python
destinations = [r if isinstance(r, Send) or r == END else self.ends[r] for r in result]
```

This is consistent with how `END` is handled when `self.ends` is `None` (no `path_map` provided), where the result passes through directly.

Fixes #6770

## Test plan

- [x] Added `test_conditional_edges_end_not_in_path_map` regression test
- [x] Verified the exact reproduction from the issue now works
- [x] All 570 existing pregel tests pass (excluding postgres/redis which require external services)
- [x] All 18 state graph tests pass