### PR TITLE
checkpoint: enforce string thread IDs in sqlite/postgres savers

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -15,6 +15,7 @@ from langgraph.checkpoint.base import (
     CheckpointTuple,
     get_checkpoint_id,
     get_serializable_checkpoint_metadata,
+    get_thread_id,
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from psycopg import Capabilities, Connection, Cursor, Pipeline
@@ -216,7 +217,7 @@ class PostgresSaver(BasePostgresSaver):
             >>> print(checkpoint_tuple)
             CheckpointTuple(...)
         """  # noqa
-        thread_id = config["configurable"]["thread_id"]
+        thread_id = get_thread_id(config)
         checkpoint_id = get_checkpoint_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
         if checkpoint_id:
@@ -285,7 +286,8 @@ class PostgresSaver(BasePostgresSaver):
             {'configurable': {'thread_id': '1', 'checkpoint_ns': '', 'checkpoint_id': '1ef4f797-8335-6428-8001-8a1503f9b875'}}
         """
         configurable = config["configurable"].copy()
-        thread_id = configurable.pop("thread_id")
+        thread_id = get_thread_id(config)
+        configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
         checkpoint_id = configurable.pop("checkpoint_id", None)
         copy = checkpoint.copy()
@@ -358,7 +360,7 @@ class PostgresSaver(BasePostgresSaver):
             cur.executemany(
                 query,
                 self._dump_writes(
-                    config["configurable"]["thread_id"],
+                    get_thread_id(config),
                     config["configurable"]["checkpoint_ns"],
                     config["configurable"]["checkpoint_id"],
                     task_id,

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -13,6 +13,7 @@ from langgraph.checkpoint.base import (
     CheckpointMetadata,
     CheckpointTuple,
     get_serializable_checkpoint_metadata,
+    get_thread_id,
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import TASKS
@@ -335,7 +336,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
             >>> print(checkpoint_tuple)
             CheckpointTuple(...)
         """  # noqa
-        thread_id = config["configurable"]["thread_id"]
+        thread_id = get_thread_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
         args = (thread_id, checkpoint_ns)
         where = "WHERE thread_id = %s AND checkpoint_ns = %s"
@@ -405,7 +406,8 @@ class ShallowPostgresSaver(BasePostgresSaver):
             {'configurable': {'thread_id': '1', 'checkpoint_ns': '', 'checkpoint_id': '1ef4f797-8335-6428-8001-8a1503f9b875'}}
         """
         configurable = config["configurable"].copy()
-        thread_id = configurable.pop("thread_id")
+        thread_id = get_thread_id(config)
+        configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
 
         copy = checkpoint.copy()
@@ -474,7 +476,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
             cur.executemany(
                 query,
                 self._dump_writes(
-                    config["configurable"]["thread_id"],
+                    get_thread_id(config),
                     config["configurable"]["checkpoint_ns"],
                     config["configurable"]["checkpoint_id"],
                     task_id,
@@ -682,7 +684,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         Returns:
             The retrieved checkpoint tuple, or None if no matching checkpoint was found.
         """
-        thread_id = config["configurable"]["thread_id"]
+        thread_id = get_thread_id(config)
         checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
         args = (thread_id, checkpoint_ns)
         where = "WHERE thread_id = %s AND checkpoint_ns = %s"
@@ -743,7 +745,8 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
             RunnableConfig: Updated configuration after storing the checkpoint.
         """
         configurable = config["configurable"].copy()
-        thread_id = configurable.pop("thread_id")
+        thread_id = get_thread_id(config)
+        configurable.pop("thread_id")
         checkpoint_ns = configurable.pop("checkpoint_ns")
 
         copy = checkpoint.copy()
@@ -810,7 +813,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         )
         params = await asyncio.to_thread(
             self._dump_writes,
-            config["configurable"]["thread_id"],
+            get_thread_id(config),
             config["configurable"]["checkpoint_ns"],
             config["configurable"]["checkpoint_id"],
             task_id,

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from langchain_core.runnables import RunnableConfig
@@ -72,6 +72,15 @@ class TestAsyncSqliteSaver:
                 **self.metadata_2,
                 "run_id": "my_run_id",
             }
+
+    async def test_rejects_non_string_thread_id(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            bad_config = cast(
+                RunnableConfig,
+                {"configurable": {"thread_id": 123, "checkpoint_ns": ""}},
+            )
+            with pytest.raises(TypeError, match="`thread_id` must be a string."):
+                await saver.aput(bad_config, self.chkpnt_1, self.metadata_1, {})
 
     async def test_asearch(self) -> None:
         async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -75,6 +75,15 @@ class TestSqliteSaver:
                 "run_id": "my_run_id",
             }
 
+    def test_rejects_non_string_thread_id(self) -> None:
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            bad_config = cast(
+                RunnableConfig,
+                {"configurable": {"thread_id": 123, "checkpoint_ns": ""}},
+            )
+            with pytest.raises(TypeError, match="`thread_id` must be a string."):
+                saver.put(bad_config, self.chkpnt_1, self.metadata_1, {})
+
     def test_search(self) -> None:
         with SqliteSaver.from_conn_string(":memory:") as saver:
             # set up test

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -487,6 +487,14 @@ def get_checkpoint_id(config: RunnableConfig) -> str | None:
     return config["configurable"].get("checkpoint_id")
 
 
+def get_thread_id(config: RunnableConfig) -> str:
+    """Get thread ID and enforce string-typed identity semantics."""
+    thread_id = config["configurable"].get("thread_id")
+    if not isinstance(thread_id, str):
+        raise TypeError("`thread_id` must be a string.")
+    return thread_id
+
+
 def get_checkpoint_metadata(
     config: RunnableConfig, metadata: CheckpointMetadata
 ) -> CheckpointMetadata:


### PR DESCRIPTION
## Problem
Checkpoint key identity can alias when non-string `thread_id` values are coerced, which risks collisions (for example `1` vs `"1"`) and weakens replay/audit guarantees.

## Why now
Multi-tenant checkpoint usage depends on strict, deterministic key contracts, and implicit coercion undermines that contract.

## What changed
- Added `get_thread_id(config)` in checkpoint base to enforce `thread_id` is a string.
- Switched sqlite and postgres saver paths to use enforced `thread_id` instead of implicit coercion.
- Updated sync/async + shallow postgres paths and sync/async sqlite paths.
- Added sqlite regression tests that assert non-string `thread_id` fails closed.

## Validation
- `make format && make lint && make test TEST=tests/test_memory.py` (libs/checkpoint) ✅
- `make format && make lint` (libs/checkpoint-postgres) ✅
- `make test TEST="tests/test_sync.py -k test_search"` (libs/checkpoint-postgres) ✅
- `make test TEST="tests/test_async.py -k test_asearch"` (libs/checkpoint-postgres) ✅
- `make format && make lint` (libs/checkpoint-sqlite) ✅
- `make test TEST=tests/test_sqlite.py` (libs/checkpoint-sqlite) ✅
- `make test TEST=tests/test_aiosqlite.py` (libs/checkpoint-sqlite) ✅

Refs #6890
