### PR TITLE
fix: hardcode version to remove importlib.metadata overhead

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,5 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "1.0.8"


### PR DESCRIPTION
## Summary

Remove dynamic version lookup using importlib.metadata and hardcode the version string to improve import time performance.

This addresses the performance issue raised in #5040 where importlib.metadata adds overhead during module import.

## Changes

- Hardcode version "1.0.8" in langgraph/version.py
- Remove importlib import and try/except block

---
