### PR TITLE
fix: inherit parent checkpoint metadata in update_state so history filters remain effective

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1496,6 +1496,19 @@ class Pregel(
             )
             if saved:
                 checkpoint_config = patch_configurable(config, saved.config[CONF])
+                # Inherit custom metadata fields from parent checkpoint
+                # (e.g., assistant_id, user_id) so update_state checkpoints
+                # remain discoverable via get_state_history metadata filters.
+                parent_meta = {
+                    k: v
+                    for k, v in saved.metadata.items()
+                    if k not in {"source", "step", "writes", "parents", "run_id"}
+                    and isinstance(v, (str, int, float, bool))
+                }
+                if parent_meta:
+                    checkpoint_config = patch_configurable(
+                        checkpoint_config, parent_meta
+                    )
             channels, managed = channels_from_checkpoint(
                 self.channels,
                 checkpoint,
@@ -1940,6 +1953,19 @@ class Pregel(
             )
             if saved:
                 checkpoint_config = patch_configurable(config, saved.config[CONF])
+                # Inherit custom metadata fields from parent checkpoint
+                # (e.g., assistant_id, user_id) so update_state checkpoints
+                # remain discoverable via get_state_history metadata filters.
+                parent_meta = {
+                    k: v
+                    for k, v in saved.metadata.items()
+                    if k not in {"source", "step", "writes", "parents", "run_id"}
+                    and isinstance(v, (str, int, float, bool))
+                }
+                if parent_meta:
+                    checkpoint_config = patch_configurable(
+                        checkpoint_config, parent_meta
+                    )
             channels, managed = channels_from_checkpoint(
                 self.channels,
                 checkpoint,

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -9337,3 +9337,77 @@ def test_fork_does_not_apply_pending_writes(
 
     # Should be: 1 (input) + 20 (forked node_a) + 100 (node_b) = 121
     assert result == {"value": 121}
+
+
+def test_update_state_preserves_additional_data_in_history(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Test that update_state preserves parent metadata so checkpoints remain discoverable via get_state_history filters."""
+
+    class State(TypedDict):
+        messages: Annotated[list, operator.add]
+
+    def echo(state: State):
+        return {"messages": [AIMessage(content="foo")]}
+
+    workflow = StateGraph(State)
+    workflow.add_node("echo", echo)
+    workflow.add_edge(START, "echo")
+    workflow.add_edge("echo", END)
+    app = workflow.compile(checkpointer=sync_checkpointer)
+
+    thread_id = uuid.uuid4()
+    assistant_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "assistant_id": assistant_id,
+            "user_id": user_id,
+        }
+    }
+
+    # 1. Invoke to create checkpoint with metadata
+    app.invoke({"messages": [HumanMessage(content="bar")]}, config)
+
+    # 2. Update state with minimal config
+    state_before_update = app.get_state(config)
+    update_config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_id": state_before_update.config["configurable"]["checkpoint_id"],
+            "checkpoint_ns": "",
+        }
+    }
+    app.update_state(
+        update_config,
+        {"messages": [AIMessage(content="baz", additional_kwargs={"feedback": "positive"})]},
+        as_node="echo",
+    )
+
+    # 3. Get history with metadata filter
+    full_history = list(app.get_state_history(config, limit=10))
+    found_update = False
+    for snapshot in full_history:
+        for msg in snapshot.values.get("messages", []):
+            if msg.content == "baz":
+                found_update = True
+                assert msg.additional_kwargs == {"feedback": "positive"}, (
+                    f"Expected additional_kwargs={{'feedback': 'positive'}}, "
+                    f"but got {msg.additional_kwargs}"
+                )
+    assert found_update, "Could not find the update message 'baz' in history"
+
+    history_filter = {"assistant_id": assistant_id, "user_id": user_id}
+    history = list(app.get_state_history(config, filter=history_filter, limit=10))
+
+    assert len(history) >= 2, (
+        "Expected at least 2 checkpoints (invoke + update_state). "
+        "update_state checkpoint may be missing assistant_id/user_id in metadata. "
+    )
+    sources = [h.metadata.get("source") for h in history]
+    assert "update" in sources, (
+        "Expected 'update' checkpoint in history. "
+        "update_state creates checkpoints without inheriting parent metadata."
+    )

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9631,3 +9631,76 @@ async def test_fork_does_not_apply_pending_writes(
 
     # 1 (input) + 20 (forked node_a) + 100 (node_b) = 121
     assert result == {"value": 121}
+
+
+async def test_update_state_preserves_additional_data_in_history(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Test that update_state preserves parent metadata so checkpoints remain discoverable via get_state_history filters."""
+
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    class State(TypedDict):
+        messages: list
+
+    workflow = StateGraph(State)
+    workflow.add_node("echo", lambda s: {"messages": [AIMessage(content="foo")]})
+    workflow.add_edge(START, "echo")
+    workflow.add_edge("echo", END)
+    app = workflow.compile(checkpointer=async_checkpointer)
+
+    thread_id = str(uuid.uuid4())
+    assistant_id = str(uuid.uuid4())
+    user_id = str(uuid.uuid4())
+
+    config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "assistant_id": assistant_id,
+            "user_id": user_id,
+        }
+    }
+
+    # 1. Invoke to create checkpoint with metadata
+    await app.ainvoke({"messages": [HumanMessage(content="bar")]}, config)
+
+    # 2. Update state with minimal config
+    state_before_update = await app.aget_state(config)
+    update_config: RunnableConfig = {
+        "configurable": {
+            "thread_id": thread_id,
+            "checkpoint_id": state_before_update.config["configurable"]["checkpoint_id"],
+            "checkpoint_ns": "",
+        }
+    }
+    await app.aupdate_state(
+        update_config,
+        {"messages": [AIMessage(content="baz", additional_kwargs={"feedback": "positive"})]},
+        as_node="echo",
+    )
+
+    # 3. Get history with metadata filter
+    full_history = [s async for s in app.aget_state_history(config, limit=10)]
+    found_update = False
+    for snapshot in full_history:
+        for msg in snapshot.values.get("messages", []):
+            if msg.content == "baz":
+                found_update = True
+                assert msg.additional_kwargs == {"feedback": "positive"}, (
+                    f"Expected additional_kwargs={{'feedback': 'positive'}}, "
+                    f"but got {msg.additional_kwargs}"
+                )
+    assert found_update, "Could not find the update message 'baz' in history"
+
+    history_filter = {"assistant_id": assistant_id, "user_id": user_id}
+    history = [s async for s in app.aget_state_history(config, filter=history_filter, limit=10)]
+
+    assert len(history) >= 2, (
+        "Expected at least 2 checkpoints (invoke + update_state). "
+        "update_state checkpoint may be missing assistant_id/user_id in metadata. "
+    )
+    sources = [h.metadata.get("source") for h in history]
+    assert "update" in sources, (
+        "Expected 'update' checkpoint in history. "
+        "update_state creates checkpoints without inheriting parent metadata."
+    )


### PR DESCRIPTION
## Problem
Fixes #6171
update_state() creates a new checkpoint but does not inherit custom metadata (e.g., assistant_id, user_id) from the parent checkpoint.

This causes get_state_history(filter=...) to omit update_state-generated checkpoints.

## Root Cause
invoke() stores configurable metadata automatically via get_checkpoint_metadata(),
while update_state() only propagates minimal checkpoint identifiers.

## Fix
- Inherit non-structural primitive metadata fields from the parent checkpoint.
- Exclude structural fields (source, step, writes, parents, run_id).
- Maintain backward compatibility.

## Files Changed
-  libs/langgraph/langgraph/pregel/main.py
- libs/langgraph/tests/test_pregel.py
- libs/langgraph/tests/test_pregel_async.py

## Tests Added
  - The test invokes a simple graph with custom metadata fields (assistant_id, user_id) embedded in the config, then calls `update_state()` using a minimal config that omits those fields.
  - It first asserts that the AIMessage passed to `update_state()` — including its additional_kwargs — is retrievable intact from `get_state_history().`
  - It then asserts that when `get_state_history()` is called with a metadata filter ({"assistant_id": ..., "user_id": ...}), the checkpoint produced by `update_state()` (identified by source: "update") is included in the results alongside the checkpoints from the original `invoke().`
  - This directly reproduces the bug where `update_state()` checkpoints were invisible to metadata filters due to missing inherited fields, and confirms the fix.