### PR TITLE
fix(checkpoint): serialize generic type args for pydantic v2 models

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -221,18 +221,62 @@ EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 
 
+def _get_pydantic_generic_info(cls: Any) -> list | None:
+    """Extract serializable generic type arg info from a pydantic v2 class.
+
+    For a generic type like ``MyModel[Inner]``, returns a nested list
+    ``[origin_module, origin_name, [[arg_module, arg_name], ...]]``.
+    Returns ``None`` for non-generic types.
+    """
+    meta = getattr(cls, "__pydantic_generic_metadata__", None)
+    if not meta:
+        return None
+    origin = meta.get("origin")
+    args = meta.get("args", ())
+    if not origin or not args:
+        return None
+    serialized_args: list = []
+    for arg in args:
+        nested = _get_pydantic_generic_info(arg)
+        if nested is not None:
+            serialized_args.append(nested)
+        else:
+            serialized_args.append([arg.__module__, arg.__name__])
+    return [origin.__module__, origin.__name__, serialized_args]
+
+
+def _resolve_pydantic_generic(generic_info: list) -> Any:
+    """Reconstruct a parameterized pydantic generic type from serialized info."""
+    module_name, cls_name, arg_infos = generic_info
+    origin_cls = getattr(importlib.import_module(module_name), cls_name)
+    type_args: list = []
+    for info in arg_infos:
+        if len(info) == 3 and isinstance(info[2], list):
+            # nested generic
+            type_args.append(_resolve_pydantic_generic(info))
+        else:
+            type_args.append(
+                getattr(importlib.import_module(info[0]), info[1])
+            )
+    if len(type_args) == 1:
+        return origin_cls[type_args[0]]
+    return origin_cls[tuple(type_args)]
+
+
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
     if hasattr(obj, "model_dump") and callable(obj.model_dump):  # pydantic v2
+        generic_info = _get_pydantic_generic_info(obj.__class__)
+        data: tuple = (
+            obj.__class__.__module__,
+            obj.__class__.__name__,
+            obj.model_dump(),
+            "model_validate_json",
+        )
+        if generic_info is not None:
+            data = data + (generic_info,)
         return ormsgpack.Ext(
             EXT_PYDANTIC_V2,
-            _msgpack_enc(
-                (
-                    obj.__class__.__module__,
-                    obj.__class__.__name__,
-                    obj.model_dump(),
-                    "model_validate_json",
-                ),
-            ),
+            _msgpack_enc(data),
         )
     elif hasattr(obj, "get_secret_value") and callable(obj.get_secret_value):
         return ormsgpack.Ext(
@@ -510,8 +554,11 @@ def _msgpack_ext_hook(code: int, data: bytes) -> Any:
             tup = ormsgpack.unpackb(
                 data, ext_hook=_msgpack_ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
             )
-            # module, name, kwargs, method
-            cls = getattr(importlib.import_module(tup[0]), tup[1])
+            # module, name, kwargs, method[, generic_info]
+            if len(tup) > 4 and tup[4] is not None:
+                cls = _resolve_pydantic_generic(tup[4])
+            else:
+                cls = getattr(importlib.import_module(tup[0]), tup[1])
             try:
                 return cls(**tup[2])
             except Exception:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -9,6 +9,7 @@ from datetime import date, datetime, time, timezone
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address
+from typing import Generic, TypeVar
 from zoneinfo import ZoneInfo
 
 import dataclasses_json
@@ -25,6 +26,15 @@ from langgraph.checkpoint.serde.jsonplus import (
     _msgpack_ext_hook_to_json,
 )
 from langgraph.store.base import Item
+
+
+TInner = TypeVar("TInner", bound=BaseModel)
+
+
+class GenericPydantic(BaseModel, Generic[TInner]):
+    name: str
+    value: int
+    inner: TInner
 
 
 class InnerPydantic(BaseModel):
@@ -514,3 +524,49 @@ def test_serde_jsonplus_pandas_series(series: pd.Series) -> None:
     result = serde.loads_typed(dumped)
 
     assert result.equals(series)
+
+
+def test_serde_jsonplus_pydantic_generic() -> None:
+    """Roundtrip generic pydantic v2 models through msgpack."""
+    instance = GenericPydantic[InnerPydantic](
+        name="outer", value=1, inner=InnerPydantic(hello="world")
+    )
+
+    serde = JsonPlusSerializer()
+    dumped = serde.dumps_typed(instance)
+    assert dumped[0] == "msgpack"
+
+    result = serde.loads_typed(dumped)
+    assert isinstance(result, GenericPydantic)
+    assert result == instance
+    assert type(result) is type(instance)  # exact parameterized type
+
+
+def test_serde_jsonplus_pydantic_generic_nested() -> None:
+    """Roundtrip nested generic pydantic v2 models."""
+    instance = GenericPydantic[GenericPydantic[InnerPydantic]](
+        name="outer",
+        value=1,
+        inner=GenericPydantic[InnerPydantic](
+            name="mid", value=2, inner=InnerPydantic(hello="deep")
+        ),
+    )
+
+    serde = JsonPlusSerializer()
+    dumped = serde.dumps_typed(instance)
+    result = serde.loads_typed(dumped)
+    assert result == instance
+    assert type(result) is type(instance)
+
+
+def test_serde_jsonplus_pydantic_generic_json_mode() -> None:
+    """JSON deserialization of generic models returns plain dicts."""
+    instance = GenericPydantic[InnerPydantic](
+        name="test", value=42, inner=InnerPydantic(hello="hi")
+    )
+    serde = JsonPlusSerializer()
+    dumped = serde.dumps_typed(instance)
+
+    json_serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
+    result = json_serde.loads_typed(dumped)
+    assert result == instance.model_dump()


### PR DESCRIPTION
When jsonplus serializes a pydantic v2 object from a generic model like MyModel[Inner], it stores the class name as "MyModel[Inner]" which can't be resolved via getattr on deserialization. Falls back silently to a plain dict. This stores the origin class and type args alongside the existing tuple, and reconstructs the parameterized type via __class_getitem__ on the way back. Backward compatible — old data without the extra element deserializes unchanged. Includes tests for simple, nested, and JSON-mode roundtrips. Fixes #6102