### PR TITLE
checkpoint-postgres: fail closed on incomplete shallow schema

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -168,9 +168,12 @@ def _ensure_shallow_schema_ready_sync(cur: Cursor[DictRow]) -> None:
     col_row = cur.execute(
         """
         SELECT 1
-        FROM information_schema.columns
-        WHERE table_name = 'checkpoint_writes' AND column_name = 'task_path'
-        """
+        FROM pg_catalog.pg_attribute
+        WHERE attrelid = to_regclass(%s)
+          AND attname = 'task_path'
+          AND NOT attisdropped
+        """,
+        ("checkpoint_writes",),
     ).fetchone()
     if col_row is None:
         raise RuntimeError(
@@ -204,9 +207,12 @@ async def _ensure_shallow_schema_ready_async(cur: AsyncCursor[DictRow]) -> None:
     res = await cur.execute(
         """
         SELECT 1
-        FROM information_schema.columns
-        WHERE table_name = 'checkpoint_writes' AND column_name = 'task_path'
-        """
+        FROM pg_catalog.pg_attribute
+        WHERE attrelid = to_regclass(%s)
+          AND attname = 'task_path'
+          AND NOT attisdropped
+        """,
+        ("checkpoint_writes",),
     )
     col_row = await res.fetchone()
     if col_row is None:

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -309,6 +309,49 @@ def test_shallow_setup_fails_on_incomplete_schema() -> None:
             conn.execute(f"DROP DATABASE {database}")
 
 
+def test_shallow_setup_uses_resolved_schema_for_task_path_check() -> None:
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+
+    try:
+        with Connection.connect(
+            DEFAULT_POSTGRES_URI + database,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as conn:
+            conn.execute("CREATE SCHEMA custom")
+            conn.execute("SET search_path TO custom, public")
+            conn.execute("CREATE TABLE checkpoint_migrations (v INTEGER PRIMARY KEY)")
+            conn.execute(
+                "INSERT INTO checkpoint_migrations (v) VALUES (%s)",
+                (len(ShallowPostgresSaver.MIGRATIONS) - 1,),
+            )
+            conn.execute(
+                "CREATE TABLE checkpoints (thread_id TEXT, checkpoint_ns TEXT, checkpoint JSONB, metadata JSONB)"
+            )
+            conn.execute(
+                "CREATE TABLE checkpoint_blobs (thread_id TEXT, checkpoint_ns TEXT, channel TEXT, type TEXT, blob BYTEA)"
+            )
+            conn.execute(
+                "CREATE TABLE checkpoint_writes (thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, task_id TEXT, idx INTEGER, channel TEXT, type TEXT, blob BYTEA)"
+            )
+            conn.execute(
+                "CREATE TABLE public.checkpoint_writes (thread_id TEXT, checkpoint_ns TEXT, checkpoint_id TEXT, task_id TEXT, task_path TEXT NOT NULL DEFAULT '', idx INTEGER, channel TEXT, type TEXT, blob BYTEA)"
+            )
+
+            saver = ShallowPostgresSaver(conn)
+            with pytest.raises(
+                RuntimeError,
+                match="missing 'checkpoint_writes.task_path' column",
+            ):
+                saver.setup()
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")
+
+
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 def test_pending_sends_migration(saver_name: str) -> None:
     with _saver(saver_name) as saver:


### PR DESCRIPTION
## Problem
`ShallowPostgresSaver.setup()` can trust migration rows alone and proceed with incomplete shallow schema, causing mixed-state runtime behavior.

## Why now
Shallow migration paths are still exercised; fail-late schema drift causes durable operational debt.

## What changed
- Added explicit shallow-schema readiness guards (sync + async setup):
  - reject unsupported future migration versions
  - require `checkpoints`, `checkpoint_blobs`, `checkpoint_writes`
  - require `checkpoint_writes.task_path`
- Added regression test that simulates inconsistent migration metadata and verifies setup fails closed.

## Validation
- `cd libs/checkpoint-postgres && make format`
- `cd libs/checkpoint-postgres && make lint`
- `cd libs/checkpoint-postgres && TEST=tests/test_sync.py make test`

Refs #6902
