### PR TITLE
fix: scan all Annotated metadata for reducer callable

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1633,21 +1633,22 @@ def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
 def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
-        if len(meta) >= 1 and callable(meta[-1]):
-            sig = signature(meta[-1])
-            params = list(sig.parameters.values())
-            if (
-                sum(
-                    p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
-                    for p in params
-                )
-                == 2
-            ):
-                return BinaryOperatorAggregate(typ, meta[-1])
-            else:
-                raise ValueError(
-                    f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"
-                )
+        for item in meta:
+            if callable(item):
+                sig = signature(item)
+                params = list(sig.parameters.values())
+                if (
+                    sum(
+                        p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+                        for p in params
+                    )
+                    == 2
+                ):
+                    return BinaryOperatorAggregate(typ, item)
+                else:
+                    raise ValueError(
+                        f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"
+                    )
     return None
 
 

--- a/libs/langgraph/tests/test_reducer_metadata_ordering.py
+++ b/libs/langgraph/tests/test_reducer_metadata_ordering.py
@@ -1,0 +1,128 @@
+"""Regression tests for reducer detection with non-trailing metadata.
+
+Before this fix, `_is_field_binop` only checked the *last* metadata item in an
+`Annotated` type.  If additional metadata (doc strings, Pydantic `Field`, etc.)
+appeared after the reducer callable, the reducer was silently ignored and the
+field fell back to `LastValue` — losing aggregation semantics.
+"""
+
+import operator
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from langgraph.graph import END, START, StateGraph
+
+# --- helpers ---
+
+
+def _add_lists(a: list, b: list) -> list:
+    return a + b
+
+
+# --- tests ---
+
+
+def test_reducer_as_last_metadata() -> None:
+    """Baseline: reducer is the last (only) metadata item — always worked."""
+
+    class State(BaseModel):
+        items: Annotated[list[str], operator.add]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"items": ["b"]})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"items": ["a"]})
+    assert result["items"] == ["a", "b"]
+
+
+def test_reducer_before_string_annotation() -> None:
+    """Reducer callable precedes a doc-string annotation — must still be found."""
+
+    class State(BaseModel):
+        items: Annotated[list[str], operator.add, "item accumulator"]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"items": ["b"]})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"items": ["a"]})
+    assert result["items"] == ["a", "b"]
+
+
+def test_reducer_between_metadata() -> None:
+    """Reducer sits between two non-callable metadata items."""
+
+    class State(BaseModel):
+        items: Annotated[list[str], "doc string", _add_lists, "another annotation"]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"items": ["b"]})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"items": ["a"]})
+    assert result["items"] == ["a", "b"]
+
+
+def test_reducer_with_field_metadata_after() -> None:
+    """Reducer followed by Pydantic Field — previously lost the reducer."""
+
+    class State(BaseModel):
+        items: Annotated[
+            list[str], operator.add, Field(description="accumulated items")
+        ]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"items": ["b"]})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"items": ["a"]})
+    assert result["items"] == ["a", "b"]
+
+
+def test_custom_reducer_not_last() -> None:
+    """Custom 2-arg reducer that is not the last metadata item."""
+
+    def sum_ints(a: int, b: int) -> int:
+        return a + b
+
+    class State(BaseModel):
+        total: Annotated[int, sum_ints, "running total"]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"total": 5})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"total": 10})
+    assert result["total"] == 15
+
+
+def test_multiple_nodes_with_non_trailing_reducer() -> None:
+    """Multi-step graph: reducer works correctly across node boundaries."""
+
+    class State(BaseModel):
+        log: Annotated[list[str], operator.add, "audit log"]
+
+    graph = StateGraph(State)
+    graph.add_node("a", lambda s: {"log": ["from_a"]})
+    graph.add_node("b", lambda s: {"log": ["from_b"]})
+    graph.add_edge(START, "a")
+    graph.add_edge("a", "b")
+    graph.add_edge("b", END)
+    result = graph.compile().invoke({"log": ["init"]})
+    assert result["log"] == ["init", "from_a", "from_b"]
+
+
+def test_no_reducer_still_falls_through() -> None:
+    """Field with only non-callable metadata falls back to LastValue."""
+
+    class State(BaseModel):
+        name: Annotated[str, "just a doc string"]
+
+    graph = StateGraph(State)
+    graph.add_node("step", lambda s: {"name": "updated"})
+    graph.add_edge(START, "step")
+    graph.add_edge("step", END)
+    result = graph.compile().invoke({"name": "original"})
+    assert result["name"] == "updated"


### PR DESCRIPTION
## Summary

`_is_field_binop` only checked the **last** metadata item in an `Annotated` type
(`meta[-1]`). If additional metadata — doc strings, Pydantic `Field()`, custom
annotations — appeared after the reducer callable, the reducer was silently
ignored and the field fell back to `LastValue`, losing aggregation semantics.

```python
# This works:
items: Annotated[list[str], operator.add]

# This silently loses the reducer (operator.add is no longer last):
items: Annotated[list[str], operator.add, "item accumulator"]
items: Annotated[list[str], operator.add, Field(description="accumulated items")]
```

**Root cause:** `meta[-1]` assumes the reducer is always the last annotation.
Python's `Annotated` makes no such guarantee, and users reasonably interleave
documentation, Pydantic field metadata, and the reducer in any order.

**Fix:** Iterate through all metadata items and return the first callable with a
2-parameter signature, consistent with how `_is_field_channel` already works
(it loops through all metadata to find channel annotations). The change is a
minimal 1-line structural fix (loop instead of index) with no new dependencies.

We reviewed the open PRs on related topic #5225 — specifically #6697 and #6886,
both of which add default-value support for reducer fields. Neither addresses
the metadata ordering issue (both still use `meta[-1]`). This fix is
complementary and compatible: once merged, those PRs' `_is_field_binop` changes
can build on the loop-based approach.

## Test plan

7 regression tests in `tests/test_reducer_metadata_ordering.py`:

- [x] `test_reducer_as_last_metadata` — baseline (always worked)
- [x] `test_reducer_before_string_annotation` — reducer precedes doc string
- [x] `test_reducer_between_metadata` — reducer between two non-callable items
- [x] `test_reducer_with_field_metadata_after` — reducer before Pydantic `Field()`
- [x] `test_custom_reducer_not_last` — custom 2-arg reducer, not last
- [x] `test_multiple_nodes_with_non_trailing_reducer` — multi-step graph
- [x] `test_no_reducer_still_falls_through` — non-callable-only metadata falls back to `LastValue`
- [x] All existing tests pass unchanged (156 passed, 4 skipped)