### PR TITLE
fix(langgraph): handle Overwrite correctly in BinaryOperatorAggregate when value is MISSING

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -102,10 +102,15 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
-            self.value = values[0]
-            values = values[1:]
         seen_overwrite: bool = False
+        if self.value is MISSING:
+            is_overwrite, overwrite_value = _get_overwrite(values[0])
+            if is_overwrite:
+                self.value = overwrite_value
+                seen_overwrite = True
+            else:
+                self.value = values[0]
+            values = values[1:]
         for value in values:
             is_overwrite, overwrite_value = _get_overwrite(value)
             if is_overwrite:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,5 +1,6 @@
 import operator
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import pytest
 
@@ -9,6 +10,7 @@ from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
+from langgraph.types import Overwrite
 
 pytestmark = pytest.mark.anyio
 
@@ -88,6 +90,31 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+@dataclass
+class Metrics:
+    count: int
+
+    def __add__(self, other: "Metrics") -> "Metrics":
+        return Metrics(self.count + other.count)
+
+
+def test_binop_overwrite_on_missing_unwraps_value() -> None:
+    channel = BinaryOperatorAggregate(Metrics, operator.add).from_checkpoint(MISSING)
+
+    channel.update([Overwrite(Metrics(count=42))])
+
+    assert channel.get() == Metrics(count=42)
+
+
+def test_binop_overwrite_on_missing_allows_only_one_per_superstep() -> None:
+    channel = BinaryOperatorAggregate(Metrics, operator.add).from_checkpoint(MISSING)
+
+    with pytest.raises(
+        InvalidUpdateError, match="Can receive only one Overwrite value per super-step."
+    ):
+        channel.update([Overwrite(Metrics(1)), Overwrite(Metrics(2))])
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Description

This PR fixes `BinaryOperatorAggregate.update` for the case where the channel starts at `MISSING` and receives `Overwrite(...)` as its first update in a super-step.

Before this change:
- The first overwrite in the `MISSING` path could be stored as `Overwrite(value=...)` instead of the unwrapped payload.
- The "only one `Overwrite` per super-step" guard was not applied consistently in that same path.

After this change:
- The first update is always checked for overwrite semantics, even when `self.value is MISSING`.
- Overwrite payloads are unwrapped correctly.
- Multiple overwrites in one super-step correctly raise `InvalidUpdateError`.

This keeps overwrite behavior consistent across both initialized and `MISSING` channel states.

Closes #6909.

## Issue

#6909

## Dependencies

None.

## Validation

Executed in `libs/langgraph`:
- `make format`
- `UV_PYTHON=3.12 make lint`
- `make test`

All passed locally.