### PR TITLE
fix(checkpoint-postgres): backfill semantic search results with non-indexed docs

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -4,15 +4,17 @@
 # TESTING AND COVERAGE
 ######################
 
+COMPOSE_PROJECT_NAME ?= langgraph_checkpoint_postgres
+
 start-postgres:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
+	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -p $(COMPOSE_PROJECT_NAME) -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
 		echo "Failed to start PostgreSQL, printing logs..."; \
-		docker compose -f tests/compose-postgres.yml logs; \
+		docker compose -p $(COMPOSE_PROJECT_NAME) -f tests/compose-postgres.yml logs; \
 		exit 1 \
 	)
 
 stop-postgres:
-	docker compose -f tests/compose-postgres.yml down
+	docker compose -p $(COMPOSE_PROJECT_NAME) -f tests/compose-postgres.yml down
 
 POSTGRES_VERSIONS ?= 15 16
 test_pg_version:

--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -1046,6 +1046,88 @@ class PostgresStore(BaseStore, BasePostgresStore[_pg_internal.Conn]):
         results: list[Result],
         cur: Cursor[DictRow],
     ) -> None:
+        def _fetch_non_vector_backfill(
+            op: SearchOp,
+            existing_rows: list[Row],
+            limit: int,
+        ) -> list[Row]:
+            """Backfill semantic search with non-indexed docs from the base store."""
+            if limit <= 0:
+                return []
+
+            filter_params: list[Any] = []
+            filter_clauses: list[str] = []
+            if op.filter:
+                for key, value in op.filter.items():
+                    if isinstance(value, dict):
+                        for op_name, val in value.items():
+                            condition, params_ = self._get_filter_condition(
+                                key, op_name, val
+                            )
+                            filter_clauses.append(condition)
+                            filter_params.extend(params_)
+                    else:
+                        filter_clauses.append("value->%s = %s::jsonb")
+                        filter_params.extend([key, orjson.dumps(value).decode("utf-8")])
+
+            ns_condition = "TRUE"
+            ns_param: Sequence[str] = ()
+            if op.namespace_prefix:
+                ns_condition = "store.prefix LIKE %s"
+                ns_param = (f"{_namespace_to_text(op.namespace_prefix)}%",)
+
+            exclude_params: list[Any] = []
+            exclude_clause = ""
+            if existing_rows:
+                pair_placeholders = ", ".join("( %s, %s )" for _ in existing_rows)
+                exclude_clause = (
+                    f" AND (store.prefix, store.key) NOT IN ({pair_placeholders})"
+                )
+                for row in existing_rows:
+                    exclude_params.extend([row["prefix"], row["key"]])
+
+            extra_filters = (
+                " AND " + " AND ".join(filter_clauses) if filter_clauses else ""
+            )
+
+            search_results_sql = f"""
+                    SELECT store.prefix, store.key, store.value, store.created_at, store.updated_at, NULL AS score
+                    FROM store
+                    WHERE {ns_condition} {extra_filters}{exclude_clause}
+                    ORDER BY store.updated_at DESC
+                    LIMIT %s
+                    OFFSET %s
+                """
+            search_results_params: list[Any] = [
+                *ns_param,
+                *filter_params,
+                *exclude_params,
+                limit,
+                0,
+            ]
+
+            if op.refresh_ttl:
+                final_sql = f"""
+                        WITH search_results AS (
+                            {search_results_sql}
+                        ),
+                        updated AS (
+                            UPDATE store s
+                            SET expires_at = NOW() + (s.ttl_minutes || ' minutes')::interval
+                            FROM search_results sr
+                            WHERE s.prefix = sr.prefix
+                            AND s.key = sr.key
+                            AND s.ttl_minutes IS NOT NULL
+                        )
+                        SELECT sr.prefix, sr.key, sr.value, sr.created_at, sr.updated_at, sr.score
+                        FROM search_results sr
+                    """
+            else:
+                final_sql = search_results_sql
+
+            cur.execute(final_sql, search_results_params)
+            return cast(list[Row], cur.fetchall())
+
         queries, embedding_requests = self._prepare_batch_search_queries(search_ops)
 
         if embedding_requests and self.embeddings:
@@ -1060,9 +1142,20 @@ class PostgresStore(BaseStore, BasePostgresStore[_pg_internal.Conn]):
                     if _paramslist[i] is PLACEHOLDER:
                         _paramslist[i] = embedding
 
-        for (idx, _), (query, params) in zip(search_ops, queries, strict=False):
+        for (idx, op), (query, params) in zip(search_ops, queries, strict=False):
             cur.execute(query, params)
             rows = cast(list[Row], cur.fetchall())
+
+            # Vector search only returns indexed rows. If the result set under-fills, backfill
+            # from the base store so `index=False` docs can still appear with score=None.
+            if (
+                op.query
+                and self.index_config
+                and op.offset == 0
+                and len(rows) < op.limit
+            ):
+                rows.extend(_fetch_non_vector_backfill(op, rows, op.limit - len(rows)))
+
             results[idx] = [
                 _row_to_search_item(
                     _decode_ns_bytes(row["prefix"]), row, loader=self._deserializer

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -739,11 +739,9 @@ def test_embed_with_path_operation_config(
         assert any(r.key == "doc5" for r in results)
 
         results = store.search(("test",), query="hhh")
-        # TODO: We don't currently fill in additional results if there are not enough
-        # returned during vector search.
-        # assert len(results) == 3
-        # doc5_result = next(r for r in results if r.key == "doc5")
-        # assert doc5_result.score is None
+        assert len(results) == 3
+        doc5_result = next(r for r in results if r.key == "doc5")
+        assert doc5_result.score is None
 
 
 def _cosine_similarity(X: list[float], Y: list[list[float]]) -> list[float]:


### PR DESCRIPTION
## Description
Backfill semantic search results in `checkpoint-postgres` when vector search under-fills the requested limit, allowing documents stored with `index=False` to appear with `score=None`.

Also updates the package `Makefile` to use a unique default Docker Compose project name to avoid `tests_default` network collisions during local test setup.

## Issue
N/A (or Closes #<issue-number>)

## Dependencies
No new dependencies added.

## Twitter handle
N/A
