### PR TITLE
fix(langgraph): get_state().next empty after second interrupt() in same node

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -79,6 +79,7 @@ from langgraph._internal._constants import (
     NS_SEP,
     NULL_TASK_ID,
     PUSH,
+    RESUME,
     TASKS,
 )
 from langgraph._internal._pydantic import create_model
@@ -1085,7 +1086,7 @@ class Pregel(
             )
         if apply_pending_writes and saved.pending_writes:
             for tid, k, v in saved.pending_writes:
-                if k in (ERROR, INTERRUPT):
+                if k in (ERROR, INTERRUPT, RESUME):
                     continue
                 if tid not in next_tasks:
                     continue
@@ -1204,7 +1205,7 @@ class Pregel(
             )
         if apply_pending_writes and saved.pending_writes:
             for tid, k, v in saved.pending_writes:
-                if k in (ERROR, INTERRUPT):
+                if k in (ERROR, INTERRUPT, RESUME):
                     continue
                 if tid not in next_tasks:
                     continue
@@ -1540,7 +1541,7 @@ class Pregel(
                         )
                     # apply writes from tasks that already ran
                     for tid, k, v in saved.pending_writes or []:
-                        if k in (ERROR, INTERRUPT):
+                        if k in (ERROR, INTERRUPT, RESUME):
                             continue
                         if tid not in next_tasks:
                             continue
@@ -1982,7 +1983,7 @@ class Pregel(
                         )
                     # apply writes from tasks that already ran
                     for tid, k, v in saved.pending_writes or []:
-                        if k in (ERROR, INTERRUPT):
+                        if k in (ERROR, INTERRUPT, RESUME):
                             continue
                         if tid not in next_tasks:
                             continue

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -3,7 +3,8 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict
 
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Durability
+from langgraph.types import Command, Durability
+from langgraph.types import interrupt as lg_interrupt
 
 pytestmark = pytest.mark.anyio
 
@@ -90,3 +91,65 @@ async def test_interruption_without_state_updates_async(
     assert (await graph.aget_state(thread)).next == ()
     n_checkpoints = len([c async for c in graph.aget_state_history(thread)])
     assert n_checkpoints == (5 if durability != "exit" else 3)
+
+
+def test_get_state_next_after_double_interrupt(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Regression test for #6956.
+
+    get_state().next must not be empty after resuming from the first of two
+    consecutive interrupt() calls inside the same node.
+    """
+
+    def ask_twice(state):
+        lg_interrupt("first question")
+        lg_interrupt("second question")
+
+    builder = StateGraph(dict)
+    builder.add_node("ask_twice", ask_twice)
+    builder.add_edge(START, "ask_twice")
+    builder.add_edge("ask_twice", END)
+
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "double-interrupt-sync"}}
+
+    # First invoke hits the first interrupt
+    graph.invoke({}, config)
+    assert graph.get_state(config).next == ("ask_twice",)
+
+    # Resume from first interrupt — hits the second interrupt
+    graph.invoke(Command(resume="ans1"), config)
+    # Must still show the node as pending, not an empty tuple
+    assert graph.get_state(config).next == ("ask_twice",)
+
+    # Resume from second interrupt — node completes
+    graph.invoke(Command(resume="ans2"), config)
+    assert graph.get_state(config).next == ()
+
+
+async def test_get_state_next_after_double_interrupt_async(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Async regression test for #6956."""
+
+    async def ask_twice(state):
+        lg_interrupt("first question")
+        lg_interrupt("second question")
+
+    builder = StateGraph(dict)
+    builder.add_node("ask_twice", ask_twice)
+    builder.add_edge(START, "ask_twice")
+    builder.add_edge("ask_twice", END)
+
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "double-interrupt-async"}}
+
+    await graph.ainvoke({}, config)
+    assert (await graph.aget_state(config)).next == ("ask_twice",)
+
+    await graph.ainvoke(Command(resume="ans1"), config)
+    assert (await graph.aget_state(config)).next == ("ask_twice",)
+
+    await graph.ainvoke(Command(resume="ans2"), config)
+    assert (await graph.aget_state(config)).next == ()


### PR DESCRIPTION
## Summary

Fixes #6956.

When a node calls `interrupt()` twice, `get_state().next` incorrectly returns `()` after resuming from the first interrupt — even though the graph is still paused at the second interrupt.

**Root cause:** In `_prepare_state_snapshot`, pending writes are replayed into `task.writes` to reconstruct state. The skip condition excluded `ERROR` and `INTERRUPT` writes, but not `RESUME` writes. So after resuming from the first interrupt, the `RESUME` write got added to `task.writes`, and the snapshot logic then excluded that task from `next` (which only includes tasks with _empty_ writes).

**Fix:** Add `RESUME` to the skip condition at all 4 call sites in `main.py`, matching the pattern already used correctly in `PregelLoop._match_writes` in `_loop.py`.

```python
# Before (all 4 sites)
if k in (ERROR, INTERRUPT):
    continue

# After
if k in (ERROR, INTERRUPT, RESUME):
    continue
```

## Test plan

- [x] Added `test_get_state_next_after_double_interrupt` (sync, 3 checkpointers: memory, sqlite, sqlite_aes)
- [x] Added `test_get_state_next_after_double_interrupt_async` (async, 2 checkpointers: memory, sqlite_aio)
- [x] All 20 tests in `test_interruption.py` pass
- [x] `make format` — clean
- [x] `make lint` — clean (`Success: no issues found in 64 source files`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)