### PR TITLE
fix(prebuilt): handle plain ToolException in default tool error handler

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -379,11 +379,11 @@ class ToolInvocationError(ToolException):
 def _default_handle_tool_errors(e: Exception) -> str:
     """Default error handler for tool errors.
 
-    If the tool is a tool invocation error, return its message.
-    Otherwise, raise the error.
+    If the exception is a `ToolException` (including `ToolInvocationError`),
+    return its string representation. Otherwise, raise the error.
     """
-    if isinstance(e, ToolInvocationError):
-        return e.message
+    if isinstance(e, ToolException):
+        return str(e)
     raise e
 
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -527,6 +527,39 @@ async def test_tool_node_handle_tool_errors_false() -> None:
         )
 
 
+async def test_tool_node_default_handler_catches_tool_exception() -> None:
+    """Regression test for #6449.
+
+    ToolException raised by a tool (e.g. from an MCP adapter) must be caught
+    and returned as an error ToolMessage when using the default handler.
+    Previously, only ToolInvocationError was caught; a plain ToolException
+    would be re-raised and crash the graph.
+    """
+    result = await ToolNode([tool2]).ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "tool2",
+                            "args": {"some_val": 0, "some_other_val": "bar"},
+                            "id": "mcp-call-id",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert msg.type == "tool"
+    assert msg.status == "error"
+    assert msg.tool_call_id == "mcp-call-id"
+    assert "Test error" in msg.content
+
+
 def test_tool_node_individual_tool_error_handling() -> None:
     # test error handling on individual tools (and that it overrides overall error handling!)
     result_individual_tool_error_handler = ToolNode(


### PR DESCRIPTION
## Summary

Fixes #6449.

`_default_handle_tool_errors` only caught `ToolInvocationError` (a subclass of `ToolException`). A plain `ToolException` — as raised by MCP adapters (`langchain_mcp_adapters`) and other tool wrappers — was re-raised instead of being returned as an error `ToolMessage`, crashing the graph.

**Before:**
```python
def _default_handle_tool_errors(e: Exception) -> str:
    if isinstance(e, ToolInvocationError):
        return e.message
    raise e  # ← ToolException from MCP falls through here
```

**After:**
```python
def _default_handle_tool_errors(e: Exception) -> str:
    if isinstance(e, ToolException):  # catches both ToolException and ToolInvocationError
        return str(e)
    raise e
```

`ToolInvocationError` calls `super().__init__(self.message)`, so `str(e)` is identical to `e.message` — no behaviour change for the existing path.

## Test plan

- [x] Added `test_tool_node_default_handler_catches_tool_exception` — verifies a plain `ToolException` from an async tool is returned as an error `ToolMessage` with the default handler
- [x] Existing `test_tool_node_error_handling` and `test_tool_node_handle_tool_errors_false` still pass
- [x] `make format` — clean
- [x] `make lint` — clean (`Success: no issues found in 5 source files`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)