### PR TITLE
Add deterministic CI checks classifier for maintenance automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,7 @@ test:
 			$(MAKE) -C $$dir test; \
 		fi; \
 	done
+
+.PHONY: ci-checks-classify
+ci-checks-classify:
+	python3 scripts/ci_checks_classifier.py $(ARGS)

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint type format test-integration update-schema bump-version
+.PHONY: test lint type format test-integration update-schema bump-version test-ci-checks-classifier test-ci-checks-classifier-real-prs
 
 ######################
 # TESTING AND COVERAGE
@@ -9,6 +9,10 @@ test:
 	uv run pytest $(TEST)
 test-integration:
 	uv run pytest tests/integration_tests
+test-ci-checks-classifier:
+	uv run pytest tests/unit_tests/test_ci_checks_classifier.py
+test-ci-checks-classifier-real-prs:
+	uv run pytest tests/integration_tests/test_ci_checks_classifier_real_prs.py
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/cli/langgraph_cli/ci_checks_classifier.py
+++ b/libs/cli/langgraph_cli/ci_checks_classifier.py
@@ -1,0 +1,161 @@
+"""Normalize PR check rollups into deterministic automation states."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypedDict
+
+NormalizedCIState = Literal["failed", "pending", "no_checks", "policy_blocked"]
+
+_NO_CHECKS_SENTINEL = "no checks reported"
+
+_FAILED_TOKENS = {
+    "fail",
+    "failed",
+    "failure",
+    "error",
+    "timed_out",
+    "timedout",
+    "action_required",
+    "startup_failure",
+}
+_PENDING_TOKENS = {
+    "pending",
+    "queued",
+    "in_progress",
+    "inprogress",
+    "requested",
+    "waiting",
+}
+_PASSING_TOKENS = {"pass", "passed", "success", "successful", "neutral"}
+_SKIPPED_TOKENS = {"skip", "skipped", "skipping"}
+_CANCELLED_TOKENS = {"cancel", "cancelled", "canceled"}
+
+
+class CICheckClassification(TypedDict):
+    schema_version: int
+    state: NormalizedCIState
+    checks_total: int
+    failed_count: int
+    pending_count: int
+    passing_count: int
+    skipped_count: int
+    cancelled_count: int
+    unknown_count: int
+    no_checks_reported: bool
+    merge_state_status: str | None
+
+
+def _as_lower_token(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    token = value.strip().lower()
+    return token or None
+
+
+def _classify_check_bucket(check: Mapping[str, Any]) -> str:
+    for raw_token in (check.get("bucket"), check.get("state")):
+        token = _as_lower_token(raw_token)
+        if token is None:
+            continue
+        if token in _FAILED_TOKENS:
+            return "failed"
+        if token in _PENDING_TOKENS:
+            return "pending"
+        if token in _PASSING_TOKENS:
+            return "passing"
+        if token in _SKIPPED_TOKENS:
+            return "skipped"
+        if token in _CANCELLED_TOKENS:
+            return "cancelled"
+    return "unknown"
+
+
+def parse_gh_pr_checks_output(raw_output: str) -> tuple[list[Mapping[str, Any]], bool]:
+    """Parse `gh pr checks` output into check rows and no-checks signal."""
+    stripped = raw_output.strip()
+    if not stripped:
+        return [], True
+    if _NO_CHECKS_SENTINEL in stripped.lower():
+        return [], True
+
+    payload = json.loads(stripped)
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, Mapping)], False
+
+    if isinstance(payload, Mapping):
+        checks = payload.get("checks")
+        if isinstance(checks, list):
+            return [row for row in checks if isinstance(row, Mapping)], False
+
+    raise ValueError("Unsupported checks payload format")
+
+
+def classify_ci_checks(
+    checks: Sequence[Mapping[str, Any]],
+    *,
+    no_checks_reported: bool = False,
+    merge_state_status: str | None = None,
+) -> CICheckClassification:
+    """Classify check rollup data into a deterministic automation state."""
+    failed_count = 0
+    pending_count = 0
+    passing_count = 0
+    skipped_count = 0
+    cancelled_count = 0
+    unknown_count = 0
+
+    for check in checks:
+        bucket = _classify_check_bucket(check)
+        if bucket == "failed":
+            failed_count += 1
+        elif bucket == "pending":
+            pending_count += 1
+        elif bucket == "passing":
+            passing_count += 1
+        elif bucket == "skipped":
+            skipped_count += 1
+        elif bucket == "cancelled":
+            cancelled_count += 1
+        else:
+            unknown_count += 1
+
+    checks_total = len(checks)
+
+    if no_checks_reported or checks_total == 0:
+        state: NormalizedCIState = "no_checks"
+    elif failed_count > 0 or cancelled_count > 0:
+        state = "failed"
+    elif pending_count > 0:
+        state = "pending"
+    else:
+        # Checks are non-blocking; the remaining blocker is repository policy
+        # (merge requirements, reviews, queue rules, etc.).
+        state = "policy_blocked"
+
+    return {
+        "schema_version": 1,
+        "state": state,
+        "checks_total": checks_total,
+        "failed_count": failed_count,
+        "pending_count": pending_count,
+        "passing_count": passing_count,
+        "skipped_count": skipped_count,
+        "cancelled_count": cancelled_count,
+        "unknown_count": unknown_count,
+        "no_checks_reported": no_checks_reported or checks_total == 0,
+        "merge_state_status": merge_state_status,
+    }
+
+
+def classify_gh_pr_checks_output(
+    raw_output: str, *, merge_state_status: str | None = None
+) -> CICheckClassification:
+    """Classify raw `gh pr checks` output."""
+    checks, no_checks_reported = parse_gh_pr_checks_output(raw_output)
+    return classify_ci_checks(
+        checks,
+        no_checks_reported=no_checks_reported,
+        merge_state_status=merge_state_status,
+    )

--- a/libs/cli/tests/integration_tests/test_ci_checks_classifier_real_prs.py
+++ b/libs/cli/tests/integration_tests/test_ci_checks_classifier_real_prs.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from langgraph_cli.ci_checks_classifier import (
+    classify_ci_checks,
+    parse_gh_pr_checks_output,
+)
+
+REAL_PR_ENV_MAP = {
+    "failed": "LANGGRAPH_REAL_PR_FAILED",
+    "pending": "LANGGRAPH_REAL_PR_PENDING",
+    "no_checks": "LANGGRAPH_REAL_PR_NO_CHECKS",
+    "policy_blocked": "LANGGRAPH_REAL_PR_POLICY_BLOCKED",
+}
+
+
+def _get_pr_number_for_state(expected_state: str) -> str:
+    env_var = REAL_PR_ENV_MAP[expected_state]
+    pr_number = os.environ.get(env_var)
+    if not pr_number:
+        pytest.skip(
+            f"Missing {env_var}; set it to enable live PR verification for {expected_state}."
+        )
+    return pr_number
+
+
+def _run_gh_pr_checks(pr_number: str) -> tuple[list[dict], bool]:
+    proc = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "checks",
+            pr_number,
+            "--repo",
+            "langchain-ai/langgraph",
+            "--json",
+            "name,state,bucket,link",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    payload = proc.stdout.strip() or proc.stderr.strip()
+    checks, no_checks_reported = parse_gh_pr_checks_output(payload)
+    if proc.returncode != 0 and not no_checks_reported:
+        pytest.fail(f"gh pr checks failed: {proc.stderr.strip()}")
+    return [dict(check) for check in checks], no_checks_reported
+
+
+@pytest.mark.skipif(shutil.which("gh") is None, reason="gh CLI is required")
+@pytest.mark.parametrize(
+    "expected_state", ["failed", "pending", "no_checks", "policy_blocked"]
+)
+def test_classifier_matches_real_langgraph_pr_state(expected_state: str) -> None:
+    pr_number = _get_pr_number_for_state(expected_state)
+    checks, no_checks_reported = _run_gh_pr_checks(pr_number)
+    result = classify_ci_checks(checks, no_checks_reported=no_checks_reported)
+    assert result["state"] == expected_state

--- a/libs/cli/tests/unit_tests/fixtures/ci_checks_classifier_cases.json
+++ b/libs/cli/tests/unit_tests/fixtures/ci_checks_classifier_cases.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "failed",
+    "raw_output": "[{\"name\":\"lint\",\"state\":\"FAILURE\",\"bucket\":\"fail\"},{\"name\":\"test\",\"state\":\"SUCCESS\",\"bucket\":\"pass\"}]",
+    "expected_state": "failed",
+    "expected": {
+      "checks_total": 2,
+      "failed_count": 1,
+      "pending_count": 0,
+      "passing_count": 1,
+      "skipped_count": 0,
+      "cancelled_count": 0,
+      "unknown_count": 0,
+      "no_checks_reported": false
+    }
+  },
+  {
+    "name": "pending",
+    "raw_output": "[{\"name\":\"lint\",\"state\":\"IN_PROGRESS\",\"bucket\":\"pending\"}]",
+    "expected_state": "pending",
+    "expected": {
+      "checks_total": 1,
+      "failed_count": 0,
+      "pending_count": 1,
+      "passing_count": 0,
+      "skipped_count": 0,
+      "cancelled_count": 0,
+      "unknown_count": 0,
+      "no_checks_reported": false
+    }
+  },
+  {
+    "name": "no_checks",
+    "raw_output": "no checks reported on the 'main' branch",
+    "expected_state": "no_checks",
+    "expected": {
+      "checks_total": 0,
+      "failed_count": 0,
+      "pending_count": 0,
+      "passing_count": 0,
+      "skipped_count": 0,
+      "cancelled_count": 0,
+      "unknown_count": 0,
+      "no_checks_reported": true
+    }
+  },
+  {
+    "name": "policy_blocked",
+    "raw_output": "[{\"name\":\"lint\",\"state\":\"SUCCESS\",\"bucket\":\"pass\"},{\"name\":\"slow-optional\",\"state\":\"SKIPPED\",\"bucket\":\"skipping\"}]",
+    "expected_state": "policy_blocked",
+    "expected": {
+      "checks_total": 2,
+      "failed_count": 0,
+      "pending_count": 0,
+      "passing_count": 1,
+      "skipped_count": 1,
+      "cancelled_count": 0,
+      "unknown_count": 0,
+      "no_checks_reported": false
+    }
+  }
+]

--- a/libs/cli/tests/unit_tests/test_ci_checks_classifier.py
+++ b/libs/cli/tests/unit_tests/test_ci_checks_classifier.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from langgraph_cli.ci_checks_classifier import classify_gh_pr_checks_output
+
+FIXTURES_PATH = Path(__file__).parent / "fixtures" / "ci_checks_classifier_cases.json"
+
+
+def _load_cases() -> list[dict]:
+    with FIXTURES_PATH.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda case: case["name"])
+def test_classify_gh_pr_checks_output_cases(case: dict) -> None:
+    result = classify_gh_pr_checks_output(case["raw_output"])
+    assert result["schema_version"] == 1
+    assert result["state"] == case["expected_state"]
+    assert result["checks_total"] == case["expected"]["checks_total"]
+    assert result["failed_count"] == case["expected"]["failed_count"]
+    assert result["pending_count"] == case["expected"]["pending_count"]
+    assert result["passing_count"] == case["expected"]["passing_count"]
+    assert result["skipped_count"] == case["expected"]["skipped_count"]
+    assert result["cancelled_count"] == case["expected"]["cancelled_count"]
+    assert result["unknown_count"] == case["expected"]["unknown_count"]
+    assert result["no_checks_reported"] == case["expected"]["no_checks_reported"]
+
+
+def test_classify_output_schema_keys_are_stable() -> None:
+    result = classify_gh_pr_checks_output("[]")
+    assert list(result.keys()) == [
+        "schema_version",
+        "state",
+        "checks_total",
+        "failed_count",
+        "pending_count",
+        "passing_count",
+        "skipped_count",
+        "cancelled_count",
+        "unknown_count",
+        "no_checks_reported",
+        "merge_state_status",
+    ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,64 @@
+# Scripts
+
+## CI Checks Classifier
+
+Use `scripts/ci_checks_classifier.py` to normalize pull request check rollups into
+deterministic states for maintenance automation.
+
+### States
+
+- `failed`
+- `pending`
+- `no_checks`
+- `policy_blocked`
+
+### Usage
+
+Classify live PR checks through `gh`:
+
+```bash
+python3 scripts/ci_checks_classifier.py --pr 6927 --repo langchain-ai/langgraph
+```
+
+Classify from saved JSON output:
+
+```bash
+python3 scripts/ci_checks_classifier.py --checks-file /tmp/checks.json
+```
+
+Classify from raw `gh pr checks` text (including `no checks reported` output):
+
+```bash
+python3 scripts/ci_checks_classifier.py --gh-output-file /tmp/gh-pr-checks.txt
+```
+
+### Example output
+
+```json
+{
+  "cancelled_count": 0,
+  "checks_total": 2,
+  "failed_count": 1,
+  "merge_state_status": "BLOCKED",
+  "no_checks_reported": false,
+  "passing_count": 1,
+  "pending_count": 0,
+  "schema_version": 1,
+  "skipped_count": 0,
+  "state": "failed",
+  "unknown_count": 0
+}
+```
+
+### Real PR verification (optional)
+
+When real PR samples are available, verify classifier behavior against live data:
+
+```bash
+cd libs/cli
+LANGGRAPH_REAL_PR_FAILED=<pr-number> \
+LANGGRAPH_REAL_PR_PENDING=<pr-number> \
+LANGGRAPH_REAL_PR_NO_CHECKS=<pr-number> \
+LANGGRAPH_REAL_PR_POLICY_BLOCKED=<pr-number> \
+make test-ci-checks-classifier-real-prs
+```

--- a/scripts/ci_checks_classifier.py
+++ b/scripts/ci_checks_classifier.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Classify PR checks into deterministic automation states.
+
+Examples:
+  python3 scripts/ci_checks_classifier.py --pr 123 --repo langchain-ai/langgraph
+  python3 scripts/ci_checks_classifier.py --checks-file ./checks.json
+  python3 scripts/ci_checks_classifier.py --gh-output-file ./gh-pr-checks.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CLI_LIB_DIR = REPO_ROOT / "libs" / "cli"
+if str(CLI_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(CLI_LIB_DIR))
+
+from langgraph_cli.ci_checks_classifier import (  # noqa: E402
+    classify_ci_checks,
+    classify_gh_pr_checks_output,
+    parse_gh_pr_checks_output,
+)
+
+
+def _load_text(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _run_gh_command(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def _fetch_merge_state_status(pr: str, repo: str) -> str | None:
+    proc = _run_gh_command(
+        ["gh", "pr", "view", pr, "--repo", repo, "--json", "mergeStateStatus"]
+    )
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    merge_state_status = payload.get("mergeStateStatus")
+    return merge_state_status if isinstance(merge_state_status, str) else None
+
+
+def _fetch_checks_payload(pr: str, repo: str) -> tuple[list[dict[str, Any]], bool]:
+    proc = _run_gh_command(
+        ["gh", "pr", "checks", pr, "--repo", repo, "--json", "name,state,bucket,link"]
+    )
+    stdout = proc.stdout.strip()
+    stderr = proc.stderr.strip()
+
+    if stdout:
+        try:
+            checks, no_checks_reported = parse_gh_pr_checks_output(stdout)
+            return [dict(check) for check in checks], no_checks_reported
+        except (ValueError, json.JSONDecodeError):
+            # Fall through to sentinel/error handling below.
+            pass
+
+    if stderr:
+        try:
+            checks, no_checks_reported = parse_gh_pr_checks_output(stderr)
+            if no_checks_reported:
+                return [dict(check) for check in checks], no_checks_reported
+        except (ValueError, json.JSONDecodeError):
+            pass
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "Failed to fetch checks via gh pr checks: "
+            f"exit={proc.returncode}; stderr={stderr}"
+        )
+
+    if not stdout:
+        return [], True
+
+    raise RuntimeError("Unable to parse `gh pr checks` JSON output")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize PR check rollups into a deterministic JSON state for automation."
+        )
+    )
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument("--pr", help="Pull request number for live `gh` lookup.")
+    source_group.add_argument(
+        "--checks-file",
+        type=pathlib.Path,
+        help="Path to JSON output from `gh pr checks --json ...`.",
+    )
+    source_group.add_argument(
+        "--gh-output-file",
+        type=pathlib.Path,
+        help="Path to raw text output from `gh pr checks`.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="langchain-ai/langgraph",
+        help="GitHub repository in OWNER/REPO form (used with --pr).",
+    )
+    parser.add_argument(
+        "--merge-state-status",
+        default=None,
+        help="Optional merge state status (for metadata enrichment).",
+    )
+
+    args = parser.parse_args()
+
+    merge_state_status = args.merge_state_status
+    if args.pr is not None:
+        checks, no_checks_reported = _fetch_checks_payload(args.pr, args.repo)
+        if merge_state_status is None:
+            merge_state_status = _fetch_merge_state_status(args.pr, args.repo)
+        result = classify_ci_checks(
+            checks,
+            no_checks_reported=no_checks_reported,
+            merge_state_status=merge_state_status,
+        )
+    elif args.checks_file is not None:
+        checks_payload = _load_text(args.checks_file)
+        checks, no_checks_reported = parse_gh_pr_checks_output(checks_payload)
+        result = classify_ci_checks(
+            checks,
+            no_checks_reported=no_checks_reported,
+            merge_state_status=merge_state_status,
+        )
+    else:
+        gh_output = _load_text(args.gh_output_file)
+        result = classify_gh_pr_checks_output(
+            gh_output, merge_state_status=merge_state_status
+        )
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description
Adds a deterministic CI checks classifier for maintenance automation.

- Normalizes states to: `failed`, `pending`, `no_checks`, `policy_blocked`
- Handles explicit `gh pr checks` output: `no checks reported`
- Adds script command: `scripts/ci_checks_classifier.py`
- Adds deterministic JSON schema output for machine consumption
- Adds unit + fixture tests for all required states
- Adds optional env-driven integration test for real-PR verification when available
- Adds usage docs in `scripts/README.md`
- Adds Makefile targets in root and `libs/cli`

Closes #6927.

Example output:
```json
{
  "cancelled_count": 0,
  "checks_total": 0,
  "failed_count": 0,
  "merge_state_status": null,
  "no_checks_reported": true,
  "passing_count": 0,
  "pending_count": 0,
  "schema_version": 1,
  "skipped_count": 0,
  "state": "no_checks",
  "unknown_count": 0
}
