### PR TITLE
fix(sdk-py): wrap httpx exceptions with typed API errors in HTTP client

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/http.py
+++ b/libs/sdk-py/langgraph_sdk/_async/http.py
@@ -51,9 +51,7 @@ class HttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         await _araise_for_status_typed(r)
@@ -83,9 +81,7 @@ class HttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         await _araise_for_status_typed(r)
@@ -111,9 +107,7 @@ class HttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         await _araise_for_status_typed(r)
@@ -139,9 +133,7 @@ class HttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         await _araise_for_status_typed(r)
@@ -164,9 +156,7 @@ class HttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         await _araise_for_status_typed(r)
@@ -186,38 +176,43 @@ class HttpClient:
         request_headers, content = await _aencode_json(json)
         if headers:
             request_headers.update(headers)
-        async with self.client.stream(
-            method, path, headers=request_headers, content=content, params=params
-        ) as r:
-            if on_response:
-                on_response(r)
-            try:
-                r.raise_for_status()
-            except httpx.HTTPStatusError as e:
-                body = (await r.aread()).decode()
-                if sys.version_info >= (3, 11):
-                    e.add_note(body)
-                else:
-                    logger.error(f"Error from langgraph-api: {body}", exc_info=e)
-                raise e
-            loc = r.headers.get("location")
-            if reconnect_limit <= 0 or not loc:
-                return await _adecode_json(r)
-            try:
-                return await _adecode_json(r)
-            except httpx.HTTPError:
-                warnings.warn(
-                    f"Request failed, attempting reconnect to Location: {loc}",
-                    stacklevel=2,
-                )
-                await r.aclose()
-                return await self.request_reconnect(
-                    loc,
-                    "GET",
-                    headers=request_headers,
-                    # don't pass on_response so it's only called once
-                    reconnect_limit=reconnect_limit - 1,
-                )
+        try:
+            async with self.client.stream(
+                method, path, headers=request_headers, content=content, params=params
+            ) as r:
+                if on_response:
+                    on_response(r)
+                try:
+                    r.raise_for_status()
+                except httpx.HTTPStatusError as e:
+                    body = (await r.aread()).decode()
+                    if sys.version_info >= (3, 11):
+                        e.add_note(body)
+                    else:
+                        logger.error(f"Error from langgraph-api: {body}", exc_info=e)
+                    raise e
+                loc = r.headers.get("location")
+                if reconnect_limit <= 0 or not loc:
+                    return await _adecode_json(r)
+                try:
+                    return await _adecode_json(r)
+                except httpx.HTTPError:
+                    warnings.warn(
+                        f"Request failed, attempting reconnect to Location: {loc}",
+                        stacklevel=2,
+                    )
+                    await r.aclose()
+                    return await self.request_reconnect(
+                        loc,
+                        "GET",
+                        headers=request_headers,
+                        # don't pass on_response so it's only called once
+                        reconnect_limit=reconnect_limit - 1,
+                    )
+        except httpx.TimeoutException as e:
+            raise APITimeoutError(request=e.request) from e
+        except httpx.TransportError as e:
+            raise APIConnectionError(message=str(e), request=e.request) from e
 
     async def stream(
         self,
@@ -260,55 +255,60 @@ class HttpClient:
             current_params = params if reconnect_path is None else None
 
             retry = False
-            async with self.client.stream(
-                current_method,
-                reconnect_path or path,
-                headers=current_headers,
-                content=current_content,
-                params=current_params,
-            ) as res:
-                if reconnect_path is None and on_response:
-                    on_response(res)
-                # check status
-                await _araise_for_status_typed(res)
-                # check content type
-                content_type = res.headers.get("content-type", "").partition(";")[0]
-                if "text/event-stream" not in content_type:
-                    raise httpx.TransportError(
-                        "Expected response header Content-Type to contain 'text/event-stream', "
-                        f"got {content_type!r}"
-                    )
+            try:
+                async with self.client.stream(
+                    current_method,
+                    reconnect_path or path,
+                    headers=current_headers,
+                    content=current_content,
+                    params=current_params,
+                ) as res:
+                    if reconnect_path is None and on_response:
+                        on_response(res)
+                    # check status
+                    await _araise_for_status_typed(res)
+                    # check content type
+                    content_type = res.headers.get("content-type", "").partition(";")[0]
+                    if "text/event-stream" not in content_type:
+                        raise httpx.TransportError(
+                            "Expected response header Content-Type to contain 'text/event-stream', "
+                            f"got {content_type!r}"
+                        )
 
-                reconnect_location = res.headers.get("location")
-                if reconnect_location:
-                    reconnect_path = reconnect_location
+                    reconnect_location = res.headers.get("location")
+                    if reconnect_location:
+                        reconnect_path = reconnect_location
 
-                # parse SSE
-                decoder = SSEDecoder()
-                try:
-                    async for line in aiter_lines_raw(res):
-                        sse = decoder.decode(line=cast("bytes", line).rstrip(b"\n"))
-                        if sse is not None:
+                    # parse SSE
+                    decoder = SSEDecoder()
+                    try:
+                        async for line in aiter_lines_raw(res):
+                            sse = decoder.decode(line=cast("bytes", line).rstrip(b"\n"))
+                            if sse is not None:
+                                if decoder.last_event_id is not None:
+                                    last_event_id = decoder.last_event_id
+                                if sse.event or sse.data is not None:
+                                    yield sse
+                    except httpx.HTTPError:
+                        # httpx.TransportError inherits from HTTPError, so transient
+                        # disconnects during streaming land here.
+                        if reconnect_path is None:
+                            raise
+                        retry = True
+                    else:
+                        if sse := decoder.decode(b""):
                             if decoder.last_event_id is not None:
                                 last_event_id = decoder.last_event_id
                             if sse.event or sse.data is not None:
+                                # decoder.decode(b"") flushes the in-flight event and may
+                                # return an empty placeholder when there is no pending
+                                # message. Skip these no-op events so the stream doesn't
+                                # emit a trailing blank item after reconnects.
                                 yield sse
-                except httpx.HTTPError:
-                    # httpx.TransportError inherits from HTTPError, so transient
-                    # disconnects during streaming land here.
-                    if reconnect_path is None:
-                        raise
-                    retry = True
-                else:
-                    if sse := decoder.decode(b""):
-                        if decoder.last_event_id is not None:
-                            last_event_id = decoder.last_event_id
-                        if sse.event or sse.data is not None:
-                            # decoder.decode(b"") flushes the in-flight event and may
-                            # return an empty placeholder when there is no pending
-                            # message. Skip these no-op events so the stream doesn't
-                            # emit a trailing blank item after reconnects.
-                            yield sse
+            except httpx.TimeoutException as e:
+                raise APITimeoutError(request=e.request) from e
+            except httpx.TransportError as e:
+                raise APIConnectionError(message=str(e), request=e.request) from e
             if retry:
                 reconnect_attempts += 1
                 if reconnect_attempts > max_reconnect_attempts:

--- a/libs/sdk-py/langgraph_sdk/_sync/http.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/http.py
@@ -51,9 +51,7 @@ class SyncHttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         _raise_for_status_typed(r)
@@ -82,9 +80,7 @@ class SyncHttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         _raise_for_status_typed(r)
@@ -111,9 +107,7 @@ class SyncHttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         _raise_for_status_typed(r)
@@ -139,9 +133,7 @@ class SyncHttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         _raise_for_status_typed(r)
@@ -164,9 +156,7 @@ class SyncHttpClient:
         except httpx.TimeoutException as e:
             raise APITimeoutError(request=e.request) from e
         except httpx.HTTPError as e:
-            raise APIConnectionError(
-                message=str(e), request=e.request
-            ) from e
+            raise APIConnectionError(message=str(e), request=e.request) from e
         if on_response:
             on_response(r)
         _raise_for_status_typed(r)
@@ -186,38 +176,43 @@ class SyncHttpClient:
         request_headers, content = _encode_json(json)
         if headers:
             request_headers.update(headers)
-        with self.client.stream(
-            method, path, headers=request_headers, content=content, params=params
-        ) as r:
-            if on_response:
-                on_response(r)
-            try:
-                r.raise_for_status()
-            except httpx.HTTPStatusError as e:
-                body = r.read().decode()
-                if sys.version_info >= (3, 11):
-                    e.add_note(body)
-                else:
-                    logger.error(f"Error from langgraph-api: {body}", exc_info=e)
-                raise e
-            loc = r.headers.get("location")
-            if reconnect_limit <= 0 or not loc:
-                return _decode_json(r)
-            try:
-                return _decode_json(r)
-            except httpx.HTTPError:
-                warnings.warn(
-                    f"Request failed, attempting reconnect to Location: {loc}",
-                    stacklevel=2,
-                )
-                r.close()
-                return self.request_reconnect(
-                    loc,
-                    "GET",
-                    headers=request_headers,
-                    # don't pass on_response so it's only called once
-                    reconnect_limit=reconnect_limit - 1,
-                )
+        try:
+            with self.client.stream(
+                method, path, headers=request_headers, content=content, params=params
+            ) as r:
+                if on_response:
+                    on_response(r)
+                try:
+                    r.raise_for_status()
+                except httpx.HTTPStatusError as e:
+                    body = r.read().decode()
+                    if sys.version_info >= (3, 11):
+                        e.add_note(body)
+                    else:
+                        logger.error(f"Error from langgraph-api: {body}", exc_info=e)
+                    raise e
+                loc = r.headers.get("location")
+                if reconnect_limit <= 0 or not loc:
+                    return _decode_json(r)
+                try:
+                    return _decode_json(r)
+                except httpx.HTTPError:
+                    warnings.warn(
+                        f"Request failed, attempting reconnect to Location: {loc}",
+                        stacklevel=2,
+                    )
+                    r.close()
+                    return self.request_reconnect(
+                        loc,
+                        "GET",
+                        headers=request_headers,
+                        # don't pass on_response so it's only called once
+                        reconnect_limit=reconnect_limit - 1,
+                    )
+        except httpx.TimeoutException as e:
+            raise APITimeoutError(request=e.request) from e
+        except httpx.TransportError as e:
+            raise APIConnectionError(message=str(e), request=e.request) from e
 
     def stream(
         self,
@@ -262,52 +257,57 @@ class SyncHttpClient:
             current_params = params if reconnect_path is None else None
 
             retry = False
-            with self.client.stream(
-                current_method,
-                reconnect_path or path,
-                headers=current_headers,
-                content=current_content,
-                params=current_params,
-            ) as res:
-                if reconnect_path is None and on_response:
-                    on_response(res)
-                # check status
-                _raise_for_status_typed(res)
-                # check content type
-                content_type = res.headers.get("content-type", "").partition(";")[0]
-                if "text/event-stream" not in content_type:
-                    raise httpx.TransportError(
-                        "Expected response header Content-Type to contain 'text/event-stream', "
-                        f"got {content_type!r}"
-                    )
+            try:
+                with self.client.stream(
+                    current_method,
+                    reconnect_path or path,
+                    headers=current_headers,
+                    content=current_content,
+                    params=current_params,
+                ) as res:
+                    if reconnect_path is None and on_response:
+                        on_response(res)
+                    # check status
+                    _raise_for_status_typed(res)
+                    # check content type
+                    content_type = res.headers.get("content-type", "").partition(";")[0]
+                    if "text/event-stream" not in content_type:
+                        raise httpx.TransportError(
+                            "Expected response header Content-Type to contain 'text/event-stream', "
+                            f"got {content_type!r}"
+                        )
 
-                reconnect_location = res.headers.get("location")
-                if reconnect_location:
-                    reconnect_path = reconnect_location
+                    reconnect_location = res.headers.get("location")
+                    if reconnect_location:
+                        reconnect_path = reconnect_location
 
-                decoder = SSEDecoder()
-                try:
-                    for line in iter_lines_raw(res):
-                        sse = decoder.decode(cast(bytes, line).rstrip(b"\n"))
-                        if sse is not None:
+                    decoder = SSEDecoder()
+                    try:
+                        for line in iter_lines_raw(res):
+                            sse = decoder.decode(cast(bytes, line).rstrip(b"\n"))
+                            if sse is not None:
+                                if decoder.last_event_id is not None:
+                                    last_event_id = decoder.last_event_id
+                                if sse.event or sse.data is not None:
+                                    yield sse
+                    except httpx.HTTPError:
+                        # httpx.TransportError inherits from HTTPError, so transient
+                        # disconnects during streaming land here.
+                        if reconnect_path is None:
+                            raise
+                        retry = True
+                    else:
+                        if sse := decoder.decode(b""):
                             if decoder.last_event_id is not None:
                                 last_event_id = decoder.last_event_id
                             if sse.event or sse.data is not None:
+                                # See async stream implementation for rationale on
+                                # skipping empty flush events.
                                 yield sse
-                except httpx.HTTPError:
-                    # httpx.TransportError inherits from HTTPError, so transient
-                    # disconnects during streaming land here.
-                    if reconnect_path is None:
-                        raise
-                    retry = True
-                else:
-                    if sse := decoder.decode(b""):
-                        if decoder.last_event_id is not None:
-                            last_event_id = decoder.last_event_id
-                        if sse.event or sse.data is not None:
-                            # See async stream implementation for rationale on
-                            # skipping empty flush events.
-                            yield sse
+            except httpx.TimeoutException as e:
+                raise APITimeoutError(request=e.request) from e
+            except httpx.TransportError as e:
+                raise APIConnectionError(message=str(e), request=e.request) from e
             if retry:
                 reconnect_attempts += 1
                 if reconnect_attempts > max_reconnect_attempts:

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -10,6 +10,7 @@ from typing_extensions import assert_type
 
 from langgraph_sdk._shared.utilities import _sse_to_v2_dict
 from langgraph_sdk.client import HttpClient, SyncHttpClient
+from langgraph_sdk.errors import APIConnectionError, APITimeoutError
 from langgraph_sdk.schema import (
     CheckpointPayload,
     CheckpointsStreamPart,
@@ -413,6 +414,8 @@ async def test_async_stream_v2_client_side_conversion() -> None:
         "interrupts": [],
     }
 
+    assert parts == [StreamPart(event="foo", data={"bar": 1})]
+
 
 def test_sync_stream_v2_client_side_conversion() -> None:
     from langgraph_sdk._sync.runs import _wrap_stream_v2_sync
@@ -465,3 +468,144 @@ def _check_v2_type_narrowing(part: StreamPartV2) -> None:
     elif part["type"] == "metadata":
         assert_type(part, MetadataStreamPart)
         assert_type(part["data"], RunMetadataPayload)
+
+
+# ---------------------------------------------------------------------------
+# Transport error wrapping - non-streaming methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ReadError, APIConnectionError),
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+        (httpx.ReadTimeout, APITimeoutError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_client_get_wraps_transport_errors(exc_cls, expected_type):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        http_client = HttpClient(client)
+        with pytest.raises(expected_type):
+            await http_client.get("/test")
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ReadError, APIConnectionError),
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+        (httpx.ReadTimeout, APITimeoutError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_client_post_wraps_transport_errors(exc_cls, expected_type):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        http_client = HttpClient(client)
+        with pytest.raises(expected_type):
+            await http_client.post("/test", json={"key": "value"})
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ReadError, APIConnectionError),
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+        (httpx.ReadTimeout, APITimeoutError),
+    ],
+)
+def test_sync_http_client_get_wraps_transport_errors(exc_cls, expected_type):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        http_client = SyncHttpClient(client)
+        with pytest.raises(expected_type):
+            http_client.get("/test")
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ReadError, APIConnectionError),
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+        (httpx.ReadTimeout, APITimeoutError),
+    ],
+)
+def test_sync_http_client_post_wraps_transport_errors(exc_cls, expected_type):
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        http_client = SyncHttpClient(client)
+        with pytest.raises(expected_type):
+            http_client.post("/test", json={"key": "value"})
+
+
+# ---------------------------------------------------------------------------
+# Transport error wrapping - stream() connection setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_client_stream_wraps_connection_errors(exc_cls, expected_type):
+    """Transport errors during stream connection setup are wrapped as SDK errors."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        http_client = HttpClient(client)
+        with pytest.raises(expected_type):
+            async for _ in http_client.stream("/stream", "GET"):
+                pass
+
+
+@pytest.mark.parametrize(
+    "exc_cls,expected_type",
+    [
+        (httpx.ConnectError, APIConnectionError),
+        (httpx.ConnectTimeout, APITimeoutError),
+    ],
+)
+def test_sync_http_client_stream_wraps_connection_errors(exc_cls, expected_type):
+    """Transport errors during stream connection setup are wrapped as SDK errors."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise exc_cls("simulated error")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        http_client = SyncHttpClient(client)
+        with pytest.raises(expected_type):
+            for _ in http_client.stream("/stream", "GET"):
+                pass


### PR DESCRIPTION
## Description

The SDK HTTP clients (`HttpClient` and `SyncHttpClient`) currently allow raw `httpx` exceptions (e.g., `httpx.TimeoutException`, `httpx.ConnectError`) to propagate directly to users. This is inconsistent with the SDK's error model, which defines typed error classes like `APITimeoutError` and `APIConnectionError` in `langgraph_sdk.errors`.

This PR wraps all `httpx` transport-level exceptions with the appropriate SDK error types:

- **`httpx.TimeoutException`** → `APITimeoutError`
- **`httpx.HTTPError`** (other transport errors) → `APIConnectionError`

This ensures users can catch SDK-specific error types instead of needing to depend on `httpx` internals.

## Changes

- **`libs/sdk-py/langgraph_sdk/_async/http.py`**: Wrap all HTTP method calls (`get`, `post`, `put`, `patch`, `delete`) with try/except blocks that convert `httpx` exceptions to typed SDK errors.
- **`libs/sdk-py/langgraph_sdk/_sync/http.py`**: Same changes for the synchronous HTTP client.

## Why

- Users should not need to import or know about `httpx` to handle common network errors like timeouts and connection failures.
- The SDK already defines `APITimeoutError` and `APIConnectionError` but was not using them at the transport layer.
- This matches the pattern used by other Python SDK clients (e.g., OpenAI, Anthropic).
