### PR TITLE
chore: simplify invoke interrupt collection

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -3105,11 +3105,11 @@ class Pregel(
             durability=durability,
             **kwargs,
         ):
-            # when subgraphs=True with a single stream_mode, stream()
-            # yields (namespace, payload) tuples — unwrap them
-            if subgraphs and isinstance(chunk, tuple):
-                chunk = chunk[-1]
             if stream_mode == "values":
+                # when subgraphs=True with a single stream_mode, stream()
+                # yields (namespace, payload) tuples — unwrap them
+                if subgraphs and isinstance(chunk, tuple):
+                    chunk = chunk[-1]
                 latest = chunk
                 if (
                     isinstance(chunk, dict)
@@ -3191,11 +3191,11 @@ class Pregel(
             durability=durability,
             **kwargs,
         ):
-            # when subgraphs=True with a single stream_mode, astream()
-            # yields (namespace, payload) tuples — unwrap them
-            if subgraphs and isinstance(chunk, tuple):
-                chunk = chunk[-1]
             if stream_mode == "values":
+                # when subgraphs=True with a single stream_mode, astream()
+                # yields (namespace, payload) tuples — unwrap them
+                if subgraphs and isinstance(chunk, tuple):
+                    chunk = chunk[-1]
                 latest = chunk
                 if (
                     isinstance(chunk, dict)


### PR DESCRIPTION
The pregel loop already merges `__interrupt__` into the `values` dict in `output_writes()`, so invoke/ainvoke don't need to subscribe to both "updates" and "values" stream modes. 

Simplify to just use stream_mode="values" and read interrupts directly from the values payload.