### PR TITLE
fix: add warning logs when JsonPlusSerializer silently returns None

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -187,6 +187,11 @@ class JsonPlusSerializer(SerializerProtocol):
                 except Exception:
                     continue
         except Exception:
+            logger.warning(
+                "Failed to revive LC2 object %s",
+                value.get("id"),
+                exc_info=True,
+            )
             return None
 
     def _check_allowed_json_modules(self, value: dict[str, Any]) -> None:
@@ -594,6 +599,11 @@ def _create_msgpack_ext_hook(
                 # module, name, arg
                 return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
             except Exception:
+                logger.warning(
+                    "Failed to deserialize object with single arg constructor: %s",
+                    data[:64],
+                    exc_info=True,
+                )
                 return None
         elif code == EXT_CONSTRUCTOR_POS_ARGS:
             try:
@@ -605,6 +615,11 @@ def _create_msgpack_ext_hook(
                 # module, name, args
                 return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
             except Exception:
+                logger.warning(
+                    "Failed to deserialize object with positional args constructor: %s",
+                    data[:64],
+                    exc_info=True,
+                )
                 return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
             try:
@@ -616,6 +631,11 @@ def _create_msgpack_ext_hook(
                 # module, name, kwargs
                 return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
             except Exception:
+                logger.warning(
+                    "Failed to deserialize object with keyword args constructor: %s",
+                    data[:64],
+                    exc_info=True,
+                )
                 return None
         elif code == EXT_METHOD_SINGLE_ARG:
             try:
@@ -629,6 +649,11 @@ def _create_msgpack_ext_hook(
                     getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
                 )(tup[2])
             except Exception:
+                logger.warning(
+                    "Failed to deserialize object with method single arg: %s",
+                    data[:64],
+                    exc_info=True,
+                )
                 return None
         elif code == EXT_PYDANTIC_V1:
             try:
@@ -646,6 +671,10 @@ def _create_msgpack_ext_hook(
             except Exception:
                 # for pydantic objects we can't find/reconstruct
                 # let's return the kwargs dict instead
+                logger.warning(
+                    "Failed to deserialize Pydantic v1 object, returning raw kwargs",
+                    exc_info=True,
+                )
                 try:
                     return tup[2]
                 except NameError:
@@ -666,6 +695,10 @@ def _create_msgpack_ext_hook(
             except Exception:
                 # for pydantic objects we can't find/reconstruct
                 # let's return the kwargs dict instead
+                logger.warning(
+                    "Failed to deserialize Pydantic v2 object, returning raw kwargs",
+                    exc_info=True,
+                )
                 try:
                     return tup[2]
                 except NameError:
@@ -680,6 +713,11 @@ def _create_msgpack_ext_hook(
                 arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
                 return arr.reshape(shape, order=order)
             except Exception:
+                logger.warning(
+                    "Failed to deserialize numpy array: %s",
+                    data[:64],
+                    exc_info=True,
+                )
                 return None
         return None
 


### PR DESCRIPTION
## Summary

Fixes #6970

When deserialization fails in `ext_hook()` or `_revive_lc2()`, the `JsonPlusSerializer` previously returned `None` without any diagnostic output. This makes it extremely difficult to debug state corruption issues — users see `None` values in their graph state with no indication of what went wrong.

## Changes

Added `logger.warning()` with `exc_info=True` to all exception handlers that silently return `None` in the msgpack `ext_hook` function and the LC2 reviver:

- `EXT_CONSTRUCTOR_SINGLE_ARG` handler
- `EXT_CONSTRUCTOR_POS_ARGS` handler
- `EXT_CONSTRUCTOR_KW_ARGS` handler
- `EXT_METHOD_SINGLE_ARG` handler
- `EXT_PYDANTIC_V1` handler (outer except)
- `EXT_PYDANTIC_V2` handler (outer except)
- `EXT_NUMPY_ARRAY` handler
- `_revive_lc2()` method

## Behavior

- **No functional changes**: all return values remain identical
- Failures are now visible in logs with full traceback (`exc_info=True`)
- Inner Pydantic fallback handlers (`cls.construct`/`cls.model_construct`) are intentionally left without logging as they represent expected fallback behavior
- Warning messages include context (`data[:64]` bytes for ext_hook, `value.get('id')` for LC2)

## Testing

All 91 existing `test_jsonplus.py` tests pass.