### PR TITLE
fix(checkpoint): avoid silent None when msgpack type import fails

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -642,52 +642,64 @@ def _create_msgpack_ext_hook(
                 tup = ormsgpack.unpackb(
                     data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
                 )
-                if not _check_allowed(tup[0], tup[1]):
-                    # We default to returning the raw data. If the user
-                    # is using this in the context of a pydantic state, etc., then
-                    # it would be validated upon construction.
-                    return tup[2]
+            except Exception:
+                return None
+            if not _check_allowed(tup[0], tup[1]):
+                # We default to returning the raw data. If the user
+                # is using this in the context of a pydantic state, etc., then
+                # it would be validated upon construction.
+                return tup[2]
+            try:
                 # module, name, arg
                 return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
             except Exception:
-                return None
+                return tup[2]
         elif code == EXT_CONSTRUCTOR_POS_ARGS:
             try:
                 tup = ormsgpack.unpackb(
                     data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
                 )
-                if not _check_allowed(tup[0], tup[1]):
-                    return tup[2]
+            except Exception:
+                return None
+            if not _check_allowed(tup[0], tup[1]):
+                return tup[2]
+            try:
                 if tup[0] == "langgraph.types" and tup[1] == "Send":
                     return _send_from_args(tup[2])
                 # module, name, args
                 return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
             except Exception:
-                return None
+                return tup[2]
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
             try:
                 tup = ormsgpack.unpackb(
                     data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
                 )
-                if not _check_allowed(tup[0], tup[1]):
-                    return tup[2]
+            except Exception:
+                return None
+            if not _check_allowed(tup[0], tup[1]):
+                return tup[2]
+            try:
                 # module, name, kwargs
                 return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
             except Exception:
-                return None
+                return tup[2]
         elif code == EXT_METHOD_SINGLE_ARG:
             try:
                 tup = ormsgpack.unpackb(
                     data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
                 )
-                if not _check_allowed_method(tup[0], tup[1], tup[3]):
-                    return tup[2]
+            except Exception:
+                return None
+            if not _check_allowed_method(tup[0], tup[1], tup[3]):
+                return tup[2]
+            try:
                 # module, name, arg, method
                 return getattr(
                     getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
                 )(tup[2])
             except Exception:
-                return None
+                return tup[2]
         elif code == EXT_PYDANTIC_V1:
             try:
                 tup = ormsgpack.unpackb(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1,9 +1,12 @@
 import dataclasses
+import importlib
 import json
 import logging
+import os
 import pathlib
 import re
 import sys
+import tempfile
 import uuid
 from collections import deque
 from datetime import date, datetime, time, timezone
@@ -904,6 +907,39 @@ def test_msgpack_none_blocks_unregistered(caplog: pytest.LogCaptureFixture) -> N
     assert "blocked" in caplog.text.lower()
     expected = obj.model_dump()
     assert result == expected
+
+
+def test_msgpack_missing_module_falls_back_to_payload_dict() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        module_path = pathlib.Path(temp_dir) / "temp_model.py"
+        module_path.write_text(
+            "from dataclasses import dataclass\n"
+            "@dataclass\n"
+            "class SavedObject:\n"
+            "    value: int\n"
+        )
+
+        sys.path.insert(0, temp_dir)
+        try:
+            module = importlib.import_module("temp_model")
+            SavedObject = module.SavedObject
+
+            serde = JsonPlusSerializer(
+                allowed_msgpack_modules=[("temp_model", "SavedObject")]
+            )
+
+            dumped = serde.dumps_typed(SavedObject(123))
+
+            sys.modules.pop("temp_model", None)
+            os.remove(module_path)
+            importlib.invalidate_caches()
+
+            result = serde.loads_typed(dumped)
+
+            assert result == {"value": 123}
+        finally:
+            if temp_dir in sys.path:
+                sys.path.remove(temp_dir)
 
 
 def test_msgpack_allowlist_blocks_non_listed(


### PR DESCRIPTION
## Summary
- preserve serialized payload values when msgpack reconstruction fails due to missing importable classes
- keep existing allowlist/blocking behavior unchanged
- add a regression test for the missing-module restore path

## Validation
- in `libs/checkpoint`: `uv run ruff format .`
- in `libs/checkpoint`: `uv run ruff check --fix .`
- in `libs/checkpoint`: `uv run ruff check .`
- in `libs/checkpoint`: `uv run ruff format . --check`
- in `libs/checkpoint`: `uv run ruff check --select I .`
- in `libs/checkpoint`: `uv run mypy . --cache-dir .mypy_cache`
- in `libs/checkpoint`: `uv run pytest`

Fixes #6970