### PR TITLE
fix(prebuilt): add timeout parameter to ToolNode for async tool execution

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -692,6 +692,14 @@ class ToolNode(RunnableCallable):
 
             Allows custom state schemas with different message field names.
 
+        timeout: Optional timeout in seconds for each individual tool call.
+            If a tool call exceeds this duration, it will be cancelled and either
+            raise a `TimeoutError` (if `handle_tool_errors` is `False`) or return
+            a `ToolMessage` with an error status (if `handle_tool_errors` is enabled).
+
+            This is particularly useful when tools involve network calls (e.g., MCP
+            servers) that may hang due to connection issues or read timeouts.
+
     Examples:
         Basic usage:
 
@@ -748,6 +756,7 @@ class ToolNode(RunnableCallable):
         messages_key: str = "messages",
         wrap_tool_call: ToolCallWrapper | None = None,
         awrap_tool_call: AsyncToolCallWrapper | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Initialize `ToolNode` with tools and configuration.
 
@@ -762,6 +771,9 @@ class ToolNode(RunnableCallable):
                 Enables retries, caching, request modification, and control flow.
             awrap_tool_call: Async wrapper function to intercept tool execution.
                 If not provided, falls back to wrap_tool_call for async execution.
+            timeout: Optional timeout in seconds for each individual tool call.
+                If a tool exceeds this duration, it will be cancelled and handled
+                according to the handle_tool_errors configuration.
         """
         super().__init__(self._func, self._afunc, name=name, tags=tags, trace=False)
         self._tools_by_name: dict[str, BaseTool] = {}
@@ -770,6 +782,7 @@ class ToolNode(RunnableCallable):
         self._messages_key = messages_key
         self._wrap_tool_call = wrap_tool_call
         self._awrap_tool_call = awrap_tool_call
+        self._timeout = timeout
         for tool in tools:
             if not isinstance(tool, BaseTool):
                 tool_ = create_tool(cast("type[BaseTool]", tool))
@@ -842,7 +855,12 @@ class ToolNode(RunnableCallable):
         # Pass original tool calls without injection
         coros = []
         for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
-            coros.append(self._arun_one(call, input_type, tool_runtime))  # type: ignore[arg-type]
+            coro = self._arun_one(call, input_type, tool_runtime)  # type: ignore[arg-type]
+            if self._timeout is not None:
+                coro = self._arun_one_with_timeout(
+                    coro, call, input_type, self._timeout
+                )
+            coros.append(coro)
         outputs = await asyncio.gather(*coros)
 
         return self._combine_tool_outputs(outputs, input_type)
@@ -1202,6 +1220,41 @@ class ToolNode(RunnableCallable):
                 content=content,
                 name=tool_request.tool_call["name"],
                 tool_call_id=tool_request.tool_call["id"],
+                status="error",
+            )
+
+    async def _arun_one_with_timeout(
+        self,
+        coro: Any,
+        call: ToolCall,
+        input_type: Literal["list", "dict", "tool_calls"],
+        timeout: float,
+    ) -> ToolMessage | Command:
+        """Wrap a tool execution coroutine with a timeout.
+
+        Args:
+            coro: The coroutine to wrap.
+            call: Tool call dict.
+            input_type: Input format.
+            timeout: Timeout in seconds.
+
+        Returns:
+            ToolMessage or Command.
+        """
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        except TimeoutError:
+            if not self._handle_tool_errors:
+                raise
+            content = (
+                f"Tool '{call['name']}' timed out after {timeout} seconds. "
+                "Consider increasing the timeout or checking the tool's "
+                "responsiveness."
+            )
+            return ToolMessage(
+                content=content,
+                name=call["name"],
+                tool_call_id=call["id"],
                 status="error",
             )
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import dataclasses
 import json
@@ -2008,3 +2009,90 @@ async def test_tool_node_inject_runtime_dynamic_tool_via_wrap_tool_call_async() 
     tool_message = result["messages"][-1]
     assert tool_message.content == "dynamic: x=42, tool_call_id=call_dynamic_2"
     assert tool_message.tool_call_id == "call_dynamic_2"
+
+
+# ────────────────────────────────────────────────────────────────
+#  Timeout tests
+# ────────────────────────────────────────────────────────────────
+
+
+@dec_tool
+async def slow_tool(x: int) -> str:
+    """A slow tool for testing timeouts."""
+    await asyncio.sleep(10)
+    return f"result: {x}"
+
+
+@dec_tool
+async def fast_tool(x: int) -> str:
+    """A fast tool for testing timeouts."""
+    return f"result: {x}"
+
+
+async def test_tool_node_timeout_returns_error_message() -> None:
+    """Timeout returns an error ToolMessage when handle_tool_errors is enabled."""
+    tool_node = ToolNode([slow_tool], timeout=0.1)
+    msg = AIMessage("", tool_calls=[ToolCall(name="slow_tool", args={"x": 1}, id="1")])
+    result = await tool_node.ainvoke(
+        {"messages": [msg]}, config=_create_config_with_runtime()
+    )
+    tool_message = result["messages"][-1]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.status == "error"
+    assert "timed out" in tool_message.content
+    assert "slow_tool" in tool_message.content
+
+
+async def test_tool_node_timeout_raises_when_errors_not_handled() -> None:
+    """Timeout raises TimeoutError when handle_tool_errors is False."""
+    tool_node = ToolNode([slow_tool], timeout=0.1, handle_tool_errors=False)
+    msg = AIMessage("", tool_calls=[ToolCall(name="slow_tool", args={"x": 1}, id="1")])
+    with pytest.raises(TimeoutError):
+        await tool_node.ainvoke(
+            {"messages": [msg]}, config=_create_config_with_runtime()
+        )
+
+
+async def test_tool_node_timeout_succeeds_when_tool_is_fast() -> None:
+    """Tools that complete before the timeout return normally."""
+    tool_node = ToolNode([fast_tool], timeout=5.0)
+    msg = AIMessage("", tool_calls=[ToolCall(name="fast_tool", args={"x": 42}, id="1")])
+    result = await tool_node.ainvoke(
+        {"messages": [msg]}, config=_create_config_with_runtime()
+    )
+    tool_message = result["messages"][-1]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "result: 42"
+    assert tool_message.status == "success"
+
+
+async def test_tool_node_no_timeout_by_default() -> None:
+    """Without timeout parameter, fast tools work as before (backward compat)."""
+    tool_node = ToolNode([fast_tool])
+    msg = AIMessage("", tool_calls=[ToolCall(name="fast_tool", args={"x": 1}, id="1")])
+    result = await tool_node.ainvoke(
+        {"messages": [msg]}, config=_create_config_with_runtime()
+    )
+    tool_message = result["messages"][-1]
+    assert tool_message.content == "result: 1"
+
+
+async def test_tool_node_timeout_parallel_tools() -> None:
+    """Timeout applies to each tool individually in parallel execution."""
+    tool_node = ToolNode([slow_tool, fast_tool], timeout=0.5)
+    msg = AIMessage(
+        "",
+        tool_calls=[
+            ToolCall(name="slow_tool", args={"x": 1}, id="1"),
+            ToolCall(name="fast_tool", args={"x": 2}, id="2"),
+        ],
+    )
+    result = await tool_node.ainvoke(
+        {"messages": [msg]}, config=_create_config_with_runtime()
+    )
+    messages = result["messages"]
+    assert len(messages) == 2
+    # One should succeed, one should timeout
+    statuses = {m.name: m.status for m in messages}
+    assert statuses["fast_tool"] == "success"
+    assert statuses["slow_tool"] == "error"


### PR DESCRIPTION
**Description:** When tools involve network calls (e.g., MCP servers with `sse_read_timeout`), `ToolNode.ainvoke()` can hang indefinitely if the underlying transport times out silently without propagating the exception. This adds an optional `timeout` parameter (in seconds) that wraps each individual async tool coroutine with `asyncio.wait_for`, ensuring that hanging tool calls are cancelled and handled gracefully.

When a tool exceeds the timeout:
- If `handle_tool_errors` is enabled (default): returns a `ToolMessage` with `status="error"` and a descriptive message
- If `handle_tool_errors` is `False`: raises `TimeoutError`

The timeout applies per-tool-call, so in parallel execution fast tools still complete successfully even if slow ones time out. When no `timeout` is specified, behavior is unchanged (full backward compatibility).

Example usage:
```python
tool_node = ToolNode(mcp_tools, timeout=30)
await tool_node.ainvoke(input)
```

**Issue:** Closes #6412

**Dependencies:** None