### PR TITLE
fix(checkpoint): don't silently return None when deserialization fails

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -607,16 +607,13 @@ def _create_msgpack_ext_hook(
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
-            try:
-                tup = ormsgpack.unpackb(
-                    data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
-                )
-                if not _check_allowed(tup[0], tup[1]):
-                    return tup[2]
-                # module, name, kwargs
-                return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
-            except Exception:
-                return None
+            tup = ormsgpack.unpackb(
+                data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+            )
+            if not _check_allowed(tup[0], tup[1]):
+                return tup[2]
+            # module, name, kwargs
+            return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
         elif code == EXT_METHOD_SINGLE_ARG:
             try:
                 tup = ormsgpack.unpackb(
@@ -631,45 +628,29 @@ def _create_msgpack_ext_hook(
             except Exception:
                 return None
         elif code == EXT_PYDANTIC_V1:
+            tup = ormsgpack.unpackb(
+                data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+            )
+            if not _check_allowed(tup[0], tup[1]):
+                return tup[2]
+            # module, name, kwargs
+            cls = getattr(importlib.import_module(tup[0]), tup[1])
             try:
-                tup = ormsgpack.unpackb(
-                    data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
-                )
-                if not _check_allowed(tup[0], tup[1]):
-                    return tup[2]
-                # module, name, kwargs
-                cls = getattr(importlib.import_module(tup[0]), tup[1])
-                try:
-                    return cls(**tup[2])
-                except Exception:
-                    return cls.construct(**tup[2])
+                return cls(**tup[2])
             except Exception:
-                # for pydantic objects we can't find/reconstruct
-                # let's return the kwargs dict instead
-                try:
-                    return tup[2]
-                except NameError:
-                    return None
+                return cls.construct(**tup[2])
         elif code == EXT_PYDANTIC_V2:
+            tup = ormsgpack.unpackb(
+                data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+            )
+            if not _check_allowed(tup[0], tup[1]):
+                return tup[2]
+            # module, name, kwargs, method
+            cls = getattr(importlib.import_module(tup[0]), tup[1])
             try:
-                tup = ormsgpack.unpackb(
-                    data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
-                )
-                if not _check_allowed(tup[0], tup[1]):
-                    return tup[2]
-                # module, name, kwargs, method
-                cls = getattr(importlib.import_module(tup[0]), tup[1])
-                try:
-                    return cls(**tup[2])
-                except Exception:
-                    return cls.model_construct(**tup[2])
+                return cls(**tup[2])
             except Exception:
-                # for pydantic objects we can't find/reconstruct
-                # let's return the kwargs dict instead
-                try:
-                    return tup[2]
-                except NameError:
-                    return None
+                return cls.model_construct(**tup[2])
         elif code == EXT_NUMPY_ARRAY:
             try:
                 import numpy as _np


### PR DESCRIPTION
## Summary

Fixes #6970 - JsonPlusSerializer was silently replacing values with None when msgpack deserialization failed.

## Problem

When a module is in the allowed list but deserialization fails (e.g., module was deleted), the serializer silently returns None instead of raising an error. This causes silent data loss in checkpoints.

## Solution

Remove the try/except blocks that swallowed exceptions in ext_hook. The allowed module check still returns the serialized data for disallowed modules, but allowed modules that fail deserialization now raise exceptions.

## Changes

- libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py: Remove exception swallowing in EXT_CONSTRUCTOR_KW_ARGS, EXT_PYDANTIC_V1, EXT_PYDANTIC_V2 handling

Fixes #6970