### PR TITLE
fix(checkpoint): cancel background batch task on async store context exit

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
@@ -405,6 +405,7 @@ class AsyncPostgresStore(AsyncBatchedBaseStore, BasePostgresStore[_ainternal.Con
             self._ttl_stop_event.set()
             # We don't wait for the task to complete here to avoid blocking
             # The task will clean up itself gracefully
+        await self.aclose()
 
     async def _execute_batch(
         self,

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -662,6 +662,43 @@ async def test_search_sorting(
         assert results[0].score > results[1].score
 
 
+async def test_no_pending_tasks_after_context_exit() -> None:
+    """Regression test for https://github.com/langchain-ai/langgraph/issues/6367.
+
+    AsyncPostgresStore.__aexit__ must cancel the background batch task so that
+    asyncio does not emit 'Task was destroyed but it is pending!' warnings.
+    """
+    from tests.conftest import DEFAULT_URI
+
+    database = f"test_{uuid.uuid4().hex[:16]}"
+    uri_parts = DEFAULT_URI.split("/")
+    uri_base = "/".join(uri_parts[:-1])
+    query_params = ""
+    if "?" in uri_parts[-1]:
+        db_name, query_params = uri_parts[-1].split("?", 1)
+        query_params = "?" + query_params
+    conn_string = f"{uri_base}/{database}{query_params}"
+
+    async with await AsyncConnection.connect(DEFAULT_URI, autocommit=True) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with AsyncPostgresStore.from_conn_string(conn_string) as store:
+            await store.setup()
+            await store.aput(("ns",), "k", {"v": 1})
+            _ = await store.aget(("ns",), "k")
+            batch_task = store._task
+
+        # After exiting the context manager the background task must be done
+        assert batch_task is not None
+        assert batch_task.done(), (
+            "Background batch task is still pending after __aexit__ — "
+            "this would cause 'Task was destroyed but it is pending!' warnings"
+        )
+    finally:
+        async with await AsyncConnection.connect(DEFAULT_URI, autocommit=True) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
 async def test_store_ttl(store):
     # Assumes a TTL of 1 minute = 60 seconds
     ns = ("foo",)

--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
@@ -348,6 +348,7 @@ class AsyncSqliteStore(AsyncBatchedBaseStore, BaseSqliteStore):
             self._ttl_stop_event.set()
             # We don't wait for the task to complete here to avoid blocking
             # The task will clean up itself gracefully
+        await self.aclose()
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         """Execute a batch of operations asynchronously.

--- a/libs/checkpoint/langgraph/store/base/batch.py
+++ b/libs/checkpoint/langgraph/store/base/batch.py
@@ -74,6 +74,15 @@ class AsyncBatchedBaseStore(BaseStore):
         except RuntimeError:
             pass
 
+    async def aclose(self) -> None:
+        """Cancel the background batch processing task."""
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
     def _ensure_task(self) -> None:
         """Ensure the background processing loop is running."""
         if self._task is None or self._task.done():


### PR DESCRIPTION
## Summary

Fixes #6367

`AsyncBatchedBaseStore` spins up a background task (`_task`) that loops forever waiting for queue items via `await aqueue.get()`. Neither `AsyncPostgresStore` nor `AsyncSqliteStore` cancelled this task in `__aexit__`, leaving it in a pending state and causing asyncio to emit:

```
[ERROR] asyncio: Task was destroyed but it is pending!
task: <Task cancelling name='Task-56124' coro=<_run() running at .../store/base/batch.py:330>>
```

**Root cause:** `__aexit__` in both stores only cleaned up `_ttl_sweeper_task` and ignored `_task` from the base class.

**Fix:**
- Add `aclose()` to `AsyncBatchedBaseStore` that cancels and awaits `_task`
- Call `await self.aclose()` from `__aexit__` in both `AsyncPostgresStore` and `AsyncSqliteStore`

This is safe because at `__aexit__` time the queue is always empty — every async operation (`aget`, `aput`, etc.) puts a future in the queue and immediately `await`s it, so the future is resolved before control returns to the caller. The background task is idle waiting for new items that will never come.

## Test plan

- [ ] New regression test `test_no_pending_tasks_after_context_exit` in `checkpoint-postgres/tests/test_async_store.py` — asserts `store._task.done()` is `True` after exiting the context manager
- [ ] `checkpoint` lib: 91 passed
- [ ] `checkpoint-sqlite` lib: 98 passed (exercises `AsyncBatchedBaseStore.aclose()` via `AsyncSqliteStore`)
- [ ] All lint/mypy/format checks pass across all three affected libs

🤖 Generated with [Claude Code](https://claude.com/claude-code)