### PR TITLE
docs(langgraph): update deprecated langchain hub imports in tutorial notebooks

### DIFF
--- a/examples/rag/langgraph_adaptive_rag.ipynb
+++ b/examples/rag/langgraph_adaptive_rag.ipynb
@@ -58,7 +58,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "! pip install -U langchain_community tiktoken langchain-openai langchain-cohere langchainhub chromadb langchain langgraph  tavily-python"
+    "! pip install -U langchain_community tiktoken langchain-openai langchain-cohere langsmith chromadb langchain langgraph  tavily-python"
    ]
   },
   {
@@ -282,11 +282,11 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",

--- a/examples/rag/langgraph_adaptive_rag_cohere.ipynb
+++ b/examples/rag/langgraph_adaptive_rag_cohere.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install --quiet langchain langchain_cohere langchain-openai tiktoken langchainhub chromadb langgraph"
+    "! pip install --quiet langchain langchain_cohere langchain-openai tiktoken langsmith chromadb langgraph"
    ]
   },
   {

--- a/examples/rag/langgraph_adaptive_rag_local.ipynb
+++ b/examples/rag/langgraph_adaptive_rag_local.ipynb
@@ -56,7 +56,7 @@
    "outputs": [],
    "source": [
     "%capture --no-stderr\n",
-    "%pip install -U langchain-nomic langchain_community tiktoken langchainhub chromadb langchain langgraph tavily-python nomic[local]"
+    "%pip install -U langchain-nomic langchain_community tiktoken langsmith chromadb langchain langgraph tavily-python nomic[local]"
    ]
   },
   {
@@ -280,12 +280,12 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_community.chat_models import ChatOllama\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOllama(model=local_llm, temperature=0)\n",

--- a/examples/rag/langgraph_agentic_rag.ipynb
+++ b/examples/rag/langgraph_agentic_rag.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U --quiet langchain-community tiktoken langchain-openai langchainhub chromadb langchain langgraph langchain-text-splitters"
+    "%pip install -U --quiet langchain-community tiktoken langchain-openai langsmith chromadb langchain langgraph langchain-text-splitters"
    ]
   },
   {
@@ -220,7 +220,7 @@
    "source": [
     "from typing import Annotated, Literal, Sequence, TypedDict\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.messages import BaseMessage, HumanMessage\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "from langchain_core.prompts import PromptTemplate\n",
@@ -364,7 +364,7 @@
     "    docs = last_message.content\n",
     "\n",
     "    # Prompt\n",
-    "    prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "    prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "    # LLM\n",
     "    llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0, streaming=True)\n",
@@ -382,7 +382,7 @@
     "\n",
     "\n",
     "print(\"*\" * 20 + \"Prompt[rlm/rag-prompt]\" + \"*\" * 20)\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\").pretty_print()  # Show what the prompt looks like"
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\").pretty_print()  # Show what the prompt looks like"
    ]
   },
   {

--- a/examples/rag/langgraph_crag.ipynb
+++ b/examples/rag/langgraph_crag.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install langchain_community tiktoken langchain-openai langchainhub chromadb langchain langgraph tavily-python"
+    "! pip install langchain_community tiktoken langchain-openai langsmith chromadb langchain langgraph tavily-python"
    ]
   },
   {
@@ -217,11 +217,11 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",

--- a/examples/rag/langgraph_crag_local.ipynb
+++ b/examples/rag/langgraph_crag_local.ipynb
@@ -67,7 +67,7 @@
    "outputs": [],
    "source": [
     "%%capture --no-stderr\n",
-    "%pip install -U langchain_community tiktoken langchainhub scikit-learn langchain langgraph tavily-python  nomic[local] langchain-nomic langchain_openai"
+    "%pip install -U langchain_community tiktoken langsmith scikit-learn langchain langgraph tavily-python  nomic[local] langchain-nomic langchain_openai"
    ]
   },
   {
@@ -643,11 +643,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",
     "# Grade prompt\n",
-    "grade_prompt_answer_accuracy = hub.pull(\"langchain-ai/rag-answer-vs-reference\")\n",
+    "grade_prompt_answer_accuracy = Client().pull_prompt(\"langchain-ai/rag-answer-vs-reference\")\n",
     "\n",
     "\n",
     "def answer_evaluator(run, example) -> dict:\n",

--- a/examples/rag/langgraph_self_rag.ipynb
+++ b/examples/rag/langgraph_self_rag.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -U langchain_community tiktoken langchain-openai langchainhub chromadb langchain langgraph"
+    "! pip install -U langchain_community tiktoken langchain-openai langsmith chromadb langchain langgraph"
    ]
   },
   {
@@ -238,11 +238,11 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",

--- a/examples/rag/langgraph_self_rag_local.ipynb
+++ b/examples/rag/langgraph_self_rag_local.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "%capture --no-stderr\n",
-    "%pip install -U langchain-nomic langchain_community tiktoken langchainhub chromadb langchain langgraph nomic[local]"
+    "%pip install -U langchain-nomic langchain_community tiktoken langsmith chromadb langchain langgraph nomic[local]"
    ]
   },
   {
@@ -253,11 +253,11 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOllama(model=local_llm, temperature=0)\n",

--- a/examples/rag/langgraph_self_rag_pinecone_movies.ipynb
+++ b/examples/rag/langgraph_self_rag_pinecone_movies.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -qU langchain-pinecone langchain-openai langchainhub langgraph"
+    "%pip install -qU langchain-pinecone langchain-openai langsmith langgraph"
    ]
   },
   {
@@ -162,7 +162,7 @@
    "source": [
     "### Retrieval Grader\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.pydantic_v1 import BaseModel, Field\n",
     "from langchain_openai import ChatOpenAI\n",
     "\n",
@@ -177,7 +177,7 @@
     "\n",
     "\n",
     "# https://smith.langchain.com/hub/efriis/self-rag-retrieval-grader\n",
-    "grade_prompt = hub.pull(\"efriis/self-rag-retrieval-grader\")\n",
+    "grade_prompt = Client().pull_prompt(\"efriis/self-rag-retrieval-grader\")\n",
     "\n",
     "# LLM with function call\n",
     "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)\n",
@@ -237,11 +237,11 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "prompt = Client().pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",
@@ -296,7 +296,7 @@
     "structured_llm_grader = llm.with_structured_output(GradeHallucinations)\n",
     "\n",
     "# https://smith.langchain.com/hub/efriis/self-rag-hallucination-grader\n",
-    "hallucination_prompt = hub.pull(\"efriis/self-rag-hallucination-grader\")\n",
+    "hallucination_prompt = Client().pull_prompt(\"efriis/self-rag-hallucination-grader\")\n",
     "\n",
     "hallucination_grader = hallucination_prompt | structured_llm_grader\n",
     "print(generation)\n",
@@ -346,7 +346,7 @@
     "structured_llm_grader = llm.with_structured_output(GradeAnswer)\n",
     "\n",
     "# Prompt\n",
-    "answer_prompt = hub.pull(\"efriis/self-rag-answer-grader\")\n",
+    "answer_prompt = Client().pull_prompt(\"efriis/self-rag-answer-grader\")\n",
     "\n",
     "answer_grader = answer_prompt | structured_llm_grader\n",
     "print(question)\n",
@@ -385,7 +385,7 @@
     "llm = ChatOpenAI(model=\"gpt-3.5-turbo-0125\", temperature=0)\n",
     "\n",
     "# Prompt\n",
-    "re_write_prompt = hub.pull(\"efriis/self-rag-question-rewriter\")\n",
+    "re_write_prompt = Client().pull_prompt(\"efriis/self-rag-question-rewriter\")\n",
     "\n",
     "question_rewriter = re_write_prompt | llm | StrOutputParser()\n",
     "print(question)\n",


### PR DESCRIPTION
**Description:** Replace deprecated `from langchain import hub` / `hub.pull()` with `from langsmith import Client` / `Client().pull_prompt()` across 9 RAG tutorial notebooks. Also update pip install commands to use `langsmith` instead of `langchainhub`.

**Issue:** #6437

**Dependencies:** None

## Files Changed
- `examples/rag/langgraph_adaptive_rag.ipynb`
- `examples/rag/langgraph_adaptive_rag_cohere.ipynb`
- `examples/rag/langgraph_adaptive_rag_local.ipynb`
- `examples/rag/langgraph_agentic_rag.ipynb`
- `examples/rag/langgraph_crag.ipynb`
- `examples/rag/langgraph_crag_local.ipynb`
- `examples/rag/langgraph_self_rag.ipynb`
- `examples/rag/langgraph_self_rag_local.ipynb`
- `examples/rag/langgraph_self_rag_pinecone_movies.ipynb`