### PR TITLE
chore: enforce codespell across all sub-libraries

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -95,3 +95,13 @@ jobs:
           else
             echo "lint_tests command not found, skipping step"
           fi
+
+      - name: Check spelling with codespell
+        if: steps.changed-files.outputs.all
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if make spell_check > /dev/null 2>&1; then
+            make spell_check
+          else
+            echo "spell_check command not found, skipping step"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,23 @@ test:
 			$(MAKE) -C $$dir test; \
 		fi; \
 	done
+
+# Spell check all projects
+.PHONY: spell_check
+spell_check:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ]; then \
+			echo "Running spell_check in $$dir"; \
+			$(MAKE) -C $$dir spell_check; \
+		fi; \
+	done
+
+# Spell fix all projects
+.PHONY: spell_fix
+spell_fix:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ]; then \
+			echo "Running spell_fix in $$dir"; \
+			$(MAKE) -C $$dir spell_fix; \
+		fi; \
+	done

--- a/libs/checkpoint-conformance/Makefile
+++ b/libs/checkpoint-conformance/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test
+.PHONY: format lint test spell_check spell_fix
 
 format:
 	uv run ruff format .
@@ -10,3 +10,9 @@ lint:
 
 test:
 	uv run pytest $(TEST)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-conformance/pyproject.toml
+++ b/libs/checkpoint-conformance/pyproject.toml
@@ -25,6 +25,7 @@ test = [
 lint = [
   "ruff",
   "ty",
+  "codespell",
 ]
 dev = [
   {include-group = "test"},

--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -67,3 +67,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-sqlite/Makefile
+++ b/libs/checkpoint-sqlite/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint/Makefile
+++ b/libs/checkpoint/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint type format test-integration update-schema bump-version
+.PHONY: test lint type format test-integration update-schema bump-version spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -35,6 +35,12 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w
 
 update-schema:
 	uv run python generate_schema.py

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -125,4 +125,4 @@ addopts = "--full-trace --strict-markers --strict-config --durations=5 --snapsho
 
 [tool.codespell]
 # Ignore words specific to the LangGraph library code
-ignore-words-list = "infor,thead,stdio,nd,jupyter,lets,lite,uis,deque,langgraph,langchain,pydantic,typing,async,await,coroutine,iterable,iterables,serializable,deserializable,checkpointer,checkpointing,stateful,statefulness,prebuilt,prebuilt,supervisor,supervisory,swarm,swarming,multiactor,multiactors,subgraph,subgraphs,workflow,workflows,streaming,streamable,streamed,streamer,streamers,streaming,streamable,streamed,streamer,streamers"
+ignore-words-list = "infor,thead,stdio,nd,jupyter,lets,lite,uis,deque,langgraph,langchain,pydantic,typing,async,await,coroutine,iterable,iterables,serializable,deserializable,checkpointer,checkpointing,stateful,statefulness,prebuilt,prebuilt,supervisor,supervisory,swarm,swarming,multiactor,multiactors,subgraph,subgraphs,workflow,workflows,streaming,streamable,streamed,streamer,streamers,streaming,streamable,streamed,streamer,streamers,whats,ans"

--- a/libs/sdk-py/Makefile
+++ b/libs/sdk-py/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint type format test
+.PHONY: lint type format test spell_check spell_fix
 
 test:
 	uv run pytest tests
@@ -25,3 +25,9 @@ type:
 format format_diff:
 	uv run ruff check --select I --fix $(PYTHON_FILES)
 	uv run ruff format $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w


### PR DESCRIPTION
## Summary
- Add `spell_check`/`spell_fix` Makefile targets to all sub-libraries that were missing them: `checkpoint`, `checkpoint-sqlite`, `checkpoint-postgres`, `cli`, `sdk-py`, and `checkpoint-conformance`
- Add `codespell` to `checkpoint-conformance` lint dependency group (only library missing it)
- Add `spell_check`/`spell_fix` orchestration targets to the root Makefile
- Add a "Check spelling with codespell" step to the CI lint workflow (`.github/workflows/_lint.yml`)
- Fix false positives in `libs/langgraph/pyproject.toml` ignore-words-list (`whats`, `ans` — test data strings)

Closes #5021

## Test plan
- [ ] `make spell_check` from root runs codespell in all sub-libraries
- [ ] `make spell_fix` from root auto-fixes typos in all sub-libraries
- [ ] CI lint workflow runs `spell_check` step for each library
- [ ] All libraries pass codespell cleanly (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)