### PR TITLE
ci: add Windows CI for CLI + fix Windows path bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,28 @@ jobs:
           fi
           echo "Schema check passed - no changes detected"
 
+  test-cli-windows:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.deps == 'true'
+    name: "cd libs/cli (windows)"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+          cache-suffix: test-cli-windows
+      - name: Install dependencies
+        shell: bash
+        working-directory: libs/cli
+        run: uv sync --frozen --group test --no-dev
+      - name: Run tests
+        shell: bash
+        working-directory: libs/cli
+        run: uv run pytest tests/unit_tests
+
   integration-test:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.deps == 'true'
@@ -160,6 +182,7 @@ jobs:
         lint,
         test,
         test-langgraph,
+        test-cli-windows,
         check-sdk-methods,
         check-schema,
         integration-test,

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -615,7 +615,7 @@ def _update_auth_path(
     # Check faux packages first (higher priority)
     for faux_path, (_, destpath) in local_deps.faux_pkgs.items():
         if resolved.is_relative_to(faux_path):
-            new_path = f"{destpath}/{resolved.relative_to(faux_path)}:{attr_str}"
+            new_path = f"{destpath}/{resolved.relative_to(faux_path).as_posix()}:{attr_str}"
             auth_conf["path"] = new_path
             return
 
@@ -623,7 +623,7 @@ def _update_auth_path(
     for real_path in local_deps.real_pkgs:
         if resolved.is_relative_to(real_path):
             new_path = (
-                f"/deps/{real_path.name}/{resolved.relative_to(real_path)}:{attr_str}"
+                f"/deps/{real_path.name}/{resolved.relative_to(real_path).as_posix()}:{attr_str}"
             )
             auth_conf["path"] = new_path
             return
@@ -658,7 +658,7 @@ def _update_encryption_path(
     # Check faux packages first (higher priority)
     for faux_path, (_, destpath) in local_deps.faux_pkgs.items():
         if resolved.is_relative_to(faux_path):
-            new_path = f"{destpath}/{resolved.relative_to(faux_path)}:{attr_str}"
+            new_path = f"{destpath}/{resolved.relative_to(faux_path).as_posix()}:{attr_str}"
             encryption_conf["path"] = new_path
             return
 
@@ -666,7 +666,7 @@ def _update_encryption_path(
     for real_path in local_deps.real_pkgs:
         if resolved.is_relative_to(real_path):
             new_path = (
-                f"/deps/{real_path.name}/{resolved.relative_to(real_path)}:{attr_str}"
+                f"/deps/{real_path.name}/{resolved.relative_to(real_path).as_posix()}:{attr_str}"
             )
             encryption_conf["path"] = new_path
             return
@@ -703,7 +703,7 @@ def _update_checkpointer_path(
     # Check faux packages first (higher priority)
     for faux_path, (_, destpath) in local_deps.faux_pkgs.items():
         if resolved.is_relative_to(faux_path):
-            new_path = f"{destpath}/{resolved.relative_to(faux_path)}:{attr_str}"
+            new_path = f"{destpath}/{resolved.relative_to(faux_path).as_posix()}:{attr_str}"
             checkpointer_conf["path"] = new_path
             return
 
@@ -711,7 +711,7 @@ def _update_checkpointer_path(
     for real_path in local_deps.real_pkgs:
         if resolved.is_relative_to(real_path):
             new_path = (
-                f"/deps/{real_path.name}/{resolved.relative_to(real_path)}:{attr_str}"
+                f"/deps/{real_path.name}/{resolved.relative_to(real_path).as_posix()}:{attr_str}"
             )
             checkpointer_conf["path"] = new_path
             return
@@ -935,7 +935,7 @@ def python_config_to_docker(
             (
                 f"COPY --from=outer-{reqpath.name} requirements.txt {destpath}"
                 if reqpath.parent in local_deps.additional_contexts
-                else f"ADD {reqpath.relative_to(config_path.parent)} {destpath}"
+                else f"ADD {reqpath.relative_to(config_path.parent).as_posix()} {destpath}"
             )
             for reqpath, destpath in local_deps.pip_reqs
         )
@@ -1251,7 +1251,8 @@ def _calculate_relative_workdir(config_path: pathlib.Path, build_context: str) -
 
     try:
         relative_path = config_dir.relative_to(build_context_path)
-        return str(relative_path) if str(relative_path) != "." else ""
+        posix = relative_path.as_posix()
+        return posix if posix != "." else ""
     except ValueError as _:
         raise ValueError(
             f"Configuration file {config_path} is not under the build context {build_context}. "

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -10,6 +10,7 @@ import pytest
 
 from langgraph_cli.config import (
     _BUILD_TOOLS,
+    _calculate_relative_workdir,
     _get_pip_cleanup_lines,
     config_to_compose,
     config_to_docker,
@@ -1692,3 +1693,100 @@ def test_config_to_compose_with_api_version():
 
     # Check that the compose file includes the correct FROM line with api_version
     assert "FROM langchain/langgraphjs-api:0.2.74-node20" in actual_compose_str
+
+
+# -- Windows path tests --
+
+
+def test_calculate_relative_workdir_returns_posix(tmp_path):
+    """Verify _calculate_relative_workdir always returns forward-slash paths."""
+    # Create nested directory: tmp_path/subdir/nested/
+    nested = tmp_path / "subdir" / "nested"
+    nested.mkdir(parents=True)
+    config_path = nested / "langgraph.json"
+    config_path.touch()
+
+    result = _calculate_relative_workdir(config_path, str(tmp_path))
+    assert "\\" not in result, f"Expected POSIX path, got: {result}"
+    assert result == "subdir/nested"
+
+
+def test_calculate_relative_workdir_same_dir(tmp_path):
+    """Verify _calculate_relative_workdir returns empty string for same directory."""
+    config_path = tmp_path / "langgraph.json"
+    config_path.touch()
+
+    result = _calculate_relative_workdir(config_path, str(tmp_path))
+    assert result == ""
+
+
+def test_config_to_docker_auth_path_posix():
+    """Verify auth path in Docker output uses forward slashes."""
+    graphs = {"agent": "./agent.py:graph"}
+    actual_docker_stdin, _ = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "python_version": "3.11",
+                "dependencies": ["."],
+                "graphs": graphs,
+                "auth": {"path": "./agent.py:my_auth"},
+            }
+        ),
+        base_image="langchain/langgraph-api",
+    )
+    assert "LANGGRAPH_AUTH=" in actual_docker_stdin
+    # Verify no backslashes in the auth path
+    for line in actual_docker_stdin.splitlines():
+        if "LANGGRAPH_AUTH=" in line:
+            assert "\\" not in line or "\\'" in line or '\\"' in line, (
+                f"Auth ENV line contains backslashes: {line}"
+            )
+
+
+def test_config_to_docker_encryption_path_posix():
+    """Verify encryption path in Docker output uses forward slashes."""
+    graphs = {"agent": "./graphs/agent.py:graph"}
+    actual_docker_stdin, _ = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "python_version": "3.11",
+                "dependencies": ["."],
+                "graphs": graphs,
+                "encryption": {"path": "./agent.py:my_encryption"},
+            }
+        ),
+        base_image="langchain/langgraph-api",
+    )
+    assert "LANGGRAPH_ENCRYPTION=" in actual_docker_stdin
+    for line in actual_docker_stdin.splitlines():
+        if "LANGGRAPH_ENCRYPTION=" in line:
+            assert "\\" not in line or "\\'" in line or '\\"' in line, (
+                f"Encryption ENV line contains backslashes: {line}"
+            )
+
+
+def test_config_to_docker_all_paths_posix():
+    """End-to-end: verify no backslash paths leak into Dockerfile output."""
+    graphs = {"agent": "./agent.py:graph"}
+    actual_docker_stdin, _ = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "python_version": "3.11",
+                "dependencies": ["."],
+                "graphs": graphs,
+            }
+        ),
+        base_image="langchain/langgraph-api",
+    )
+    # Check all ADD/COPY/ENV lines for Windows-style backslashes
+    for line in actual_docker_stdin.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("ADD ", "COPY ", "ENV ", "WORKDIR ")):
+            # Allow escaped quotes but not path separators
+            cleaned = stripped.replace("\\'", "").replace('\\"', "")
+            assert "\\" not in cleaned, (
+                f"Docker instruction contains backslash path: {line}"
+            )


### PR DESCRIPTION
## Summary
- Fix 9 places in `libs/cli/langgraph_cli/config.py` where `pathlib.Path.relative_to()` was interpolated into Docker instructions without `.as_posix()`, producing backslash paths on Windows
- Add a standalone `test-cli-windows` CI job running CLI unit tests on `windows-latest`
- Add 5 unit tests verifying all Docker output uses POSIX forward-slash paths

### Path bugs fixed
| Function | Lines | Issue |
|----------|-------|-------|
| `_calculate_relative_workdir()` | 1254 | `str(relative_path)` → `.as_posix()` |
| `_update_auth_path()` | 618, 626 | Missing `.as_posix()` on `relative_to()` |
| `_update_encryption_path()` | 661, 669 | Same |
| `_update_checkpointer_path()` | 706, 714 | Same |
| `python_config_to_docker()` | 938 | Missing `.as_posix()` on ADD instruction path |

Note: `_update_graph_paths()` and `_update_http_app_path()` already used `.as_posix()` correctly.

### CI addition
A standalone Windows job (not modifying the shared `_test.yml`) that runs `uv run pytest tests/unit_tests` for `libs/cli` on `windows-latest`. This avoids the `make` dependency issue (not pre-installed on Windows GH Actions runners).

Closes #5029

## Test plan
- [ ] Existing CLI unit tests pass on Ubuntu (via existing CI)
- [ ] New Windows path tests pass on both Ubuntu and Windows
- [ ] `test-cli-windows` job appears in CI and passes
- [ ] No backslash paths appear in any Docker output on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)