### PR TITLE
fix(cli): normalize auth and encryption paths to POSIX format

### DIFF
--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -615,16 +615,16 @@ def _update_auth_path(
     # Check faux packages first (higher priority)
     for faux_path, (_, destpath) in local_deps.faux_pkgs.items():
         if resolved.is_relative_to(faux_path):
-            new_path = f"{destpath}/{resolved.relative_to(faux_path)}:{attr_str}"
+            rel = resolved.relative_to(faux_path).as_posix()
+            new_path = f"{destpath}/{rel}:{attr_str}"
             auth_conf["path"] = new_path
             return
 
     # Check real packages
     for real_path in local_deps.real_pkgs:
         if resolved.is_relative_to(real_path):
-            new_path = (
-                f"/deps/{real_path.name}/{resolved.relative_to(real_path)}:{attr_str}"
-            )
+            rel = resolved.relative_to(real_path).as_posix()
+            new_path = f"/deps/{real_path.name}/{rel}:{attr_str}"
             auth_conf["path"] = new_path
             return
 
@@ -658,16 +658,16 @@ def _update_encryption_path(
     # Check faux packages first (higher priority)
     for faux_path, (_, destpath) in local_deps.faux_pkgs.items():
         if resolved.is_relative_to(faux_path):
-            new_path = f"{destpath}/{resolved.relative_to(faux_path)}:{attr_str}"
+            rel = resolved.relative_to(faux_path).as_posix()
+            new_path = f"{destpath}/{rel}:{attr_str}"
             encryption_conf["path"] = new_path
             return
 
     # Check real packages
     for real_path in local_deps.real_pkgs:
         if resolved.is_relative_to(real_path):
-            new_path = (
-                f"/deps/{real_path.name}/{resolved.relative_to(real_path)}:{attr_str}"
-            )
+            rel = resolved.relative_to(real_path).as_posix()
+            new_path = f"/deps/{real_path.name}/{rel}:{attr_str}"
             encryption_conf["path"] = new_path
             return
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -817,6 +817,31 @@ def test_config_to_docker_python_encryption_formatted():
     )
 
 
+def test_config_to_docker_python_auth_formatted():
+    # Test that auth config is properly formatted in Docker output with POSIX paths
+    graphs = {"agent": "./graphs/agent.py:graph"}
+    actual_docker_stdin, _ = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "python_version": "3.11",
+                "dependencies": ["."],
+                "graphs": graphs,
+                "auth": {"path": "./agent.py:auth"},
+            }
+        ),
+        base_image="langchain/langgraph-api",
+    )
+    # Verify that LANGGRAPH_AUTH is in the docker output with the correct POSIX path
+    assert "LANGGRAPH_AUTH=" in actual_docker_stdin
+    assert "/deps/outer-unit_tests/unit_tests/agent.py:auth" in actual_docker_stdin
+    # Verify no backslashes in the auth path (Windows path separators)
+    auth_line = [
+        line for line in actual_docker_stdin.splitlines() if "LANGGRAPH_AUTH=" in line
+    ][0]
+    assert "\\" not in auth_line or "\\\\" not in auth_line.split("LANGGRAPH_AUTH=")[1]
+
+
 def test_config_to_docker_nodejs_internal_docker_tag():
     graphs = {"agent": "./graphs/agent.js:graph"}
     actual_docker_stdin, additional_contexts = config_to_docker(


### PR DESCRIPTION
**Description:** Normalize Windows paths to POSIX format in `_update_auth_path` and `_update_encryption_path` by calling `.as_posix()` on `relative_to()` results. This matches the existing pattern used in `_update_graphs_paths` (line 576, 583) where `container_path.as_posix()` and `container_subpath.as_posix()` are already called. Without this, on Windows the `LANGGRAPH_AUTH` ENV in the generated Dockerfile contains backslash path separators (e.g. `flowee\\security\\auth.py`) instead of forward slashes.

**Issue:** Fixes #5815

**Dependencies:** None