### PR TITLE
fix(langgraph): yield task_result events with errors in single debug stream mode

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -187,6 +187,8 @@ class PregelRunner:
                     fut.set_exception(exc)
                     futures.done.add(fut)
                 elif reraise:
+                    # yield control so caller can drain stream (e.g. task_result events)
+                    yield
                     if tb := exc.__traceback__:
                         while tb.tb_next is not None and any(
                             tb.tb_frame.f_code.co_filename.endswith(name)
@@ -327,6 +329,8 @@ class PregelRunner:
                     fut.set_exception(exc)
                     futures.done.add(fut)
                 elif reraise:
+                    # yield control so caller can drain stream (e.g. task_result events)
+                    yield
                     if tb := exc.__traceback__:
                         while tb.tb_next is not None and any(
                             tb.tb_frame.f_code.co_filename.endswith(name)

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -4391,6 +4391,41 @@ def test_debug_retry(sync_checkpointer: BaseCheckpointSaver):
         assert stream_parent_conf == history_parent_conf
 
 
+def test_debug_stream_error_task_result():
+    """Test that task_result events with errors are yielded in debug stream mode.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/5764
+    """
+
+    class State(TypedDict):
+        value: str
+
+    def failing_node(state: State):
+        raise ValueError("This node always fails")
+
+    builder = StateGraph(State)
+    builder.add_node("failer", failing_node)
+    builder.set_entry_point("failer")
+    builder.add_edge("failer", END)
+    graph = builder.compile()
+
+    # Single debug mode should yield task_result with error before raising
+    events: list[dict] = []
+    with pytest.raises(ValueError, match="This node always fails"):
+        for event in graph.stream({"value": "test"}, stream_mode="debug"):
+            events.append(event)
+
+    # Should have both task and task_result events
+    event_types = [e["type"] for e in events]
+    assert "task" in event_types
+    assert "task_result" in event_types
+
+    # task_result should contain the error
+    task_result = next(e for e in events if e["type"] == "task_result")
+    assert task_result["payload"]["error"] is not None
+    assert isinstance(task_result["payload"]["error"], ValueError)
+
+
 def test_debug_subgraphs(
     sync_checkpointer: BaseCheckpointSaver, durability: Durability
 ):

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -5839,6 +5839,38 @@ async def test_debug_retry(async_checkpointer: BaseCheckpointSaver):
         assert stream_parent_conf == history_parent_conf
 
 
+async def test_debug_stream_error_task_result():
+    """Test that task_result events with errors are yielded in async debug stream mode.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/5764
+    """
+
+    class State(TypedDict):
+        value: str
+
+    def failing_node(state: State):
+        raise ValueError("This node always fails")
+
+    builder = StateGraph(State)
+    builder.add_node("failer", failing_node)
+    builder.set_entry_point("failer")
+    builder.add_edge("failer", END)
+    graph = builder.compile()
+
+    events: list[dict] = []
+    with pytest.raises(ValueError, match="This node always fails"):
+        async for event in graph.astream({"value": "test"}, stream_mode="debug"):
+            events.append(event)
+
+    event_types = [e["type"] for e in events]
+    assert "task" in event_types
+    assert "task_result" in event_types
+
+    task_result = next(e for e in events if e["type"] == "task_result")
+    assert task_result["payload"]["error"] is not None
+    assert isinstance(task_result["payload"]["error"], ValueError)
+
+
 async def test_debug_subgraphs(
     async_checkpointer: BaseCheckpointSaver, durability: Durability
 ):


### PR DESCRIPTION
**Description:** When using `stream_mode="debug"` (single mode), `task_result` events containing errors were not yielded before the exception was raised. This happened because the runner's fast path (single task, no waiter/timeout) raised the exception immediately after committing the error writes without yielding control back to the caller to drain the stream queue.

The fix adds a `yield` in the fast path error handling of both `tick()` and `atick()`, matching the behavior of the concurrent path which already yields before `_panic_or_proceed`. This allows the main loop to call `_output()` and emit the `task_result` event before the exception propagates.

With `stream_mode=["debug", "messages"]` the issue didn't occur because `get_waiter` is not None when "messages" is in stream_modes, bypassing the fast path.

Fixes #5764

**Dependencies:** None