### PR TITLE
fix(prebuilt): retry create_react_agent on MALFORMED_FUNCTION_CALL finish_reason

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from typing import (
@@ -45,6 +46,13 @@ from pydantic import BaseModel
 from typing_extensions import NotRequired, TypedDict, deprecated
 
 from langgraph.prebuilt.tool_node import ToolCallWithContext, ToolNode
+
+logger = logging.getLogger(__name__)
+
+# Finish reasons that indicate the LLM attempted a tool call but produced
+# malformed output. When detected, the agent retries the LLM call.
+# LangGraph's recursion limit prevents infinite retry loops.
+_RETRYABLE_FINISH_REASONS: set[str] = {"MALFORMED_FUNCTION_CALL"}
 
 StructuredResponse = dict | BaseModel
 StructuredResponseSchema = dict | type[BaseModel]
@@ -833,6 +841,20 @@ def create_react_agent(
         last_message = messages[-1]
         # If there is no function call, then we finish
         if not isinstance(last_message, AIMessage) or not last_message.tool_calls:
+            # Check if the LLM returned a retryable finish reason
+            # (e.g. Gemini's MALFORMED_FUNCTION_CALL)
+            if isinstance(last_message, AIMessage):
+                finish_reason = (last_message.response_metadata or {}).get(
+                    "finish_reason"
+                )
+                if finish_reason in _RETRYABLE_FINISH_REASONS:
+                    logger.warning(
+                        "LLM returned finish_reason '%s' with no tool calls. "
+                        "Retrying the agent node.",
+                        finish_reason,
+                    )
+                    return entrypoint
+
             if post_model_hook is not None:
                 return "post_model_hook"
             elif response_format is not None:
@@ -884,7 +906,7 @@ def create_react_agent(
     # This means that this node is the first one called
     workflow.set_entry_point(entrypoint)
 
-    agent_paths = []
+    agent_paths = [entrypoint]
     post_model_hook_paths = [entrypoint, "tools"]
 
     # Add a post model hook node if post_model_hook is provided

--- a/libs/prebuilt/tests/__snapshots__/test_react_agent_graph.ambr
+++ b/libs/prebuilt/tests/__snapshots__/test_react_agent_graph.ambr
@@ -14,6 +14,7 @@
   	agent -.-> __end__;
   	agent -.-> tools;
   	tools --> agent;
+  	agent -.-> agent;
   
   '''
 # ---
@@ -31,6 +32,7 @@
   graph TD;
   	__start__ --> pre_model_hook;
   	agent -.-> __end__;
+  	agent -.-> pre_model_hook;
   	agent -.-> tools;
   	pre_model_hook --> agent;
   	tools --> pre_model_hook;
@@ -55,6 +57,7 @@
   	post_model_hook -.-> agent;
   	post_model_hook -.-> tools;
   	tools --> agent;
+  	agent -.-> agent;
   
   '''
 # ---
@@ -73,6 +76,7 @@
   graph TD;
   	__start__ --> pre_model_hook;
   	agent --> post_model_hook;
+  	agent -.-> pre_model_hook;
   	post_model_hook -.-> __end__;
   	post_model_hook -.-> pre_model_hook;
   	post_model_hook -.-> tools;
@@ -98,6 +102,7 @@
   	agent -.-> tools;
   	tools --> agent;
   	generate_structured_response --> __end__;
+  	agent -.-> agent;
   
   '''
 # ---
@@ -116,6 +121,7 @@
   graph TD;
   	__start__ --> pre_model_hook;
   	agent -.-> generate_structured_response;
+  	agent -.-> pre_model_hook;
   	agent -.-> tools;
   	pre_model_hook --> agent;
   	tools --> pre_model_hook;
@@ -143,6 +149,7 @@
   	post_model_hook -.-> tools;
   	tools --> agent;
   	generate_structured_response --> __end__;
+  	agent -.-> agent;
   
   '''
 # ---
@@ -162,6 +169,7 @@
   graph TD;
   	__start__ --> pre_model_hook;
   	agent --> post_model_hook;
+  	agent -.-> pre_model_hook;
   	post_model_hook -.-> generate_structured_response;
   	post_model_hook -.-> pre_model_hook;
   	post_model_hook -.-> tools;

--- a/libs/prebuilt/tests/model.py
+++ b/libs/prebuilt/tests/model.py
@@ -22,6 +22,7 @@ from langgraph.prebuilt.chat_agent_executor import StructuredResponse
 class FakeToolCallingModel(BaseChatModel):
     tool_calls: list[list[ToolCall]] | None = None
     structured_response: StructuredResponse | None = None
+    response_metadata_list: list[dict[str, Any]] | None = None
     index: int = 0
     tool_style: Literal["openai", "anthropic"] = "openai"
 
@@ -39,8 +40,16 @@ class FakeToolCallingModel(BaseChatModel):
             if self.tool_calls
             else []
         )
+        metadata = (
+            self.response_metadata_list[self.index % len(self.response_metadata_list)]
+            if self.response_metadata_list
+            else {}
+        )
         message = AIMessage(
-            content=messages_string, id=str(self.index), tool_calls=tool_calls.copy()
+            content=messages_string,
+            id=str(self.index),
+            tool_calls=tool_calls.copy(),
+            response_metadata=metadata,
         )
         self.index += 1
         return ChatResult(generations=[ChatGeneration(message=message)])

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -2154,3 +2154,128 @@ def test_create_react_agent_inject_vars_with_post_model_hook(
         AIMessage("hi-hi-6", id="1"),
     ]
     assert result["foo"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests for retrying on MALFORMED_FUNCTION_CALL finish_reason (#6574)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+def test_malformed_function_call_retries(version: str) -> None:
+    """Agent should retry when LLM returns MALFORMED_FUNCTION_CALL."""
+
+    @dec_tool
+    def search(query: str) -> str:
+        """Search tool."""
+        return f"Results for: {query}"
+
+    tool_call = ToolCall(name="search", args={"query": "test"}, id="call_1")
+
+    # First call: MALFORMED_FUNCTION_CALL with no tool_calls
+    # Second call: successful tool call
+    # Third call: final response (no tool calls)
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [],
+            [tool_call],
+            [],
+        ],
+        response_metadata_list=[
+            {"finish_reason": "MALFORMED_FUNCTION_CALL"},
+            {},
+            {},
+        ],
+    )
+    agent = create_react_agent(model, [search], version=version)
+    result = agent.invoke({"messages": [HumanMessage("test")]})
+
+    messages = result["messages"]
+    # Should have: Human, AIMessage(malformed), AIMessage(tool_call),
+    # ToolMessage, AIMessage(final)
+    assert len(messages) == 5
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[1], AIMessage)
+    assert messages[1].tool_calls == []
+    assert isinstance(messages[2], AIMessage)
+    assert len(messages[2].tool_calls) == 1
+    assert isinstance(messages[3], ToolMessage)
+    assert isinstance(messages[4], AIMessage)
+
+
+def test_normal_finish_reason_no_retry() -> None:
+    """Normal finish_reason (e.g. 'stop') should NOT trigger retry."""
+
+    @dec_tool
+    def search(query: str) -> str:
+        """Search tool."""
+        return f"Results for: {query}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[[]],
+        response_metadata_list=[{"finish_reason": "stop"}],
+    )
+    agent = create_react_agent(model, [search])
+    result = agent.invoke({"messages": [HumanMessage("test")]})
+
+    messages = result["messages"]
+    # Should have 2 messages: Human + AIMessage (no retry)
+    assert len(messages) == 2
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[1], AIMessage)
+    assert messages[1].tool_calls == []
+
+
+def test_malformed_function_call_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """MALFORMED_FUNCTION_CALL should log a warning."""
+    import logging
+
+    @dec_tool
+    def search(query: str) -> str:
+        """Search tool."""
+        return f"Results for: {query}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[[], []],
+        response_metadata_list=[
+            {"finish_reason": "MALFORMED_FUNCTION_CALL"},
+            {},
+        ],
+    )
+    agent = create_react_agent(model, [search])
+
+    with caplog.at_level(
+        logging.WARNING, logger="langgraph.prebuilt.chat_agent_executor"
+    ):
+        agent.invoke({"messages": [HumanMessage("test")]})
+
+    assert "MALFORMED_FUNCTION_CALL" in caplog.text
+
+
+def test_malformed_function_call_retries_with_pre_model_hook() -> None:
+    """Retry should route through pre_model_hook when configured."""
+
+    @dec_tool
+    def search(query: str) -> str:
+        """Search tool."""
+        return f"Results for: {query}"
+
+    hook_call_count = 0
+
+    def pre_hook(state: dict) -> dict:
+        nonlocal hook_call_count
+        hook_call_count += 1
+        return state
+
+    model = FakeToolCallingModel(
+        tool_calls=[[], []],
+        response_metadata_list=[
+            {"finish_reason": "MALFORMED_FUNCTION_CALL"},
+            {},
+        ],
+    )
+    agent = create_react_agent(model, [search], pre_model_hook=pre_hook)
+    agent.invoke({"messages": [HumanMessage("test")]})
+
+    # pre_model_hook should be called twice: initial + retry
+    assert hook_call_count == 2


### PR DESCRIPTION



**Description:** When using `create_react_agent` with Google Gemini models, the agent silently terminates without making any tool calls when the LLM returns `finish_reason: MALFORMED_FUNCTION_CALL`. The `should_continue` conditional edge only checks for `tool_calls` presence on the `AIMessage` — when Gemini fails to produce valid JSON for a tool call, it returns an `AIMessage` with no `tool_calls` and sets `finish_reason: MALFORMED_FUNCTION_CALL` in `response_metadata`. The router sees no tool calls and routes to `END`, with no indication of the failure.

This PR adds detection of retryable `finish_reason` values in the `should_continue` router. When a retryable finish reason is detected (currently `MALFORMED_FUNCTION_CALL`), the agent logs a warning and routes back to the entrypoint node for a retry attempt. LangGraph's built-in recursion limit (default 25) prevents infinite retry loops.

Key changes:
- Added `_RETRYABLE_FINISH_REASONS` module-level constant in `chat_agent_executor.py` — an extensible set of finish reasons that trigger retry
- Modified `should_continue` to inspect `response_metadata.finish_reason` when no tool calls are present; retryable reasons route back to the agent entrypoint
- Added `entrypoint` to `agent_paths` so the conditional edge accepts the retry target
- Extended `FakeToolCallingModel` in tests with `response_metadata_list` support
- Added 4 unit tests covering: retry on malformed call (v1/v2), no-retry on normal finish reason, warning log verification, and retry with `pre_model_hook`
- Updated graph structure snapshots

Design rationale: retry (instead of raising) aligns with Google's own recommendation for handling `MALFORMED_FUNCTION_CALL`, and is backwards compatible since the only behavioral change is that previously-broken flows now recover instead of silently failing.

Closes #6574

**Issue:** #6574

**Dependencies:** None
