### PR TITLE
perf(pregel): only copy selected channels in local_read

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -194,12 +194,14 @@ def local_read(
             if c in select:
                 updated[c].append(v)
     if fresh:
-        # apply writes
+        # apply writes — only copy channels that will actually be read
         local_channels: dict[str, BaseChannel] = {}
-        for k in channels:
-            cc = channels[k].copy()
-            cc.update(updated[k])
-            local_channels[k] = cc
+        selected_keys = [select] if isinstance(select, str) else select
+        for k in selected_keys:
+            if k in channels:
+                cc = channels[k].copy()
+                cc.update(updated[k])
+                local_channels[k] = cc
         # read fresh values
         values = read_channels(local_channels, select)
     else:


### PR DESCRIPTION


**Description:** When `fresh=True`, `local_read()` copies **all** channels in the graph before passing them to `read_channels()`, which only accesses the channels specified by `select` (typically 1–3 channels). For a graph with C channels and E conditional edges per superstep, this wastes O((C−S)×E) channel copy operations per step.

This PR narrows the copy loop to only iterate over the channels in `select`, matching what `read_channels()` actually accesses. Copies of non-selected channels were always no-ops (`updated[k]` returns `[]` for keys not in the defaultdict) and the resulting objects were never read.

**Benchmark:**

| Scenario | Before | After | Speedup |
|---|---|---|---|
| 10 channels, select 1 | 7.63 µs/call | 1.35 µs/call | 5.6× |
| 20 channels, select 1 | 14.77 µs/call | 1.32 µs/call | 11.2× |
| 50 channels, select 3 | 38.56 µs/call | 3.04 µs/call | 12.7× |
| 20 channels, select 5 | 15.84 µs/call | 4.73 µs/call | 3.4× |

`local_read()` is called on every conditional edge evaluation, so the savings compound in graphs with many channels and branching logic.

**Tests:**

- All conditional edge tests pass (`test_cond_edge_after_send`, `test_conditional_entrypoint_to_multiple_state_graph`, etc.)
- All state graph tests pass (41/41)
- All channel unit tests pass (5/5)
- `test_algo.py` passes (2/2)

**Dependencies:** none