### PR TITLE
perf(langgraph): remove importlib.metadata lookup from version module

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,6 @@
-"""Exports package version."""
-
-from importlib import metadata
+"""Exports package version without runtime metadata lookups."""
 
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Keep in sync with [project].version in pyproject.toml.
+__version__ = "1.0.10"

--- a/libs/langgraph/tests/test_version.py
+++ b/libs/langgraph/tests/test_version.py
@@ -1,0 +1,23 @@
+import importlib
+import re
+import sys
+
+import importlib.metadata as importlib_metadata
+
+
+def test_version_is_semver_string() -> None:
+    from langgraph.version import __version__
+
+    assert re.fullmatch(r"\d+\.\d+\.\d+(?:[abrc]\d+)?", __version__)
+
+
+def test_version_import_does_not_call_importlib_metadata(monkeypatch) -> None:
+    sys.modules.pop("langgraph.version", None)
+
+    def _raise_if_called(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("importlib.metadata.version should not be called")
+
+    monkeypatch.setattr(importlib_metadata, "version", _raise_if_called)
+
+    module = importlib.import_module("langgraph.version")
+    assert module.__version__


### PR DESCRIPTION
## Summary
- remove runtime `importlib.metadata` lookup from `langgraph.version`
- keep `langgraph.version.__version__` as a stable public constant
- add regression tests to ensure importing `langgraph.version` never calls `importlib.metadata.version`

## Why
Issue #5040 asks to avoid `importlib.metadata` for version access because it adds unnecessary import-time overhead.

## Changes
- `libs/langgraph/langgraph/version.py`
  - replace metadata lookup + fallback with constant version string
- `libs/langgraph/tests/test_version.py`
  - assert `__version__` is a semver-like string
  - assert import path does not call `importlib.metadata.version`

## Validation
I couldn't run the full project test matrix in this environment (no `uv` / `pytest` tooling installed globally), but I ran targeted smoke checks:

```bash
PYTHONPATH=. python3 - <<'PY'
import importlib
import importlib.metadata as metadata
import re
import sys

mod = importlib.import_module('langgraph.version')
assert re.fullmatch(r"\d+\.\d+\.\d+(?:[abrc]\d+)?", mod.__version__)

sys.modules.pop('langgraph.version', None)
old = metadata.version
metadata.version = lambda *a, **k: (_ for _ in ()).throw(RuntimeError('should not be called'))
try:
    mod2 = importlib.import_module('langgraph.version')
    assert mod2.__version__
finally:
    metadata.version = old
PY

python3 -m py_compile libs/langgraph/langgraph/version.py libs/langgraph/tests/test_version.py
```

## Local micro-benchmark (illustrative)
```text
metadata.version('pip') ms/1000: [346.7, 298.26, 315.0, 304.44, 301.43]
const assignment ms/1000: [0.0047, 0.0045, 0.0045, 0.0046, 0.005]
median ratio: 66428.0x
```

Fixes #5040
