### PR TITLE
Document Command.goto behavior with static edges

### DIFF
--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -385,6 +385,11 @@ class Command(Generic[N], ToolOutputMixin):
             - Sequence of node names to navigate to next
             - `Send` object (to execute a node with the input provided)
             - Sequence of `Send` objects
+
+    Notes:
+        If a node has static outgoing edges (added via `add_edge`) and also
+        returns `Command(goto=...)`, both routes are scheduled. `goto` augments
+        routing; it does not suppress static edges.
     """
 
     graph: str | None = None

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -155,6 +155,35 @@ def test_graph_validation_with_command() -> None:
     assert graph.invoke({"foo": ""}) == {"foo": "bar", "bar": "baz"}
 
 
+def test_command_goto_with_static_edges_executes_both_routes() -> None:
+    class State(TypedDict):
+        executed_nodes: Annotated[list[str], operator.add]
+
+    def start_node(state: State) -> Command[Literal["goto_target"]]:
+        return Command(goto="goto_target", update={"executed_nodes": ["start_node"]})
+
+    def goto_target(state: State) -> dict[str, list[str]]:
+        return {"executed_nodes": ["goto_target"]}
+
+    def static_target(state: State) -> dict[str, list[str]]:
+        return {"executed_nodes": ["static_target"]}
+
+    builder = StateGraph(State)
+    builder.add_node("start_node", start_node)
+    builder.add_node("goto_target", goto_target)
+    builder.add_node("static_target", static_target)
+    builder.add_edge(START, "start_node")
+    builder.add_edge("start_node", "static_target")
+    builder.add_edge("goto_target", END)
+    builder.add_edge("static_target", END)
+
+    graph = builder.compile()
+    result = graph.invoke({"executed_nodes": []})
+
+    assert "goto_target" in result["executed_nodes"]
+    assert "static_target" in result["executed_nodes"]
+
+
 def test_checkpoint_errors() -> None:
     class FaultyGetCheckpointer(InMemorySaver):
         def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:


### PR DESCRIPTION
## Summary
- document `Command(goto=...)` behavior when a node also has static outgoing edges
- clarify that `goto` augments routing and does not suppress static edges
- add a regression test proving both routes execute when static edge + `Command.goto` are combined

## Why
Issue #5829 reports that this routing behavior is currently undocumented and surprising in practice.

Fixes #5829

## Validation
- `python3 -m ruff check libs/langgraph/langgraph/types.py libs/langgraph/tests/test_pregel.py`
- `uv run pytest -q tests/test_pregel.py -k "command_goto_with_static_edges_executes_both_routes or graph_validation_with_command"`
