### PR TITLE
fix: prevent UnboundLocalError in route_tool_responses on empty messages

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -968,6 +968,7 @@ def create_react_agent(
     )
 
     def route_tool_responses(state: StateSchema) -> str:
+        m = None
         for m in reversed(_get_state_value(state, "messages")):
             if not isinstance(m, ToolMessage):
                 break

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1084,6 +1084,41 @@ async def test_return_direct(version: str) -> None:
     ]
 
 
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+async def test_return_direct_empty_messages(version: str) -> None:
+    """Test that route_tool_responses does not raise UnboundLocalError on empty messages.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/7017.
+    """
+
+    @dec_tool(return_direct=True)
+    def tool_return_direct(input: str) -> str:
+        """A tool that returns directly."""
+        return f"Direct result: {input}"
+
+    first_tool_call = [
+        ToolCall(
+            name="tool_return_direct",
+            args={"input": "Test direct"},
+            id="1",
+        ),
+    ]
+    model = FakeToolCallingModel(tool_calls=[first_tool_call, []])
+    agent = create_react_agent(
+        model,
+        [tool_return_direct],
+        version=version,
+    )
+
+    # Access the route_tool_responses function from the graph's conditional edges.
+    # It is registered on the "tools" node when should_return_direct is non-empty.
+    tools_branches = agent.builder.branches["tools"]
+    route_fn = tools_branches["route_tool_responses"].path
+    # Calling with empty messages should not raise UnboundLocalError
+    result = route_fn.invoke({"messages": []})
+    assert result == "agent"
+
+
 def test_inspect_react() -> None:
     model = FakeToolCallingModel(tool_calls=[])
     agent = create_react_agent(model, [])


### PR DESCRIPTION
## Description

Fixes #7017.

`route_tool_responses` uses a `for` loop variable `m` after the loop without guaranteeing it was assigned. When the messages list from state is empty, the loop body never executes and `m` remains unbound. The subsequent `isinstance(m, AIMessage)` check then raises `UnboundLocalError`.

## Fix

Initialize `m = None` before the loop. When the messages list is empty, `isinstance(None, AIMessage)` safely evaluates to `False` and the function returns the expected `entrypoint` value.

## Test

Added `test_return_direct_empty_messages` that directly invokes `route_tool_responses` with an empty messages list to verify no `UnboundLocalError` is raised. All 83 existing tests in `test_react_agent.py` continue to pass.