### PR TITLE
fix(performance): lazy version check to reduce import overhead

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -23,7 +23,7 @@ from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
 
 from langgraph.checkpoint.postgres import _internal
-from langgraph.checkpoint.postgres.base import BasePostgresSaver
+from langgraph.checkpoint.postgres.base import BasePostgresSaver, _check_version
 from langgraph.checkpoint.postgres.shallow import ShallowPostgresSaver
 
 Conn = _internal.Conn  # For backward compatibility
@@ -41,6 +41,7 @@ class PostgresSaver(BasePostgresSaver):
         serde: SerializerProtocol | None = None,
     ) -> None:
         super().__init__(serde=serde)
+        _check_version()
         if isinstance(conn, ConnectionPool) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single Connection, not ConnectionPool."

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 import warnings
 from collections.abc import Sequence
-from importlib.metadata import version as get_version
 from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -18,17 +17,21 @@ from psycopg.types.json import Jsonb
 
 MetadataInput = dict[str, Any] | None
 
-try:
-    major, minor = get_version("langgraph").split(".")[:2]
-    if int(major) == 0 and int(minor) < 5:
-        warnings.warn(
-            "You're using incompatible versions of langgraph and checkpoint-postgres. Please upgrade langgraph to avoid unexpected behavior.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-except Exception:
-    # skip version check if running from source
-    pass
+
+def _check_version() -> None:
+    """Check langgraph version lazily to avoid import overhead."""
+    try:
+        from importlib.metadata import version as get_version
+        major, minor = get_version("langgraph").split(".")[:2]
+        if int(major) == 0 and int(minor) < 5:
+            warnings.warn(
+                "You're using incompatible versions of langgraph and checkpoint-postgres. Please upgrade langgraph to avoid unexpected behavior.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+    except Exception:
+        # skip version check if running from source
+        pass
 
 """
 To add a new migration, add a new string to the MIGRATIONS list.


### PR DESCRIPTION
## Summary

This PR moves the `importlib.metadata.version()` call from module import time to lazy evaluation. The version check now runs only when `PostgresSaver` is instantiated, reducing import time for the `checkpoint-postgres` package.

## Changes

- Move `importlib.metadata.version()` call from module-level to a lazy `_check_version()` function
- Call `_check_version()` only when `PostgresSaver.__init__()` is invoked
- This eliminates the import overhead for users who don't use PostgresSaver

## Fixes

Fixes #5040

## Testing

The change maintains backward compatibility - the version check still runs, just lazily.
