### PR TITLE
fix(checkpoint): use insertion order for latest checkpoint in InMemorySaver

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -179,7 +179,7 @@ class InMemorySaver(
                 )
         else:
             if checkpoints := self.storage[thread_id][checkpoint_ns]:
-                checkpoint_id = max(checkpoints.keys())
+                checkpoint_id = next(reversed(checkpoints))
                 checkpoint, metadata, parent_checkpoint_id = checkpoints[checkpoint_id]
                 writes = self.writes[(thread_id, checkpoint_ns, checkpoint_id)].values()
                 checkpoint_ = self.serde.loads_typed(checkpoint)
@@ -249,24 +249,34 @@ class InMemorySaver(
                 ):
                     continue
 
-                for checkpoint_id, (
-                    checkpoint,
-                    metadata_b,
-                    parent_checkpoint_id,
-                ) in sorted(
-                    self.storage[thread_id][checkpoint_ns].items(),
-                    key=lambda x: x[0],
-                    reverse=True,
-                ):
+                ns_items = list(self.storage[thread_id][checkpoint_ns].items())
+                # Determine the insertion position of the 'before' checkpoint
+                # so we can filter by insertion order rather than string collation.
+                before_insert_pos: int | None = None
+                if before and (before_checkpoint_id := get_checkpoint_id(before)):
+                    ns_keys = [k for k, _ in ns_items]
+                    try:
+                        before_insert_pos = ns_keys.index(before_checkpoint_id)
+                    except ValueError:
+                        pass
+
+                for pos, (
+                    checkpoint_id,
+                    (
+                        checkpoint,
+                        metadata_b,
+                        parent_checkpoint_id,
+                    ),
+                ) in enumerate(reversed(ns_items)):
                     # filter by checkpoint ID from config
                     if config_checkpoint_id and checkpoint_id != config_checkpoint_id:
                         continue
 
-                    # filter by checkpoint ID from `before` config
+                    # filter by checkpoint ID from `before` config:
+                    # skip checkpoints inserted at or after the before checkpoint.
                     if (
-                        before
-                        and (before_checkpoint_id := get_checkpoint_id(before))
-                        and checkpoint_id >= before_checkpoint_id
+                        before_insert_pos is not None
+                        and (len(ns_items) - 1 - pos) >= before_insert_pos
                     ):
                         continue
 

--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -283,6 +283,57 @@ def test_memory_saver_strict_blocks_unregistered(
     assert result.checkpoint["channel_values"]["foo"] == expected
 
 
+def test_get_tuple_returns_last_written_checkpoint_by_insertion_order() -> None:
+    """Regression test: get_tuple() must use insertion order, not lexicographic max.
+
+    IDs like "2" and "10" are non-lexicographically sortable ("2" > "10"),
+    so max() would return the wrong checkpoint.
+    """
+    saver = InMemorySaver()
+    config: RunnableConfig = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+
+    # Checkpoint IDs are set on the checkpoint object itself (the storage key).
+    # Write "2" first, then "10": lexicographic max("2", "10") == "2" (wrong),
+    # but insertion order correctly yields "10" as the latest.
+    chkpnt_a = empty_checkpoint()
+    chkpnt_a["id"] = "2"
+    chkpnt_b = empty_checkpoint()
+    chkpnt_b["id"] = "10"
+
+    saver.put(config, chkpnt_a, {}, chkpnt_a["channel_versions"])
+    saver.put(config, chkpnt_b, {}, chkpnt_b["channel_versions"])
+
+    result = saver.get_tuple(config)
+    assert result is not None
+    assert result.config["configurable"]["checkpoint_id"] == "10", (
+        "get_tuple() returned the lexicographically larger ID ('2') instead of "
+        "the last written checkpoint ('10')"
+    )
+
+
+def test_list_returns_checkpoints_in_insertion_order() -> None:
+    """Regression test: list() must iterate in reverse insertion order, not lexicographic."""
+    saver = InMemorySaver()
+    config: RunnableConfig = {"configurable": {"thread_id": "t2", "checkpoint_ns": ""}}
+
+    chkpnt_a = empty_checkpoint()
+    chkpnt_a["id"] = "2"
+    chkpnt_b = empty_checkpoint()
+    chkpnt_b["id"] = "10"
+    chkpnt_c = empty_checkpoint()
+    chkpnt_c["id"] = "3"
+
+    saver.put(config, chkpnt_a, {}, chkpnt_a["channel_versions"])
+    saver.put(config, chkpnt_b, {}, chkpnt_b["channel_versions"])
+    saver.put(config, chkpnt_c, {}, chkpnt_c["channel_versions"])
+
+    results = list(saver.list(config))
+    ids = [r.config["configurable"]["checkpoint_id"] for r in results]
+    assert ids == ["3", "10", "2"], (
+        f"Expected insertion-order-reversed ['3', '10', '2'], got {ids}"
+    )
+
+
 def test_memory_saver_with_allowlist_proxy_isolated() -> None:
     serde = JsonPlusSerializer(allowed_msgpack_modules=None)
     memory_saver = InMemorySaver(serde=serde)


### PR DESCRIPTION
Fixes #6821

## Problem

`InMemorySaver.get_tuple()` selected the latest checkpoint using `max()` on checkpoint IDs, which is a lexicographic comparison. This returns the wrong result for non-padded IDs — e.g. `"2" > "10"` lexicographically, so the older checkpoint would be returned instead of the newer one.

`list()` had the same issue via `sorted(key=lambda x: x[0], reverse=True)`, and its `before` filter compared IDs with `>=` (also string-collation based).

## Fix

Python dicts preserve insertion order since 3.7. Both methods now rely on that guarantee:

- **`get_tuple`**: `max(checkpoints.keys())` → `next(reversed(checkpoints))`
- **`list`**: `sorted(...)` → `reversed(list(items()))` for iteration; the `before` filter now pre-computes the insertion position of the before checkpoint and compares positions instead of ID strings.

## Tests

Added two regression tests that fail with the old lexicographic behavior and pass with insertion-order behavior:

- `test_get_tuple_returns_last_written_checkpoint_by_insertion_order` — writes IDs `"2"` then `"10"`, asserts `get_tuple()` returns `"10"`.
- `test_list_returns_checkpoints_in_insertion_order` — writes `"2"`, `"10"`, `"3"`, asserts `list()` yields them in reverse insertion order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)