### PR TITLE
fix: guard _infer_handled_types against non-class type annotations

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -475,7 +475,9 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
             origin = get_origin(first_param.annotation)
             if origin in [Union, UnionType]:
                 args = get_args(first_param.annotation)
-                if all(issubclass(arg, Exception) for arg in args):
+                if all(
+                    isinstance(arg, type) and issubclass(arg, Exception) for arg in args
+                ):
                     return tuple(args)
                 msg = (
                     "All types in the error handler error annotation must be "
@@ -486,7 +488,9 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
                 raise ValueError(msg)
 
             exception_type = type_hints[first_param.name]
-            if Exception in exception_type.__mro__:
+            if isinstance(exception_type, type) and issubclass(
+                exception_type, Exception
+            ):
                 return (exception_type,)
             msg = (
                 f"Arbitrary types are not supported in the error handler "

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -493,6 +493,16 @@ def test__infer_handled_types() -> None:
 
         _infer_handled_types(handler)
 
+    # Non-class type annotations should raise ValueError, not AttributeError
+    T = TypeVar("T", bound=Exception)
+
+    with pytest.raises(ValueError):
+
+        def handler(e: T) -> str:  # type: ignore[valid-type]
+            return ""
+
+        _infer_handled_types(handler)
+
 
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
 def test_react_agent_with_structured_response(version: str) -> None:


### PR DESCRIPTION
## Description

`_infer_handled_types` in `tool_node.py` accessed `.__mro__` on type hints without verifying they are actual classes. Non-class annotations such as `TypeVar` or generic aliases (e.g. `list[Exception]`) caused an `AttributeError` instead of the expected `ValueError`.

## Changes

Replace the raw `.__mro__` / bare `issubclass()` checks with `isinstance(exception_type, type)` guards in both the single-type and Union branches so that non-class annotations now correctly fall through to the existing `ValueError` path.

**Single-type branch** (line 489):
```python
# Before
if Exception in exception_type.__mro__:

# After
if isinstance(exception_type, type) and issubclass(exception_type, Exception):
```

**Union branch** (line 478):
```python
# Before
if all(issubclass(arg, Exception) for arg in args):

# After
if all(isinstance(arg, type) and issubclass(arg, Exception) for arg in args):
```

## Test

Added a test case for `TypeVar` annotation (`T = TypeVar("T", bound=Exception)`) that previously raised `AttributeError` and now correctly raises `ValueError`.

The existing test for `list[Exception]` (line 484) already covered the generic alias case — it was previously passing only by coincidence (the `AttributeError` was caught by `pytest.raises(ValueError)` would have failed if the exception type were checked more strictly). With this fix it now raises `ValueError` as intended.

Fixes #7016