### PR TITLE
fix: remove use of `importlib.metadata` for version access

### DIFF
--- a/libs/cli/langgraph_cli/version.py
+++ b/libs/cli/langgraph_cli/version.py
@@ -1,10 +1,3 @@
-"""Main entrypoint into package."""
+from langgraph_cli import __version__
 
-from importlib import metadata
-
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__all__ = ("__version__",)

--- a/libs/cli/tests/unit_tests/test_version.py
+++ b/libs/cli/tests/unit_tests/test_version.py
@@ -1,0 +1,13 @@
+from langgraph_cli.version import __version__
+
+
+def test_version_is_set():
+    assert isinstance(__version__, str)
+    assert __version__ != ""
+
+
+def test_version_no_importlib_metadata():
+    import langgraph_cli.version as version_mod
+
+    source = open(version_mod.__file__).read()
+    assert "importlib" not in source

--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,3 @@
-"""Exports package version."""
-
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+__version__ = "1.0.10"

--- a/libs/langgraph/tests/test_version.py
+++ b/libs/langgraph/tests/test_version.py
@@ -1,0 +1,13 @@
+from langgraph.version import __version__
+
+
+def test_version_is_set():
+    assert isinstance(__version__, str)
+    assert __version__ != ""
+
+
+def test_version_no_importlib_metadata():
+    import langgraph.version as version_mod
+
+    source = open(version_mod.__file__).read()
+    assert "importlib" not in source


### PR DESCRIPTION
## Summary

Closes #5040.

## What changed

<!-- Claude filled in the implementation details at commit time -->
Implemented a fix based on the issue description. See the diff for specifics.

## Testing

- Verified against the existing test suite
- Checked that the fix addresses the reported behavior
