### PR TITLE
fix: handle missing NotRequired state fields in InjectedState tool args

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1355,12 +1355,12 @@ class ToolNode(RunnableCallable):
             if isinstance(state, dict):
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        state[state_field] if state_field else state
+                        state.get(state_field) if state_field else state  # ← changed here
                     )
             else:
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        getattr(state, state_field) if state_field else state
+                        getattr(state, state_field, None) if state_field else state  # ← also add None default here
                     )
 
         # Inject store


### PR DESCRIPTION
## Problem
When a tool uses `InjectedState("city")` and `city` is declared as 
`NotRequired` in a custom state schema, `ToolNode` crashes with a 
`KeyError` if that field was never populated in state.

## Fix
Changed `state[state_field]` to `state.get(state_field)` so missing 
optional fields safely return `None` instead of crashing.

Also added `None` as default to `getattr(state, state_field, None)` 
for the non-dict branch for consistency.

## Related Issue
Fixes #[35585](https://github.com/langchain-ai/langchain/issues/35585)