### PR TITLE
fix(langgraph): propagate config context var in async nodes/tools on Python < 3.11

### DIFF
--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -463,7 +463,11 @@ class RunnableCallable(Runnable):
                     with set_config_context(child_config, run) as context:
                         ret = await asyncio.create_task(coro, context=context)
                 else:
-                    ret = await coro
+                    token = var_child_runnable_config.set(child_config)
+                    try:
+                        ret = await coro
+                    finally:
+                        var_child_runnable_config.reset(token)
             except BaseException as e:
                 await run_manager.on_chain_error(e)
                 raise
@@ -706,7 +710,11 @@ class RunnableSeq(Runnable):
                                 step.ainvoke(input, config, **kwargs), context=context
                             )
                     else:
-                        input = await step.ainvoke(input, config, **kwargs)
+                        token = var_child_runnable_config.set(config)
+                        try:
+                            input = await step.ainvoke(input, config, **kwargs)
+                        finally:
+                            var_child_runnable_config.reset(token)
                 else:
                     input = await step.ainvoke(input, config)
         # finish the root run

--- a/libs/langgraph/langgraph/config.py
+++ b/libs/langgraph/langgraph/config.py
@@ -1,5 +1,3 @@
-import asyncio
-import sys
 from typing import Any
 
 from langchain_core.runnables import RunnableConfig
@@ -15,14 +13,6 @@ def _no_op_stream_writer(c: Any) -> None:
 
 
 def get_config() -> RunnableConfig:
-    if sys.version_info < (3, 11):
-        try:
-            if asyncio.current_task():
-                raise RuntimeError(
-                    "Python 3.11 or later required to use this in an async context"
-                )
-        except RuntimeError:
-            pass
     if var_config := var_child_runnable_config.get():
         return var_config
     else:
@@ -128,11 +118,6 @@ def get_stream_writer() -> StreamWriter:
 
     Can be called from inside any [`StateGraph`][langgraph.graph.StateGraph] node or
     functional API [`task`][langgraph.func.task].
-
-    !!! warning "Async with Python < 3.11"
-
-        If you are using Python < 3.11 and are running LangGraph asynchronously,
-        `get_stream_writer()` won't work since it uses [`contextvar`](https://docs.python.org/3/library/contextvars.html) propagation (only available in [Python >= 3.11](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task)).
 
     Example: Using with `StateGraph`
         ```python

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -7164,6 +7164,66 @@ def test_get_stream_writer() -> None:
     ]
 
 
+async def test_get_stream_writer_async() -> None:
+    """Regression: get_stream_writer() must work inside async nodes via astream."""
+
+    class State(TypedDict):
+        foo: str
+
+    async def my_async_node(state):
+        writer = get_stream_writer()
+        writer("custom!")
+        return state
+
+    graph = (
+        StateGraph(State)
+        .add_node(my_async_node)
+        .add_edge(START, "my_async_node")
+        .compile()
+    )
+
+    chunks = [c async for c in graph.astream({"foo": "bar"}, stream_mode="custom")]
+    assert chunks == ["custom!"]
+
+    chunks = [
+        c
+        async for c in graph.astream({"foo": "bar"}, stream_mode=["custom", "updates"])
+    ]
+    assert chunks == [
+        ("custom", "custom!"),
+        ("updates", {"my_async_node": {"foo": "bar"}}),
+    ]
+
+
+async def test_get_stream_writer_async_pre311(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: get_stream_writer() must work on Python < 3.11 (no create_task context arg).
+
+    Forces ASYNCIO_ACCEPTS_CONTEXT=False to exercise the set/reset token fallback path
+    that fixes context propagation without asyncio.create_task(..., context=ctx).
+    """
+    import langgraph._internal._runnable as _runnable_mod
+
+    monkeypatch.setattr(_runnable_mod, "ASYNCIO_ACCEPTS_CONTEXT", False)
+
+    class State(TypedDict):
+        foo: str
+
+    async def my_async_node(state):
+        writer = get_stream_writer()
+        writer("custom!")
+        return state
+
+    graph = (
+        StateGraph(State)
+        .add_node(my_async_node)
+        .add_edge(START, "my_async_node")
+        .compile()
+    )
+
+    chunks = [c async for c in graph.astream({"foo": "bar"}, stream_mode="custom")]
+    assert chunks == ["custom!"]
+
+
 def test_stream_messages_dedupe_inputs() -> None:
     from langchain_core.messages import AIMessage
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1613,6 +1613,112 @@ def test_tool_node_stream_writer() -> None:
     ]
 
 
+async def test_async_tool_node_stream_writer() -> None:
+    """Regression: get_stream_writer() must work inside async tools via ToolNode.astream."""
+
+    @dec_tool
+    async def async_streaming_tool(x: int) -> str:
+        """Do something async with writer."""
+        my_writer = get_stream_writer()
+        for value in ["foo", "bar", "baz"]:
+            my_writer({"custom_tool_value": value})
+        return str(x)
+
+    tool_node = ToolNode([async_streaming_tool])
+    graph = (
+        StateGraph(MessagesState)
+        .add_node("tools", tool_node)
+        .add_edge(START, "tools")
+        .compile()
+    )
+
+    tool_call = {
+        "name": "async_streaming_tool",
+        "args": {"x": 1},
+        "id": "1",
+        "type": "tool_call",
+    }
+    inputs = {"messages": [AIMessage("", tool_calls=[tool_call])]}
+
+    chunks = [c async for c in graph.astream(inputs, stream_mode="custom")]
+    assert chunks == [
+        {"custom_tool_value": "foo"},
+        {"custom_tool_value": "bar"},
+        {"custom_tool_value": "baz"},
+    ]
+
+    chunks = [c async for c in graph.astream(inputs, stream_mode=["custom", "updates"])]
+    assert chunks == [
+        ("custom", {"custom_tool_value": "foo"}),
+        ("custom", {"custom_tool_value": "bar"}),
+        ("custom", {"custom_tool_value": "baz"}),
+        (
+            "updates",
+            {
+                "tools": {
+                    "messages": [
+                        _AnyIdToolMessage(
+                            content="1",
+                            name="async_streaming_tool",
+                            tool_call_id="1",
+                        ),
+                    ],
+                },
+            },
+        ),
+    ]
+
+
+async def test_async_tool_node_stream_writer_parallel() -> None:
+    """Regression: get_stream_writer() must work for parallel async tools via asyncio.gather."""
+
+    @dec_tool
+    async def tool_a(x: int) -> str:
+        """Tool A."""
+        get_stream_writer()({"tool": "a", "x": x})
+        return f"a:{x}"
+
+    @dec_tool
+    async def tool_b(x: int) -> str:
+        """Tool B."""
+        get_stream_writer()({"tool": "b", "x": x})
+        return f"b:{x}"
+
+    tool_node = ToolNode([tool_a, tool_b])
+    graph = (
+        StateGraph(MessagesState)
+        .add_node("tools", tool_node)
+        .add_edge(START, "tools")
+        .compile()
+    )
+
+    inputs = {
+        "messages": [
+            AIMessage(
+                "",
+                tool_calls=[
+                    {
+                        "name": "tool_a",
+                        "args": {"x": 1},
+                        "id": "id_a",
+                        "type": "tool_call",
+                    },
+                    {
+                        "name": "tool_b",
+                        "args": {"x": 2},
+                        "id": "id_b",
+                        "type": "tool_call",
+                    },
+                ],
+            )
+        ],
+    }
+
+    chunks = [c async for c in graph.astream(inputs, stream_mode="custom")]
+    assert {"tool": "a", "x": 1} in chunks
+    assert {"tool": "b", "x": 2} in chunks
+
+
 def test_tool_call_request_setattr_deprecation_warning():
     """Test that ToolCallRequest raises a deprecation warning on direct attribute modification."""
     import warnings


### PR DESCRIPTION
## Summary

- `get_stream_writer()` (and `get_config()` in general) silently returned a no-op writer inside **async nodes and async tools** on Python 3.10. The root cause is in the Python < 3.11 fallback paths of `RunnableCallable.ainvoke` and `RunnableSequence.ainvoke` — both called `await coro` / `await step.ainvoke(...)` without ever setting `var_child_runnable_config`, the context var that `get_stream_writer()` reads.
- On Python ≥ 3.11 this was already correct: `asyncio.create_task(..., context=ctx)` propagates the context var into the new task. For Python 3.10, add a direct `token = var_child_runnable_config.set(config)` / `reset(token)` around the `await` so that `asyncio.gather` subtasks (e.g. parallel tool calls in `ToolNode`) inherit the correct config when they copy the current task context at creation time.
- Also removes the broken guard in `get_config()` that tried to raise `RuntimeError` for async callers on Python < 3.11 but caught its own exception via `except RuntimeError: pass`, making it a silent no-op.

## Root cause

The `ASYNCIO_ACCEPTS_CONTEXT` split was introduced in `560d6a1f` (April 2025) as a perf optimisation. The `else` branch for Python < 3.11 was left as a bare `await coro` — sufficient for tracing (callbacks passed explicitly in the config dict) but insufficient for `get_stream_writer()` which relies entirely on `var_child_runnable_config`.

## Test plan

- [x] `test_get_stream_writer` — existing sync node test, still passes
- [x] `test_get_stream_writer_async` — **new**: async node via `astream`, `stream_mode="custom"` and `["custom", "updates"]`
- [x] `test_get_stream_writer_async_pre311` — **new**: monkeypatches `ASYNCIO_ACCEPTS_CONTEXT=False` to force the `else` branch, confirming the `set/reset` fallback works
- [x] `test_tool_node_stream_writer` — existing sync tool test, still passes
- [x] `test_async_tool_node_stream_writer` — **new**: async tool via `ToolNode.astream`
- [x] `test_async_tool_node_stream_writer_parallel` — **new**: two parallel async tools via `asyncio.gather`, both emit custom events

Fixes #6447

🤖 Generated with [Claude Code](https://claude.com/claude-code)