### PR TITLE
fix: initialize resume_is_map before conditional block

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -637,6 +637,7 @@ class PregelLoop:
 
         # map command to writes
         if isinstance(self.input, Command):
+            resume_is_map = False
             if (resume := self.input.resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes issue #7034 where using `Command(resume=None)` raises an `UnboundLocalError` instead of the expected `EmptyInputError`.

## Changes

In `langgraph/pregel/_loop.py`, the variable `resume_is_map` was only defined inside the conditional block when `resume is not None`, but referenced unconditionally on lines 661 and 663. This caused an `UnboundLocalError` when `resume=None` was passed.

The fix initializes `resume_is_map = False` before the conditional block, ensuring proper error handling.

## Testing

- All 93 interrupt-related tests pass
- Manual verification confirms the fix works correctly - the code now raises `EmptyInputError: Received empty Command input` as expected instead of crashing with `UnboundLocalError`