### PR TITLE
fix(langgraph): preserve metadata for custom stream events

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -27,6 +27,7 @@ from typing import (
 )
 from uuid import UUID, uuid5
 
+from langchain_core.callbacks.manager import dispatch_custom_event
 from langchain_core.globals import get_debug
 from langchain_core.runnables import (
     RunnableSequence,
@@ -156,6 +157,15 @@ except ImportError:
 __all__ = ("NodeBuilder", "Pregel")
 
 _WriteValue = Callable[[Input], Output] | Any
+
+
+def _should_dispatch_custom_events(handlers: Sequence[Any]) -> bool:
+    """Whether custom stream chunks should surface as `on_custom_event`."""
+    return any(
+        type(handler).__name__ == "_AstreamEventsCallbackHandler"
+        and type(handler).__module__ == "langchain_core.tracers.event_stream"
+        for handler in handlers
+    )
 
 
 class NodeBuilder:
@@ -2527,6 +2537,7 @@ class Pregel(
             name=config.get("run_name", self.get_name()),
             run_id=config.get("run_id"),
         )
+        dispatch_custom_events = _should_dispatch_custom_events(run_manager.handlers)
         try:
             # assign defaults
             (
@@ -2568,19 +2579,24 @@ class Pregel(
 
             # set up custom stream mode
             if "custom" in stream_modes:
+                if dispatch_custom_events:
 
-                def stream_writer(c: Any) -> None:
-                    stream.put(
-                        (
-                            tuple(
-                                get_config()[CONF][CONFIG_KEY_CHECKPOINT_NS].split(
-                                    NS_SEP
-                                )[:-1]
-                            ),
-                            "custom",
-                            c,
+                    def stream_writer(c: Any) -> None:
+                        dispatch_custom_event("custom", c, config=get_config())
+                else:
+
+                    def stream_writer(c: Any) -> None:
+                        stream.put(
+                            (
+                                tuple(
+                                    get_config()[CONF][CONFIG_KEY_CHECKPOINT_NS].split(
+                                        NS_SEP
+                                    )[:-1]
+                                ),
+                                "custom",
+                                c,
+                            )
                         )
-                    )
             elif CONFIG_KEY_STREAM in config[CONF]:
                 stream_writer = config[CONF][CONFIG_KEY_RUNTIME].stream_writer
             else:
@@ -2820,6 +2836,7 @@ class Pregel(
             if _StreamingCallbackHandler is not None
             else False
         )
+        dispatch_custom_events = _should_dispatch_custom_events(run_manager.handlers)
         try:
             # assign defaults
             (
@@ -2861,35 +2878,26 @@ class Pregel(
                 )
 
             # set up custom stream mode
-            def stream_writer(c: Any) -> None:
-                aioloop.call_soon_threadsafe(
-                    stream.put_nowait,
-                    (
-                        tuple(
-                            get_config()[CONF][CONFIG_KEY_CHECKPOINT_NS].split(NS_SEP)[
-                                :-1
-                            ]
-                        ),
-                        "custom",
-                        c,
-                    ),
-                )
-
             if "custom" in stream_modes:
+                if dispatch_custom_events:
 
-                def stream_writer(c: Any) -> None:
-                    aioloop.call_soon_threadsafe(
-                        stream.put_nowait,
-                        (
-                            tuple(
-                                get_config()[CONF][CONFIG_KEY_CHECKPOINT_NS].split(
-                                    NS_SEP
-                                )[:-1]
+                    def stream_writer(c: Any) -> None:
+                        dispatch_custom_event("custom", c, config=get_config())
+                else:
+
+                    def stream_writer(c: Any) -> None:
+                        aioloop.call_soon_threadsafe(
+                            stream.put_nowait,
+                            (
+                                tuple(
+                                    get_config()[CONF][CONFIG_KEY_CHECKPOINT_NS].split(
+                                        NS_SEP
+                                    )[:-1]
+                                ),
+                                "custom",
+                                c,
                             ),
-                            "custom",
-                            c,
-                        ),
-                    )
+                        )
             elif CONFIG_KEY_STREAM in config[CONF]:
                 stream_writer = config[CONF][CONFIG_KEY_RUNTIME].stream_writer
             else:

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -44,6 +44,7 @@ from langgraph._internal._queue import AsyncQueue
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
+from langgraph.config import get_stream_writer
 from langgraph.errors import (
     GraphRecursionError,
     InvalidUpdateError,
@@ -5203,6 +5204,86 @@ async def test_stream_buffering_single_node(
         (FloatBetween(0.0, 0.1), "Before sleep"),
         (FloatBetween(0.2, 0.3), "After sleep"),
     ]
+
+
+@NEEDS_CONTEXTVARS
+async def test_astream_events_custom_stream_preserves_node_metadata(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    class State(TypedDict):
+        value: str
+
+    async def node(state: State) -> dict[str, str]:
+        writer = get_stream_writer()
+        writer({"custom": "first"})
+        await asyncio.sleep(0)
+        writer({"custom": "second"})
+        return {"value": state["value"] + "!"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("node", node)
+        .add_edge(START, "node")
+        .add_edge("node", END)
+        .compile(checkpointer=async_checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "custom-events"}}
+    events = [
+        event
+        async for event in graph.astream_events(
+            {"value": "x"},
+            config,
+            version="v2",
+            stream_mode="custom",
+        )
+    ]
+
+    root_run_id = events[0]["run_id"]
+    custom_events = [event for event in events if event["event"] == "on_custom_event"]
+
+    assert custom_events == [
+        {
+            "event": "on_custom_event",
+            "run_id": AnyStr(),
+            "name": "custom",
+            "tags": ["seq:step:1"],
+            "metadata": {
+                "thread_id": "custom-events",
+                "langgraph_step": 1,
+                "langgraph_node": "node",
+                "langgraph_triggers": ("branch:to:node",),
+                "langgraph_path": ("__pregel_pull", "node"),
+                "langgraph_checkpoint_ns": AnyStr(),
+                "checkpoint_ns": AnyStr(),
+            },
+            "data": {"custom": "first"},
+            "parent_ids": [root_run_id],
+        },
+        {
+            "event": "on_custom_event",
+            "run_id": AnyStr(),
+            "name": "custom",
+            "tags": ["seq:step:1"],
+            "metadata": {
+                "thread_id": "custom-events",
+                "langgraph_step": 1,
+                "langgraph_node": "node",
+                "langgraph_triggers": ("branch:to:node",),
+                "langgraph_path": ("__pregel_pull", "node"),
+                "langgraph_checkpoint_ns": AnyStr(),
+                "checkpoint_ns": AnyStr(),
+            },
+            "data": {"custom": "second"},
+            "parent_ids": [root_run_id],
+        },
+    ]
+    assert not any(
+        event["event"] == "on_chain_stream"
+        and event["name"] == "LangGraph"
+        and event["data"].get("chunk") in ({"custom": "first"}, {"custom": "second"})
+        for event in events
+    )
 
 
 async def test_nested_graph_interrupts_parallel(


### PR DESCRIPTION
## Summary
- preserve node-level metadata for `get_stream_writer()` output when consumed via `astream_events(..., version="v2")`
- surface those chunks as `on_custom_event` entries tied to the originating node instead of root `LangGraph` `on_chain_stream` events
- add a regression test covering custom stream metadata propagation

## Why
Fixes #6330.

Today, `get_stream_writer()` chunks show up under the root `LangGraph` run in `astream_events(v2)`, so they lose the originating node metadata (`langgraph_node`, `langgraph_path`, `parent_ids`, etc.).

This change only special-cases the `astream_events(v2)` path. Direct `stream` / `astream` calls with `stream_mode="custom"` still yield raw custom chunks as before.

## Testing
- `NO_DOCKER=true .venv311/bin/pytest libs/langgraph/tests/test_pregel_async.py -k 'custom_stream_preserves_node_metadata or stream_buffering_single_node'`
- `NO_DOCKER=true .venv311/bin/ruff check libs/langgraph/langgraph/pregel/main.py libs/langgraph/tests/test_pregel_async.py`
