### PR TITLE
fix(prebuilt): handle missing NotRequired state fields in InjectedState

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1351,16 +1351,16 @@ class ToolNode(RunnableCallable):
                         )
                     raise ValueError(err_msg)
 
-            # Extract state values
+            # Extract state values (use .get / getattr default for NotRequired fields)
             if isinstance(state, dict):
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        state[state_field] if state_field else state
+                        state.get(state_field) if state_field else state
                     )
             else:
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        getattr(state, state_field) if state_field else state
+                        getattr(state, state_field, None) if state_field else state
                     )
 
         # Inject store

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1382,8 +1382,14 @@ def test_tool_node_inject_state(schema_: type[T]) -> None:
             with contextlib.suppress(Exception):
                 failure_input = schema_(messages=[msg], notfoo="bar")
             if failure_input is not None:
-                with pytest.raises(KeyError):
-                    node.invoke(failure_input, config=_create_config_with_runtime())
+                # Missing state fields inject None (safe for NotRequired).
+                # The tool itself validates args, so a missing required
+                # field surfaces as a tool invocation error, not KeyError.
+                result = node.invoke(
+                    failure_input, config=_create_config_with_runtime()
+                )
+                tool_message = result["messages"][-1]
+                assert tool_message.status == "error"
 
                 with pytest.raises(ValueError):
                     node.invoke([msg], config=_create_config_with_runtime())
@@ -2008,3 +2014,42 @@ async def test_tool_node_inject_runtime_dynamic_tool_via_wrap_tool_call_async() 
     tool_message = result["messages"][-1]
     assert tool_message.content == "dynamic: x=42, tool_call_id=call_dynamic_2"
     assert tool_message.tool_call_id == "call_dynamic_2"
+
+
+def test_tool_node_inject_state_not_required_missing() -> None:
+    """Regression: InjectedState with NotRequired field should not raise KeyError.
+
+    When a state field is declared as NotRequired and is missing from the
+    state dict, InjectedState should inject None instead of raising KeyError.
+
+    See: https://github.com/langchain-ai/langchain/issues/35585
+    """
+
+    def weather_tool(
+        city: Annotated[str | None, InjectedState("city")],
+    ) -> str:
+        """Get weather for a city."""
+        if city is None:
+            return "No city provided"
+        return f"Sunny in {city}"
+
+    node = ToolNode([weather_tool], handle_tool_errors=True)
+    tool_call = {
+        "name": "weather_tool",
+        "args": {},
+        "id": "call_1",
+        "type": "tool_call",
+    }
+    msg = AIMessage("weather?", tool_calls=[tool_call])
+
+    # State dict WITHOUT the 'city' key (simulating NotRequired field missing)
+    result = node.invoke({"messages": [msg]}, config=_create_config_with_runtime())
+    tool_message = result["messages"][-1]
+    assert tool_message.content == "No city provided"
+
+    # State dict WITH the 'city' key
+    result = node.invoke(
+        {"messages": [msg], "city": "Rome"}, config=_create_config_with_runtime()
+    )
+    tool_message = result["messages"][-1]
+    assert tool_message.content == "Sunny in Rome"


### PR DESCRIPTION
## Bug

When a tool parameter uses `InjectedState("field")` and the referenced field is declared as `NotRequired` in the custom state schema, `ToolNode` crashes with an unhandled `KeyError` if that field was never populated in the state.

**Reported in:** langchain-ai/langchain#35585

### Root cause

In `_inject_tool_args()`, state field extraction uses direct dict access (`state[state_field]`) and bare `getattr(state, state_field)`, both of which raise when the key/attribute is missing. This is correct for required fields but fails for `NotRequired` fields that may legitimately be absent.

### Fix

- Replace `state[state_field]` with `state.get(state_field)` for dict-based state
- Replace `getattr(state, state_field)` with `getattr(state, state_field, None)` for object-based state

Missing fields now inject `None` instead of raising `KeyError`/`AttributeError`. Tools that declare their injected parameter as `Optional[T]` (matching the `NotRequired` state field) will receive `None` and can handle it gracefully.

### Testing

- Added `test_tool_node_inject_state_not_required_missing`: verifies that a tool with `Annotated[str | None, InjectedState("city")]` receives `None` when `city` is absent from state, and receives the value when present
- Updated existing `test_tool_node_inject_state` to reflect new behavior (missing field = error response, not `KeyError`)
- All 11 inject-related tests pass

Fixes langchain-ai/langchain#35585