### PR TITLE
fix(checkpoint): support nested enum deserialization via qualname

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -440,7 +440,7 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
-                (obj.__class__.__module__, obj.__class__.__name__, obj.value),
+                (obj.__class__.__module__, obj.__class__.__qualname__, obj.value),
             ),
         )
     elif isinstance(obj, SendProtocol):
@@ -580,6 +580,13 @@ def _create_msgpack_ext_hook(
         )
         return False
 
+    def _resolve_type(module: str, name: str) -> Any:
+        """Resolve a type from module and name, supporting dotted qualnames for nested classes."""
+        obj = importlib.import_module(module)
+        for part in name.split("."):
+            obj = getattr(obj, part)
+        return obj
+
     def ext_hook(code: int, data: bytes) -> Any:
         if code == EXT_CONSTRUCTOR_SINGLE_ARG:
             try:
@@ -592,7 +599,7 @@ def _create_msgpack_ext_hook(
                     # it would be validated upon construction.
                     return tup[2]
                 # module, name, arg
-                return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
+                return _resolve_type(tup[0], tup[1])(tup[2])
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_POS_ARGS:
@@ -603,7 +610,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
                 # module, name, args
-                return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
+                return _resolve_type(tup[0], tup[1])(*tup[2])
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
@@ -614,7 +621,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
                 # module, name, kwargs
-                return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
+                return _resolve_type(tup[0], tup[1])(**tup[2])
             except Exception:
                 return None
         elif code == EXT_METHOD_SINGLE_ARG:
@@ -625,9 +632,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed_method(tup[0], tup[1], tup[3]):
                     return tup[2]
                 # module, name, arg, method
-                return getattr(
-                    getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
-                )(tup[2])
+                return getattr(_resolve_type(tup[0], tup[1]), tup[3])(tup[2])
             except Exception:
                 return None
         elif code == EXT_PYDANTIC_V1:
@@ -638,7 +643,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
                 # module, name, kwargs
-                cls = getattr(importlib.import_module(tup[0]), tup[1])
+                cls = _resolve_type(tup[0], tup[1])
                 try:
                     return cls(**tup[2])
                 except Exception:
@@ -658,7 +663,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
                 # module, name, kwargs, method
-                cls = getattr(importlib.import_module(tup[0]), tup[1])
+                cls = _resolve_type(tup[0], tup[1])
                 try:
                     return cls(**tup[2])
                 except Exception:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -93,6 +93,14 @@ class MyEnum(Enum):
     BAR = "bar"
 
 
+class OuterContainer:
+    """Container with nested enum for testing nested enum serialization."""
+
+    class NestedEnum(str, Enum):
+        ALPHA = "alpha"
+        BETA = "beta"
+
+
 @dataclasses_json.dataclass_json
 @dataclasses.dataclass
 class Person:
@@ -983,3 +991,21 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def test_nested_enum_serde_roundtrip() -> None:
+    """Test that nested enum classes (defined inside another class) survive serialization.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/6718.
+    Nested enums have __qualname__ like 'Outer.Inner' while __name__ is just 'Inner'.
+    Previously, serialization used __name__, making deserialization fail with
+    getattr(module, 'Inner') since 'Inner' isn't a top-level module attribute.
+    """
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[("tests.test_jsonplus", "OuterContainer.NestedEnum")]
+    )
+    data = {"status": OuterContainer.NestedEnum.ALPHA}
+    dumped = serde.dumps_typed(data)
+    loaded = serde.loads_typed(dumped)
+    assert loaded["status"] == OuterContainer.NestedEnum.ALPHA
+    assert type(loaded["status"]) is OuterContainer.NestedEnum


### PR DESCRIPTION
## Bug

Nested enums (defined inside a class) become `None` after checkpoint deserialization, breaking Pydantic validation on resume.

**Reported in:** #6718

### Root cause

The enum serializer stores `__name__` (e.g., `"PhaseEnum"`) but for nested classes `__name__` is only the leaf name — the class is only reachable via its parent: `module.DatasetArtifact.PhaseEnum`.

On deserialization, `getattr(importlib.import_module(module), "PhaseEnum")` fails because `PhaseEnum` isn't a top-level module attribute. The `except Exception: return None` catches this silently.

### Fix

1. **Serialize with `__qualname__`** instead of `__name__` — for nested enums this produces dotted names like `"DatasetArtifact.PhaseEnum"`. For top-level classes, `__qualname__ == __name__`, so this is backward compatible.

2. **Add `_resolve_type()` helper** that walks dotted qualnames via chained `getattr` calls:
   ```python
   def _resolve_type(module, name):
       obj = importlib.import_module(module)
       for part in name.split("."):
           obj = getattr(obj, part)
       return obj
   ```

3. **Use `_resolve_type()` in all EXT_\* deserialization paths** for consistency.

### Backward compatibility

Existing checkpoints with top-level enum names (e.g., `"MyEnum"`) still deserialize correctly — a single-component split produces the same `getattr(module, "MyEnum")` call as before.

### Testing

- Added `test_nested_enum_serde_roundtrip` — verifies a nested enum (`OuterContainer.NestedEnum`) survives a full serialize → deserialize round-trip
- All 92 existing jsonplus tests pass

Fixes #6718