### PR TITLE
fix(langgraph): initialize resume_is_map before conditional block

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -637,6 +637,7 @@ class PregelLoop:
 
         # map command to writes
         if isinstance(self.input, Command):
+            resume_is_map = False
             if (resume := self.input.resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -155,6 +155,42 @@ def test_graph_validation_with_command() -> None:
     assert graph.invoke({"foo": ""}) == {"foo": "bar", "bar": "baz"}
 
 
+def test_command_resume_none_does_not_crash() -> None:
+    """Command(resume=None) should raise EmptyInputError, not UnboundLocalError.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/7034.
+    """
+
+    class State(TypedDict):
+        result: str
+
+    def checkpoint_node(state: State) -> dict:
+        interrupt(None)
+        return {}
+
+    def work_node(state: State) -> dict:
+        return {"result": "done"}
+
+    builder = StateGraph(State)
+    builder.add_node("checkpoint", checkpoint_node)
+    builder.add_node("work", work_node)
+    builder.add_edge(START, "checkpoint")
+    builder.add_edge("checkpoint", "work")
+    builder.add_edge("work", END)
+
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "resume-none-test"}}
+
+    # Run until interrupt
+    graph.invoke({"result": ""}, config)
+
+    # Resume with None — should not crash with UnboundLocalError
+    from langgraph.errors import EmptyInputError
+
+    with pytest.raises(EmptyInputError):
+        graph.invoke(Command(resume=None), config)
+
+
 def test_checkpoint_errors() -> None:
     class FaultyGetCheckpointer(InMemorySaver):
         def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:


### PR DESCRIPTION
## Bug

`Command(resume=None)` crashes with `UnboundLocalError: cannot access local variable 'resume_is_map'` instead of raising `EmptyInputError`.

**Reported in:** #7034

### Root cause

In `PregelLoop._first()`, `resume_is_map` is defined only inside an `if (resume := self.input.resume) is not None:` block (line 646), but is referenced **unconditionally** on lines 661 and 663:

```python
# resume_is_map defined ONLY here (when resume is not None)
if (resume := self.input.resume) is not None:
    if resume_is_map := (isinstance(resume, dict) and ...):
        ...

# referenced UNCONDITIONALLY — UnboundLocalError when resume is None
for tid, c, v in map_command(cmd=self.input):
    if not (c == RESUME and resume_is_map):   # crash
        writes[tid].append((c, v))
if not writes and not resume_is_map:          # crash
    raise EmptyInputError(...)
```

When `Command(resume=None)` is used, the guard `is not None` skips the block, leaving `resume_is_map` uninitialized.

### Fix

Initialize `resume_is_map = False` before the conditional block. This ensures the variable is always defined, allowing the code to correctly reach the `EmptyInputError` path when resume is `None`.

### Testing

- Added `test_command_resume_none_does_not_crash` — verifies `Command(resume=None)` raises `EmptyInputError` instead of `UnboundLocalError`
- Test passes with the fix

Fixes #7034