### PR TITLE
fix(langgraph): unwrap Overwrite in BinaryOperatorAggregate when value is MISSING

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -102,10 +102,15 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
-            self.value = values[0]
-            values = values[1:]
         seen_overwrite: bool = False
+        if self.value is MISSING:
+            is_overwrite, overwrite_value = _get_overwrite(values[0])
+            if is_overwrite:
+                self.value = overwrite_value
+                seen_overwrite = True
+            else:
+                self.value = values[0]
+            values = values[1:]
         for value in values:
             is_overwrite, overwrite_value = _get_overwrite(value)
             if is_overwrite:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -9,6 +9,7 @@ from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
+from langgraph.types import Overwrite
 
 pytestmark = pytest.mark.anyio
 
@@ -88,6 +89,36 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_overwrite_when_missing() -> None:
+    """Overwrite on a MISSING channel must unwrap the value and set the guard.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/6909.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class Metrics:
+        count: int
+
+        def __add__(self, other: "Metrics") -> "Metrics":
+            return Metrics(self.count + other.count)
+
+    # Metrics has no zero-arg constructor → channel starts as MISSING
+    channel = BinaryOperatorAggregate(Metrics, operator.add)
+    assert channel.value is MISSING
+
+    # Bug 1: Overwrite should be unwrapped, not stored as wrapper
+    channel.update([Overwrite(Metrics(count=42))])
+    result = channel.get()
+    assert isinstance(result, Metrics), f"Expected Metrics, got {type(result)}"
+    assert result.count == 42
+
+    # Bug 2: Two Overwrites in same super-step must raise InvalidUpdateError
+    channel2 = BinaryOperatorAggregate(Metrics, operator.add)
+    with pytest.raises(InvalidUpdateError):
+        channel2.update([Overwrite(Metrics(1)), Overwrite(Metrics(2))])
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Bug

`BinaryOperatorAggregate` stores the `Overwrite` wrapper object instead of the unwrapped value when the channel starts with `MISSING` (type has no zero-arg constructor). Additionally, the duplicate-`Overwrite` guard is skipped for the first value.

**Reported in:** #6909

### Root cause

In `update()`, the `MISSING` fast-path assigns `values[0]` directly without calling `_get_overwrite()`:

```python
if self.value is MISSING:
    self.value = values[0]  # ← Does NOT unwrap Overwrite!
    values = values[1:]
seen_overwrite: bool = False  # ← Initialized AFTER the MISSING branch
```

This causes:
1. `channel.get()` returns `Overwrite(value=Metrics(count=42))` instead of `Metrics(count=42)`
2. Two `Overwrite` values in the same super-step silently succeed instead of raising `InvalidUpdateError`

### Fix

Move `seen_overwrite` initialization before the `MISSING` branch and apply `_get_overwrite()` to `values[0]` when `self.value is MISSING`.

### Testing

- Added `test_binop_overwrite_when_missing` — verifies both bugs:
  1. `Overwrite` is unwrapped when channel starts `MISSING`
  2. Two `Overwrite` values raise `InvalidUpdateError`
- All 6 channel tests pass

Fixes #6909