### PR TITLE
fix(langgraph): handle END in conditional edges when path_map omits __end__

### DIFF
--- a/libs/langgraph/langgraph/graph/_branch.py
+++ b/libs/langgraph/langgraph/graph/_branch.py
@@ -200,7 +200,8 @@ class BranchSpec(NamedTuple):
             result = [result]
         if self.ends:
             destinations: Sequence[Send | str] = [
-                r if isinstance(r, Send) else self.ends[r] for r in result
+                r if isinstance(r, Send) else (END if r == END else self.ends[r])
+                for r in result
             ]
         else:
             destinations = cast(Sequence[Send | str], result)

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -2944,7 +2944,31 @@ def test_function_in_conditional_edges_with_no_path_map() -> None:
     }
 
 
-def test_in_one_fan_out_state_graph_waiting_edge_multiple_cond_edge() -> None:
+def test_conditional_edges_end_without_path_map_entry() -> None:
+    """Router returning END should work even when path_map omits __end__.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/6770.
+    """
+
+    def router(state: dict) -> str:
+        if state.get("counter", 0) >= 5:
+            return END
+        return "worker"
+
+    def worker(state: dict) -> dict:
+        return {"counter": state.get("counter", 0) + 1}
+
+    g = StateGraph(dict)
+    g.add_node("entry", lambda s: dict(s))
+    g.add_node("worker", worker)
+    g.set_entry_point("entry")
+    g.add_conditional_edges("entry", router, {"worker": "worker"})
+    g.add_edge("worker", END)
+    app = g.compile()
+
+    # counter=5 → router returns END → should terminate, not KeyError
+    result = app.invoke({"counter": 5})
+    assert result == {"counter": 5}
     def sorted_add(x: list[str], y: list[str] | list[tuple[str, str]]) -> list[str]:
         if isinstance(y[0], tuple):
             for rem, _ in y:


### PR DESCRIPTION
## Bug

When a conditional router returns `END` (`"__end__"`) but the `path_map` argument to `add_conditional_edges()` does not include an `__end__` mapping, the graph crashes at runtime with `KeyError('__end__')`.

**Reported in:** #6770

### Root cause

In `Branch._finish()`, when `self.ends` (path_map) is provided, every router result is looked up via `self.ends[r]`:

```python
destinations = [r if isinstance(r, Send) else self.ends[r] for r in result]
```

`END` is a reserved terminal value, but it's treated like any other key — if missing from the map, `KeyError`.

### Fix

Treat `END` as a special terminal value: if the router returns `END`, map it directly to `END` without looking it up in `self.ends`:

```python
destinations = [
    r if isinstance(r, Send) else (END if r == END else self.ends[r])
    for r in result
]
```

### Testing

- Added `test_conditional_edges_end_without_path_map_entry` — graph with `path_map={"worker": "worker"}` and router returning `END` terminates correctly
- Test passes

Fixes #6770