### PR TITLE
fix: hardcode version to avoid importlib.metadata overhead

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,6 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Hardcoded version for faster imports (avoids importlib.metadata overhead)
+__version__ = "1.0.10"


### PR DESCRIPTION
## Summary

Removes use of `importlib.metadata` for version access as requested in issue #5040.

## Changes

- Replaces dynamic version lookup with hardcoded version `1.0.10`
- Improves import performance by avoiding metadata lookup overhead

## Testing

```python
from langgraph.version import __version__
assert __version__ == "1.0.10"
```

Closes #5040