### PR TITLE
fix: `get_state().next` is empty after a node calls `interrupt()` t...

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -80,6 +80,7 @@ from langgraph._internal._constants import (
     NS_SEP,
     NULL_TASK_ID,
     PUSH,
+    RESUME,
     TASKS,
 )
 from langgraph._internal._pydantic import create_model
@@ -1094,7 +1095,7 @@ class Pregel(
             )
         if apply_pending_writes and saved.pending_writes:
             for tid, k, v in saved.pending_writes:
-                if k in (ERROR, INTERRUPT):
+                if k in (ERROR, INTERRUPT, RESUME):
                     continue
                 if tid not in next_tasks:
                     continue
@@ -1213,7 +1214,7 @@ class Pregel(
             )
         if apply_pending_writes and saved.pending_writes:
             for tid, k, v in saved.pending_writes:
-                if k in (ERROR, INTERRUPT):
+                if k in (ERROR, INTERRUPT, RESUME):
                     continue
                 if tid not in next_tasks:
                     continue

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5299,6 +5299,7 @@ def test_multiple_interrupt_state_persistence(
     # State should still be empty since node hasn't returned
     state = app.get_state(config)
     assert state.values == {"steps": []}
+    assert state.next == ("node",)
 
     # Resume after first interrupt - should hit second interrupt
     app.invoke(Command(resume="step1"), config)
@@ -5306,6 +5307,7 @@ def test_multiple_interrupt_state_persistence(
     # State should still be empty since node hasn't returned
     state = app.get_state(config)
     assert state.values == {"steps": []}
+    assert state.next == ("node",)
 
     # Resume after second interrupt - node should complete
     result = app.invoke(Command(resume="step2"), config)
@@ -5314,6 +5316,7 @@ def test_multiple_interrupt_state_persistence(
     assert result["steps"] == ["step1", "step2"]
     state = app.get_state(config)
     assert state.values["steps"] == ["step1", "step2"]
+    assert state.next == ()
 
 
 def test_concurrent_execution_thread_safety():

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -6513,6 +6513,7 @@ async def test_multiple_interrupt_state_persistence(
     # State should still be empty since node hasn't returned
     state = await app.aget_state(config)
     assert state.values == {"steps": []}
+    assert state.next == ("node",)
 
     # Resume after first interrupt - should hit second interrupt
     await app.ainvoke(Command(resume="step1"), config)
@@ -6520,6 +6521,7 @@ async def test_multiple_interrupt_state_persistence(
     # State should still be empty since node hasn't returned
     state = await app.aget_state(config)
     assert state.values == {"steps": []}
+    assert state.next == ("node",)
 
     # Resume after second interrupt - node should complete
     result = await app.ainvoke(Command(resume="step2"), config)
@@ -6528,6 +6530,7 @@ async def test_multiple_interrupt_state_persistence(
     assert result["steps"] == ["step1", "step2"]
     state = await app.aget_state(config)
     assert state.values["steps"] == ["step1", "step2"]
+    assert state.next == ()
 
 
 async def test_concurrent_execution():


### PR DESCRIPTION
## Summary

This addresses #6956.

## What changed

<!-- Claude filled in the implementation details at commit time -->
Implemented a fix based on the issue description. See the diff for specifics.

## Testing

- Verified against the existing test suite
- Checked that the fix addresses the reported behavior
