### PR TITLE
feat(sdk-py): add version=v2 support for wait() method

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_async/runs.py
@@ -10,7 +10,11 @@ from typing import Any, overload
 import httpx
 
 from langgraph_sdk._async.http import HttpClient
-from langgraph_sdk._shared.utilities import _get_run_metadata_from_response
+from langgraph_sdk._shared.utilities import (
+    _get_run_metadata_from_response,
+    _parse_wait_v2,
+    _sse_to_v2_dict,
+)
 from langgraph_sdk.schema import (
     All,
     BulkCancelRunsStatus,
@@ -21,6 +25,7 @@ from langgraph_sdk.schema import (
     Context,
     DisconnectMode,
     Durability,
+    GraphOutput,
     IfNotExists,
     Input,
     MultitaskStrategy,
@@ -548,6 +553,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v1"] = "v1",
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     @overload
@@ -573,7 +579,34 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v1"] = "v1",
     ) -> builtins.list[dict] | dict[str, Any]: ...
+
+    @overload
+    async def wait(
+        self,
+        thread_id: None,
+        assistant_id: str,
+        *,
+        input: Input | None = None,
+        command: Command | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        config: Config | None = None,
+        context: Context | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        raise_error: bool = True,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v2"],
+    ) -> builtins.list[GraphOutput[dict[str, Any]]] | GraphOutput[dict[str, Any]]: ...
 
     async def wait(
         self,
@@ -601,7 +634,13 @@ class RunsClient:
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
         durability: Durability | None = None,
-    ) -> builtins.list[dict] | dict[str, Any]:
+        version: StreamVersion = "v1",
+    ) -> (
+        builtins.list[dict]
+        | dict[str, Any]
+        | builtins.list[GraphOutput[dict[str, Any]]]
+        | GraphOutput[dict[str, Any]]
+    ):
         """Create a run, wait until it finishes and return the final state.
 
         Args:
@@ -636,6 +675,8 @@ class RunsClient:
                 "async" means checkpoints are persisted async while next graph step executes, replaces checkpoint_during=True
                 "sync" means checkpoints are persisted sync after graph step executes, replaces checkpoint_during=False
                 "exit" means checkpoints are only persisted when the run exits, does not save intermediate steps
+            version: Stream format version. "v1" (default) returns plain dicts. "v2" returns
+                ``GraphOutput`` objects with ``value`` and ``interrupts`` attributes.
 
         Returns:
             The output of the run.
@@ -743,6 +784,8 @@ class RunsClient:
             raise Exception(
                 f"{response['__error__'].get('error')}: {response['__error__'].get('message')}"
             )
+        if version == "v2":
+            return _parse_wait_v2(response)  # type: ignore[arg-type]
         return response
 
     async def list(

--- a/libs/sdk-py/langgraph_sdk/_shared/utilities.py
+++ b/libs/sdk-py/langgraph_sdk/_shared/utilities.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import httpx
 
 import langgraph_sdk
-from langgraph_sdk.schema import RunCreateMetadata
+from langgraph_sdk.schema import GraphOutput, RunCreateMetadata
 
 RESERVED_HEADERS = ("x-api-key",)
 
@@ -107,6 +107,33 @@ def _get_run_metadata_from_response(
     return None
 
 
+def _sse_to_v2_dict(event: str, data: Any) -> dict[str, Any] | None:
+    """Convert an SSE event+data pair into a v2 stream part dict.
+
+    Returns None for ``end`` events (signals end of stream).
+    """
+    if event == "end":
+        return None
+    parts = event.split("|")
+    event_type = parts[0]
+    ns = parts[1:] if len(parts) > 1 else []
+    return {"type": event_type, "ns": ns, "data": data}
+
+
+def _parse_wait_v2(
+    response: dict[str, Any] | list[dict[str, Any]],
+) -> GraphOutput[dict[str, Any]] | list[GraphOutput[dict[str, Any]]]:
+    if isinstance(response, list):
+        return [_parse_wait_v2_single(r) for r in response]
+    return _parse_wait_v2_single(response)
+
+
+def _parse_wait_v2_single(response: dict[str, Any]) -> GraphOutput[dict[str, Any]]:
+    response_copy = dict(response)
+    interrupts = response_copy.pop("__interrupt__", ())
+    if interrupts and not isinstance(interrupts, tuple):
+        interrupts = tuple(interrupts)
+    return GraphOutput(value=response_copy, interrupts=interrupts)
 def _provided_vals(d: Mapping[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in d.items() if v is not None}
 

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -9,7 +9,11 @@ from typing import Any, overload
 
 import httpx
 
-from langgraph_sdk._shared.utilities import _get_run_metadata_from_response
+from langgraph_sdk._shared.utilities import (
+    _get_run_metadata_from_response,
+    _parse_wait_v2,
+    _sse_to_v2_dict,
+)
 from langgraph_sdk._sync.http import SyncHttpClient
 from langgraph_sdk.schema import (
     All,
@@ -18,9 +22,9 @@ from langgraph_sdk.schema import (
     Checkpoint,
     Command,
     Config,
-    Context,
     DisconnectMode,
     Durability,
+    GraphOutput,
     IfNotExists,
     Input,
     MultitaskStrategy,
@@ -544,6 +548,61 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v1"] = "v1",
+    ) -> builtins.list[dict] | dict[str, Any]: ...
+
+    @overload
+    def wait(
+        self,
+        thread_id: str,
+        assistant_id: str,
+        *,
+        input: Input | None = None,
+        command: Command | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        config: Config | None = None,
+        context: Context | None = None,
+        checkpoint: Checkpoint | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        multitask_strategy: MultitaskStrategy | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        raise_error: bool = True,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v2"],
+    ) -> builtins.list[GraphOutput[dict[str, Any]]] | GraphOutput[dict[str, Any]]: ...
+
+    @overload
+    def wait(
+        self,
+        thread_id: None,
+        assistant_id: str,
+        *,
+        input: Input | None = None,
+        command: Command | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        config: Config | None = None,
+        context: Context | None = None,
+        checkpoint_during: bool | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        webhook: str | None = None,
+        on_disconnect: DisconnectMode | None = None,
+        on_completion: OnCompletionBehavior | None = None,
+        if_not_exists: IfNotExists | None = None,
+        after_seconds: int | None = None,
+        raise_error: bool = True,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        version: Literal["v1"] = "v1",
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     @overload
@@ -569,7 +628,8 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
-    ) -> builtins.list[dict] | dict[str, Any]: ...
+        version: Literal["v2"],
+    ) -> builtins.list[GraphOutput[dict[str, Any]]] | GraphOutput[dict[str, Any]]: ...
 
     def wait(
         self,
@@ -597,7 +657,13 @@ class SyncRunsClient:
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
         durability: Durability | None = None,
-    ) -> builtins.list[dict] | dict[str, Any]:
+        version: StreamVersion = "v1",
+    ) -> (
+        builtins.list[dict]
+        | dict[str, Any]
+        | builtins.list[GraphOutput[dict[str, Any]]]
+        | GraphOutput[dict[str, Any]]
+    ):
         """Create a run, wait until it finishes and return the final state.
 
         Args:
@@ -633,6 +699,8 @@ class SyncRunsClient:
                 "async" means checkpoints are persisted async while next graph step executes, replaces checkpoint_during=True
                 "sync" means checkpoints are persisted sync after graph step executes, replaces checkpoint_during=False
                 "exit" means checkpoints are only persisted when the run exits, does not save intermediate steps
+            version: Stream format version. "v1" (default) returns plain dicts. "v2" returns
+                ``GraphOutput`` objects with ``value`` and ``interrupts`` attributes.
 
         Returns:
             The output of the `Run`.
@@ -725,7 +793,7 @@ class SyncRunsClient:
         endpoint = (
             f"/threads/{thread_id}/runs/wait" if thread_id is not None else "/runs/wait"
         )
-        return self.http.request_reconnect(
+        response = self.http.request_reconnect(
             endpoint,
             "POST",
             json={k: v for k, v in payload.items() if v is not None},
@@ -733,6 +801,13 @@ class SyncRunsClient:
             headers=headers,
             on_response=on_response if on_run_created else None,
         )
+        if hasattr(response, "get") and response.get("__error__"):
+            raise Exception(
+                f"{response['__error__'].get('error')}: {response['__error__'].get('message')}"
+            )
+        if version == "v2":
+            return _parse_wait_v2(response)  # type: ignore[arg-type]
+        return response
 
     def list(
         self,

--- a/libs/sdk-py/langgraph_sdk/schema.py
+++ b/libs/sdk-py/langgraph_sdk/schema.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import Field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     Any,
     ClassVar,
+    Generic,
     Literal,
     NamedTuple,
     Protocol,
     TypeAlias,
+    TypeVar,
     Union,
 )
 
@@ -206,6 +208,56 @@ class Checkpoint(TypedDict):
     """Optional unique identifier for the checkpoint itself."""
     checkpoint_map: dict[str, Any] | None
     """Optional dictionary containing checkpoint-specific data."""
+
+
+OutputT = TypeVar("OutputT")
+
+
+@dataclass(frozen=True)
+class GraphOutput(Generic[OutputT]):
+    """Typed container returned by `wait()` with `version="v2"`.
+
+    Attributes:
+        value: The final output of the run (dict, Pydantic model, dataclass, etc.).
+        interrupts: Any interrupts that occurred during execution.
+    """
+
+    value: OutputT
+    interrupts: tuple[Interrupt, ...] = ()
+
+    def __getitem__(self, key: str) -> Any:
+        """Backward compat: `result['__interrupt__']` and dict-key access."""
+        import warnings
+        warnings.warn(
+            "Accessing GraphOutput via `result[key]` is deprecated. "
+            "Use `result.value` to access the output value directly, "
+            "or `result.interrupts` for interrupts.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if key == "__interrupt__":
+            return self.interrupts
+        if isinstance(self.value, dict):
+            return self.value[key]
+        try:
+            return getattr(self.value, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        import warnings
+        warnings.warn(
+            "Accessing GraphOutput via `key in result` is deprecated. "
+            "Use `result.value` to access the output value directly, "
+            "or `result.interrupts` for interrupts.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if key == "__interrupt__":
+            return bool(self.interrupts)
+        if isinstance(self.value, dict):
+            return key in self.value
+        return isinstance(key, str) and hasattr(self.value, key)
 
 
 class GraphSchema(TypedDict):

--- a/libs/sdk-py/tests/test_wait.py
+++ b/libs/sdk-py/tests/test_wait.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from langgraph_sdk._async.http import HttpClient
+from langgraph_sdk._async.runs import RunsClient as AsyncRunsClient
+from langgraph_sdk._sync.http import SyncHttpClient
+from langgraph_sdk._sync.runs import SyncRunsClient
+from langgraph_sdk.schema import GraphOutput
+
+
+def test_sync_wait_v1():
+    """Verify that version='v1' (default) returns the raw dict unchanged."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": "completed", "__interrupt__": [{"value": "test", "id": "123"}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        runs = SyncRunsClient(http=SyncHttpClient(client))
+        result = runs.wait(
+            thread_id="thread-id",
+            assistant_id="agent",
+            version="v1",
+        )
+
+    assert isinstance(result, dict)
+    assert result == {
+        "status": "completed",
+        "__interrupt__": [{"value": "test", "id": "123"}],
+    }
+
+
+def test_sync_wait_v2_single():
+    """Verify that version='v2' extracts __interrupt__ and wraps in GraphOutput."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": "completed", "__interrupt__": [{"value": "test", "id": "123"}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        runs = SyncRunsClient(http=SyncHttpClient(client))
+        result = runs.wait(
+            thread_id="thread-id",
+            assistant_id="agent",
+            version="v2",
+        )
+
+    assert isinstance(result, GraphOutput)
+    assert result.value == {"status": "completed"}
+    assert result.interrupts == ({"value": "test", "id": "123"},)
+
+    # Test dictionary backward compatibility
+    with pytest.warns(DeprecationWarning, match="Accessing GraphOutput via `result\\[key\\]` is deprecated"):
+        assert result["status"] == "completed"
+    with pytest.warns(DeprecationWarning, match="Accessing GraphOutput via `result\\[key\\]` is deprecated"):
+        assert result["__interrupt__"] == ({"value": "test", "id": "123"},)
+    with pytest.warns(DeprecationWarning, match="Accessing GraphOutput via `key in result` is deprecated"):
+        assert "__interrupt__" in result
+    with pytest.warns(DeprecationWarning, match="Accessing GraphOutput via `key in result` is deprecated"):
+        assert "status" in result
+
+
+def test_sync_wait_v2_list():
+    """Verify that version='v2' handles a list response from a batch run."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[
+                {"status": "completed", "__interrupt__": [{"value": "test", "id": "123"}]},
+                {"status": "pending"}
+            ],
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        runs = SyncRunsClient(http=SyncHttpClient(client))
+        result = runs.wait(
+            thread_id=None,
+            assistant_id="agent",
+            version="v2",
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], GraphOutput)
+    assert result[0].value == {"status": "completed"}
+    assert result[0].interrupts == ({"value": "test", "id": "123"},)
+    
+    assert isinstance(result[1], GraphOutput)
+    assert result[1].value == {"status": "pending"}
+    assert result[1].interrupts == ()
+
+
+@pytest.mark.asyncio
+async def test_async_wait_v1():
+    """Verify async version='v1' returns original dict."""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": "completed", "__interrupt__": [{"value": "test", "id": "123"}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        runs = AsyncRunsClient(http=HttpClient(client))
+        result = await runs.wait(
+            thread_id="thread-id",
+            assistant_id="agent",
+            version="v1",
+        )
+
+    assert isinstance(result, dict)
+    assert "__interrupt__" in result
+
+
+@pytest.mark.asyncio
+async def test_async_wait_v2_multiple_interrupts():
+    """Verify async version='v2' correctly parses multiple interrupts."""
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": "interrupted", 
+                "__interrupt__": [
+                    {"value": "question 1", "id": "1"},
+                    {"value": "question 2", "id": "2"}
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        runs = AsyncRunsClient(http=HttpClient(client))
+        result = await runs.wait(
+            thread_id="thread-id",
+            assistant_id="agent",
+            version="v2",
+        )
+
+    assert isinstance(result, GraphOutput)
+    assert result.value == {"status": "interrupted"}
+    assert len(result.interrupts) == 2
+    assert result.interrupts[0] == {"value": "question 1", "id": "1"}
+    assert result.interrupts[1] == {"value": "question 2", "id": "2"}


### PR DESCRIPTION
**Description:** 
This PR implements the `stream_version="v2"` (or `version="v2"`) functionality for the `.wait()` method in the Python SDK. By default, the [v1](cci:1://file:///Users/ijasahammed/Documents/open_source/langgraph/libs/sdk-py/tests/test_wait.py:12:0-33:5) method returns the raw response dictionary. When `version="v2"` is used, the SDK now correctly parses and returns a strongly-typed [GraphOutput](cci:2://file:///Users/ijasahammed/Documents/open_source/langgraph/libs/sdk-py/langgraph_sdk/schema.py:215:0-259:64) container that cleanly separates the final `value` state from any [interrupts](cci:1://file:///Users/ijasahammed/Documents/open_source/langgraph/libs/sdk-py/tests/test_wait.py:123:0-153:69) that happened during execution. 

This brings the SDK's `.wait()` method into exact parity with the `.invoke()` method in the LangGraph core library.

Extensive unit tests were added in [tests/test_wait.py](cci:7://file:///Users/ijasahammed/Documents/open_source/langgraph/libs/sdk-py/tests/test_wait.py:0:0-0:0) to ensure backward compatibility for old code expecting `__interrupt__` keys, while verifying successful wrapping for single executions and batch API calls.

**Issue:** 
Fixes #7008

**Dependencies:** 
None
