### PR TITLE
fix: guard against non-class type annotations in _infer_handled_types

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -486,7 +486,7 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
                 raise ValueError(msg)
 
             exception_type = type_hints[first_param.name]
-            if Exception in exception_type.__mro__:
+            if isinstance(exception_type, type) and issubclass(exception_type, Exception):
                 return (exception_type,)
             msg = (
                 f"Arbitrary types are not supported in the error handler "


### PR DESCRIPTION
## Summary

Fixes #7016.

`_infer_handled_types` crashes with `AttributeError: 'TypeVar' object has no attribute '__mro__'` when an error handler's parameter is annotated with a non-class type (TypeVar, generic alias, or forward reference).

## Fix

Replace the direct `__mro__` access with `isinstance` + `issubclass` guards:

```python
# Before (crashes on non-class types):
if Exception in exception_type.__mro__:

# After (safe for any type annotation):
if isinstance(exception_type, type) and issubclass(exception_type, Exception):
```

**`libs/prebuilt/langgraph/prebuilt/tool_node.py`** line 489 — one-line fix.