### PR TITLE
fix: prevent UnboundLocalError in route_tool_responses on empty messages

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -968,6 +968,7 @@ def create_react_agent(
     )
 
     def route_tool_responses(state: StateSchema) -> str:
+        m = None
         for m in reversed(_get_state_value(state, "messages")):
             if not isinstance(m, ToolMessage):
                 break
@@ -976,7 +977,7 @@ def create_react_agent(
 
         # handle a case of parallel tool calls where
         # the tool w/ `return_direct` was executed in a different `Send`
-        if isinstance(m, AIMessage) and m.tool_calls:
+        if m is not None and isinstance(m, AIMessage) and m.tool_calls:
             if any(call["name"] in should_return_direct for call in m.tool_calls):
                 return END
 


### PR DESCRIPTION
## Summary

Fixes #7017.

`route_tool_responses` crashes with `UnboundLocalError: cannot access local variable 'm'` when the messages list is empty, because the loop variable `m` is never assigned.

## Fix

Initialize `m = None` before the loop and add a `m is not None` guard before the post-loop `isinstance` check:

```python
def route_tool_responses(state: StateSchema) -> str:
    m = None  # Guard against empty messages
    for m in reversed(_get_state_value(state, "messages")):
        ...

    if m is not None and isinstance(m, AIMessage) and m.tool_calls:
        ...
```

**`libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py`** — two-line fix.