### PR TITLE
fix: skip caching ERROR/INTERRUPT writes in SyncPregelLoop.put_writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1068,6 +1068,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks
+            return
         self.submit(
             self.cache.set,
             {


### PR DESCRIPTION
## Summary

Fixes #7015.

`SyncPregelLoop.put_writes` is missing the `ERROR`/`INTERRUPT` guard that `AsyncPregelLoop.put_writes` has. This causes failed/interrupted task results to be cached and replayed on subsequent runs instead of re-executing the task.

## Fix

Add the missing guard from the async version:

```python
# Added before self.submit(self.cache.set, ...):
if writes[0][0] in (INTERRUPT, ERROR):
    # only cache successful tasks
    return
```

**`libs/langgraph/langgraph/pregel/_loop.py`** — two-line addition matching the async version at line 1246.