### PR TITLE
fix: initialize resume_is_map before conditional to prevent UnboundLocalError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -637,6 +637,7 @@ class PregelLoop:
 
         # map command to writes
         if isinstance(self.input, Command):
+            resume_is_map = False
             if (resume := self.input.resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes #7034.

`Command(resume=None)` crashes with `UnboundLocalError: cannot access local variable 'resume_is_map'` because the variable is only assigned inside `if (resume := self.input.resume) is not None:`, but referenced unconditionally on lines 661 and 663.

## Fix

Initialize `resume_is_map = False` before the conditional block:

```python
resume_is_map = False  # default when resume is None
if (resume := self.input.resume) is not None:
    ...
```

This lets the code fall through to the existing `EmptyInputError` instead of crashing with an unrelated `UnboundLocalError`.

**`libs/langgraph/langgraph/pregel/_loop.py`** — one-line addition at line 640.