### PR TITLE
fix: handle END in conditional edges without explicit path_map entry

### DIFF
--- a/libs/langgraph/langgraph/graph/_branch.py
+++ b/libs/langgraph/langgraph/graph/_branch.py
@@ -200,7 +200,8 @@ class BranchSpec(NamedTuple):
             result = [result]
         if self.ends:
             destinations: Sequence[Send | str] = [
-                r if isinstance(r, Send) else self.ends[r] for r in result
+                r if isinstance(r, Send) else (r if r == END else self.ends[r])
+                for r in result
             ]
         else:
             destinations = cast(Sequence[Send | str], result)

--- a/libs/langgraph/tests/test_conditional_end.py
+++ b/libs/langgraph/tests/test_conditional_end.py
@@ -1,0 +1,106 @@
+"""Test that conditional edges handle END without explicit path_map entry.
+
+Regression test for https://github.com/langchain-ai/langgraph/issues/6770
+"""
+
+from typing_extensions import TypedDict
+
+from langgraph.constants import END
+from langgraph.graph.state import StateGraph
+
+
+class CounterState(TypedDict, total=False):
+    counter: int
+
+
+def test_conditional_edge_end_without_path_map_entry() -> None:
+    """Router returning END should work even when path_map omits __end__."""
+
+    def router(state: CounterState) -> str:
+        if state.get("counter", 0) >= 5:
+            return END
+        return "worker"
+
+    def worker(state: CounterState) -> CounterState:
+        return {"counter": state.get("counter", 0) + 1}
+
+    g = StateGraph(CounterState)
+    g.add_node("entry", lambda s: s)
+    g.add_node("router_node", lambda s: s)
+    g.add_node("worker", worker)
+
+    g.set_entry_point("entry")
+    g.add_edge("entry", "router_node")
+
+    # path_map intentionally lacks an END mapping â€” this must not crash
+    g.add_conditional_edges(
+        "router_node",
+        router,
+        {"worker": "worker"},
+    )
+    g.add_edge("worker", "router_node")
+
+    app = g.compile()
+
+    # counter starts at 0 â†’ loops 5 times then hits END
+    result = app.invoke({"counter": 0})
+    assert result == {"counter": 5}
+
+
+def test_conditional_edge_end_with_path_map_entry() -> None:
+    """Router returning END still works when path_map explicitly maps it."""
+
+    def router(state: CounterState) -> str:
+        if state.get("counter", 0) >= 3:
+            return END
+        return "worker"
+
+    def worker(state: CounterState) -> CounterState:
+        return {"counter": state.get("counter", 0) + 1}
+
+    g = StateGraph(CounterState)
+    g.add_node("entry", lambda s: s)
+    g.add_node("router_node", lambda s: s)
+    g.add_node("worker", worker)
+
+    g.set_entry_point("entry")
+    g.add_edge("entry", "router_node")
+
+    # path_map explicitly includes END â€” should still work
+    g.add_conditional_edges(
+        "router_node",
+        router,
+        {"worker": "worker", END: END},
+    )
+    g.add_edge("worker", "router_node")
+
+    app = g.compile()
+
+    result = app.invoke({"counter": 0})
+    assert result == {"counter": 3}
+
+
+def test_conditional_edge_end_immediate() -> None:
+    """Router returning END on the very first invocation terminates immediately."""
+
+    def always_end(state: CounterState) -> str:
+        return END
+
+    g = StateGraph(CounterState)
+    g.add_node("entry", lambda s: s)
+    g.add_node("router_node", lambda s: s)
+    g.add_node("worker", lambda s: s)
+
+    g.set_entry_point("entry")
+    g.add_edge("entry", "router_node")
+
+    g.add_conditional_edges(
+        "router_node",
+        always_end,
+        {"worker": "worker"},
+    )
+
+    app = g.compile()
+
+    result = app.invoke({"counter": 42})
+    assert result == {"counter": 42}


### PR DESCRIPTION
## Summary

Fixes #6770.

When a router function passed to `add_conditional_edges()` returns `END` (`"__end__"`) but the `path_map` does not include an explicit `END` mapping, the graph crashes at runtime with `KeyError('__end__')`.

`END` is a built-in sentinel destination that should always be recognized by the routing logic. This change treats `END` as a passthrough in `BranchSpec._finish()` so it bypasses the `path_map` lookup, consistent with the behavior when no `path_map` is provided.

### The fix

In `libs/langgraph/langgraph/graph/_branch.py`, the list comprehension in `_finish()` that resolves router return values through `self.ends` now checks for `END` first:

```python
# Before (crashes when r == END and END not in self.ends):
r if isinstance(r, Send) else self.ends[r]

# After (END passes through without lookup):
r if isinstance(r, Send) else (r if r == END else self.ends[r])
```

### Reproduction

```python
from langgraph.graph import StateGraph, END

def router(state):
    if state.get("counter", 0) >= 5:
        return END       # <-- crashes with KeyError
    return "worker"

g = StateGraph(dict)
g.add_node("entry", lambda s: s)
g.add_node("router_node", lambda s: s)
g.add_node("worker", lambda s: {"counter": s.get("counter", 0) + 1})

g.set_entry_point("entry")
g.add_edge("entry", "router_node")
g.add_conditional_edges("router_node", router, {"worker": "worker"})
g.add_edge("worker", "router_node")

app = g.compile()
app.invoke({"counter": 0})  # KeyError("__end__")
```

## Test plan

- Added `libs/langgraph/tests/test_conditional_end.py` with three test cases:
  - `test_conditional_edge_end_without_path_map_entry` -- the exact scenario from the issue (loop until END, no END in path_map)
  - `test_conditional_edge_end_with_path_map_entry` -- verifies existing behavior is preserved when END is explicitly in path_map
  - `test_conditional_edge_end_immediate` -- router returns END immediately on first call

Generated with [Claude Code](https://claude.com/claude-code)