### PR TITLE
Fix KeyError in ToolNode when InjectedState field is missing from state

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1355,12 +1355,12 @@ class ToolNode(RunnableCallable):
             if isinstance(state, dict):
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        state[state_field] if state_field else state
+                        state.get(state_field) if state_field else state
                     )
             else:
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        getattr(state, state_field) if state_field else state
+                        getattr(state, state_field, None) if state_field else state
                     )
 
         # Inject store


### PR DESCRIPTION
## Description
This PR fixes a `KeyError` that occurs when using `InjectedState` with a `NotRequired` state field that is absent from the current state.

In `ToolNode._inject_tool_args`, state values were being extracted using direct dictionary indexing (`state[state_field]`) or `getattr(state, state_field)`. If the field was marked as `NotRequired` in the state schema and not present in the state, this would raise a `KeyError` or `AttributeError`.

The fix switches to `.get()` for dictionaries and `getattr(..., None)` for objects, ensuring that missing optional fields default to `None` instead of crashing the node.

## Related Issues
Fixes https://github.com/langchain-ai/langchain/issues/35585

## Checklist
- [x] Verified fix for dict-based state injection
- [x] Verified fix for object-based state injection
- [x] Syntax checked via py_compile
