### PR TITLE
feat(langgraph): add __repr__ methods to all channel classes for better debugging

### DIFF
--- a/libs/langgraph/langgraph/channels/any_value.py
+++ b/libs/langgraph/langgraph/channels/any_value.py
@@ -27,6 +27,11 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, AnyValue)
 
+    def __repr__(self) -> str:
+        if self.value is MISSING:
+            return f"AnyValue(typ={self.typ!r}, key={self.key!r}, value=MISSING)"
+        return f"AnyValue(typ={self.typ!r}, key={self.key!r}, value={self.value!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -75,6 +75,12 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
             else True
         )
 
+    def __repr__(self) -> str:
+        op_name = getattr(self.operator, "__name__", repr(self.operator))
+        if self.value is MISSING:
+            return f"BinaryOperatorAggregate(typ={self.typ!r}, key={self.key!r}, operator={op_name}, value=MISSING)"
+        return f"BinaryOperatorAggregate(typ={self.typ!r}, key={self.key!r}, operator={op_name}, value={self.value!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""

--- a/libs/langgraph/langgraph/channels/ephemeral_value.py
+++ b/libs/langgraph/langgraph/channels/ephemeral_value.py
@@ -28,6 +28,11 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, EphemeralValue) and value.guard == self.guard
 
+    def __repr__(self) -> str:
+        if self.value is MISSING:
+            return f"EphemeralValue(typ={self.typ!r}, key={self.key!r}, guard={self.guard}, value=MISSING)"
+        return f"EphemeralValue(typ={self.typ!r}, key={self.key!r}, guard={self.guard}, value={self.value!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""

--- a/libs/langgraph/langgraph/channels/last_value.py
+++ b/libs/langgraph/langgraph/channels/last_value.py
@@ -31,6 +31,11 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, LastValue)
 
+    def __repr__(self) -> str:
+        if self.value is MISSING:
+            return f"LastValue(typ={self.typ!r}, key={self.key!r}, value=MISSING)"
+        return f"LastValue(typ={self.typ!r}, key={self.key!r}, value={self.value!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""
@@ -96,6 +101,11 @@ class LastValueAfterFinish(
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, LastValueAfterFinish)
+
+    def __repr__(self) -> str:
+        if self.value is MISSING:
+            return f"LastValueAfterFinish(typ={self.typ!r}, key={self.key!r}, value=MISSING, finished={self.finished})"
+        return f"LastValueAfterFinish(typ={self.typ!r}, key={self.key!r}, value={self.value!r}, finished={self.finished})"
 
     @property
     def ValueType(self) -> type[Value]:

--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -26,6 +26,9 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, NamedBarrierValue) and value.names == self.names
 
+    def __repr__(self) -> str:
+        return f"NamedBarrierValue(key={self.key!r}, names={self.names!r}, seen={self.seen!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""
@@ -102,6 +105,9 @@ class NamedBarrierValueAfterFinish(
             isinstance(value, NamedBarrierValueAfterFinish)
             and value.names == self.names
         )
+
+    def __repr__(self) -> str:
+        return f"NamedBarrierValueAfterFinish(key={self.key!r}, names={self.names!r}, seen={self.seen!r}, finished={self.finished})"
 
     @property
     def ValueType(self) -> type[Value]:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -43,6 +43,9 @@ class Topic(
     def __eq__(self, value: object) -> bool:
         return isinstance(value, Topic) and value.accumulate == self.accumulate
 
+    def __repr__(self) -> str:
+        return f"Topic(typ={self.typ!r}, key={self.key!r}, accumulate={self.accumulate}, len={len(self.values)})"
+
     @property
     def ValueType(self) -> Any:
         """The type of the value stored in the channel."""

--- a/libs/langgraph/langgraph/channels/untracked_value.py
+++ b/libs/langgraph/langgraph/channels/untracked_value.py
@@ -28,6 +28,11 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
     def __eq__(self, value: object) -> bool:
         return isinstance(value, UntrackedValue) and value.guard == self.guard
 
+    def __repr__(self) -> str:
+        if self.value is MISSING:
+            return f"UntrackedValue(typ={self.typ!r}, key={self.key!r}, guard={self.guard}, value=MISSING)"
+        return f"UntrackedValue(typ={self.typ!r}, key={self.key!r}, guard={self.guard}, value={self.value!r})"
+
     @property
     def ValueType(self) -> type[Value]:
         """The type of the value stored in the channel."""


### PR DESCRIPTION
> This PR adds human-readable __repr__ methods to all 9 channel classes in libs/langgraph/langgraph/channels/. Currently, debugging channel state requires manually inspecting attributes. With these changes, repr(channel) now shows key information at a glance:
>
> - LastValue / LastValueAfterFinish: shows typ, key, value (or MISSING), and finished flag
> - EphemeralValue / UntrackedValue: shows typ, key, guard, and value
> - AnyValue: shows typ, key, and value
> - Topic: shows typ, key, accumulate, and current length
> - BinaryOperatorAggregate: shows typ, key, operator name, and value
> - NamedBarrierValue / NamedBarrierValueAfterFinish: shows key, names, seen, and finished flag
>
> Example: LastValue(typ=<class 'int'>, key='counter', value=42)