### PR TITLE
chore: raise `ValueError` on graph input with `Command(resume=..., update=...)`

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -637,13 +637,13 @@ class PregelLoop:
 
         # map command to writes
         if isinstance(self.input, Command):
-            if self.input.resume is not None and self.input.update:
+            if self.input.update:
                 raise ValueError(
-                    "Command(resume=..., update=...) is not allowed as graph input. "
-                    "Use Command(resume=...) to resume execution, or use "
-                    "graph.update_state(...) to update state before resuming. "
+                    "Command(update=...) is not allowed as graph input. "
+                    "To modify state before resuming, use graph.update_state(...) "
+                    "to fork the graph state, then resume with Command(resume=...). "
                     "Note: Command(update=...) can still be used as a return "
-                    "value from a node to update graph state."
+                    "value from a node to update graph state during execution."
                 )
             if (resume := self.input.resume) is not None:
                 if not self.checkpointer:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5850,11 +5850,10 @@ def test_task_before_interrupt_resume(
     assert result == {"answers": ["answer1", "answer2"]}
 
 
-def test_command_resume_with_update_raises(
+def test_command_with_update_input_raises(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:
-    """Test that Command(resume=..., update=...) raises InvalidUpdateError
-    when used as graph input."""
+    """Test that Command(update=...) raises ValueError when used as graph input."""
 
     @entrypoint(checkpointer=sync_checkpointer)
     def workflow(inputs: str) -> str:
@@ -5867,11 +5866,13 @@ def test_command_resume_with_update_raises(
     result = workflow.invoke("start", config=config)
     assert "__interrupt__" in result
 
-    # Resuming with both resume and update should raise
-    with pytest.raises(ValueError, match="Command\\(resume=.*update="):
-        workflow.invoke(
-            Command(resume="answer", update={"foo": "bar"}), config=config
-        )
+    # Command with update (and resume) should raise
+    with pytest.raises(ValueError, match="Command\\(update="):
+        workflow.invoke(Command(resume="answer", update={"foo": "bar"}), config=config)
+
+    # Command with update only (no resume) should also raise
+    with pytest.raises(ValueError, match="Command\\(update="):
+        workflow.invoke(Command(update={"foo": "bar"}), config=config)
 
 
 def test_multiple_tasks_before_interrupt_resume(


### PR DESCRIPTION
Requested by rippling - we don't support `Command(update=...)` in graph input, so let's make this easier for users to troubleshoot.