### PR TITLE
fix(prebuilt): tolerate absent NotRequired state fields in InjectedState

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1355,12 +1355,12 @@ class ToolNode(RunnableCallable):
             if isinstance(state, dict):
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        state[state_field] if state_field else state
+                        state.get(state_field) if state_field else state
                     )
             else:
                 for tool_arg, state_field in injected.state.items():
                     injected_args[tool_arg] = (
-                        getattr(state, state_field) if state_field else state
+                        getattr(state, state_field, None) if state_field else state
                     )
 
         # Inject store


### PR DESCRIPTION
## Problem

When a tool parameter is annotated with `InjectedState("field")` and that field is declared as `NotRequired` in the custom graph state schema, the `ToolNode` crashed with an unhandled `KeyError` if the field was not yet populated in the state dict:

```
File ".../langgraph/prebuilt/tool_node.py", line 1358, in _inject_tool_args
    state[state_field] if state_field else state
    ~~~~~^^^^^^^^^^^^^
KeyError: 'city'
```

**Minimal reproduction:**
```python
from typing import Annotated
from typing_extensions import NotRequired
from langgraph.prebuilt import InjectedState
from langchain.agents import AgentState

class CustomAgentState(AgentState):
    city: NotRequired[str]  # Optional — may not be present in state

@tool
def get_weather(city: Annotated[str, InjectedState("city")]) -> str:
    return f"It's always sunny in {city}!"
```
If `city` is absent from the state (never set by the user), the `ToolNode` raises `KeyError: 'city'` instead of gracefully passing `None`.

## Fix

Use `state.get(state_field)` instead of `state[state_field]` for the `dict` case, and `getattr(state, state_field, None)` instead of `getattr(state, state_field)` for the object case. Both return `None` when the field is absent, which is the correct sentinel for an optional / not-yet-populated state field.

Tools that **require** the field to be non-None will still fail at their own validation boundary, which gives a cleaner error than an internal `KeyError`.

Closes langchain-ai/langchain#35585