### PR TITLE
feat(a2a): add low-level A2A protocol client and data types; implement configuration sanitization

### DIFF
--- a/libs/langgraph/langgraph/_internal/_a2a.py
+++ b/libs/langgraph/langgraph/_internal/_a2a.py
@@ -1,0 +1,737 @@
+"""Low-level A2A protocol client and data types.
+
+Implements the JSON-RPC 2.0 transport for A2A v1.0 specification.
+This is an internal module — use `A2ARemoteGraph` from `langgraph.pregel.a2a_remote`.
+
+Architecture:
+    _a2a.py (this file)          <- Pure protocol layer, zero LangGraph dependencies
+        |
+    a2a_remote.py                <- LangGraph adapter layer, bridges two state models
+        |
+    remote A2A agent (any framework)
+
+Design decisions:
+    - dataclass over Pydantic: protocol layer doesn't need validation/serialization magic
+    - httpx over requests: single library provides both sync + async clients
+    - Only implements client-side subset of a2a.proto, not the full spec
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# JSON-RPC 2.0 version string, required by the A2A protocol
+_JSONRPC_VERSION = "2.0"
+
+# Default timeout configuration:
+#   - connect/pool: 5s (connection setup should be quick)
+#   - read/write: 300s (agent may need significant time to think)
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5, read=300, write=300, pool=5)
+
+
+# --------------------------------------------------------------------------- #
+#  A2A data types (mirrors a2a.proto, client-side subset)
+# --------------------------------------------------------------------------- #
+
+
+class TaskState(str, Enum):
+    """A2A task lifecycle states.
+
+    State transitions:
+        SUBMITTED -> WORKING -> COMPLETED (normal completion)
+                              -> FAILED    (processing error)
+                              -> CANCELED  (cancelled by caller)
+                              -> REJECTED  (rejected by agent)
+                              -> INPUT_REQUIRED (needs user input, resumable)
+                              -> AUTH_REQUIRED  (needs auth, resumable)
+
+    Inherits str so enum values serialize directly to JSON, e.g.:
+        json.dumps(TaskState.COMPLETED)  # "TASK_STATE_COMPLETED"
+    """
+
+    UNSPECIFIED = "TASK_STATE_UNSPECIFIED"
+    SUBMITTED = "TASK_STATE_SUBMITTED"
+    WORKING = "TASK_STATE_WORKING"
+    COMPLETED = "TASK_STATE_COMPLETED"
+    FAILED = "TASK_STATE_FAILED"
+    CANCELED = "TASK_STATE_CANCELED"
+    INPUT_REQUIRED = "TASK_STATE_INPUT_REQUIRED"
+    REJECTED = "TASK_STATE_REJECTED"
+    AUTH_REQUIRED = "TASK_STATE_AUTH_REQUIRED"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether this is a terminal state (no further transitions possible).
+
+        Once terminal, polling can stop.
+        """
+        return self in (
+            TaskState.COMPLETED,
+            TaskState.FAILED,
+            TaskState.CANCELED,
+            TaskState.REJECTED,
+        )
+
+    @property
+    def is_interrupted(self) -> bool:
+        """Whether this is an interrupted state (needs external intervention to resume).
+
+        Maps to LangGraph's GraphInterrupt:
+            - INPUT_REQUIRED -> agent is waiting for user input
+            - AUTH_REQUIRED  -> agent is waiting for authentication
+        """
+        return self in (TaskState.INPUT_REQUIRED, TaskState.AUTH_REQUIRED)
+
+
+class Role(str, Enum):
+    """A2A message role.
+
+    Note: A2A only has USER/AGENT roles,
+    unlike LangGraph which has human/ai/system/tool.
+    """
+
+    UNSPECIFIED = "ROLE_UNSPECIFIED"
+    USER = "ROLE_USER"
+    AGENT = "ROLE_AGENT"
+
+
+@dataclass
+class Part:
+    """A2A message's minimal content unit.
+
+    Similar to LangGraph message's `content` field but more flexible:
+        - text:       plain text
+        - data:       structured JSON data
+        - url:        file/resource link
+        - media_type: MIME type (e.g. "image/png")
+        - filename:   filename
+
+    A single message can contain multiple Parts for multimodal content.
+    """
+
+    text: str | None = None
+    data: Any | None = None
+    url: str | None = None
+    media_type: str | None = None
+    filename: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict, only including non-None fields.
+
+        A2A protocol convention: empty fields are omitted to reduce payload size.
+        Note: text uses `is not None` (empty string "" is valid text),
+        while media_type uses truthy check (empty string is meaningless).
+        """
+        d: dict[str, Any] = {}
+        if self.text is not None:
+            d["text"] = self.text
+        if self.data is not None:
+            d["data"] = self.data
+        if self.url is not None:
+            d["url"] = self.url
+        if self.media_type:
+            d["media_type"] = self.media_type
+        if self.filename:
+            d["filename"] = self.filename
+        if self.metadata:
+            d["metadata"] = self.metadata
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Part:
+        """Deserialize from a JSON-RPC response dict."""
+        return cls(
+            text=d.get("text"),
+            data=d.get("data"),
+            url=d.get("url"),
+            media_type=d.get("media_type"),
+            filename=d.get("filename"),
+            metadata=d.get("metadata"),
+        )
+
+
+@dataclass
+class A2AMessage:
+    """A2A message.
+
+    Core field mapping to LangGraph:
+        - context_id  <-> thread_id     (conversation ID)
+        - task_id     <-> checkpoint_id (task ID)
+        - parts       <-> content       (message content)
+        - role        <-> type          (USER->human, AGENT->ai)
+    """
+
+    message_id: str                          # Unique message identifier
+    role: Role                               # USER or AGENT
+    parts: list[Part]                        # Message content (can be multiple)
+    context_id: str | None = None            # Conversation ID (-> LangGraph thread_id)
+    task_id: str | None = None               # Task ID (-> LangGraph checkpoint_id)
+    metadata: dict[str, Any] | None = None   # Custom metadata
+    extensions: list[str] | None = None      # A2A protocol extension identifiers
+    reference_task_ids: list[str] | None = None  # Referenced task IDs
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-RPC params."""
+        d: dict[str, Any] = {
+            "message_id": self.message_id,
+            "role": self.role.value,         # Enum value -> string
+            "parts": [p.to_dict() for p in self.parts],
+        }
+        # Optional fields only included when present
+        if self.context_id:
+            d["context_id"] = self.context_id
+        if self.task_id:
+            d["task_id"] = self.task_id
+        if self.metadata:
+            d["metadata"] = self.metadata
+        if self.extensions:
+            d["extensions"] = self.extensions
+        if self.reference_task_ids:
+            d["reference_task_ids"] = self.reference_task_ids
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> A2AMessage:
+        """Deserialize from a JSON-RPC response."""
+        return cls(
+            message_id=d["message_id"],
+            role=Role(d["role"]),
+            parts=[Part.from_dict(p) for p in d.get("parts", [])],
+            context_id=d.get("context_id"),
+            task_id=d.get("task_id"),
+            metadata=d.get("metadata"),
+            extensions=d.get("extensions"),
+            reference_task_ids=d.get("reference_task_ids"),
+        )
+
+
+@dataclass
+class TaskStatus:
+    """A2A task status snapshot.
+
+    Returned by tasks/get or received via SSE events.
+    The message field carries context about the state (e.g. failure reason,
+    interruption prompt, etc.).
+    """
+
+    state: TaskState
+    message: A2AMessage | None = None
+    timestamp: str | None = None             # ISO 8601 timestamp
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TaskStatus:
+        msg = d.get("message")
+        return cls(
+            state=TaskState(d["state"]),
+            message=A2AMessage.from_dict(msg) if msg else None,
+            timestamp=d.get("timestamp"),
+        )
+
+
+@dataclass
+class Artifact:
+    """A2A task artifact — output produced by the agent.
+
+    Examples of artifacts:
+        - Translated text
+        - Generated code
+        - Analysis report
+
+    A single Task can have multiple Artifacts (multi-step output).
+    """
+
+    artifact_id: str
+    parts: list[Part]                        # Artifact content
+    name: str | None = None
+    description: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Artifact:
+        return cls(
+            artifact_id=d["artifact_id"],
+            parts=[Part.from_dict(p) for p in d.get("parts", [])],
+            name=d.get("name"),
+            description=d.get("description"),
+            metadata=d.get("metadata"),
+        )
+
+
+@dataclass
+class A2ATask:
+    """A2A Task — the core protocol object.
+
+    A single message/send call creates a Task with a full lifecycle:
+        SUBMITTED -> WORKING -> COMPLETED/FAILED/INPUT_REQUIRED/...
+
+    Fields:
+        - id:         Unique task ID (-> LangGraph checkpoint_id)
+        - context_id: Conversation ID (-> LangGraph thread_id)
+        - status:     Current state snapshot
+        - artifacts:  Output artifacts list
+        - history:    Full message history
+    """
+
+    id: str
+    status: TaskStatus
+    context_id: str | None = None
+    artifacts: list[Artifact] = field(default_factory=list)
+    history: list[A2AMessage] = field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> A2ATask:
+        return cls(
+            id=d["id"],
+            status=TaskStatus.from_dict(d["status"]),
+            context_id=d.get("context_id"),
+            artifacts=[Artifact.from_dict(a) for a in d.get("artifacts", [])],
+            history=[A2AMessage.from_dict(m) for m in d.get("history", [])],
+            metadata=d.get("metadata"),
+        )
+
+
+@dataclass
+class AgentSkill:
+    """A skill declared by the agent in its Agent Card.
+
+    Used for service discovery — callers can select agents
+    based on tags/description.
+    """
+
+    id: str
+    name: str
+    description: str
+    tags: list[str] = field(default_factory=list)
+    examples: list[str] | None = None        # Example inputs
+    input_modes: list[str] | None = None     # Supported input formats
+    output_modes: list[str] | None = None    # Supported output formats
+
+
+@dataclass
+class AgentCapabilities:
+    """Agent capability declarations.
+
+    A2ARemoteGraph uses these to decide communication strategy:
+        - streaming=True  -> use message/stream (SSE)
+        - streaming=False -> use message/send + poll tasks/get
+    """
+
+    streaming: bool = False
+    push_notifications: bool = False
+    extended_agent_card: bool = False
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AgentCapabilities:
+        return cls(
+            streaming=d.get("streaming", False),
+            push_notifications=d.get("push_notifications", False),
+            extended_agent_card=d.get("extended_agent_card", False),
+        )
+
+
+@dataclass
+class AgentInterface:
+    """Agent communication interface declaration.
+
+    An agent can support multiple protocol bindings (HTTP, gRPC, WebSocket, etc.).
+    We only care about protocol_binding == "JSONRPC".
+    """
+
+    url: str                                 # JSON-RPC endpoint URL
+    protocol_binding: str                    # "JSONRPC" / "HTTP" / ...
+    protocol_version: str                    # "1.0"
+    tenant: str | None = None                # Multi-tenancy identifier
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AgentInterface:
+        return cls(
+            url=d["url"],
+            protocol_binding=d["protocol_binding"],
+            protocol_version=d["protocol_version"],
+            tenant=d.get("tenant"),
+        )
+
+
+@dataclass
+class AgentCard:
+    """Agent Card — A2A's service discovery mechanism.
+
+    Similar to an OpenAPI spec: describes who an agent is, what it can do,
+    and how to call it. Typically hosted at /.well-known/agent-card.json:
+        https://agent.example.com/.well-known/agent-card.json
+
+    A2ARemoteGraph.from_agent_card_sync() fetches and parses the Agent Card
+    to extract the JSON-RPC endpoint and capability declarations.
+    """
+
+    name: str                                # Agent name
+    description: str                         # Agent description
+    version: str                             # Agent version
+    supported_interfaces: list[AgentInterface]  # Communication interfaces
+    capabilities: AgentCapabilities          # Capability declarations
+    skills: list[AgentSkill]                 # Skill list
+    default_input_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+    default_output_modes: list[str] = field(default_factory=lambda: ["text/plain"])
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AgentCard:
+        skills = [
+            AgentSkill(
+                id=s["id"],
+                name=s["name"],
+                description=s["description"],
+                tags=s.get("tags", []),
+                examples=s.get("examples"),
+                input_modes=s.get("input_modes"),
+                output_modes=s.get("output_modes"),
+            )
+            for s in d.get("skills", [])
+        ]
+        return cls(
+            name=d["name"],
+            description=d["description"],
+            version=d["version"],
+            supported_interfaces=[
+                AgentInterface.from_dict(i)
+                for i in d.get("supported_interfaces", [])
+            ],
+            capabilities=AgentCapabilities.from_dict(d.get("capabilities", {})),
+            skills=skills,
+            default_input_modes=d.get("default_input_modes", ["text/plain"]),
+            default_output_modes=d.get("default_output_modes", ["text/plain"]),
+        )
+
+    @property
+    def jsonrpc_url(self) -> str | None:
+        """Find the JSON-RPC endpoint URL from supported_interfaces.
+
+        Returns None if no JSONRPC interface is declared;
+        the caller will fall back to deriving it from the Agent Card URL.
+        """
+        for iface in self.supported_interfaces:
+            if iface.protocol_binding == "JSONRPC":
+                return iface.url
+        return None
+
+
+# --------------------------------------------------------------------------- #
+#  A2A error
+# --------------------------------------------------------------------------- #
+
+
+class A2AClientError(Exception):
+    """Wraps a JSON-RPC 2.0 error response.
+
+    Raised when the remote agent returns {"error": {"code": -32600, "message": "..."}}.
+    Error codes follow the JSON-RPC 2.0 spec:
+        - -32700: Parse error
+        - -32600: Invalid Request
+        - -32601: Method not found
+        - -32602: Invalid params
+        - -32603: Internal error
+        - Custom negative codes: Application-level errors
+    """
+
+    def __init__(self, code: int, message: str, data: Any = None):
+        self.code = code
+        self.data = data
+        super().__init__(f"A2A error {code}: {message}")
+
+
+# --------------------------------------------------------------------------- #
+#  Sync JSON-RPC client
+# --------------------------------------------------------------------------- #
+
+
+class SyncA2AClient:
+    """Synchronous A2A JSON-RPC 2.0 client.
+
+    Built on httpx.Client, provides:
+        - send_message():           message/send (request/response)
+        - send_streaming_message(): message/stream (SSE streaming)
+        - get_task():               tasks/get (query task state)
+        - cancel_task():            tasks/cancel (cancel a task)
+        - fetch_agent_card():       GET Agent Card (service discovery)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+    ):
+        self.url = url.rstrip("/")           # Strip trailing slash to prevent //
+        # Standard JSON-RPC request headers
+        h = {"Content-Type": "application/json", "Accept": "application/json"}
+        if api_key:
+            h["Authorization"] = f"Bearer {api_key}"  # Bearer token auth
+        if headers:
+            h.update(headers)                # Custom headers can override defaults
+        self._http = httpx.Client(headers=h, timeout=timeout or _DEFAULT_TIMEOUT)
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        self._http.close()
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Make a single JSON-RPC 2.0 call.
+
+        Builds the standard JSON-RPC payload:
+            {"jsonrpc": "2.0", "id": "<uuid>", "method": "...", "params": {...}}
+
+        Returns the `result` field from the response.
+        Raises A2AClientError if the response contains an `error` field.
+        """
+        payload = {
+            "jsonrpc": _JSONRPC_VERSION,
+            "id": str(uuid.uuid4()),         # Request ID for correlating req/resp
+            "method": method,
+            "params": params,
+        }
+        resp = self._http.post(self.url, json=payload)
+        resp.raise_for_status()              # Check HTTP-level errors (4xx/5xx) first
+        body = resp.json()
+        if "error" in body:                  # Then check JSON-RPC-level errors
+            e = body["error"]
+            raise A2AClientError(e["code"], e["message"], e.get("data"))
+        return body.get("result", {})
+
+    def send_message(
+        self,
+        message: A2AMessage,
+        *,
+        configuration: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call message/send — send a message and wait for a full response.
+
+        Response is typically a Task dict (with id + status),
+        but may also be a Message dict (with message_id).
+        """
+        params: dict[str, Any] = {"message": message.to_dict()}
+        if configuration:
+            params["configuration"] = configuration
+        if metadata:
+            params["metadata"] = metadata
+        return self._call("message/send", params)
+
+    def send_streaming_message(
+        self,
+        message: A2AMessage,
+        *,
+        configuration: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Call message/stream — send a message and receive SSE events.
+
+        SSE event format:
+            data: {"id": "task_1", "status": {"state": "TASK_STATE_WORKING"}}
+            data: {"task_id": "task_1", "artifact": {"artifact_id": "a1", ...}}
+            data: {"id": "task_1", "status": {"state": "TASK_STATE_COMPLETED"}, ...}
+
+        Each `data:` line is parsed into a dict and yielded.
+        Uses httpx.stream() context manager to avoid loading the entire response
+        into memory.
+        """
+        params: dict[str, Any] = {"message": message.to_dict()}
+        if configuration:
+            params["configuration"] = configuration
+        if metadata:
+            params["metadata"] = metadata
+        payload = {
+            "jsonrpc": _JSONRPC_VERSION,
+            "id": str(uuid.uuid4()),
+            "method": "message/stream",
+            "params": params,
+        }
+        with self._http.stream("POST", self.url, json=payload) as resp:
+            resp.raise_for_status()
+            yield from _iter_sse_lines(resp.iter_lines())
+
+    def get_task(
+        self, task_id: str, *, history_length: int | None = None
+    ) -> dict[str, Any]:
+        """Call tasks/get — query the current state of a task.
+
+        Used for polling: called repeatedly after send_message until the
+        state becomes terminal. history_length limits the returned message
+        history count.
+        """
+        params: dict[str, Any] = {"id": task_id}
+        if history_length is not None:
+            params["history_length"] = history_length
+        return self._call("tasks/get", params)
+
+    def cancel_task(self, task_id: str) -> dict[str, Any]:
+        """Call tasks/cancel — cancel an in-progress task."""
+        return self._call("tasks/cancel", {"id": task_id})
+
+    def fetch_agent_card(self, card_url: str) -> AgentCard:
+        """GET request to fetch an Agent Card (plain HTTP GET, not JSON-RPC).
+
+        Agent Cards are typically at /.well-known/agent-card.json
+        """
+        resp = self._http.get(card_url)
+        resp.raise_for_status()
+        return AgentCard.from_dict(resp.json())
+
+
+# --------------------------------------------------------------------------- #
+#  Async JSON-RPC client
+# --------------------------------------------------------------------------- #
+
+
+class AsyncA2AClient:
+    """Asynchronous A2A JSON-RPC 2.0 client.
+
+    Symmetric with SyncA2AClient, built on httpx.AsyncClient.
+    All method signatures and logic are identical, just with async/await.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+    ):
+        self.url = url.rstrip("/")
+        h = {"Content-Type": "application/json", "Accept": "application/json"}
+        if api_key:
+            h["Authorization"] = f"Bearer {api_key}"
+        if headers:
+            h.update(headers)
+        self._http = httpx.AsyncClient(headers=h, timeout=timeout or _DEFAULT_TIMEOUT)
+
+    async def close(self) -> None:
+        """Close the underlying async HTTP connection pool."""
+        await self._http.aclose()
+
+    async def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Async JSON-RPC 2.0 call; logic mirrors SyncA2AClient._call."""
+        payload = {
+            "jsonrpc": _JSONRPC_VERSION,
+            "id": str(uuid.uuid4()),
+            "method": method,
+            "params": params,
+        }
+        resp = await self._http.post(self.url, json=payload)
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body:
+            e = body["error"]
+            raise A2AClientError(e["code"], e["message"], e.get("data"))
+        return body.get("result", {})
+
+    async def send_message(
+        self,
+        message: A2AMessage,
+        *,
+        configuration: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Async message/send."""
+        params: dict[str, Any] = {"message": message.to_dict()}
+        if configuration:
+            params["configuration"] = configuration
+        if metadata:
+            params["metadata"] = metadata
+        return await self._call("message/send", params)
+
+    async def send_streaming_message(
+        self,
+        message: A2AMessage,
+        *,
+        configuration: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Async message/stream (SSE)."""
+        params: dict[str, Any] = {"message": message.to_dict()}
+        if configuration:
+            params["configuration"] = configuration
+        if metadata:
+            params["metadata"] = metadata
+        payload = {
+            "jsonrpc": _JSONRPC_VERSION,
+            "id": str(uuid.uuid4()),
+            "method": "message/stream",
+            "params": params,
+        }
+        async with self._http.stream("POST", self.url, json=payload) as resp:
+            resp.raise_for_status()
+            async for event in _aiter_sse_lines(resp.aiter_lines()):
+                yield event
+
+    async def get_task(
+        self, task_id: str, *, history_length: int | None = None
+    ) -> dict[str, Any]:
+        """Async tasks/get."""
+        params: dict[str, Any] = {"id": task_id}
+        if history_length is not None:
+            params["history_length"] = history_length
+        return await self._call("tasks/get", params)
+
+    async def cancel_task(self, task_id: str) -> dict[str, Any]:
+        """Async tasks/cancel."""
+        return await self._call("tasks/cancel", {"id": task_id})
+
+    async def fetch_agent_card(self, card_url: str) -> AgentCard:
+        """Async Agent Card fetch."""
+        resp = await self._http.get(card_url)
+        resp.raise_for_status()
+        return AgentCard.from_dict(resp.json())
+
+
+# --------------------------------------------------------------------------- #
+#  SSE helpers
+# --------------------------------------------------------------------------- #
+
+
+def _iter_sse_lines(lines: Iterator[str]) -> Iterator[dict[str, Any]]:
+    """Parse an SSE (Server-Sent Events) stream.
+
+    SSE format: each event line starts with "data:", followed by a JSON string:
+        data: {"id": "task_1", "status": {"state": "TASK_STATE_WORKING"}}
+        (blank line)
+        data: {"task_id": "task_1", "artifact": {...}}
+
+    Malformed lines are logged at debug level and skipped without breaking
+    the stream.
+    """
+    for line in lines:
+        if line.startswith("data:"):
+            data_str = line[5:].strip()      # Strip "data:" prefix and whitespace
+            if data_str:
+                try:
+                    yield json.loads(data_str)
+                except json.JSONDecodeError:
+                    logger.debug("Skipping malformed SSE data: %s", data_str)
+
+
+async def _aiter_sse_lines(
+    lines: AsyncIterator[str],
+) -> AsyncIterator[dict[str, Any]]:
+    """Async SSE parser; logic mirrors _iter_sse_lines."""
+    async for line in lines:
+        if line.startswith("data:"):
+            data_str = line[5:].strip()
+            if data_str:
+                try:
+                    yield json.loads(data_str)
+                except json.JSONDecodeError:
+                    logger.debug("Skipping malformed SSE data: %s", data_str)

--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -327,3 +327,32 @@ def _exclude_as_metadata(key: str, value: Any, metadata: Mapping[str, Any]) -> b
         or key in metadata
         or any(substr in key_lower for substr in _OMIT)
     )
+
+
+def sanitize_config_value(v: Any) -> Any:
+    """Recursively sanitize a config value to ensure it contains only primitives.
+
+    Returns ``None`` for values that cannot be serialized to JSON.
+    Used by ``RemoteGraph`` and ``A2ARemoteGraph`` to strip non-serializable
+    entries before sending configs over the wire.
+    """
+    from uuid import UUID
+
+    if isinstance(v, (str, int, float, bool, UUID)):
+        return v
+    elif isinstance(v, dict):
+        sanitized_dict = {}
+        for k, val in v.items():
+            if isinstance(k, str):
+                sanitized_value = sanitize_config_value(val)
+                if sanitized_value is not None:
+                    sanitized_dict[k] = sanitized_value
+        return sanitized_dict
+    elif isinstance(v, (list, tuple)):
+        sanitized_list = []
+        for item in v:
+            sanitized_item = sanitize_config_value(item)
+            if sanitized_item is not None:
+                sanitized_list.append(sanitized_item)
+        return sanitized_list
+    return None

--- a/libs/langgraph/langgraph/pregel/a2a_remote.py
+++ b/libs/langgraph/langgraph/pregel/a2a_remote.py
@@ -1,0 +1,1293 @@
+"""A2ARemoteGraph — LangGraph adapter for remote A2A agents.
+
+This module bridges two fundamentally different state models:
+    - LangGraph: checkpoint-based, with thread_id / checkpoint_id / messages
+    - A2A: task-based, with context_id / task_id / parts
+
+Key mappings:
+    LangGraph thread_id      <-> A2A context_id
+    LangGraph checkpoint_id  <-> A2A task_id
+    LangGraph messages       <-> A2A parts
+    LangGraph GraphInterrupt <-> A2A INPUT_REQUIRED / AUTH_REQUIRED
+    LangGraph StreamMode     <-> A2A SSE events
+
+Implements `PregelProtocol` so it can be used anywhere a `CompiledGraph`
+or `RemoteGraph` is accepted — including `builder.add_node("agent", a2a)`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterator, Sequence
+from typing import Any, Literal, overload
+
+from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables.graph import (
+    Edge as DrawableEdge,
+)
+from langchain_core.runnables.graph import (
+    Graph as DrawableGraph,
+)
+from langchain_core.runnables.graph import (
+    Node as DrawableNode,
+)
+from typing_extensions import Self
+
+from langgraph._internal._a2a import (
+    A2AClientError,
+    A2AMessage,
+    A2ATask,
+    AgentCard,
+    Artifact,
+    AsyncA2AClient,
+    Part,
+    Role,
+    SyncA2AClient,
+    TaskState,
+    TaskStatus,
+)
+from langgraph._internal._config import merge_configs, sanitize_config_value
+from langgraph._internal._constants import (
+    CONF,
+    CONFIG_KEY_CHECKPOINT_ID,
+    CONFIG_KEY_CHECKPOINT_MAP,
+    CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_STREAM,
+    CONFIG_KEY_TASK_ID,
+    INTERRUPT,
+    NS_SEP,
+)
+from langgraph.checkpoint.base import CheckpointMetadata
+from langgraph.errors import GraphInterrupt
+from langgraph.pregel.protocol import PregelProtocol, StreamProtocol
+from langgraph.types import (
+    All,
+    Command,
+    GraphOutput,
+    Interrupt,
+    PregelTask,
+    StateSnapshot,
+    StreamMode,
+)
+# Note: StreamPart comes from langgraph_sdk.schema (NamedTuple, instantiable),
+# NOT from langgraph.types.StreamPart (TypeAliasType, not instantiable).
+# RemoteGraph uses the same import.
+from langgraph_sdk.schema import StreamPart
+
+logger = logging.getLogger(__name__)
+
+__all__ = ("A2ARemoteGraph",)
+
+# LangGraph-internal config keys that must be stripped before sending to
+# remote A2A agents — they are LangGraph-specific and the remote agent
+# would not understand them.
+_CONF_DROPLIST = frozenset(
+    (
+        CONFIG_KEY_CHECKPOINT_MAP,
+        CONFIG_KEY_CHECKPOINT_ID,
+        CONFIG_KEY_CHECKPOINT_NS,
+        CONFIG_KEY_TASK_ID,
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+#  State conversion: LangGraph <-> A2A
+# --------------------------------------------------------------------------- #
+
+
+def _messages_to_parts(messages: list[Any]) -> list[Part]:
+    """Convert LangGraph messages into A2A Parts.
+
+    LangGraph messages come in at least 4 formats, all handled:
+        1. dict:   {"role": "user", "content": "hi"}
+        2. tuple:  ("user", "hi")
+        3. object: HumanMessage(content="hi")
+        4. multimodal: {"content": [{"type": "text", "text": "hi"}, ...]}
+    """
+    parts: list[Part] = []
+    for msg in messages:
+        # Step 1: Extract content from different message formats
+        if isinstance(msg, dict):
+            content = msg.get("content", "")
+        elif isinstance(msg, tuple):
+            # ("user", "hi") format
+            content = msg[1] if len(msg) > 1 else ""
+        elif hasattr(msg, "content"):
+            # BaseMessage objects (HumanMessage, AIMessage, etc.)
+            content = msg.content
+        else:
+            content = str(msg)
+
+        # Step 2: Content itself may also come in multiple formats
+        if isinstance(content, str):
+            # Plain string -> single text Part
+            parts.append(Part(text=content))
+        elif isinstance(content, list):
+            # Multimodal content list -> process each item
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(Part(text=item))
+                elif isinstance(item, dict) and "text" in item:
+                    # {"type": "text", "text": "..."}
+                    parts.append(Part(text=item["text"]))
+                elif isinstance(item, dict):
+                    # Structured data (image URLs, etc.)
+                    parts.append(Part(data=item))
+        else:
+            parts.append(Part(text=str(content)))
+    return parts
+
+
+def _last_user_messages(messages: list[Any]) -> list[Any]:
+    """Extract the trailing contiguous block of user messages.
+
+    A2A uses a "send message" model rather than sending the full history.
+    Only the last round of user messages is sent.
+
+    Examples:
+        [user, assistant, user, user] -> [user, user] (last two)
+        [user, assistant, user]       -> [user]       (last one)
+        [user, assistant]             -> [assistant]  (no trailing user, take last msg)
+    """
+    result: list[Any] = []
+    for msg in reversed(messages):
+        # Extract role from different message formats
+        role = None
+        if isinstance(msg, dict):
+            role = msg.get("role", msg.get("type"))
+        elif isinstance(msg, tuple):
+            role = msg[0]
+        elif hasattr(msg, "type"):
+            role = msg.type
+
+        if role in ("user", "human"):
+            result.insert(0, msg)            # Preserve original order
+        elif result:
+            break                            # Hit non-user msg after collecting some -> stop
+    # Fall back to the last message (regardless of role) if no trailing user messages
+    return result if result else messages[-1:] if messages else []
+
+
+def _task_to_ai_messages(task: A2ATask) -> list[dict[str, Any]]:
+    """Convert an A2A Task into a list of LangGraph AI message dicts.
+
+    Extracts content from two sources:
+        1. task.status.message — the latest status message
+        2. task.artifacts      — output artifacts produced by the agent
+
+    Uses a `seen` set to deduplicate: some agents put the same text in
+    both places. Falls back to a placeholder message if both are empty.
+    """
+    messages: list[dict[str, Any]] = []
+    seen: set[str] = set()                   # For deduplication
+
+    def _add(text: str) -> None:
+        """Add an AI message, automatically deduplicating."""
+        if text and text not in seen:
+            seen.add(text)
+            messages.append({"role": "assistant", "type": "ai", "content": text})
+
+    # Source 1: Status message (only process AGENT role)
+    if task.status.message and task.status.message.role == Role.AGENT:
+        for part in task.status.message.parts:
+            if part.text:
+                _add(part.text)
+            elif part.data:
+                _add(json.dumps(part.data))  # Structured data -> JSON string
+
+    # Source 2: Artifacts
+    for artifact in task.artifacts:
+        for part in artifact.parts:
+            if part.text:
+                _add(part.text)
+            elif part.data:
+                _add(json.dumps(part.data))
+
+    # Fallback: generate a placeholder if both sources are empty
+    if not messages:
+        messages.append({
+            "role": "assistant",
+            "type": "ai",
+            "content": f"[A2A task {task.status.state.value}]",
+        })
+    return messages
+
+
+# --------------------------------------------------------------------------- #
+#  A2ARemoteGraph
+# --------------------------------------------------------------------------- #
+
+
+class A2ARemoteGraph(PregelProtocol):
+    """Client for calling remote A2A-compliant agents.
+
+    Unlike `RemoteGraph` which only talks to LangGraph Server,
+    `A2ARemoteGraph` uses the A2A JSON-RPC 2.0 protocol and can
+    communicate with agents built on any framework.
+
+    Can be used directly as a node in `StateGraph`:
+
+        a2a = A2ARemoteGraph("https://agent.example.com/a2a", name="translator")
+        builder = StateGraph(MessagesState)
+        builder.add_node("translator", a2a)
+    """
+
+    name: str
+
+    def __init__(
+        self,
+        url: str,
+        /,
+        *,
+        name: str | None = None,
+        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
+        client: AsyncA2AClient | None = None,
+        sync_client: SyncA2AClient | None = None,
+        config: RunnableConfig | None = None,
+        agent_card: AgentCard | None = None,
+    ):
+        """Create an A2A remote graph.
+
+        Specify ``url``, ``api_key`` and/or ``headers`` to create default
+        sync and async clients. Pre-built ``client`` / ``sync_client``
+        instances are used when provided (mainly for injecting mocks in tests).
+
+        Args:
+            url: The A2A JSON-RPC endpoint URL.
+            name: Human-readable node name. Defaults to ``"a2a_agent"``.
+            api_key: Bearer token for the ``Authorization`` header.
+            headers: Extra HTTP headers forwarded to both clients.
+            client: An existing async A2A client.
+            sync_client: An existing sync A2A client.
+            config: Optional base ``RunnableConfig``.
+            agent_card: A pre-fetched ``AgentCard``. When provided the
+                agent's capabilities are used to auto-configure streaming.
+        """
+        self.name = name or "a2a_agent"
+        self.url = url
+        self.config = config
+        self.agent_card = agent_card
+
+        # Auto-create clients if not injected (standard production usage)
+        if client is None:
+            client = AsyncA2AClient(url, api_key=api_key, headers=headers)
+        self.client = client
+
+        if sync_client is None:
+            sync_client = SyncA2AClient(url, api_key=api_key, headers=headers)
+        self.sync_client = sync_client
+
+    # -- factory ------------------------------------------------------------ #
+
+    @classmethod
+    def from_agent_card_sync(
+        cls,
+        card_url: str,
+        *,
+        name: str | None = None,
+        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> A2ARemoteGraph:
+        """Discover an agent via its Agent Card URL (sync).
+
+        Flow:
+            1. Create a temporary client to fetch the Agent Card (GET card_url)
+            2. Find the JSON-RPC endpoint from the Card's supported_interfaces
+            3. Create an A2ARemoteGraph instance with the resolved endpoint
+
+        Falls back to the Card URL's base URL if no JSONRPC interface is declared.
+        """
+        tmp = SyncA2AClient(card_url, api_key=api_key, headers=headers)
+        try:
+            card = tmp.fetch_agent_card(card_url)
+        finally:
+            tmp.close()                      # Temp client closed after use
+        # Prefer the JSONRPC URL declared in the Card; derive from Card URL otherwise
+        endpoint = card.jsonrpc_url or card_url.rsplit("/.well-known/", 1)[0]
+        return cls(
+            endpoint,
+            name=name or card.name,          # Default to the Card's agent name
+            api_key=api_key,
+            headers=headers,
+            agent_card=card,
+        )
+
+    @classmethod
+    async def from_agent_card(
+        cls,
+        card_url: str,
+        *,
+        name: str | None = None,
+        api_key: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> A2ARemoteGraph:
+        """Discover an agent via its Agent Card URL (async).
+
+        Async version; logic mirrors from_agent_card_sync.
+        """
+        tmp = AsyncA2AClient(card_url, api_key=api_key, headers=headers)
+        try:
+            card = await tmp.fetch_agent_card(card_url)
+        finally:
+            await tmp.close()
+        endpoint = card.jsonrpc_url or card_url.rsplit("/.well-known/", 1)[0]
+        return cls(
+            endpoint,
+            name=name or card.name,
+            api_key=api_key,
+            headers=headers,
+            agent_card=card,
+        )
+
+    # -- copy / config ------------------------------------------------------ #
+
+    def copy(self, update: dict[str, Any]) -> Self:
+        """Create a shallow copy of this instance, overriding specified attrs."""
+        attrs = {**self.__dict__, **update}
+        return self.__class__(attrs.pop("url"), **attrs)
+
+    def with_config(
+        self, config: RunnableConfig | None = None, **kwargs: Any
+    ) -> Self:
+        """Create a new instance with merged config (original is not mutated).
+
+        Consistent with RemoteGraph.with_config behavior:
+            copy = graph.with_config({"configurable": {"thread_id": "t1"}})
+            assert copy is not graph  # New instance
+        """
+        return self.copy(
+            {"config": merge_configs(self.config, config, dict(kwargs))}
+        )
+
+    # -- graph introspection ------------------------------------------------ #
+
+    def get_graph(
+        self,
+        config: RunnableConfig | None = None,
+        *,
+        xray: int | bool = False,
+    ) -> DrawableGraph:
+        """Return a minimal drawable graph.
+
+        A2A agents are opaque — their internal topology is not exposed.
+        Returns a single-node graph: __start__ -> agent -> __end__
+        This is the correct semantic representation: from the outside it's a black box.
+        """
+        node = DrawableNode(id="0", name=self.name, data={}, metadata=None)
+        start = DrawableNode(id="__start__", name="__start__", data={}, metadata=None)
+        end = DrawableNode(id="__end__", name="__end__", data={}, metadata=None)
+        return DrawableGraph(
+            nodes={"__start__": start, "0": node, "__end__": end},
+            edges=[
+                DrawableEdge(source="__start__", target="0"),
+                DrawableEdge(source="0", target="__end__"),
+            ],
+        )
+
+    async def aget_graph(
+        self,
+        config: RunnableConfig | None = None,
+        *,
+        xray: int | bool = False,
+    ) -> DrawableGraph:
+        """Async get_graph; delegates to sync version (no I/O needed)."""
+        return self.get_graph(config, xray=xray)
+
+    # -- state management --------------------------------------------------- #
+
+    def _context_id(self, config: RunnableConfig | None) -> str:
+        """Extract thread_id from LangGraph config as A2A context_id.
+
+        Generates a UUID if no thread_id is present (creates a new conversation).
+        """
+        if config and "configurable" in config:
+            return config["configurable"].get("thread_id", str(uuid.uuid4()))
+        return str(uuid.uuid4())
+
+    def _task_id(self, config: RunnableConfig | None) -> str | None:
+        """Extract checkpoint_id from LangGraph config as A2A task_id.
+
+        Returns None if no checkpoint_id (new conversation, no existing task).
+        """
+        if config and "configurable" in config:
+            return config["configurable"].get("checkpoint_id")
+        return None
+
+    def _task_to_snapshot(self, task: A2ATask) -> StateSnapshot:
+        """Convert an A2A Task into a LangGraph StateSnapshot.
+
+        This is the core conversion in the adapter layer:
+            - A2A terminal (COMPLETED/FAILED/...)    -> next=(), graph execution done
+            - A2A interrupted (INPUT_REQUIRED/...)    -> next=(), with interrupts
+            - A2A in-progress (WORKING/SUBMITTED)     -> next=(self.name,), still running
+            - A2A FAILED                              -> pregel_task.error is set
+
+        metadata.source="a2a" marks the data source; step=-1 because A2A
+        doesn't expose the step concept.
+        """
+        is_done = task.status.state.is_terminal
+        is_interrupted = task.status.state.is_interrupted
+
+        # Build interrupt info for INPUT_REQUIRED / AUTH_REQUIRED
+        interrupts: tuple[Interrupt, ...] = ()
+        if is_interrupted:
+            msg = ""
+            if task.status.message:
+                texts = [p.text for p in task.status.message.parts if p.text]
+                msg = "\n".join(texts)
+            interrupts = (Interrupt(value=msg or task.status.state.value),)
+
+        # Determine next nodes: only non-terminal + non-interrupted have next
+        next_nodes: tuple[str, ...] = ()
+        if not is_done and not is_interrupted:
+            next_nodes = (self.name,)
+
+        values = {"messages": _task_to_ai_messages(task)}
+
+        # PregelTask is LangGraph's internal task representation
+        pregel_task = PregelTask(
+            id=task.id,
+            name=self.name,
+            path=(),
+            error=(
+                # Extract error message from status.message if FAILED
+                Exception(task.status.message.parts[0].text)
+                if task.status.state == TaskState.FAILED
+                and task.status.message
+                and task.status.message.parts
+                and task.status.message.parts[0].text
+                else None
+            ),
+            interrupts=interrupts,
+        )
+
+        return StateSnapshot(
+            values=values,
+            next=next_nodes,
+            config={
+                "configurable": {
+                    "thread_id": task.context_id or "",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": task.id,    # Map task_id back to checkpoint_id
+                }
+            },
+            metadata=CheckpointMetadata(
+                source="a2a",                    # Mark origin
+                step=-1,                         # A2A doesn't expose step
+                writes={},
+                parents={},
+            ),
+            created_at=task.status.timestamp,
+            parent_config=None,
+            tasks=(pregel_task,),
+            interrupts=interrupts,
+        )
+
+    def get_state(
+        self,
+        config: RunnableConfig,
+        *,
+        subgraphs: bool = False,
+    ) -> StateSnapshot:
+        """Fetch the current A2A task state.
+
+        Maps ``configurable.checkpoint_id`` to the A2A task ID and calls
+        ``tasks/get`` via JSON-RPC. Requires checkpoint_id to be present
+        in the config.
+        """
+        merged = merge_configs(self.config, config)
+        task_id = self._task_id(merged)
+        if not task_id:
+            raise ValueError(
+                "No task ID found: set `checkpoint_id` in the config's "
+                "`configurable` dict to the A2A task ID."
+            )
+        raw = self.sync_client.get_task(task_id)
+        return self._task_to_snapshot(A2ATask.from_dict(raw))
+
+    async def aget_state(
+        self,
+        config: RunnableConfig,
+        *,
+        subgraphs: bool = False,
+    ) -> StateSnapshot:
+        """Async version of `get_state`."""
+        merged = merge_configs(self.config, config)
+        task_id = self._task_id(merged)
+        if not task_id:
+            raise ValueError(
+                "No task ID found: set `checkpoint_id` in the config's "
+                "`configurable` dict to the A2A task ID."
+            )
+        raw = await self.client.get_task(task_id)
+        return self._task_to_snapshot(A2ATask.from_dict(raw))
+
+    def get_state_history(
+        self,
+        config: RunnableConfig,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> Iterator[StateSnapshot]:
+        """Yield a single state snapshot.
+
+        A2A protocol does not expose a checkpoint history — only the current
+        task state is available. Yields one entry for interface compatibility.
+        """
+        yield self.get_state(config)
+
+    async def aget_state_history(
+        self,
+        config: RunnableConfig,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[StateSnapshot]:
+        """Async version of get_state_history."""
+        yield await self.aget_state(config)
+
+    def update_state(
+        self,
+        config: RunnableConfig,
+        values: dict[str, Any] | Any | None,
+        as_node: str | None = None,
+    ) -> RunnableConfig:
+        """Not supported — A2A agents are opaque.
+
+        A2A agents are black boxes; their internal state cannot be modified
+        directly. To continue a conversation, send a new message via invoke().
+        """
+        raise NotImplementedError(
+            "A2A agents do not support direct state updates. "
+            "Send a new message via invoke() instead."
+        )
+
+    async def aupdate_state(
+        self,
+        config: RunnableConfig,
+        values: dict[str, Any] | Any | None,
+        as_node: str | None = None,
+    ) -> RunnableConfig:
+        """Async update_state — also not supported."""
+        raise NotImplementedError(
+            "A2A agents do not support direct state updates. "
+            "Send a new message via ainvoke() instead."
+        )
+
+    def bulk_update_state(
+        self,
+        config: RunnableConfig,
+        updates: list[tuple[dict[str, Any] | None, str | None]],
+    ) -> RunnableConfig:
+        raise NotImplementedError
+
+    async def abulk_update_state(
+        self,
+        config: RunnableConfig,
+        updates: list[tuple[dict[str, Any] | None, str | None]],
+    ) -> RunnableConfig:
+        raise NotImplementedError
+
+    # -- helpers ------------------------------------------------------------ #
+
+    def _sanitize_config(self, config: RunnableConfig) -> RunnableConfig:
+        """Sanitize config to make it safe for sending to remote A2A agents.
+
+        Does three things:
+            1. tags:         keep only string-typed tags
+            2. metadata:     recursively drop non-JSON-serializable values
+            3. configurable: drop LangGraph-internal keys + non-serializable values
+
+        Aligned with RemoteGraph._sanitize_config logic.
+        """
+        sanitized: RunnableConfig = {}
+        if "tags" in config:
+            sanitized["tags"] = [t for t in config["tags"] if isinstance(t, str)]
+        if "metadata" in config:
+            sanitized["metadata"] = {
+                k: sv
+                for k, v in config["metadata"].items()
+                if isinstance(k, str)
+                and (sv := sanitize_config_value(v)) is not None
+            }
+        if "configurable" in config:
+            sanitized["configurable"] = {
+                k: sv
+                for k, v in config["configurable"].items()
+                if isinstance(k, str)
+                and k not in _CONF_DROPLIST   # Drop internal keys
+                and (sv := sanitize_config_value(v)) is not None  # Drop non-serializable
+            }
+        return sanitized
+
+    def _build_a2a_message(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig,
+    ) -> A2AMessage:
+        """Build an A2A message from LangGraph input.
+
+        Flow:
+            1. Extract messages list from input
+            2. Get the trailing user messages (_last_user_messages)
+            3. Convert to A2A Parts (_messages_to_parts)
+            4. Attach context_id (from thread_id) and task_id (from checkpoint_id)
+        """
+        if isinstance(input, dict):
+            messages = input.get("messages", [])
+        else:
+            messages = [input] if input else []
+        user_msgs = _last_user_messages(messages)
+        parts = _messages_to_parts(user_msgs)
+        return A2AMessage(
+            message_id=str(uuid.uuid4()),
+            role=Role.USER,
+            parts=parts,
+            context_id=self._context_id(config),
+            task_id=self._task_id(config),
+        )
+
+    def _parse_send_response(self, result: dict[str, Any]) -> A2ATask:
+        """Parse the message/send response.
+
+        A2A spec allows two response formats:
+            1. Task dict (has id + status) — standard format
+            2. Message dict (has message_id) — some agents return a message directly
+
+        For format 2, wraps it into a COMPLETED Task.
+        """
+        if "id" in result and "status" in result:
+            return A2ATask.from_dict(result)
+        if "message_id" in result:
+            # Received a Message instead of a Task — wrap it
+            msg = A2AMessage.from_dict(result)
+            return A2ATask(
+                id=msg.task_id or str(uuid.uuid4()),
+                status=TaskStatus(state=TaskState.COMPLETED, message=msg),
+                context_id=msg.context_id,
+            )
+        return A2ATask.from_dict(result)
+
+    def _poll_until_done(
+        self,
+        task: A2ATask,
+        *,
+        initial_interval: float = 0.5,
+        backoff_factor: float = 2.0,
+        max_interval: float = 30.0,
+        max_elapsed: float = 300.0,
+    ) -> A2ATask:
+        """Synchronously poll tasks/get until the task reaches a terminal or interrupted state.
+
+        Uses exponential backoff:
+            Wait sequence: 0.5s -> 1s -> 2s -> 4s -> 8s -> 16s -> 30s -> 30s -> ...
+            Total timeout: 300s (5 minutes)
+
+        Exponential backoff avoids hammering the agent during long-running tasks.
+        """
+        interval = initial_interval
+        elapsed = 0.0
+        while (
+            not task.status.state.is_terminal
+            and not task.status.state.is_interrupted
+        ):
+            if elapsed >= max_elapsed:
+                raise TimeoutError(
+                    f"A2A task {task.id} did not complete within {max_elapsed}s"
+                )
+            time.sleep(interval)
+            elapsed += interval
+            interval = min(interval * backoff_factor, max_interval)
+            raw = self.sync_client.get_task(task.id)
+            task = A2ATask.from_dict(raw)
+        return task
+
+    async def _apoll_until_done(
+        self,
+        task: A2ATask,
+        *,
+        initial_interval: float = 0.5,
+        backoff_factor: float = 2.0,
+        max_interval: float = 30.0,
+        max_elapsed: float = 300.0,
+    ) -> A2ATask:
+        """Async polling; logic mirrors _poll_until_done, uses asyncio.sleep."""
+        interval = initial_interval
+        elapsed = 0.0
+        while (
+            not task.status.state.is_terminal
+            and not task.status.state.is_interrupted
+        ):
+            if elapsed >= max_elapsed:
+                raise TimeoutError(
+                    f"A2A task {task.id} did not complete within {max_elapsed}s"
+                )
+            await asyncio.sleep(interval)
+            elapsed += interval
+            interval = min(interval * backoff_factor, max_interval)
+            raw = await self.client.get_task(task.id)
+            task = A2ATask.from_dict(raw)
+        return task
+
+    def _task_to_output(
+        self,
+        task: A2ATask,
+        config: RunnableConfig | None,
+    ) -> dict[str, Any]:
+        """Process a completed A2A Task and convert to LangGraph output format.
+
+        Three cases:
+            1. Interrupted + called as subgraph -> raise GraphInterrupt
+               (only raises in subgraph context, matching RemoteGraph behavior)
+            2. Failed -> raise A2AClientError
+            3. Normal -> return {"messages": [...]}
+        """
+        if task.status.state.is_interrupted:
+            # Check if this is a subgraph call (checkpoint_ns present = called by parent)
+            caller_ns = (config or {}).get(CONF, {}).get(CONFIG_KEY_CHECKPOINT_NS)
+            if caller_ns:
+                msg = ""
+                if task.status.message:
+                    texts = [p.text for p in task.status.message.parts if p.text]
+                    msg = "\n".join(texts)
+                raise GraphInterrupt(
+                    [Interrupt(value=msg or task.status.state.value)]
+                )
+        if task.status.state == TaskState.FAILED:
+            error_msg = "A2A task failed"
+            if task.status.message and task.status.message.parts:
+                texts = [p.text for p in task.status.message.parts if p.text]
+                if texts:
+                    error_msg = "\n".join(texts)
+            raise A2AClientError(-1, error_msg)
+        return {"messages": _task_to_ai_messages(task)}
+
+    # -- stream ------------------------------------------------------------- #
+
+    def _get_stream_modes(
+        self,
+        stream_mode: StreamMode | list[StreamMode] | None,
+        config: RunnableConfig | None,
+        default: StreamMode = "updates",
+    ) -> tuple[list[StreamMode], list[StreamMode], bool, StreamProtocol | None]:
+        """Parse stream_mode parameter. Aligned with RemoteGraph._get_stream_modes.
+
+        Returns:
+            - updated:    all modes to handle (including parent graph requirements)
+            - requested:  modes explicitly requested by the user
+            - req_single: True if user requested only one mode; affects output format:
+                          single mode: yield data
+                          multi mode:  yield StreamPart(event=mode, data=data)
+            - stream:     parent graph's StreamProtocol (for propagating events upstream)
+        """
+        updated: list[StreamMode] = []
+        req_single = True
+        if stream_mode:
+            if isinstance(stream_mode, str):
+                updated.append(stream_mode)
+            else:
+                req_single = False           # Multiple modes
+                updated.extend(stream_mode)
+        else:
+            updated.append(default)
+        requested = updated.copy()
+        # Check if parent graph requires additional stream modes
+        stream: StreamProtocol | None = (
+            (config or {}).get(CONF, {}).get(CONFIG_KEY_STREAM)
+        )
+        if stream:
+            updated.extend(stream.modes)
+        # Ensure "updates" is always present (needed internally)
+        if "updates" not in updated:
+            updated.append("updates")
+        return updated, requested, req_single, stream
+
+    # -- stream overloads (type signatures: v1 and v2 return different types) - #
+
+    @overload
+    def stream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v2"],
+        **kwargs: Any,
+    ) -> Iterator[StreamPart]: ...
+
+    @overload
+    def stream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v1"] = ...,
+        **kwargs: Any,
+    ) -> Iterator[dict[str, Any] | Any]: ...
+
+    def stream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v1", "v2"] = "v1",
+        **kwargs: Any,
+    ) -> Iterator[dict[str, Any] | Any]:
+        """Send a message and stream A2A events back.
+
+        Selects strategy based on agent's capabilities.streaming:
+            - True  -> _stream_sync (SSE streaming: message/stream)
+            - False -> _stream_fallback_sync (fallback: message/send + polling)
+
+        Defaults to True when no agent_card is available (optimistic strategy).
+        """
+        merged = merge_configs(self.config, config)
+        sanitized = self._sanitize_config(merged)
+        stream_modes, requested, req_single, parent_stream = (
+            self._get_stream_modes(stream_mode, config)
+        )
+
+        msg = self._build_a2a_message(input, merged)
+        supports_streaming = (
+            self.agent_card.capabilities.streaming if self.agent_card else True
+        )
+
+        if supports_streaming:
+            yield from self._stream_sync(
+                msg, merged, sanitized, requested, req_single, parent_stream, version
+            )
+        else:
+            yield from self._stream_fallback_sync(
+                msg, merged, sanitized, requested, req_single, parent_stream, version
+            )
+
+    def _stream_sync(
+        self,
+        msg: A2AMessage,
+        config: RunnableConfig,
+        sanitized_config: RunnableConfig,
+        requested: list[StreamMode],
+        req_single: bool,
+        parent_stream: StreamProtocol | None,
+        version: str,
+    ) -> Iterator[dict[str, Any] | Any]:
+        """Process SSE streaming events (sync version).
+
+        Three types of SSE events:
+            1. Full Task (has id + status)        -> emit "values" event
+            2. Status update (has task_id + status, no id) -> emit "updates" event
+            3. Artifact (has task_id + artifact)   -> emit "updates" event
+
+        Output format depends on version and req_single:
+            - v2:          {"type": "values", "ns": (), "data": ..., "interrupts": ()}
+            - v1 single:   data (yield bare data)
+            - v1 multi:    StreamPart(event="values", data=data)
+        """
+        metadata = sanitized_config.get("metadata")
+        last_task: A2ATask | None = None
+
+        for event in self.sync_client.send_streaming_message(
+            msg, metadata=metadata
+        ):
+            # SSE event may be wrapped in a "result" field (JSON-RPC format)
+            event_data = event.get("result", event)
+
+            # Case 1: Full Task update (contains id + status)
+            if "id" in event_data and "status" in event_data:
+                last_task = A2ATask.from_dict(event_data)
+                output = {"messages": _task_to_ai_messages(last_task)}
+                # Propagate to parent graph if running as subgraph
+                if parent_stream and "values" in parent_stream.modes:
+                    parent_stream(((), "values", output))
+                if "values" in requested:
+                    if version == "v2":
+                        yield {"type": "values", "ns": (), "data": output, "interrupts": ()}
+                    elif req_single:
+                        yield output
+                    else:
+                        yield StreamPart(event="values", data=output)
+
+            # Case 2: Status update (has task_id + status, but no full id -> not a full Task)
+            elif "status" in event_data and "task_id" in event_data:
+                status = TaskStatus.from_dict(event_data["status"])
+                update = {self.name: {"status": status.state.value}}
+                if parent_stream and "updates" in parent_stream.modes:
+                    parent_stream(((), "updates", update))
+                if "updates" in requested:
+                    if version == "v2":
+                        yield {"type": "updates", "ns": (), "data": update, "interrupts": ()}
+                    elif req_single:
+                        yield update
+                    else:
+                        yield StreamPart(event="updates", data=update)
+
+            # Case 3: Artifact event (agent produced an output artifact)
+            elif "artifact" in event_data and "task_id" in event_data:
+                artifact = Artifact.from_dict(event_data["artifact"])
+                texts = [p.text for p in artifact.parts if p.text]
+                if texts:
+                    ai_msg = {
+                        "role": "assistant",
+                        "type": "ai",
+                        "content": "\n".join(texts),
+                    }
+                    update = {self.name: {"messages": [ai_msg]}}
+                    if parent_stream and "updates" in parent_stream.modes:
+                        parent_stream(((), "updates", update))
+                    if "updates" in requested:
+                        if version == "v2":
+                            yield {"type": "updates", "ns": (), "data": update, "interrupts": ()}
+                        elif req_single:
+                            yield update
+                        else:
+                            yield StreamPart(event="updates", data=update)
+
+        # After stream ends: if last task is interrupted + called as subgraph -> raise
+        if last_task and last_task.status.state.is_interrupted:
+            caller_ns = config.get(CONF, {}).get(CONFIG_KEY_CHECKPOINT_NS)
+            if caller_ns:
+                raise GraphInterrupt(
+                    [Interrupt(value=last_task.status.state.value)]
+                )
+
+    def _stream_fallback_sync(
+        self,
+        msg: A2AMessage,
+        config: RunnableConfig,
+        sanitized_config: RunnableConfig,
+        requested: list[StreamMode],
+        req_single: bool,
+        parent_stream: StreamProtocol | None,
+        version: str,
+    ) -> Iterator[dict[str, Any] | Any]:
+        """Fallback: message/send -> poll tasks/get -> return final result.
+
+        Used when the agent does not support SSE streaming.
+        Emits a single "values" event with the complete result.
+        """
+        metadata = sanitized_config.get("metadata")
+        raw = self.sync_client.send_message(msg, metadata=metadata)
+        task = self._parse_send_response(raw)
+        task = self._poll_until_done(task)
+        output = self._task_to_output(task, config)
+
+        if parent_stream and "values" in parent_stream.modes:
+            parent_stream(((), "values", output))
+        if "values" in requested:
+            if version == "v2":
+                yield {"type": "values", "ns": (), "data": output, "interrupts": ()}
+            elif req_single:
+                yield output
+            else:
+                yield StreamPart(event="values", data=output)
+
+    # -- astream ------------------------------------------------------------ #
+
+    @overload
+    def astream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v2"],
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamPart]: ...
+
+    @overload
+    def astream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v1"] = ...,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any] | Any]: ...
+
+    async def astream(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        stream_mode: StreamMode | list[StreamMode] | None = None,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        subgraphs: bool = False,
+        version: Literal["v1", "v2"] = "v1",
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any] | Any]:
+        """Async version of ``stream``.
+
+        Uses ``message/stream`` (SSE) via the async A2A client.
+        Logic is symmetric with the sync version.
+        """
+        merged = merge_configs(self.config, config)
+        sanitized = self._sanitize_config(merged)
+        stream_modes, requested, req_single, parent_stream = (
+            self._get_stream_modes(stream_mode, config)
+        )
+
+        msg = self._build_a2a_message(input, merged)
+        supports_streaming = (
+            self.agent_card.capabilities.streaming if self.agent_card else True
+        )
+
+        if supports_streaming:
+            async for chunk in self._astream_sse(
+                msg, merged, sanitized, requested, req_single, parent_stream, version
+            ):
+                yield chunk
+        else:
+            async for chunk in self._astream_fallback(
+                msg, merged, sanitized, requested, req_single, parent_stream, version
+            ):
+                yield chunk
+
+    async def _astream_sse(
+        self,
+        msg: A2AMessage,
+        config: RunnableConfig,
+        sanitized_config: RunnableConfig,
+        requested: list[StreamMode],
+        req_single: bool,
+        parent_stream: StreamProtocol | None,
+        version: str,
+    ) -> AsyncIterator[dict[str, Any] | Any]:
+        """Async SSE streaming handler; logic mirrors _stream_sync."""
+        metadata = sanitized_config.get("metadata")
+        last_task: A2ATask | None = None
+
+        async for event in self.client.send_streaming_message(
+            msg, metadata=metadata
+        ):
+            event_data = event.get("result", event)
+
+            # Full Task update
+            if "id" in event_data and "status" in event_data:
+                last_task = A2ATask.from_dict(event_data)
+                output = {"messages": _task_to_ai_messages(last_task)}
+                if parent_stream and "values" in parent_stream.modes:
+                    parent_stream(((), "values", output))
+                if "values" in requested:
+                    if version == "v2":
+                        yield {"type": "values", "ns": (), "data": output, "interrupts": ()}
+                    elif req_single:
+                        yield output
+                    else:
+                        yield StreamPart(event="values", data=output)
+
+            # Status update
+            elif "status" in event_data and "task_id" in event_data:
+                status = TaskStatus.from_dict(event_data["status"])
+                update = {self.name: {"status": status.state.value}}
+                if parent_stream and "updates" in parent_stream.modes:
+                    parent_stream(((), "updates", update))
+                if "updates" in requested:
+                    if version == "v2":
+                        yield {"type": "updates", "ns": (), "data": update, "interrupts": ()}
+                    elif req_single:
+                        yield update
+                    else:
+                        yield StreamPart(event="updates", data=update)
+
+            # Artifact event
+            elif "artifact" in event_data and "task_id" in event_data:
+                artifact = Artifact.from_dict(event_data["artifact"])
+                texts = [p.text for p in artifact.parts if p.text]
+                if texts:
+                    ai_msg = {
+                        "role": "assistant",
+                        "type": "ai",
+                        "content": "\n".join(texts),
+                    }
+                    update = {self.name: {"messages": [ai_msg]}}
+                    if parent_stream and "updates" in parent_stream.modes:
+                        parent_stream(((), "updates", update))
+                    if "updates" in requested:
+                        if version == "v2":
+                            yield {"type": "updates", "ns": (), "data": update, "interrupts": ()}
+                        elif req_single:
+                            yield update
+                        else:
+                            yield StreamPart(event="updates", data=update)
+
+        # Post-stream interrupt check
+        if last_task and last_task.status.state.is_interrupted:
+            caller_ns = config.get(CONF, {}).get(CONFIG_KEY_CHECKPOINT_NS)
+            if caller_ns:
+                raise GraphInterrupt(
+                    [Interrupt(value=last_task.status.state.value)]
+                )
+
+    async def _astream_fallback(
+        self,
+        msg: A2AMessage,
+        config: RunnableConfig,
+        sanitized_config: RunnableConfig,
+        requested: list[StreamMode],
+        req_single: bool,
+        parent_stream: StreamProtocol | None,
+        version: str,
+    ) -> AsyncIterator[dict[str, Any] | Any]:
+        """Async fallback; logic mirrors _stream_fallback_sync."""
+        metadata = sanitized_config.get("metadata")
+        raw = await self.client.send_message(msg, metadata=metadata)
+        task = self._parse_send_response(raw)
+        task = await self._apoll_until_done(task)
+        output = self._task_to_output(task, config)
+
+        if parent_stream and "values" in parent_stream.modes:
+            parent_stream(((), "values", output))
+        if "values" in requested:
+            if version == "v2":
+                yield {"type": "values", "ns": (), "data": output, "interrupts": ()}
+            elif req_single:
+                yield output
+            else:
+                yield StreamPart(event="values", data=output)
+
+    # -- invoke ------------------------------------------------------------- #
+
+    @overload
+    def invoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v2"],
+        **kwargs: Any,
+    ) -> GraphOutput[dict[str, Any]]: ...
+
+    @overload
+    def invoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v1"] = ...,
+        **kwargs: Any,
+    ) -> dict[str, Any] | Any: ...
+
+    def invoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v1", "v2"] = "v1",
+        **kwargs: Any,
+    ) -> dict[str, Any] | Any:
+        """Send a message and wait for the A2A task to complete.
+
+        Built on top of stream: consumes all events, returns the last chunk.
+        Same implementation pattern as RemoteGraph.invoke.
+        """
+        # Consume the entire stream, keeping only the last value
+        for chunk in self.stream(  # type: ignore[call-overload]
+            input,
+            config=config,
+            interrupt_before=interrupt_before,
+            interrupt_after=interrupt_after,
+            stream_mode="values",
+            version=version,
+            **kwargs,
+        ):
+            pass
+        try:
+            if version == "v2":
+                return GraphOutput(
+                    value=chunk["data"],
+                    interrupts=tuple(chunk.get("interrupts", ())),
+                )
+            return chunk
+        except UnboundLocalError:
+            # Stream produced no events (chunk is undefined)
+            logger.warning("No events received from A2A agent")
+            return None
+
+    @overload
+    async def ainvoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v2"],
+        **kwargs: Any,
+    ) -> GraphOutput[dict[str, Any]]: ...
+
+    @overload
+    async def ainvoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v1"] = ...,
+        **kwargs: Any,
+    ) -> dict[str, Any] | Any: ...
+
+    async def ainvoke(
+        self,
+        input: dict[str, Any] | Any,
+        config: RunnableConfig | None = None,
+        *,
+        interrupt_before: All | Sequence[str] | None = None,
+        interrupt_after: All | Sequence[str] | None = None,
+        version: Literal["v1", "v2"] = "v1",
+        **kwargs: Any,
+    ) -> dict[str, Any] | Any:
+        """Async version of ``invoke``."""
+        async for chunk in self.astream(  # type: ignore[call-overload]
+            input,
+            config=config,
+            interrupt_before=interrupt_before,
+            interrupt_after=interrupt_after,
+            stream_mode="values",
+            version=version,
+            **kwargs,
+        ):
+            pass
+        try:
+            if version == "v2":
+                return GraphOutput(
+                    value=chunk["data"],
+                    interrupts=tuple(chunk.get("interrupts", ())),
+                )
+            return chunk
+        except UnboundLocalError:
+            logger.warning("No events received from A2A agent")
+            return None

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "langgraph-prebuilt>=1.0.8,<1.1.0",
     "xxhash>=3.5.0",
     "pydantic>=2.7.4",
+    "httpx>=0.25.0",
 ]
 
 

--- a/libs/langgraph/tests/test_a2a_remote_graph.py
+++ b/libs/langgraph/tests/test_a2a_remote_graph.py
@@ -1,0 +1,666 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.runnables.graph import Edge as DrawableEdge
+from langchain_core.runnables.graph import Node as DrawableNode
+
+from langgraph._internal._a2a import (
+    A2AClientError,
+    A2AMessage,
+    A2ATask,
+    AgentCard,
+    AgentCapabilities,
+    AgentInterface,
+    Artifact,
+    Part,
+    Role,
+    TaskState,
+    TaskStatus,
+)
+from langgraph.errors import GraphInterrupt
+from langgraph.pregel.a2a_remote import A2ARemoteGraph
+from langgraph.types import Interrupt, StateSnapshot
+
+pytestmark = pytest.mark.anyio
+
+
+# --------------------------------------------------------------------------- #
+#  Fixtures & helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_task(
+    task_id: str = "task_1",
+    context_id: str = "ctx_1",
+    state: TaskState = TaskState.COMPLETED,
+    agent_text: str = "Hello from A2A agent",
+    artifacts: list[Artifact] | None = None,
+) -> dict:
+    """Build a raw A2A Task dict as returned by JSON-RPC."""
+    status: dict = {"state": state.value}
+    if agent_text:
+        status["message"] = {
+            "message_id": "msg_resp",
+            "role": "ROLE_AGENT",
+            "parts": [{"text": agent_text}],
+        }
+    d: dict = {
+        "id": task_id,
+        "context_id": context_id,
+        "status": status,
+        "artifacts": [],
+        "history": [],
+    }
+    if artifacts:
+        d["artifacts"] = [
+            {
+                "artifact_id": a.artifact_id,
+                "parts": [p.to_dict() for p in a.parts],
+            }
+            for a in artifacts
+        ]
+    return d
+
+
+def _make_graph(
+    *,
+    sync_client: MagicMock | None = None,
+    async_client: AsyncMock | None = None,
+    name: str = "test_a2a",
+    agent_card: AgentCard | None = None,
+) -> A2ARemoteGraph:
+    return A2ARemoteGraph(
+        "http://fake-a2a:8000",
+        name=name,
+        sync_client=sync_client or MagicMock(),
+        client=async_client or AsyncMock(),
+        agent_card=agent_card,
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  with_config
+# --------------------------------------------------------------------------- #
+
+
+def test_with_config():
+    graph = _make_graph()
+    graph.config = {"configurable": {"thread_id": "t1", "foo": "bar"}}
+    copy = graph.with_config({"configurable": {"hello": "world"}})
+
+    assert copy is not graph
+    assert copy.config == {
+        "configurable": {"thread_id": "t1", "foo": "bar", "hello": "world"}
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  get_graph / aget_graph
+# --------------------------------------------------------------------------- #
+
+
+def test_get_graph():
+    graph = _make_graph(name="my_agent")
+    drawable = graph.get_graph()
+
+    assert "0" in drawable.nodes
+    assert drawable.nodes["0"].name == "my_agent"
+    assert DrawableEdge(source="__start__", target="0") in drawable.edges
+    assert DrawableEdge(source="0", target="__end__") in drawable.edges
+
+
+async def test_aget_graph():
+    graph = _make_graph(name="my_agent")
+    drawable = await graph.aget_graph()
+
+    assert drawable.nodes["0"].name == "my_agent"
+
+
+# --------------------------------------------------------------------------- #
+#  get_state / aget_state
+# --------------------------------------------------------------------------- #
+
+
+def test_get_state():
+    mock_sync = MagicMock()
+    mock_sync.get_task.return_value = _make_task()
+
+    graph = _make_graph(sync_client=mock_sync)
+    config = {"configurable": {"thread_id": "ctx_1", "checkpoint_id": "task_1"}}
+    snapshot = graph.get_state(config)
+
+    assert isinstance(snapshot, StateSnapshot)
+    assert snapshot.values["messages"][0]["content"] == "Hello from A2A agent"
+    assert snapshot.config["configurable"]["checkpoint_id"] == "task_1"
+    assert snapshot.next == ()  # COMPLETED → no next nodes
+    mock_sync.get_task.assert_called_once_with("task_1")
+
+
+def test_get_state_no_task_id_raises():
+    graph = _make_graph()
+    with pytest.raises(ValueError, match="No task ID found"):
+        graph.get_state({"configurable": {"thread_id": "t1"}})
+
+
+async def test_aget_state():
+    mock_async = AsyncMock()
+    mock_async.get_task.return_value = _make_task()
+
+    graph = _make_graph(async_client=mock_async)
+    config = {"configurable": {"thread_id": "ctx_1", "checkpoint_id": "task_1"}}
+    snapshot = await graph.aget_state(config)
+
+    assert snapshot.values["messages"][0]["content"] == "Hello from A2A agent"
+    mock_async.get_task.assert_awaited_once_with("task_1")
+
+
+def test_get_state_interrupted():
+    mock_sync = MagicMock()
+    mock_sync.get_task.return_value = _make_task(
+        state=TaskState.INPUT_REQUIRED,
+        agent_text="What is your name?",
+    )
+
+    graph = _make_graph(sync_client=mock_sync)
+    config = {"configurable": {"thread_id": "ctx_1", "checkpoint_id": "task_1"}}
+    snapshot = graph.get_state(config)
+
+    assert snapshot.next == ()  # interrupted, not in-progress
+    assert len(snapshot.interrupts) == 1
+    assert "What is your name?" in snapshot.interrupts[0].value
+
+
+def test_get_state_working():
+    mock_sync = MagicMock()
+    mock_sync.get_task.return_value = _make_task(
+        state=TaskState.WORKING,
+        agent_text="",
+    )
+
+    graph = _make_graph(sync_client=mock_sync, name="worker")
+    config = {"configurable": {"thread_id": "ctx_1", "checkpoint_id": "task_1"}}
+    snapshot = graph.get_state(config)
+
+    assert snapshot.next == ("worker",)  # still has work to do
+
+
+# --------------------------------------------------------------------------- #
+#  get_state_history
+# --------------------------------------------------------------------------- #
+
+
+def test_get_state_history():
+    mock_sync = MagicMock()
+    mock_sync.get_task.return_value = _make_task()
+
+    graph = _make_graph(sync_client=mock_sync)
+    config = {"configurable": {"thread_id": "ctx_1", "checkpoint_id": "task_1"}}
+    history = list(graph.get_state_history(config))
+
+    assert len(history) == 1
+    assert history[0].values["messages"][0]["content"] == "Hello from A2A agent"
+
+
+# --------------------------------------------------------------------------- #
+#  update_state — must raise
+# --------------------------------------------------------------------------- #
+
+
+def test_update_state_raises():
+    graph = _make_graph()
+    with pytest.raises(NotImplementedError, match="do not support direct state"):
+        graph.update_state({"configurable": {"thread_id": "t1"}}, {"key": "val"})
+
+
+async def test_aupdate_state_raises():
+    graph = _make_graph()
+    with pytest.raises(NotImplementedError):
+        await graph.aupdate_state(
+            {"configurable": {"thread_id": "t1"}}, {"key": "val"}
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  invoke / ainvoke
+# --------------------------------------------------------------------------- #
+
+
+def test_invoke():
+    mock_sync = MagicMock()
+    mock_sync.send_message.return_value = _make_task()
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(sync_client=mock_sync, agent_card=card)
+
+    result = graph.invoke(
+        {"messages": [("user", "hi")]},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+
+    assert result is not None
+    assert result["messages"][0]["content"] == "Hello from A2A agent"
+    mock_sync.send_message.assert_called_once()
+
+
+async def test_ainvoke():
+    mock_async = AsyncMock()
+    mock_async.send_message.return_value = _make_task()
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(async_client=mock_async, agent_card=card)
+
+    result = await graph.ainvoke(
+        {"messages": [("user", "hi")]},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+
+    assert result is not None
+    assert result["messages"][0]["content"] == "Hello from A2A agent"
+    mock_async.send_message.assert_awaited_once()
+
+
+def test_invoke_failed_raises():
+    mock_sync = MagicMock()
+    mock_sync.send_message.return_value = _make_task(
+        state=TaskState.FAILED,
+        agent_text="Something went wrong",
+    )
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(sync_client=mock_sync, agent_card=card)
+
+    with pytest.raises(A2AClientError, match="Something went wrong"):
+        graph.invoke(
+            {"messages": [("user", "hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+        )
+
+
+def test_invoke_interrupt_as_subgraph():
+    mock_sync = MagicMock()
+    mock_sync.send_message.return_value = _make_task(
+        state=TaskState.INPUT_REQUIRED,
+        agent_text="What is your name?",
+    )
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(sync_client=mock_sync, agent_card=card)
+
+    with pytest.raises(GraphInterrupt):
+        graph.invoke(
+            {"messages": [("user", "hi")]},
+            config={
+                "configurable": {"thread_id": "t1", "checkpoint_ns": "some_ns"}
+            },
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  stream (sync, non-streaming agent → fallback)
+# --------------------------------------------------------------------------- #
+
+
+def test_stream_fallback():
+    mock_sync = MagicMock()
+    mock_sync.send_message.return_value = _make_task()
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(sync_client=mock_sync, agent_card=card)
+
+    parts = list(
+        graph.stream(
+            {"messages": [("user", "hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+            stream_mode="values",
+        )
+    )
+
+    assert len(parts) == 1
+    assert parts[0]["messages"][0]["content"] == "Hello from A2A agent"
+
+
+# --------------------------------------------------------------------------- #
+#  stream (sync, SSE streaming agent)
+# --------------------------------------------------------------------------- #
+
+
+def test_stream_sse():
+    mock_sync = MagicMock()
+    mock_sync.send_streaming_message.return_value = iter([
+        {
+            "result": {
+                "task_id": "task_1",
+                "context_id": "ctx_1",
+                "status": {"state": "TASK_STATE_WORKING"},
+            }
+        },
+        {
+            "result": {
+                "task_id": "task_1",
+                "context_id": "ctx_1",
+                "artifact": {
+                    "artifact_id": "a1",
+                    "parts": [{"text": "streaming chunk"}],
+                },
+            }
+        },
+        {
+            "result": _make_task(
+                state=TaskState.COMPLETED,
+                agent_text="final answer",
+            )
+        },
+    ])
+
+    graph = _make_graph(sync_client=mock_sync)  # no card → assumes streaming
+
+    parts = list(
+        graph.stream(
+            {"messages": [("user", "hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+            stream_mode=["updates", "values"],
+        )
+    )
+
+    assert len(parts) > 0
+    # v1 multi-mode returns StreamPart NamedTuples with .event and .data
+    events = {p.event for p in parts}
+    assert "updates" in events or "values" in events
+
+
+# --------------------------------------------------------------------------- #
+#  stream v2 format
+# --------------------------------------------------------------------------- #
+
+
+def test_stream_v2():
+    mock_sync = MagicMock()
+    mock_sync.send_message.return_value = _make_task()
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(sync_client=mock_sync, agent_card=card)
+
+    parts = list(
+        graph.stream(
+            {"messages": [("user", "hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+            stream_mode="values",
+            version="v2",
+        )
+    )
+
+    assert len(parts) == 1
+    assert parts[0]["type"] == "values"
+    assert parts[0]["data"]["messages"][0]["content"] == "Hello from A2A agent"
+    assert parts[0]["interrupts"] == ()
+
+
+# --------------------------------------------------------------------------- #
+#  astream
+# --------------------------------------------------------------------------- #
+
+
+async def test_astream_fallback():
+    mock_async = AsyncMock()
+    mock_async.send_message.return_value = _make_task()
+
+    card = AgentCard(
+        name="test",
+        description="test",
+        version="1.0",
+        supported_interfaces=[],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[],
+    )
+    graph = _make_graph(async_client=mock_async, agent_card=card)
+
+    parts = []
+    async for chunk in graph.astream(
+        {"messages": [("user", "hi")]},
+        config={"configurable": {"thread_id": "t1"}},
+        stream_mode="values",
+    ):
+        parts.append(chunk)
+
+    assert len(parts) == 1
+    assert parts[0]["messages"][0]["content"] == "Hello from A2A agent"
+
+
+# --------------------------------------------------------------------------- #
+#  polling backoff
+# --------------------------------------------------------------------------- #
+
+
+def test_poll_backoff():
+    mock_sync = MagicMock()
+
+    # first call returns WORKING, second returns COMPLETED
+    mock_sync.get_task.side_effect = [
+        _make_task(state=TaskState.WORKING, agent_text=""),
+        _make_task(state=TaskState.COMPLETED, agent_text="done"),
+    ]
+
+    graph = _make_graph(sync_client=mock_sync)
+    task = A2ATask.from_dict(_make_task(state=TaskState.WORKING, agent_text=""))
+
+    with patch("langgraph.pregel.a2a_remote.time.sleep") as mock_sleep:
+        result = graph._poll_until_done(task, initial_interval=1.0, backoff_factor=2.0)
+
+    assert result.status.state == TaskState.COMPLETED
+    assert mock_sync.get_task.call_count == 2
+    # first sleep should be 1.0s (initial)
+    mock_sleep.assert_called()
+    assert mock_sleep.call_args_list[0].args[0] == 1.0
+
+
+def test_poll_timeout():
+    mock_sync = MagicMock()
+    mock_sync.get_task.return_value = _make_task(
+        state=TaskState.WORKING, agent_text=""
+    )
+
+    graph = _make_graph(sync_client=mock_sync)
+    task = A2ATask.from_dict(_make_task(state=TaskState.WORKING, agent_text=""))
+
+    with patch("langgraph.pregel.a2a_remote.time.sleep"):
+        with pytest.raises(TimeoutError, match="did not complete"):
+            graph._poll_until_done(task, max_elapsed=0.0)
+
+
+# --------------------------------------------------------------------------- #
+#  from_agent_card_sync
+# --------------------------------------------------------------------------- #
+
+
+def test_from_agent_card_sync():
+    card_data = {
+        "name": "Currency Agent",
+        "description": "Converts currencies",
+        "version": "1.0.0",
+        "supported_interfaces": [
+            {
+                "url": "https://agent.example.com/jsonrpc",
+                "protocol_binding": "JSONRPC",
+                "protocol_version": "1.0",
+            }
+        ],
+        "capabilities": {"streaming": True},
+        "skills": [
+            {
+                "id": "convert",
+                "name": "Convert Currency",
+                "description": "Convert between currencies",
+                "tags": ["currency"],
+            }
+        ],
+        "default_input_modes": ["text/plain"],
+        "default_output_modes": ["text/plain"],
+    }
+
+    card = AgentCard.from_dict(card_data)
+
+    with patch(
+        "langgraph.pregel.a2a_remote.SyncA2AClient"
+    ) as MockSyncClient:
+        mock_instance = MockSyncClient.return_value
+        mock_instance.fetch_agent_card.return_value = card
+        mock_instance.close.return_value = None
+
+        graph = A2ARemoteGraph.from_agent_card_sync(
+            "https://agent.example.com/.well-known/agent-card.json"
+        )
+
+    assert graph.name == "Currency Agent"
+    assert graph.agent_card is not None
+    assert graph.agent_card.capabilities.streaming is True
+    assert graph.url == "https://agent.example.com/jsonrpc"
+
+
+# --------------------------------------------------------------------------- #
+#  sanitize_config
+# --------------------------------------------------------------------------- #
+
+
+def test_sanitize_config():
+    graph = _make_graph()
+
+    config = {
+        "configurable": {
+            "thread_id": "t1",
+            "checkpoint_id": "c1",  # should be dropped
+            "checkpoint_ns": "ns",  # should be dropped
+            "custom_key": "value",
+            "non_serializable": object(),  # should be dropped
+        },
+        "tags": ["tag1", "tag2"],
+        "metadata": {"key": "val", "nested": {"a": 1}},
+    }
+    sanitized = graph._sanitize_config(config)
+
+    assert "checkpoint_id" not in sanitized.get("configurable", {})
+    assert "checkpoint_ns" not in sanitized.get("configurable", {})
+    assert sanitized["configurable"]["thread_id"] == "t1"
+    assert sanitized["configurable"]["custom_key"] == "value"
+    assert "non_serializable" not in sanitized["configurable"]
+    assert sanitized["tags"] == ["tag1", "tag2"]
+    assert sanitized["metadata"]["nested"]["a"] == 1
+
+
+# --------------------------------------------------------------------------- #
+#  message conversion
+# --------------------------------------------------------------------------- #
+
+
+def test_messages_to_parts_dict():
+    from langgraph.pregel.a2a_remote import _messages_to_parts
+
+    parts = _messages_to_parts([{"role": "user", "content": "hello"}])
+    assert len(parts) == 1
+    assert parts[0].text == "hello"
+
+
+def test_messages_to_parts_tuple():
+    from langgraph.pregel.a2a_remote import _messages_to_parts
+
+    parts = _messages_to_parts([("user", "hi there")])
+    assert len(parts) == 1
+    assert parts[0].text == "hi there"
+
+
+def test_last_user_messages():
+    from langgraph.pregel.a2a_remote import _last_user_messages
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "response"},
+        {"role": "user", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+    result = _last_user_messages(messages)
+    assert len(result) == 2
+    assert result[0]["content"] == "second"
+    assert result[1]["content"] == "third"
+
+
+def test_task_to_ai_messages():
+    from langgraph.pregel.a2a_remote import _task_to_ai_messages
+
+    task = A2ATask.from_dict(_make_task(agent_text="hello world"))
+    msgs = _task_to_ai_messages(task)
+    assert len(msgs) == 1
+    assert msgs[0]["content"] == "hello world"
+    assert msgs[0]["role"] == "assistant"
+
+
+def test_task_to_ai_messages_with_artifacts():
+    from langgraph.pregel.a2a_remote import _task_to_ai_messages
+
+    task_dict = _make_task(
+        agent_text="summary",
+        artifacts=[Artifact(artifact_id="a1", parts=[Part(text="detailed result")])],
+    )
+    task = A2ATask.from_dict(task_dict)
+    msgs = _task_to_ai_messages(task)
+
+    contents = [m["content"] for m in msgs]
+    assert "summary" in contents
+    assert "detailed result" in contents
+
+
+def test_task_to_ai_messages_deduplicates():
+    from langgraph.pregel.a2a_remote import _task_to_ai_messages
+
+    # same text in status message and artifact → should be deduplicated
+    task_dict = _make_task(
+        agent_text="same text",
+        artifacts=[Artifact(artifact_id="a1", parts=[Part(text="same text")])],
+    )
+    task = A2ATask.from_dict(task_dict)
+    msgs = _task_to_ai_messages(task)
+
+    assert len(msgs) == 1
+    assert msgs[0]["content"] == "same text"


### PR DESCRIPTION
## Summary

Add `A2ARemoteGraph` — a client-side adapter that enables LangGraph agents to call
remote [A2A (Agent-to-Agent)](https://github.com/google/A2A) protocol compliant agents as first-class graph nodes.

- Implements `PregelProtocol` so `A2ARemoteGraph` can be used anywhere a `CompiledGraph` or `RemoteGraph` is accepted (
  e.g. `builder.add_node("agent", a2a)`)
- Provides full sync + async support: `invoke`/`ainvoke`, `stream`/`astream`, `get_state`/`aget_state`
- Supports SSE streaming (`message/stream`) with automatic fallback to `message/send` + polling for non-streaming agents
- Includes Agent Card discovery via `from_agent_card_sync` / `from_agent_card` factory methods
- Internal `_a2a.py` module has zero LangGraph dependencies — pure A2A JSON-RPC 2.0 transport layer
- Extracts `sanitize_config_value` to `_internal/_config.py` to share between `RemoteGraph` and `A2ARemoteGraph`

### Motivation

`RemoteGraph` only speaks LangGraph Server's proprietary API. As the A2A protocol gains adoption across frameworks (
Google ADK, CrewAI, etc.), LangGraph users need a way to orchestrate heterogeneous agents. `A2ARemoteGraph` fills this
gap with the same interface developers already know.

### Files changed

| File                             | Change                                                                  |
|----------------------------------|-------------------------------------------------------------------------|
| `langgraph/pregel/a2a_remote.py` | **New** — `A2ARemoteGraph(PregelProtocol)` implementation (~1100 lines) |
| `langgraph/_internal/_a2a.py`    | **New** — A2A data types + JSON-RPC client (~510 lines)                 |
| `langgraph/_internal/_config.py` | **Modified** — Added shared `sanitize_config_value()`                   |
| `pyproject.toml`                 | **Modified** — Added `httpx>=0.25.0` to dependencies                    |
| `tests/test_a2a_remote_graph.py` | **New** — 29 unit tests                                                 |

### Usage example

```python
from langgraph.pregel.a2a_remote import A2ARemoteGraph
from langgraph.graph import StateGraph, MessagesState

# Option 1: Direct URL
a2a = A2ARemoteGraph("https://agent.example.com/a2a", name="translator")

# Option 2: Auto-discover via Agent Card
a2a = A2ARemoteGraph.from_agent_card_sync(
    "https://agent.example.com/.well-known/agent-card.json"
)

# Use as a node in StateGraph
builder = StateGraph(MessagesState)
builder.add_node("translator", a2a)
```
