### PR TITLE
perf: cache inspect.signature and UntrackedValue isinstance scan

### DIFF
--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -142,6 +142,9 @@ ANY_TYPE = object()
 
 ASYNCIO_ACCEPTS_CONTEXT = sys.version_info >= (3, 11)
 
+# Cache for inspect.signature results, keyed by function object
+_SIGNATURE_CACHE: dict[Callable, inspect.Signature] = {}
+
 # List of keyword arguments that can be injected into nodes / tasks / tools at runtime.
 # A named argument may appear multiple times if it appears with distinct types.
 KWARGS_CONFIG_KEYS: tuple[tuple[str, tuple[Any, ...], str, Any], ...] = (
@@ -315,7 +318,16 @@ class RunnableCallable(Runnable):
             raise ValueError("At least one of func or afunc must be provided.")
 
         self.func_accepts: dict[str, tuple[str, Any]] = {}
-        params = inspect.signature(cast(Callable, func or afunc)).parameters
+        target = cast(Callable, func or afunc)
+        try:
+            sig = _SIGNATURE_CACHE[target]
+        except (KeyError, TypeError):
+            sig = inspect.signature(target)
+            try:
+                _SIGNATURE_CACHE[target] = sig
+            except TypeError:
+                pass  # unhashable function, skip caching
+        params = sig.parameters
 
         for kw, typ, runtime_key, default in KWARGS_CONFIG_KEYS:
             p = params.get(kw)

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -198,6 +198,7 @@ class PregelLoop:
     _migrate_checkpoint: Callable[[Checkpoint], None] | None
     submit: Submit
     channels: Mapping[str, BaseChannel]
+    _has_untracked_channels: bool
     # Futures from `checkpointer.put_writes` calls that produced delta-channel
     # writes. `_checkpointer_put_after_previous` drains this list (swap to a
     # local `futs` then reset to `[]` and wait/gather) before putting the

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -437,9 +437,7 @@ class PregelLoop:
             writes_to_save = writes
 
         # check if any writes are to an UntrackedValue channel
-        if any(
-            isinstance(channel, UntrackedValue) for channel in self.channels.values()
-        ):
+        if self._has_untracked_channels:
             # we do not persist untracked values in checkpoints
             writes_to_save = [
                 # sanitize UntrackedValues that are nested within Send packets
@@ -1161,9 +1159,7 @@ class PregelLoop:
         elif "counters_since_delta_snapshot" in self.checkpoint_metadata:
             del self.checkpoint_metadata["counters_since_delta_snapshot"]
         # sanitize TASK channel in the checkpoint before saving (durability=="exit")
-        if TASKS in self.checkpoint["channel_values"] and any(
-            isinstance(channel, UntrackedValue) for channel in self.channels.values()
-        ):
+        if TASKS in self.checkpoint["channel_values"] and self._has_untracked_channels:
             sanitized_tasks = [
                 sanitize_untracked_values_in_send(value, self.channels)
                 if isinstance(value, Send)
@@ -1695,6 +1691,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             saver=self.checkpointer,
             config=self.checkpoint_config,
         )
+        self._has_untracked_channels = any(
+            isinstance(ch, UntrackedValue) for ch in self.channels.values()
+        )
         self.stack.push(self._suppress_interrupt)
         self.status = "input"
         self.step = self.checkpoint_metadata["step"] + 1
@@ -1954,6 +1953,9 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             self.checkpoint,
             saver=self.checkpointer,
             config=self.checkpoint_config,
+        )
+        self._has_untracked_channels = any(
+            isinstance(ch, UntrackedValue) for ch in self.channels.values()
         )
         self.stack.push(self._suppress_interrupt)
         self.status = "input"


### PR DESCRIPTION
## Summary
- Cache `inspect.signature` results in `RunnableCallable.__init__` via a module-level `_SIGNATURE_CACHE` dict, avoiding repeated signature introspection for the same function (e.g. 1000 `ChannelWrite` instances all inspecting the same `_write`/`_awrite` methods)
- Cache the `any(isinstance(ch, UntrackedValue) ...)` scan as `_has_untracked_channels` once in `__enter__`/`__aenter__`, replacing two per-call scan sites in `put_writes` and checkpoint sanitization — eliminates 1M+ `isinstance` calls through the ABC machinery for `sequential_1000`

Split out from #6969 to keep cache changes separate from other optimizations.

## Test plan
- [ ] Existing test suite passes (`make test` in `libs/langgraph`)
- [ ] Benchmark confirms no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)