### PR TITLE
Return completed subgraph state snapshots

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -81,6 +81,7 @@ from langgraph._internal._constants import (
     NS_END,
     NS_SEP,
     NULL_TASK_ID,
+    PULL,
     PUSH,
     TASKS,
 )
@@ -145,6 +146,7 @@ from langgraph.types import (
     Durability,
     GraphOutput,
     Interrupt,
+    PregelTask,
     Send,
     StateSnapshot,
     StateUpdate,
@@ -1014,6 +1016,76 @@ class Pregel(
                 checkpoint["channel_versions"].values()
             )
 
+    def _completed_subgraph_tasks(
+        self,
+        saved: CheckpointTuple,
+        recurse: BaseCheckpointSaver,
+        subgraphs: Mapping[str, PregelProtocol],
+        next_tasks: Mapping[str, PregelExecutableTask],
+    ) -> tuple[PregelTask, ...]:
+        active_subgraph_names = {task.name for task in next_tasks.values()}
+        parent_ns = saved.config[CONF].get(CONFIG_KEY_CHECKPOINT_NS, "")
+        out: list[PregelTask] = []
+        for name, pregel in subgraphs.items():
+            if name in active_subgraph_names:
+                continue
+            checkpoint_ns = f"{parent_ns}{NS_SEP}{name}" if parent_ns else name
+            state = pregel.get_state(
+                {
+                    CONF: {
+                        CONFIG_KEY_CHECKPOINTER: recurse,
+                        CONFIG_KEY_THREAD_ID: saved.config[CONF][CONFIG_KEY_THREAD_ID],
+                        CONFIG_KEY_CHECKPOINT_NS: checkpoint_ns,
+                    }
+                },
+                subgraphs=True,
+            )
+            if (
+                state.metadata is None
+                and not state.values
+                and not state.next
+                and not state.tasks
+                and not state.interrupts
+            ):
+                continue
+            out.append(PregelTask(name, name, (PULL, name), None, (), state, None))
+        return tuple(out)
+
+    async def _acompleted_subgraph_tasks(
+        self,
+        saved: CheckpointTuple,
+        recurse: BaseCheckpointSaver,
+        subgraphs: Mapping[str, PregelProtocol],
+        next_tasks: Mapping[str, PregelExecutableTask],
+    ) -> tuple[PregelTask, ...]:
+        active_subgraph_names = {task.name for task in next_tasks.values()}
+        parent_ns = saved.config[CONF].get(CONFIG_KEY_CHECKPOINT_NS, "")
+        out: list[PregelTask] = []
+        for name, pregel in subgraphs.items():
+            if name in active_subgraph_names:
+                continue
+            checkpoint_ns = f"{parent_ns}{NS_SEP}{name}" if parent_ns else name
+            state = await pregel.aget_state(
+                {
+                    CONF: {
+                        CONFIG_KEY_CHECKPOINTER: recurse,
+                        CONFIG_KEY_THREAD_ID: saved.config[CONF][CONFIG_KEY_THREAD_ID],
+                        CONFIG_KEY_CHECKPOINT_NS: checkpoint_ns,
+                    }
+                },
+                subgraphs=True,
+            )
+            if (
+                state.metadata is None
+                and not state.values
+                and not state.next
+                and not state.tasks
+                and not state.interrupts
+            ):
+                continue
+            out.append(PregelTask(name, name, (PULL, name), None, (), state, None))
+        return tuple(out)
+
     def _prepare_state_snapshot(
         self,
         config: RunnableConfig,
@@ -1121,6 +1193,10 @@ class Pregel(
             task_states,
             self.stream_channels_asis,
         )
+        if recurse:
+            tasks_with_writes = tasks_with_writes + self._completed_subgraph_tasks(
+                saved, recurse, subgraphs, next_tasks
+            )
         # assemble the state snapshot
         return StateSnapshot(
             read_channels(channels, self.stream_channels_asis),
@@ -1241,6 +1317,12 @@ class Pregel(
             task_states,
             self.stream_channels_asis,
         )
+        if recurse:
+            tasks_with_writes = tasks_with_writes + (
+                await self._acompleted_subgraph_tasks(
+                    saved, recurse, subgraphs, next_tasks
+                )
+            )
         # assemble the state snapshot
         return StateSnapshot(
             read_channels(channels, self.stream_channels_asis),

--- a/libs/langgraph/tests/test_completed_subgraph_state.py
+++ b/libs/langgraph/tests/test_completed_subgraph_state.py
@@ -1,0 +1,192 @@
+﻿import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import START, MessagesState, StateGraph
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class ConversationState(MessagesState):
+    pass
+
+
+def build_sync_graph(*, nested: bool):
+    def leaf_node(state: ConversationState) -> ConversationState:
+        return {
+            "messages": state["messages"]
+            + [{"role": "assistant", "content": "leaf-reply"}]
+        }
+
+    leaf_graph = (
+        StateGraph(ConversationState)
+        .add_node("leaf", leaf_node)
+        .add_edge(START, "leaf")
+        .compile(checkpointer=True)
+    )
+
+    if nested:
+        middle_graph = (
+            StateGraph(ConversationState)
+            .add_node("middle", leaf_graph)
+            .add_edge(START, "middle")
+            .compile(checkpointer=True)
+        )
+        target = middle_graph
+        target_name = "agent"
+    else:
+        target = leaf_graph
+        target_name = "agent"
+
+    graph = (
+        StateGraph(ConversationState)
+        .add_node(target_name, target)
+        .add_edge(START, target_name)
+        .compile(checkpointer=InMemorySaver())
+    )
+    return graph
+
+
+def build_async_graph(*, nested: bool):
+    async def leaf_node(state: ConversationState) -> ConversationState:
+        return {
+            "messages": state["messages"]
+            + [{"role": "assistant", "content": "leaf-reply"}]
+        }
+
+    leaf_graph = (
+        StateGraph(ConversationState)
+        .add_node("leaf", leaf_node)
+        .add_edge(START, "leaf")
+        .compile(checkpointer=True)
+    )
+
+    if nested:
+        middle_graph = (
+            StateGraph(ConversationState)
+            .add_node("middle", leaf_graph)
+            .add_edge(START, "middle")
+            .compile(checkpointer=True)
+        )
+        target = middle_graph
+        target_name = "agent"
+    else:
+        target = leaf_graph
+        target_name = "agent"
+
+    graph = (
+        StateGraph(ConversationState)
+        .add_node(target_name, target)
+        .add_edge(START, target_name)
+        .compile(checkpointer=InMemorySaver())
+    )
+    return graph
+
+
+def invoke_twice_sync(graph) -> dict:
+    config = {"configurable": {"thread_id": "thread-sync"}}
+    graph.invoke({"messages": [{"role": "user", "content": "hi"}]}, config)
+    graph.invoke(
+        {"messages": [{"role": "user", "content": "what did I say?"}]},
+        config,
+    )
+    return config
+
+
+async def invoke_twice_async(graph) -> dict:
+    config = {"configurable": {"thread_id": "thread-async"}}
+    await graph.ainvoke({"messages": [{"role": "user", "content": "hi"}]}, config)
+    await graph.ainvoke(
+        {"messages": [{"role": "user", "content": "what did I say?"}]},
+        config,
+    )
+    return config
+
+
+def assert_completed_subgraph_snapshot(state) -> None:
+    assert len(state.tasks) == 1
+    subgraph_task = state.tasks[0]
+    assert subgraph_task.name == "agent"
+    assert subgraph_task.state is not None
+    assert subgraph_task.state.metadata is not None
+    assert subgraph_task.state.values["messages"][-1].content == "leaf-reply"
+    assert len(subgraph_task.state.values["messages"]) == 4
+
+
+def assert_nested_completed_subgraph_snapshot(state) -> None:
+    assert len(state.tasks) == 1
+    middle_task = state.tasks[0]
+    assert middle_task.name == "agent"
+    assert middle_task.state is not None
+    assert len(middle_task.state.tasks) == 1
+
+    leaf_task = middle_task.state.tasks[0]
+    assert leaf_task.name == "middle"
+    assert leaf_task.state is not None
+    assert leaf_task.state.values["messages"][-1].content == "leaf-reply"
+    assert len(leaf_task.state.values["messages"]) == 4
+
+
+def test_get_state_with_subgraphs_returns_completed_subgraph_state_sync() -> None:
+    graph = build_sync_graph(nested=False)
+    config = invoke_twice_sync(graph)
+
+    state = graph.get_state(config, subgraphs=True)
+
+    assert state.next == ()
+    assert state.values["messages"][-1].content == "leaf-reply"
+    assert_completed_subgraph_snapshot(state)
+
+
+def test_get_state_with_subgraphs_returns_completed_nested_subgraph_state_sync() -> None:
+    graph = build_sync_graph(nested=True)
+    config = invoke_twice_sync(graph)
+
+    state = graph.get_state(config, subgraphs=True)
+
+    assert state.next == ()
+    assert_nested_completed_subgraph_snapshot(state)
+
+
+async def test_get_state_with_subgraphs_returns_completed_subgraph_state_async() -> None:
+    graph = build_async_graph(nested=False)
+    config = await invoke_twice_async(graph)
+
+    state = await graph.aget_state(config, subgraphs=True)
+
+    assert state.next == ()
+    assert state.values["messages"][-1].content == "leaf-reply"
+    assert_completed_subgraph_snapshot(state)
+
+
+async def test_get_state_with_subgraphs_returns_completed_nested_subgraph_state_async() -> None:
+    graph = build_async_graph(nested=True)
+    config = await invoke_twice_async(graph)
+
+    state = await graph.aget_state(config, subgraphs=True)
+
+    assert state.next == ()
+    assert_nested_completed_subgraph_snapshot(state)
+
+
+def test_get_state_without_subgraphs_keeps_completed_tasks_hidden_sync() -> None:
+    graph = build_sync_graph(nested=False)
+    config = invoke_twice_sync(graph)
+
+    state = graph.get_state(config, subgraphs=False)
+
+    assert state.tasks == ()
+    assert state.next == ()
+
+
+async def test_get_state_without_subgraphs_keeps_completed_tasks_hidden_async() -> None:
+    graph = build_async_graph(nested=False)
+    config = await invoke_twice_async(graph)
+
+    state = await graph.aget_state(config, subgraphs=False)
+
+    assert state.tasks == ()
+    assert state.next == ()


### PR DESCRIPTION
## Summary

Fixes `get_state(config, subgraphs=True)` for completed subgraphs that use per-thread checkpointing.

Before this change, completed subgraph state was only surfaced when the subgraph still appeared in `next_tasks` (for example, paused/interruptible cases). Once the graph had fully completed, `next_tasks` became empty and `get_state(..., subgraphs=True)` returned `tasks=()`, even though the subgraph's checkpointed state still existed and could be fetched directly by namespace.

## Changes

- hydrate completed immediate subgraph snapshots when `subgraphs=True` is requested
- keep existing behavior for active subgraph tasks
- preserve `subgraphs=False` behavior so completed tasks remain hidden unless explicitly requested
- add regression coverage for:
  - completed sync subgraphs
  - completed async subgraphs
  - completed nested sync subgraphs
  - completed nested async subgraphs
  - non-subgraph state reads staying unchanged

## Testing

```bash
python -m py_compile libs/langgraph/langgraph/pregel/main.py libs/langgraph/tests/test_completed_subgraph_state.py
python -m pytest --noconftest libs/langgraph/tests/test_completed_subgraph_state.py -q
```

Passed locally:

- `6 passed in 0.23s`

## Issue

Closes #7128
