### PR TITLE
checkpoint-sqlite: add sync/async ordering parity regression

### DIFF
--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -236,7 +236,7 @@ class TestAsyncSqliteSaver:
                 cp
                 async for cp in async_saver.alist(
                     {"configurable": {"thread_id": "thread-parity"}},
-                    before={"configurable": {"checkpoint_id": "a-newer"}},
+                    before={"configurable": {"checkpoint_id": "z-older"}},
                 )
             ]
 
@@ -248,7 +248,7 @@ class TestAsyncSqliteSaver:
             before_sync = list(
                 sync_saver.list(
                     {"configurable": {"thread_id": "thread-parity"}},
-                    before={"configurable": {"checkpoint_id": "a-newer"}},
+                    before={"configurable": {"checkpoint_id": "z-older"}},
                 )
             )
 
@@ -258,6 +258,7 @@ class TestAsyncSqliteSaver:
         assert [cp.checkpoint["id"] for cp in list_async] == [
             cp.checkpoint["id"] for cp in list_sync
         ]
+        assert before_async
         assert [cp.checkpoint["id"] for cp in before_async] == [
             cp.checkpoint["id"] for cp in before_sync
         ]


### PR DESCRIPTION
## Problem
Sync and async checkpoint saver paths need explicit parity checks so ordering/cursor behavior does not drift by transport style.

## Why now
Ordering/recency correctness is a runtime contract for reproducible history and pagination behavior.

## What changed
- Added `test_sync_and_async_checkpoint_ordering_parity` in `libs/checkpoint-sqlite/tests/test_aiosqlite.py`.
- New test writes a shared fixture DB and verifies sync (`SqliteSaver`) and async (`AsyncSqliteSaver`) return identical:
  - latest checkpoint
  - list ordering
  - `before` cursor ordering

## Validation
- `cd libs/checkpoint-sqlite && make format`
- `cd libs/checkpoint-sqlite && make lint`
- `cd libs/checkpoint-sqlite && TEST='tests/test_aiosqlite.py' make test`

Refs #7136
