### PR TITLE
fix(cli): cleanup client creation code

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -762,8 +762,8 @@ def _deploy_base_options(
         "This command is in beta and under active development. "
         "Expect frequent updates and improvements.\n\n"
         "Run from the root of your LangGraph project (where langgraph.json "
-        "is located). This command also accepts build flags (--config, "
-        "--base-image, --pull, etc.). See 'langgraph build --help' for details."
+        "is located). This command also accepts build flags (--base-image, "
+        "--config, --pull, etc.). See 'langgraph build --help' for details."
     ),
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
     invoke_without_command=True,  # allow `deploy` click group to execute without command


### PR DESCRIPTION
make following fixes for deploy cli:
- allow logs command to read in `_DEPLOYMENT_NAME_ENV`
- change prompt for api key to be more user friendly
- refactor prompt for org scoped keys
- make sure --config option is documented in deploy help