### PR TITLE
fix(cli): use --tag for langgraph deploy

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -717,7 +717,7 @@ def _deploy_base_options(
             OPT_HOST_URL,
             click.option("--image-name", hidden=True),
             click.option(
-                "--image-tag",
+                "--tag",
                 "-t",
                 default="latest",
                 show_default=True,


### PR DESCRIPTION
langgraph deploy should use the `--tag/-t` instead of `--image-tag`. This matches langgraph build