### PR TITLE
fix(serde): return raw data instead of None on msgpack deserialization failure

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -594,7 +594,10 @@ def _create_msgpack_ext_hook(
                 # module, name, arg
                 return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
             except Exception:
-                return None
+                try:
+                    return tup[2]
+                except NameError:
+                    return None
         elif code == EXT_CONSTRUCTOR_POS_ARGS:
             try:
                 tup = ormsgpack.unpackb(
@@ -605,7 +608,10 @@ def _create_msgpack_ext_hook(
                 # module, name, args
                 return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
             except Exception:
-                return None
+                try:
+                    return tup[2]
+                except NameError:
+                    return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
             try:
                 tup = ormsgpack.unpackb(
@@ -616,7 +622,10 @@ def _create_msgpack_ext_hook(
                 # module, name, kwargs
                 return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
             except Exception:
-                return None
+                try:
+                    return tup[2]
+                except NameError:
+                    return None
         elif code == EXT_METHOD_SINGLE_ARG:
             try:
                 tup = ormsgpack.unpackb(
@@ -629,7 +638,10 @@ def _create_msgpack_ext_hook(
                     getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
                 )(tup[2])
             except Exception:
-                return None
+                try:
+                    return tup[2]
+                except NameError:
+                    return None
         elif code == EXT_PYDANTIC_V1:
             try:
                 tup = ormsgpack.unpackb(


### PR DESCRIPTION
## Summary

The ext_hook in _create_msgpack_ext_hook silently returns None for EXT_CONSTRUCTOR_SINGLE_ARG, EXT_CONSTRUCTOR_POS_ARGS, EXT_CONSTRUCTOR_KW_ARGS, and EXT_METHOD_SINGLE_ARG when construction fails. This causes deserialized values to become None unexpectedly.

The Pydantic ext types (EXT_PYDANTIC_V1/V2) already have the correct pattern: they fall back to returning tup[2] (the raw serialized data) before returning None. This PR applies the same fallback pattern to the other ext types for consistency and to prevent silent data loss.

## Changes

- Return tup[2] (raw serialized data) as fallback instead of None when ext type construction fails
- Consistent with existing Pydantic ext type handling

Fixes #6970