### PR TITLE
fix: skip caching ERROR/INTERRUPT writes in SyncPregelLoop.put_writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1123,6 +1123,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks
+            return
         self.submit(
             self.cache.set,
             {


### PR DESCRIPTION
## Summary

AsyncPregelLoop.put_writes already has a guard that prevents caching writes that start with INTERRUPT or ERROR channels, since failed or interrupted tasks should not pollute the cache. The synchronous SyncPregelLoop.put_writes was missing this guard, causing error results to be cached and potentially replayed on retry.

## Changes

Add the same `writes[0][0] in (INTERRUPT, ERROR)` early-return guard to the sync variant for parity.

Fixes #7015