### PR TITLE
fix(prebuilt): handle non-class type annotations in _infer_handled_types

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -475,7 +475,7 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
             origin = get_origin(first_param.annotation)
             if origin in [Union, UnionType]:
                 args = get_args(first_param.annotation)
-                if all(issubclass(arg, Exception) for arg in args):
+                if all(isinstance(arg, type) and issubclass(arg, Exception) for arg in args):
                     return tuple(args)
                 msg = (
                     "All types in the error handler error annotation must be "
@@ -486,7 +486,7 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
                 raise ValueError(msg)
 
             exception_type = type_hints[first_param.name]
-            if Exception in exception_type.__mro__:
+            if isinstance(exception_type, type) and issubclass(exception_type, Exception):
                 return (exception_type,)
             msg = (
                 f"Arbitrary types are not supported in the error handler "


### PR DESCRIPTION
## Summary

`_infer_handled_types` assumed that type annotations would always be concrete classes, accessing `__mro__` directly and calling `issubclass()` without type guards. When a handler's annotation contains a non-class type (e.g. a generic alias or special form), this raises `AttributeError` or `TypeError`.

## Changes

Add `isinstance(..., type)` checks before `issubclass()` and `__mro__` access.

Fixes #7016