### PR TITLE
fix: add missing None to aupdate_state values type annotation

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2355,7 +2355,7 @@ class Pregel(
     async def aupdate_state(
         self,
         config: RunnableConfig,
-        values: dict[str, Any] | Any,
+        values: dict[str, Any] | Any | None,
         as_node: str | None = None,
         task_id: str | None = None,
     ) -> RunnableConfig:


### PR DESCRIPTION
## Summary

The sync `update_state()` already accepts `None` for its `values` parameter, but the async `aupdate_state()` was missing `None` in its type annotation. This makes the two signatures inconsistent.

## Changes

Add `None` to the `values` parameter type annotation in `aupdate_state()` for parity with `update_state()`.

Fixes #7018