### PR TITLE
fix: initialize resume_is_map before conditional in PregelLoop._first

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -672,6 +672,7 @@ class PregelLoop:
 
         # map command to writes
         if input_is_command:
+            resume_is_map = False
             if (resume := cast(Command, self.input).resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(


### PR DESCRIPTION
## Summary

When `Command(resume=None)` is passed, the `if resume is not None` branch is skipped, leaving `resume_is_map` unbound. The subsequent references to `resume_is_map` in map_command filtering and the empty writes check then raise `UnboundLocalError`.

## Changes

Initialize `resume_is_map = False` before the conditional so it always has a defined value.

Fixes #7034