### PR TITLE
fix: break reference chain in _checkpointer_put_after_previous to prevent memory leak

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1088,6 +1088,8 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             if prev is not None:
                 prev.result()
         finally:
+            # Break the reference chain so previous checkpoint data can be GC'd.
+            del prev
             cast(BaseCheckpointSaver, self.checkpointer).put(
                 config, checkpoint, metadata, new_versions
             )
@@ -1284,6 +1286,8 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             if prev is not None:
                 await prev
         finally:
+            # Break the reference chain so previous checkpoint data can be GC'd.
+            del prev
             await cast(BaseCheckpointSaver, self.checkpointer).aput(
                 config, checkpoint, metadata, new_versions
             )


### PR DESCRIPTION
## Summary

Both Sync and Async versions of `_checkpointer_put_after_previous` hold a reference to the previous Future/Task via the `prev` parameter. Since each checkpoint save chains to the previous one, this creates a linked list of futures that prevents all intermediate checkpoint data from being garbage collected until the entire graph run completes.

## Changes

Add `del prev` after awaiting/getting the result to break the reference chain early, allowing intermediate checkpoint data to be freed promptly.

Fixes #7094