### PR TITLE
fix: initialize handlers to empty list in push_message to prevent UnboundLocalError

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -348,6 +348,7 @@ def push_message(
     if message.id is None:
         raise ValueError("Message ID is required")
 
+    handlers: list[BaseCallbackHandler] = []
     if isinstance(config["callbacks"], BaseCallbackManager):
         manager = config["callbacks"]
         handlers = manager.handlers


### PR DESCRIPTION
## Summary

In `push_message()`, when `config["callbacks"]` is not an instance of the expected types, the `handlers` variable is never assigned, leading to an `UnboundLocalError` when it is referenced later.

## Changes

Initialize `handlers = []` before the conditional block so it always has a defined value.

Fixes #7100