### PR TITLE
fix: use elif in map_output_updates to prevent TypeError on None value

### DIFF
--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -167,7 +167,7 @@ def map_output_updates(
     for node, value in grouped.items():
         if len(value) == 0:
             grouped[node] = None
-        if len(value) == 1:
+        elif len(value) == 1:
             grouped[node] = value[0]
     if cached:
         grouped["__metadata__"] = {"cached": cached}


### PR DESCRIPTION
## Summary

In `map_output_updates()`, when a value is empty/falsy, it gets set to `None`. The next `if` branch then calls `len()` on the now-`None` value, raising a `TypeError`. This should be an `elif` since the branches are mutually exclusive.

## Changes

Change the second `if` to `elif` so it is skipped when the value has already been set to `None`.

Fixes #7101