### PR TITLE
fix(checkpoint): don't add the task to the checkpoint batch if it was…

### DIFF
--- a/libs/checkpoint/langgraph/store/base/batch.py
+++ b/libs/checkpoint/langgraph/store/base/batch.py
@@ -328,6 +328,9 @@ async def _run(
     store: weakref.ReferenceType[BaseStore],
 ) -> None:
     while item := await aqueue.get():
+        # don't run batch if the future is done (e.g. cancelled)
+        if item[0].done():
+            continue
         # check if store is still alive
         if s := store():
             try:
@@ -335,6 +338,9 @@ async def _run(
                 items = [item]
                 try:
                     while item := aqueue.get_nowait():
+                        # don't insert if the future is done (e.g. cancelled)
+                        if item[0].done():
+                            continue
                         items.append(item)
                 except asyncio.QueueEmpty:
                     pass


### PR DESCRIPTION
Cleaning up CI for #6701 
```md
  I'm trying to help a customer with some issues related to their checkpointing in postgres. They have some timeouts and retries around the langgraph checkpoint queries and I suspect the queue may be filling up with cancelled tasks.
  
  This PR adds some eager checks to not execute an operation if the future was already cancelled.
  This is to prevent the queue executing tasks that might have already timed out, which would otherwise cause more tasks to timeout due to the longer execution delay.
  
  Thank you for contributing to LangGraph! Follow these steps to mark your pull request as ready for review. **If any of these steps are not completed, your PR will not be considered for review.**
```