### PR TITLE
fix(cli): ignore .langgraph_api runtime watch noise in dev

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -1772,6 +1772,7 @@ def dev(
         port,
         not no_reload,
         graphs,
+        reload_excludes=["**/.langgraph_api/*", "**/.langgraph_api/**/*"],
         n_jobs_per_worker=n_jobs_per_worker,
         open_browser=not no_browser,
         debug_port=debug_port,

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -2,8 +2,10 @@ import json
 import pathlib
 import re
 import shutil
+import sys
 import tempfile
 import textwrap
+import types
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -286,6 +288,40 @@ def test_version_option() -> None:
     assert "LangGraph CLI, version" in result.output, (
         "Expected version information in output"
     )
+
+
+def test_dev_excludes_langgraph_api_from_reload(monkeypatch) -> None:
+    runner = CliRunner()
+    captured: dict[str, object] = {}
+
+    def fake_run_server(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    fake_langgraph_api = types.ModuleType("langgraph_api")
+    fake_langgraph_api_cli = types.ModuleType("langgraph_api.cli")
+    fake_langgraph_api_cli.run_server = fake_run_server
+    fake_langgraph_api.cli = fake_langgraph_api_cli
+
+    monkeypatch.setitem(sys.modules, "langgraph_api", fake_langgraph_api)
+    monkeypatch.setitem(sys.modules, "langgraph_api.cli", fake_langgraph_api_cli)
+    monkeypatch.setattr(
+        cli_module.langgraph_cli.config,
+        "validate_config_file",
+        lambda path: {"graphs": {"agent": "agent.py:graph"}},
+    )
+
+    with runner.isolated_filesystem():
+        Path("langgraph.json").write_text(
+            json.dumps({"graphs": {"agent": "agent.py:graph"}}), encoding="utf-8"
+        )
+        result = runner.invoke(cli, ["dev", "--no-browser"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert captured["kwargs"]["reload_excludes"] == [
+        "**/.langgraph_api/*",
+        "**/.langgraph_api/**/*",
+    ]
 
 
 def test_top_level_help_shows_deploy_subcommands() -> None:


### PR DESCRIPTION
## Summary
- exclude `.langgraph_api` runtime files from `langgraph dev` reload watching
- add a focused regression test for the `reload_excludes` wiring

## Why
`langgraph dev` writes runtime persistence files under `.langgraph_api` inside the project tree. Those writes can trigger repeated `watchfiles` reload noise even without source edits.

## Validation
- reproduced the repeated watchfiles log behavior locally with `langgraph dev --config tests/example_app/langgraph.json`
- ran `pytest -q libs/cli/tests/unit_tests/cli/test_cli.py -k dev_excludes_langgraph_api_from_reload`
- ran `make -C libs/cli format`
- ran `make -C libs/cli lint`
- ran `make -C libs/cli test TEST="tests/unit_tests/cli/test_cli.py -k dev_excludes_langgraph_api_from_reload"`