### PR TITLE
fix(langgraph): forward RemoteGraph context

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -31,6 +31,7 @@ from langgraph_sdk.client import (
 )
 from langgraph_sdk.schema import (
     Checkpoint,
+    Context,
     QueryParamTypes,
     ThreadState,
 )
@@ -691,6 +692,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -707,6 +709,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -722,6 +725,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -740,6 +744,7 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Optional runtime context to pass to the remote graph.
             stream_mode: Stream mode(s) to use.
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
@@ -769,6 +774,7 @@ class RemoteGraph(PregelProtocol):
             input=input,
             command=command,
             config=sanitized_config,
+            context=context,
             stream_mode=stream_modes,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
@@ -842,6 +848,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -858,6 +865,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -873,6 +881,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         stream_mode: StreamMode | list[StreamMode] | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -891,6 +900,7 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Optional runtime context to pass to the remote graph.
             stream_mode: Stream mode(s) to use.
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
@@ -920,6 +930,7 @@ class RemoteGraph(PregelProtocol):
             input=input,
             command=command,
             config=sanitized_config,
+            context=context,
             stream_mode=stream_modes,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
@@ -1009,6 +1020,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1023,6 +1035,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1036,6 +1049,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1048,6 +1062,7 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Optional runtime context to pass to the remote graph.
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
             headers: Additional headers to pass to the request.
@@ -1061,6 +1076,7 @@ class RemoteGraph(PregelProtocol):
         for chunk in self.stream(  # type: ignore[misc, call-overload]
             input,
             config=config,
+            context=context,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
             headers=headers,
@@ -1087,6 +1103,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1101,6 +1118,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1114,6 +1132,7 @@ class RemoteGraph(PregelProtocol):
         input: dict[str, Any] | Any,
         config: RunnableConfig | None = None,
         *,
+        context: Context | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
         headers: dict[str, str] | None = None,
@@ -1126,6 +1145,7 @@ class RemoteGraph(PregelProtocol):
         Args:
             input: Input to the graph.
             config: A `RunnableConfig` for graph invocation.
+            context: Optional runtime context to pass to the remote graph.
             interrupt_before: Interrupt the graph before these nodes.
             interrupt_after: Interrupt the graph after these nodes.
             headers: Additional headers to pass to the request.
@@ -1139,6 +1159,7 @@ class RemoteGraph(PregelProtocol):
         async for chunk in self.astream(  # type: ignore[misc, call-overload]
             input,
             config=config,
+            context=context,
             interrupt_before=interrupt_before,
             interrupt_after=interrupt_after,
             headers=headers,

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -880,6 +880,42 @@ def test_stream_sanitizes_thread_id():
     assert not passed_config["configurable"]
 
 
+def test_stream_forwards_context():
+    mock_sync_client = MagicMock()
+    mock_sync_client.runs.stream.return_value = []
+    remote_pregel = RemoteGraph("test_graph_id", sync_client=mock_sync_client)
+
+    context = {"user_id": "user-123"}
+    list(
+        remote_pregel.stream(
+            {"input": {"messages": []}},
+            {"configurable": {"thread_id": "thread_2"}},
+            context=context,
+        )
+    )
+
+    _, kwargs = mock_sync_client.runs.stream.call_args
+    assert kwargs["context"] == context
+
+
+def test_invoke_forwards_context():
+    mock_sync_client = MagicMock()
+    mock_sync_client.runs.stream.return_value = [
+        StreamPart(event="values", data={"messages": []})
+    ]
+    remote_pregel = RemoteGraph("test_graph_id", sync_client=mock_sync_client)
+
+    context = {"user_id": "user-123"}
+    remote_pregel.invoke(
+        {"input": {"messages": []}},
+        {"configurable": {"thread_id": "thread_1"}},
+        context=context,
+    )
+
+    _, kwargs = mock_sync_client.runs.stream.call_args
+    assert kwargs["context"] == context
+
+
 @pytest.mark.anyio
 async def test_ainvoke():
     # set up test
@@ -906,6 +942,47 @@ async def test_ainvoke():
     )
 
     assert result == {"messages": [{"type": "human", "content": "world"}]}
+
+
+@pytest.mark.anyio
+async def test_astream_forwards_context():
+    mock_async_client = MagicMock()
+    async_iter = MagicMock()
+    async_iter.__aiter__.return_value = []
+    mock_async_client.runs.stream.return_value = async_iter
+    remote_pregel = RemoteGraph("test_graph_id", client=mock_async_client)
+
+    context = {"user_id": "user-123"}
+    async for _ in remote_pregel.astream(
+        {"input": {"messages": []}},
+        {"configurable": {"thread_id": "thread_1"}},
+        context=context,
+    ):
+        pass
+
+    _, kwargs = mock_async_client.runs.stream.call_args
+    assert kwargs["context"] == context
+
+
+@pytest.mark.anyio
+async def test_ainvoke_forwards_context():
+    mock_async_client = MagicMock()
+    async_iter = MagicMock()
+    async_iter.__aiter__.return_value = [
+        StreamPart(event="values", data={"messages": []})
+    ]
+    mock_async_client.runs.stream.return_value = async_iter
+    remote_pregel = RemoteGraph("test_graph_id", client=mock_async_client)
+
+    context = {"user_id": "user-123"}
+    await remote_pregel.ainvoke(
+        {"input": {"messages": []}},
+        {"configurable": {"thread_id": "thread_1"}},
+        context=context,
+    )
+
+    _, kwargs = mock_async_client.runs.stream.call_args
+    assert kwargs["context"] == context
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Summary
- add `context` to `RemoteGraph.stream`, `astream`, `invoke`, and `ainvoke`
- forward the provided context to the underlying SDK `runs.stream` call
- add sync and async regression tests covering both streaming and invoke paths

## Why this fix
`PregelProtocol` and local graph execution already accept `context`, and the underlying LangGraph SDK supports it too. `RemoteGraph` was the gap in the stack, so remote callers had no way to pass execution context even though the server API already supports it.

Closes #6115.

## Validation
- `PYTHONPATH=D:/project/me/githubAutoPR/langgraph-fork-git/libs/langgraph;D:/project/me/githubAutoPR/langgraph-fork-git/libs/sdk-py;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-postgres;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-sqlite pytest libs/langgraph/tests/test_remote_graph.py -q -k "test_stream or test_astream or test_invoke or test_ainvoke or test_stream_sanitizes_thread_id or test_include_headers or forwards_context"`
- Result: `18 passed, 13 deselected`
- Note: the full file currently includes two existing tests that attempt to connect to `localhost:2024`, so full-file execution is not green in this environment without a local server.

## AI assistance disclosure
Prepared with AI assistance and validated locally.
