### PR TITLE
fix(prebuilt): preserve parallel parent tool updates

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -864,22 +864,11 @@ class ToolNode(RunnableCallable):
             Command | list[ToolMessage] | dict[str, list[ToolMessage]]
         ] = []
 
-        # combine all parent commands with goto into a single parent command
-        parent_command: Command | None = None
+        parent_commands: list[Command] = []
         for output in outputs:
             if isinstance(output, Command):
-                if (
-                    output.graph is Command.PARENT
-                    and isinstance(output.goto, list)
-                    and all(isinstance(send, Send) for send in output.goto)
-                ):
-                    if parent_command:
-                        parent_command = replace(
-                            parent_command,
-                            goto=cast("list[Send]", parent_command.goto) + output.goto,
-                        )
-                    else:
-                        parent_command = Command(graph=Command.PARENT, goto=output.goto)
+                if output.graph is Command.PARENT:
+                    parent_commands.append(output)
                 else:
                     combined_outputs.append(output)
             else:
@@ -887,9 +876,50 @@ class ToolNode(RunnableCallable):
                     [output] if input_type == "list" else {self._messages_key: [output]}
                 )
 
-        if parent_command:
-            combined_outputs.append(parent_command)
+        if len(parent_commands) == 1:
+            combined_outputs.append(parent_commands[0])
+        elif parent_commands:
+            combined_outputs.append(self._combine_parent_commands(parent_commands))
         return combined_outputs
+
+    def _combine_parent_commands(self, commands: list[Command]) -> Command:
+        updates: list[tuple[str, Any]] = []
+        goto_targets: list[Send | str] = []
+        seen_gotos: set[str] = set()
+        resume: dict[str, Any] | Any | None = None
+
+        for command in commands:
+            updates.extend(command._update_as_tuples())
+
+            if command.resume is not None and resume is None:
+                resume = command.resume
+
+            if isinstance(command.goto, (str, Send)):
+                command_gotos = [command.goto]
+            else:
+                command_gotos = list(command.goto)
+
+            for goto in command_gotos:
+                if isinstance(goto, str):
+                    if goto not in seen_gotos:
+                        seen_gotos.add(goto)
+                        goto_targets.append(goto)
+                else:
+                    goto_targets.append(goto)
+
+        if not goto_targets:
+            merged_goto: Send | Sequence[Send | str] | str = ()
+        elif len(goto_targets) == 1:
+            merged_goto = goto_targets[0]
+        else:
+            merged_goto = goto_targets
+
+        return Command(
+            graph=Command.PARENT,
+            update=updates or None,
+            resume=resume,
+            goto=merged_goto,
+        )
 
     def _execute_tool_sync(
         self,

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -25,7 +25,7 @@ from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools import tool as dec_tool
 from langgraph.config import get_stream_writer
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
-from langgraph.graph import START, MessagesState, StateGraph
+from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.graph.message import REMOVE_ALL_MESSAGES, add_messages
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
@@ -807,28 +807,28 @@ async def test_tool_node_command(input_type: str) -> None:
     )
     assert result == [
         Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content="Transferred to Bob",
-                        tool_call_id="1",
-                        name="transfer_to_bob",
-                    )
-                ]
-            },
-            goto="bob",
-            graph=Command.PARENT,
-        ),
-        Command(
-            update={
-                "messages": [
-                    ToolMessage(
-                        content="Transferred to Bob",
-                        tool_call_id="2",
-                        name="custom_transfer_to_bob",
-                    )
-                ]
-            },
+            update=[
+                (
+                    "messages",
+                    [
+                        ToolMessage(
+                            content="Transferred to Bob",
+                            tool_call_id="1",
+                            name="transfer_to_bob",
+                        )
+                    ],
+                ),
+                (
+                    "messages",
+                    [
+                        ToolMessage(
+                            content="Transferred to Bob",
+                            tool_call_id="2",
+                            name="custom_transfer_to_bob",
+                        )
+                    ],
+                ),
+            ],
             goto="bob",
             graph=Command.PARENT,
         ),
@@ -1088,22 +1088,26 @@ async def test_tool_node_command_list_input() -> None:
     assert result == [
         Command(
             update=[
-                ToolMessage(
-                    content="Transferred to Bob",
-                    tool_call_id="1",
-                    name="transfer_to_bob",
-                )
-            ],
-            goto="bob",
-            graph=Command.PARENT,
-        ),
-        Command(
-            update=[
-                ToolMessage(
-                    content="Transferred to Bob",
-                    tool_call_id="2",
-                    name="custom_transfer_to_bob",
-                )
+                (
+                    "__root__",
+                    [
+                        ToolMessage(
+                            content="Transferred to Bob",
+                            tool_call_id="1",
+                            name="transfer_to_bob",
+                        )
+                    ],
+                ),
+                (
+                    "__root__",
+                    [
+                        ToolMessage(
+                            content="Transferred to Bob",
+                            tool_call_id="2",
+                            name="custom_transfer_to_bob",
+                        )
+                    ],
+                ),
             ],
             goto="bob",
             graph=Command.PARENT,
@@ -1273,6 +1277,69 @@ def test_tool_node_parent_command_with_send() -> None:
             graph=Command.PARENT,
         )
     ]
+
+
+def test_tool_node_parallel_parent_commands_reach_parent_graph() -> None:
+    @dec_tool
+    def fetch_a() -> Command:
+        """Set a."""
+        return Command(graph=Command.PARENT, goto="result_node", update={"a": True})
+
+    @dec_tool
+    def fetch_b() -> Command:
+        """Set b."""
+        return Command(graph=Command.PARENT, goto="result_node", update={"b": True})
+
+    @dec_tool
+    def fetch_c() -> Command:
+        """Set c."""
+        return Command(graph=Command.PARENT, goto="result_node", update={"c": True})
+
+    class ParentState(TypedDict, total=False):
+        messages: Annotated[list[AnyMessage], add_messages]
+        a: bool
+        b: bool
+        c: bool
+
+    def call_model(state: ParentState) -> dict[str, Any]:
+        return {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {"args": {}, "id": "1", "name": "fetch_a"},
+                        {"args": {}, "id": "2", "name": "fetch_b"},
+                        {"args": {}, "id": "3", "name": "fetch_c"},
+                    ],
+                )
+            ]
+        }
+
+    def result_node(state: ParentState) -> ParentState:
+        return state
+
+    agent_builder = StateGraph(ParentState)
+    agent_builder.add_node("call_model", call_model)
+    agent_builder.add_node("tools", ToolNode([fetch_a, fetch_b, fetch_c]))
+    agent_builder.add_edge(START, "call_model")
+    agent_builder.add_conditional_edges(
+        "call_model",
+        tools_condition,
+        {"tools": "tools", "__end__": END},
+    )
+    agent = agent_builder.compile(name="agent")
+
+    parent = StateGraph(ParentState)
+    parent.add_node("agent", agent, destinations=("result_node",))
+    parent.add_node("result_node", result_node)
+    parent.set_entry_point("agent")
+    parent.add_edge("result_node", END)
+
+    result = parent.compile().invoke({"messages": [("user", "run all tools")]})
+
+    assert result["a"] is True
+    assert result["b"] is True
+    assert result["c"] is True
 
 
 async def test_tool_node_command_remove_all_messages() -> None:


### PR DESCRIPTION
## Summary
- merge multiple parallel `Command(graph=Command.PARENT, ...)` tool results into a single parent command
- preserve all parent-state updates instead of dropping later tool outputs
- add regression coverage for both merged ToolNode outputs and a nested agent-subgraph execution path

## Why this fix
When a subgraph agent triggers multiple tools in parallel and each tool returns a parent command, LangGraph currently bubbles up only the first command. That means later tool updates are silently discarded before the parent graph can apply them.

This patch aggregates parallel parent commands into one parent command, preserving all updates and consolidating parent routing so the parent graph sees the full result of the parallel tool turn.

Closes #7129.

## Validation
- `PYTHONPATH=D:/project/me/githubAutoPR/langgraph-fork-git/libs/langgraph;D:/project/me/githubAutoPR/langgraph-fork-git/libs/prebuilt;D:/project/me/githubAutoPR/langgraph-fork-git/libs/sdk-py;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-postgres;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-sqlite pytest libs/prebuilt/tests/test_tool_node.py -q`
- Result: `31 passed`
- Reproduced the issue locally before the patch with a nested parent graph and parallel tool calls; after the patch the parent graph receives all `a/b/c` updates.

## AI assistance disclosure
Prepared with AI assistance and validated locally.
