### PR TITLE
fix(langgraph): resume remote subgraphs from parent interrupts

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -45,13 +45,17 @@ from typing_extensions import Self
 from langgraph._internal._config import merge_configs
 from langgraph._internal._constants import (
     CONF,
+    CONFIG_KEY_CHECKPOINTER,
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_RESUMING,
     CONFIG_KEY_STREAM,
     CONFIG_KEY_TASK_ID,
     INTERRUPT,
+    NULL_TASK_ID,
     NS_SEP,
+    RESUME,
 )
 from langgraph.errors import GraphInterrupt, ParentCommand
 from langgraph.pregel.protocol import PregelProtocol, StreamProtocol
@@ -397,6 +401,45 @@ class RemoteGraph(PregelProtocol):
                     sanitized["configurable"][k] = sanitized_value
 
         return sanitized
+
+    def _get_resume_command(
+        self, input: dict[str, Any] | Any, config: RunnableConfig
+    ) -> CommandSDK | None:
+        """Translate nested resume state into a remote command."""
+        if isinstance(input, Command):
+            return cast(CommandSDK, asdict(input))
+
+        configurable = config.get(CONF, {})
+        if not configurable.get(CONFIG_KEY_RESUMING):
+            return None
+
+        checkpointer = configurable.get(CONFIG_KEY_CHECKPOINTER)
+        thread_id = configurable.get("thread_id")
+        if checkpointer is None or thread_id is None:
+            return None
+
+        checkpoint_config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
+        if checkpoint_id := configurable.get(CONFIG_KEY_CHECKPOINT_MAP, {}).get(
+            "", configurable.get(CONFIG_KEY_CHECKPOINT_ID)
+        ):
+            checkpoint_config["configurable"][CONFIG_KEY_CHECKPOINT_ID] = checkpoint_id
+
+        saved = checkpointer.get_tuple(checkpoint_config)
+        if saved is None or saved.pending_writes is None:
+            return None
+
+        resume = next(
+            (
+                value
+                for task_id, channel, value in reversed(saved.pending_writes)
+                if task_id == NULL_TASK_ID and channel == RESUME
+            ),
+            None,
+        )
+        if resume is None:
+            return None
+
+        return cast(CommandSDK, asdict(Command(resume=resume)))
 
     def get_state(
         self,
@@ -752,15 +795,13 @@ class RemoteGraph(PregelProtocol):
         """
         sync_client = self._validate_sync_client()
         merged_config = merge_configs(self.config, config)
+        command = self._get_resume_command(input, merged_config)
+        if command is not None:
+            input = None
         sanitized_config = self._sanitize_config(merged_config)
         stream_modes, requested, req_single, stream = self._get_stream_modes(
             stream_mode, config
         )
-        if isinstance(input, Command):
-            command: CommandSDK | None = cast(CommandSDK, asdict(input))
-            input = None
-        else:
-            command = None
         thread_id = sanitized_config.get("configurable", {}).pop("thread_id", None)
 
         for chunk in sync_client.runs.stream(
@@ -903,15 +944,13 @@ class RemoteGraph(PregelProtocol):
         """
         client = self._validate_client()
         merged_config = merge_configs(self.config, config)
+        command = self._get_resume_command(input, merged_config)
+        if command is not None:
+            input = None
         sanitized_config = self._sanitize_config(merged_config)
         stream_modes, requested, req_single, stream = self._get_stream_modes(
             stream_mode, config
         )
-        if isinstance(input, Command):
-            command: CommandSDK | None = cast(CommandSDK, asdict(input))
-            input = None
-        else:
-            command = None
         thread_id = sanitized_config.get("configurable", {}).pop("thread_id", None)
 
         async for chunk in client.runs.stream(

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from types import SimpleNamespace
 from typing import Annotated
 from unittest.mock import AsyncMock, MagicMock
 
@@ -12,6 +13,12 @@ from langchain_core.runnables.graph import Node as DrawableNode
 from langgraph_sdk.schema import StreamPart
 from typing_extensions import TypedDict
 
+from langgraph._internal._constants import (
+    CONFIG_KEY_CHECKPOINTER,
+    CONFIG_KEY_RESUMING,
+    NULL_TASK_ID,
+    RESUME,
+)
 from langgraph.errors import GraphInterrupt
 from langgraph.graph import StateGraph, add_messages
 from langgraph.pregel import Pregel
@@ -604,6 +611,34 @@ def test_stream():
     ]
 
 
+def test_stream_forwards_nested_resume_as_command():
+    mock_sync_client = MagicMock()
+    mock_sync_client.runs.stream.return_value = []
+    checkpointer = MagicMock()
+    checkpointer.get_tuple.return_value = SimpleNamespace(
+        pending_writes=[(NULL_TASK_ID, RESUME, "Alice")]
+    )
+
+    remote_pregel = RemoteGraph("test_graph_id", sync_client=mock_sync_client)
+
+    list(
+        remote_pregel.stream(
+            {"messages": [{"type": "human", "content": "hello"}]},
+            config={
+                "configurable": {
+                    "thread_id": "thread_1",
+                    CONFIG_KEY_RESUMING: True,
+                    CONFIG_KEY_CHECKPOINTER: checkpointer,
+                }
+            },
+        )
+    )
+
+    _, kwargs = mock_sync_client.runs.stream.call_args
+    assert kwargs["input"] is None
+    assert kwargs["command"]["resume"] == "Alice"
+
+
 @pytest.mark.anyio
 async def test_astream():
     # set up test
@@ -813,6 +848,36 @@ async def test_astream():
         (("hello", "subgraph"), {"chunk": "data4"}),
         (("bye", "subgraph"), {"__interrupt__": ()}),
     ]
+
+
+@pytest.mark.anyio
+async def test_astream_forwards_nested_resume_as_command():
+    mock_async_client = MagicMock()
+    async_iter = MagicMock()
+    async_iter.__aiter__.return_value = []
+    mock_async_client.runs.stream.return_value = async_iter
+    checkpointer = MagicMock()
+    checkpointer.get_tuple.return_value = SimpleNamespace(
+        pending_writes=[(NULL_TASK_ID, RESUME, "Alice")]
+    )
+
+    remote_pregel = RemoteGraph("test_graph_id", client=mock_async_client)
+
+    async for _ in remote_pregel.astream(
+        {"messages": [{"type": "human", "content": "hello"}]},
+        config={
+            "configurable": {
+                "thread_id": "thread_1",
+                CONFIG_KEY_RESUMING: True,
+                CONFIG_KEY_CHECKPOINTER: checkpointer,
+            }
+        },
+    ):
+        pass
+
+    _, kwargs = mock_async_client.runs.stream.call_args
+    assert kwargs["input"] is None
+    assert kwargs["command"]["resume"] == "Alice"
 
 
 def test_invoke():


### PR DESCRIPTION
## Summary
- translate parent interrupt resume writes into `command.resume` when `RemoteGraph` is resumed as a nested subgraph
- stop forwarding the parent state as fresh remote input on that resume path
- add sync and async regression tests covering nested resume forwarding

## Why this fix
Local subgraphs can resume from the parent checkpointer with `__pregel_resuming`, but remote graphs run in a separate deployment and need the actual resume payload. Without translating the pending `__resume__` write into a remote command, the interrupt fires again instead of continuing.

Fixes #4879.

## Validation
```powershell
$env:PYTHONPATH='D:/project/me/githubAutoPR/langgraph-fork-git/libs/langgraph;D:/project/me/githubAutoPR/langgraph-fork-git/libs/sdk-py;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-postgres;D:/project/me/githubAutoPR/langgraph-fork-git/libs/checkpoint-sqlite;D:/project/me/githubAutoPR/langgraph-fork-git/libs/prebuilt'; pytest libs/langgraph/tests/test_remote_graph.py -q -k "test_stream or test_astream or test_invoke or test_ainvoke or forwards_nested_resume_as_command or test_stream_sanitizes_thread_id or test_include_headers"
```

Result: `16 passed, 13 deselected`
