### PR TITLE
Add restart coverage for put_writes retries

### DIFF
--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -330,6 +330,51 @@ def test_pending_sends_migration(saver_name: str) -> None:
         assert TASKS in search_results[0].checkpoint["channel_versions"]
 
 
+def test_put_writes_is_retry_safe_across_saver_restart() -> None:
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+
+    try:
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "thread-restart",
+                "checkpoint_ns": "",
+            }
+        }
+        task_id = "task-restart"
+
+        with Connection.connect(
+            DEFAULT_POSTGRES_URI + database,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as conn:
+            saver = PostgresSaver(conn)
+            saver.setup()
+            checkpoint = empty_checkpoint()
+            stored = saver.put(config, checkpoint, {}, {})
+            saver.put_writes(stored, [("ch", "val")], task_id=task_id)
+
+        with Connection.connect(
+            DEFAULT_POSTGRES_URI + database,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as conn:
+            saver = PostgresSaver(conn)
+            saver.setup()
+            saver.put_writes(stored, [("ch", "val")], task_id=task_id)
+            checkpoint_tuple = saver.get_tuple(stored)
+
+        assert checkpoint_tuple is not None
+        assert checkpoint_tuple.pending_writes is not None
+        assert checkpoint_tuple.pending_writes == [(task_id, "ch", "val")]
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")
+
+
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 def test_get_checkpoint_no_channel_values(
     monkeypatch, saver_name: str, test_data

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -307,3 +308,20 @@ class TestSqliteSaver:
             # Nested digit-starting key via dotted path
             results = list(saver.list(None, filter={"user.123abc": "ok2"}))
             assert len(results) == 1
+
+    def test_put_writes_is_retry_safe_across_saver_restart(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "restart-safe.sqlite"
+        task_id = "task-restart"
+
+        with SqliteSaver.from_conn_string(str(db_path)) as saver:
+            stored = saver.put(self.config_1, self.chkpnt_1, self.metadata_1, {})
+            saver.put_writes(stored, [("ch", "val")], task_id)
+
+        with SqliteSaver.from_conn_string(str(db_path)) as saver:
+            saver.put_writes(stored, [("ch", "val")], task_id)
+            checkpoint_tuple = saver.get_tuple(stored)
+
+        assert checkpoint_tuple is not None
+        assert checkpoint_tuple.pending_writes == [(task_id, "ch", "val")]


### PR DESCRIPTION
Problem
`put_writes` retry safety was only covered within a single saver instance, so a restart regression could slip through even though resumed graphs depend on replaying the same pending writes safely.

Why now
The existing conformance coverage already asserts idempotency for repeated calls in-process. This closes the remaining validation gap for the operational case that matters most: re-opening a saver and replaying the same writes after interruption.

What changed
- added a Postgres regression test that reopens the saver and replays the same `put_writes` payload
- added a matching SQLite regression test for the same restart/replay path

Validation
- `make format` in `libs/checkpoint-postgres` ✅
- `make lint` in `libs/checkpoint-postgres` ✅
- `TEST='tests/test_sync.py -k put_writes_is_retry_safe_across_saver_restart' make test_pg_version POSTGRES_VERSION=16` ⚠️ blocked locally because Docker is unavailable (`Cannot connect to the Docker daemon`)
- `make format && make lint && TEST='tests/test_sqlite.py -k put_writes_is_retry_safe_across_saver_restart' make test` in `libs/checkpoint-sqlite` ✅

Refs #7201
