### PR TITLE
Ignore late writes after delete_thread

### DIFF
--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_delete_thread.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_delete_thread.py
@@ -115,12 +115,35 @@ async def test_delete_thread_nonexistent_noop(
     await saver.adelete_thread(str(uuid4()))
 
 
+async def test_delete_thread_blocks_late_writes(
+    saver: BaseCheckpointSaver,
+) -> None:
+    """Late checkpoint and write inserts must not recreate a deleted thread."""
+    tid = str(uuid4())
+    config = generate_config(tid)
+    checkpoint = generate_checkpoint()
+    stored = await saver.aput(config, checkpoint, generate_metadata(), {})
+
+    await saver.adelete_thread(tid)
+
+    await saver.aput(stored, generate_checkpoint(), generate_metadata(step=99), {})
+    await saver.aput_writes(stored, [("ch", "late-write")], str(uuid4()))
+
+    assert await saver.aget_tuple(generate_config(tid)) is None
+
+    results = []
+    async for item in saver.alist(generate_config(tid)):
+        results.append(item)
+    assert results == []
+
+
 ALL_DELETE_THREAD_TESTS = [
     test_delete_thread_removes_checkpoints,
     test_delete_thread_removes_writes,
     test_delete_thread_removes_all_namespaces,
     test_delete_thread_preserves_other_threads,
     test_delete_thread_nonexistent_noop,
+    test_delete_thread_blocks_late_writes,
 ]
 
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -308,6 +308,12 @@ class PostgresSaver(BasePostgresSaver):
                 blob_values[k] = copy["channel_values"].pop(k)
 
         with self._cursor(pipeline=True) as cur:
+            cur.execute(
+                self.CHECK_CHECKPOINT_DELETED_THREAD_SQL,
+                (thread_id,),
+            )
+            if cur.fetchone():
+                return next_config
             if blob_versions := {
                 k: v for k, v in new_versions.items() if k in blob_values
             }:
@@ -355,6 +361,12 @@ class PostgresSaver(BasePostgresSaver):
             else self.INSERT_CHECKPOINT_WRITES_SQL
         )
         with self._cursor(pipeline=True) as cur:
+            cur.execute(
+                self.CHECK_CHECKPOINT_DELETED_THREAD_SQL,
+                (config["configurable"]["thread_id"],),
+            )
+            if cur.fetchone():
+                return
             cur.executemany(
                 query,
                 self._dump_writes(
@@ -377,6 +389,10 @@ class PostgresSaver(BasePostgresSaver):
             None
         """
         with self._cursor(pipeline=True) as cur:
+            cur.execute(
+                self.INSERT_CHECKPOINT_DELETED_THREAD_SQL,
+                (str(thread_id),),
+            )
             cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = %s",
                 (str(thread_id),),

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -267,6 +267,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 blob_values[k] = copy["channel_values"].pop(k)
 
         async with self._cursor(pipeline=True) as cur:
+            await cur.execute(
+                self.CHECK_CHECKPOINT_DELETED_THREAD_SQL,
+                (thread_id,),
+            )
+            if await cur.fetchone():
+                return next_config
             if blob_versions := {
                 k: v for k, v in new_versions.items() if k in blob_values
             }:
@@ -324,6 +330,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
             writes,
         )
         async with self._cursor(pipeline=True) as cur:
+            await cur.execute(
+                self.CHECK_CHECKPOINT_DELETED_THREAD_SQL,
+                (config["configurable"]["thread_id"],),
+            )
+            if await cur.fetchone():
+                return
             await cur.executemany(query, params)
 
     async def adelete_thread(self, thread_id: str) -> None:
@@ -336,6 +348,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
             None
         """
         async with self._cursor(pipeline=True) as cur:
+            await cur.execute(
+                self.INSERT_CHECKPOINT_DELETED_THREAD_SQL,
+                (str(thread_id),),
+            )
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = %s",
                 (str(thread_id),),

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -82,6 +82,9 @@ MIGRATIONS = [
     CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_writes_thread_id_idx ON checkpoint_writes(thread_id);
     """,
     """ALTER TABLE checkpoint_writes ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';""",
+    """CREATE TABLE IF NOT EXISTS checkpoint_deleted_threads (
+    thread_id TEXT PRIMARY KEY
+);""",
 ]
 
 SELECT_SQL = """
@@ -152,6 +155,18 @@ INSERT_CHECKPOINT_WRITES_SQL = """
     ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
 """
 
+INSERT_CHECKPOINT_DELETED_THREAD_SQL = """
+    INSERT INTO checkpoint_deleted_threads (thread_id)
+    VALUES (%s)
+    ON CONFLICT (thread_id) DO NOTHING
+"""
+
+CHECK_CHECKPOINT_DELETED_THREAD_SQL = """
+    SELECT 1
+    FROM checkpoint_deleted_threads
+    WHERE thread_id = %s
+"""
+
 
 class BasePostgresSaver(BaseCheckpointSaver[str]):
     SELECT_SQL = SELECT_SQL
@@ -161,6 +176,8 @@ class BasePostgresSaver(BaseCheckpointSaver[str]):
     UPSERT_CHECKPOINTS_SQL = UPSERT_CHECKPOINTS_SQL
     UPSERT_CHECKPOINT_WRITES_SQL = UPSERT_CHECKPOINT_WRITES_SQL
     INSERT_CHECKPOINT_WRITES_SQL = INSERT_CHECKPOINT_WRITES_SQL
+    INSERT_CHECKPOINT_DELETED_THREAD_SQL = INSERT_CHECKPOINT_DELETED_THREAD_SQL
+    CHECK_CHECKPOINT_DELETED_THREAD_SQL = CHECK_CHECKPOINT_DELETED_THREAD_SQL
 
     supports_pipeline: bool
 

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -279,6 +279,28 @@ async def test_asearch(saver_name: str, test_data) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])
+async def test_delete_thread_ignores_late_writes(saver_name: str) -> None:
+    async with _saver(saver_name) as saver:
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "thread-delete",
+                "checkpoint_ns": "",
+            }
+        }
+
+        stored = await saver.aput(config, empty_checkpoint(), {}, {})
+        await saver.adelete_thread("thread-delete")
+
+        await saver.aput(stored, empty_checkpoint(), {"step": 99}, {})
+        await saver.aput_writes(stored, [("ch", "late-write")], str(uuid4()))
+
+        assert await saver.aget_tuple({"configurable": {"thread_id": "thread-delete"}}) is None
+        assert [
+            c async for c in saver.alist({"configurable": {"thread_id": "thread-delete"}})
+        ] == []
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])
 async def test_null_chars(saver_name: str, test_data) -> None:
     async with _saver(saver_name) as saver:
         config = await saver.aput(

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -259,6 +259,26 @@ def test_search(saver_name: str, test_data) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])
+def test_delete_thread_ignores_late_writes(saver_name: str) -> None:
+    with _saver(saver_name) as saver:
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": "thread-delete",
+                "checkpoint_ns": "",
+            }
+        }
+
+        stored = saver.put(config, empty_checkpoint(), {}, {})
+        saver.delete_thread("thread-delete")
+
+        saver.put(stored, empty_checkpoint(), {"step": 99}, {})
+        saver.put_writes(stored, [("ch", "late-write")], str(uuid4()))
+
+        assert saver.get_tuple({"configurable": {"thread_id": "thread-delete"}}) is None
+        assert list(saver.list({"configurable": {"thread_id": "thread-delete"}})) == []
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])
 def test_null_chars(saver_name: str, test_data) -> None:
     with _saver(saver_name) as saver:
         config = saver.put(

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -153,6 +153,9 @@ class SqliteSaver(BaseCheckpointSaver[str]):
                 value BLOB,
                 PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
             );
+            CREATE TABLE IF NOT EXISTS checkpoint_deleted_threads (
+                thread_id TEXT PRIMARY KEY
+            );
             """
         )
 
@@ -416,6 +419,18 @@ class SqliteSaver(BaseCheckpointSaver[str]):
         ).encode("utf-8", "ignore")
         with self.cursor() as cur:
             cur.execute(
+                "SELECT 1 FROM checkpoint_deleted_threads WHERE thread_id = ?",
+                (str(thread_id),),
+            )
+            if cur.fetchone():
+                return {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": checkpoint["id"],
+                    }
+                }
+            cur.execute(
                 "INSERT OR REPLACE INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     str(config["configurable"]["thread_id"]),
@@ -458,6 +473,12 @@ class SqliteSaver(BaseCheckpointSaver[str]):
             else "INSERT OR IGNORE INTO writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         )
         with self.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM checkpoint_deleted_threads WHERE thread_id = ?",
+                (str(config["configurable"]["thread_id"]),),
+            )
+            if cur.fetchone():
+                return
             cur.executemany(
                 query,
                 [
@@ -484,6 +505,10 @@ class SqliteSaver(BaseCheckpointSaver[str]):
             None
         """
         with self.cursor() as cur:
+            cur.execute(
+                "INSERT OR IGNORE INTO checkpoint_deleted_threads (thread_id) VALUES (?)",
+                (str(thread_id),),
+            )
             cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",
                 (str(thread_id),),

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -307,6 +307,9 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                     value BLOB,
                     PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
                 );
+                CREATE TABLE IF NOT EXISTS checkpoint_deleted_threads (
+                    thread_id TEXT PRIMARY KEY
+                );
                 """
             ):
                 await self.conn.commit()
@@ -504,9 +507,20 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         serialized_metadata = json.dumps(
             get_checkpoint_metadata(config, metadata), ensure_ascii=False
         ).encode("utf-8", "ignore")
-        async with (
-            self.lock,
-            self.conn.execute(
+        async with self.lock, self.conn.cursor() as cur:
+            await cur.execute(
+                "SELECT 1 FROM checkpoint_deleted_threads WHERE thread_id = ?",
+                (str(thread_id),),
+            )
+            if await cur.fetchone():
+                return {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": checkpoint["id"],
+                    }
+                }
+            await cur.execute(
                 "INSERT OR REPLACE INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     str(config["configurable"]["thread_id"]),
@@ -517,8 +531,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                     serialized_checkpoint,
                     serialized_metadata,
                 ),
-            ),
-        ):
+            )
             await self.conn.commit()
         return {
             "configurable": {
@@ -552,6 +565,12 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         )
         await self.setup()
         async with self.lock, self.conn.cursor() as cur:
+            await cur.execute(
+                "SELECT 1 FROM checkpoint_deleted_threads WHERE thread_id = ?",
+                (str(config["configurable"]["thread_id"]),),
+            )
+            if await cur.fetchone():
+                return
             await cur.executemany(
                 query,
                 [
@@ -578,7 +597,12 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             None
         """
+        await self.setup()
         async with self.lock, self.conn.cursor() as cur:
+            await cur.execute(
+                "INSERT OR IGNORE INTO checkpoint_deleted_threads (thread_id) VALUES (?)",
+                (str(thread_id),),
+            )
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",
                 (str(thread_id),),

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from langchain_core.runnables import RunnableConfig
@@ -188,3 +189,24 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_delete_thread_ignores_late_writes(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": "thread-delete",
+                    "checkpoint_ns": "",
+                }
+            }
+
+            stored = await saver.aput(config, empty_checkpoint(), {}, {})
+            await saver.adelete_thread("thread-delete")
+
+            await saver.aput(stored, empty_checkpoint(), {"step": 99}, {})
+            await saver.aput_writes(stored, [("ch", "late-write")], str(uuid4()))
+
+            assert await saver.aget_tuple({"configurable": {"thread_id": "thread-delete"}}) is None
+            assert [
+                item
+                async for item in saver.alist({"configurable": {"thread_id": "thread-delete"}})
+            ] == []

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from uuid import uuid4
 
 import pytest
 from langchain_core.runnables import RunnableConfig
@@ -197,6 +198,24 @@ class TestSqliteSaver:
         for malicious_key in malicious_keys:
             with pytest.raises(ValueError, match="Invalid filter key"):
                 _metadata_predicate({malicious_key: "dummy"})
+
+    def test_delete_thread_ignores_late_writes(self) -> None:
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": "thread-delete",
+                    "checkpoint_ns": "",
+                }
+            }
+
+            stored = saver.put(config, empty_checkpoint(), {}, {})
+            saver.delete_thread("thread-delete")
+
+            saver.put(stored, empty_checkpoint(), {"step": 99}, {})
+            saver.put_writes(stored, [("ch", "late-write")], str(uuid4()))
+
+            assert saver.get_tuple({"configurable": {"thread_id": "thread-delete"}}) is None
+            assert list(saver.list({"configurable": {"thread_id": "thread-delete"}})) == []
 
     def test_checkpoint_search_sql_injection_prevention(self) -> None:
         """Test that SQL injection via malicious filter keys is prevented in checkpoint search."""


### PR DESCRIPTION
Closes #7206

## Problem
A stale worker can still call `put` or `put_writes` after `delete_thread`, which recreates checkpoint state for a thread that was already deleted.

## What changed
- add deleted-thread tombstones to the SQLite and Postgres checkpoint savers
- short-circuit stale `put` and `put_writes` calls after a thread has been deleted
- add adapter-level regression tests for late writes plus a conformance-spec case for the new behavior

## Validation
- `uv run pytest tests/test_sqlite.py::TestSqliteSaver::test_delete_thread_ignores_late_writes tests/test_aiosqlite.py::TestAsyncSqliteSaver::test_delete_thread_ignores_late_writes` in `libs/checkpoint-sqlite`
- `uv run python -m compileall langgraph/checkpoint/postgres tests/test_sync.py tests/test_async.py` in `libs/checkpoint-postgres`

Postgres runtime tests are still Docker-gated locally.