### PR TITLE
prebuilt: add filter_orphaned_reasoning_messages pre_model_hook

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/__init__.py
+++ b/libs/prebuilt/langgraph/prebuilt/__init__.py
@@ -1,6 +1,9 @@
 """langgraph.prebuilt exposes a higher-level API for creating and executing agents and tools."""
 
-from langgraph.prebuilt.chat_agent_executor import create_react_agent
+from langgraph.prebuilt.chat_agent_executor import (
+    create_react_agent,
+    filter_orphaned_reasoning_messages,
+)
 from langgraph.prebuilt.tool_node import (
     InjectedState,
     InjectedStore,
@@ -12,6 +15,7 @@ from langgraph.prebuilt.tool_validator import ValidationNode
 
 __all__ = [
     "create_react_agent",
+    "filter_orphaned_reasoning_messages",
     "ToolNode",
     "tools_condition",
     "ValidationNode",

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -33,7 +33,7 @@ from langgraph._internal._runnable import RunnableCallable, RunnableLike
 from langgraph._internal._typing import MISSING
 from langgraph.errors import ErrorCode, create_error_message
 from langgraph.graph import END, StateGraph
-from langgraph.graph.message import add_messages
+from langgraph.graph.message import RemoveMessage, add_messages
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.managed import RemainingSteps
 from langgraph.runtime import Runtime
@@ -269,6 +269,88 @@ def _validate_chat_history(
         error_code=ErrorCode.INVALID_CHAT_HISTORY,
     )
     raise ValueError(error_message)
+
+
+def _is_reasoning_only(msg: AIMessage) -> bool:
+    """Return True if the message contains only reasoning blocks and no tool calls.
+
+    An AIMessage is "reasoning-only" when its content is a non-empty list whose
+    every item has `type="reasoning"`, and it carries no `tool_calls`.  These
+    messages represent incomplete assistant turns — the actual text or
+    function-call output that must follow a reasoning block is absent.
+
+    Empty-content messages (`content=[]` or `content=""`) are intentionally
+    excluded: they do not contain reasoning blocks and therefore do not trigger
+    the OpenAI `BadRequestError` that `filter_orphaned_reasoning_messages`
+    targets.
+    """
+    if msg.tool_calls:
+        return False
+    content = msg.content
+    if not isinstance(content, list) or not content:
+        return False
+    return all(
+        isinstance(block, dict) and block.get("type") == "reasoning"
+        for block in content
+    )
+
+
+def filter_orphaned_reasoning_messages(
+    state: dict[str, Any],
+) -> dict[str, list[RemoveMessage]] | None:
+    """Remove orphaned reasoning-only AIMessages from conversation history.
+
+    Some LLM providers (e.g. OpenAI with the Responses API) require that every
+    reasoning block in the message history be immediately followed by the
+    assistant output it produced.  When a client aborts a streaming response
+    mid-flight, LangGraph may persist an `AIMessage` whose content consists
+    only of `type="reasoning"` blocks with no accompanying text or tool-call
+    output.  Replaying that orphaned message on the next turn causes a provider
+    error such as::
+
+        BadRequestError: Item 'rs_...' of type 'reasoning' was provided
+        without its required following item.
+
+    This function is designed to be used as a `pre_model_hook` in
+    `create_react_agent`.  It scans ``state["messages"]`` for such orphaned
+    messages and returns `RemoveMessage` entries to delete them before the
+    model is called.  If no orphaned messages are found it returns `None` so
+    the state is left unchanged.
+
+    Example::
+
+        from langgraph.prebuilt import create_react_agent
+        from langgraph.prebuilt.chat_agent_executor import (
+            filter_orphaned_reasoning_messages,
+        )
+
+        agent = create_react_agent(
+            model,
+            tools,
+            pre_model_hook=filter_orphaned_reasoning_messages,
+        )
+
+    Args:
+        state: The current agent state dict.  Must contain a ``"messages"`` key
+            holding the conversation history.
+
+    Returns:
+        A dict ``{"messages": [RemoveMessage(...), ...]}`` for each orphaned
+        message found, or ``None`` if no orphaned messages are present.
+    """
+    messages = state.get("messages", [])
+
+    orphaned_ids: list[str] = []
+    for msg in messages:
+        if not isinstance(msg, AIMessage) or not _is_reasoning_only(msg):
+            continue
+        if msg.id is not None:
+            orphaned_ids.append(msg.id)
+
+    if not orphaned_ids:
+        return None
+
+    return {"messages": [RemoveMessage(id=msg_id) for msg_id in orphaned_ids]}
 
 
 @deprecated(
@@ -1008,6 +1090,7 @@ create_tool_calling_executor = create_react_agent
 __all__ = [
     "create_react_agent",
     "create_tool_calling_executor",
+    "filter_orphaned_reasoning_messages",
     "AgentState",
     "AgentStatePydantic",
     "AgentStateWithStructuredResponse",

--- a/libs/prebuilt/tests/test_filter_orphaned_reasoning.py
+++ b/libs/prebuilt/tests/test_filter_orphaned_reasoning.py
@@ -1,0 +1,167 @@
+"""Tests for filter_orphaned_reasoning_messages pre_model_hook."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langgraph.graph.message import RemoveMessage
+
+from langgraph.prebuilt.chat_agent_executor import (
+    _is_reasoning_only,
+    filter_orphaned_reasoning_messages,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _reasoning_msg(id: str = "msg-r1") -> AIMessage:
+    return AIMessage(
+        content=[{"type": "reasoning", "id": "rs_1", "summary": []}],
+        id=id,
+    )
+
+
+def _text_msg(id: str = "msg-t1") -> AIMessage:
+    return AIMessage(content="here is my answer", id=id)
+
+
+def _state(messages: list) -> dict:
+    return {"messages": messages}
+
+
+# ---------------------------------------------------------------------------
+# _is_reasoning_only
+# ---------------------------------------------------------------------------
+
+
+def test_is_reasoning_only_pure_reasoning() -> None:
+    assert _is_reasoning_only(_reasoning_msg()) is True
+
+
+def test_is_reasoning_only_text_is_false() -> None:
+    assert _is_reasoning_only(_text_msg()) is False
+
+
+def test_is_reasoning_only_empty_list_is_false() -> None:
+    assert _is_reasoning_only(AIMessage(content=[], id="e")) is False
+
+
+def test_is_reasoning_only_empty_string_is_false() -> None:
+    assert _is_reasoning_only(AIMessage(content="", id="e")) is False
+
+
+def test_is_reasoning_only_mixed_reasoning_and_text_is_false() -> None:
+    msg = AIMessage(
+        content=[
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {"type": "text", "text": "here is my answer"},
+        ],
+        id="mixed",
+    )
+    assert _is_reasoning_only(msg) is False
+
+
+def test_is_reasoning_only_with_tool_calls_is_false() -> None:
+    msg = AIMessage(
+        content=[{"type": "reasoning", "id": "rs_1", "summary": []}],
+        tool_calls=[ToolCall(name="my_tool", args={}, id="call-1")],
+        id="tc",
+    )
+    assert _is_reasoning_only(msg) is False
+
+
+# ---------------------------------------------------------------------------
+# filter_orphaned_reasoning_messages
+# ---------------------------------------------------------------------------
+
+
+def test_no_orphans_returns_none() -> None:
+    state = _state([HumanMessage(content="hi"), _text_msg()])
+    assert filter_orphaned_reasoning_messages(state) is None
+
+
+def test_orphaned_reasoning_message_removed() -> None:
+    orphan = _reasoning_msg("orphan-id")
+    state = _state([HumanMessage(content="hi"), orphan, HumanMessage(content="retry")])
+
+    result = filter_orphaned_reasoning_messages(state)
+
+    assert result is not None
+    removes = result["messages"]
+    assert len(removes) == 1
+    assert isinstance(removes[0], RemoveMessage)
+    assert removes[0].id == "orphan-id"
+
+
+def test_empty_content_message_not_removed() -> None:
+    state = _state([HumanMessage(content="hi"), AIMessage(content=[], id="e1")])
+    assert filter_orphaned_reasoning_messages(state) is None
+
+
+def test_tool_call_message_not_removed() -> None:
+    ai_with_tool = AIMessage(
+        content=[{"type": "reasoning", "id": "rs_1", "summary": []}],
+        tool_calls=[ToolCall(name="my_tool", args={}, id="call-1")],
+        id="tool-msg",
+    )
+    state = _state(
+        [
+            HumanMessage(content="hi"),
+            ai_with_tool,
+            ToolMessage(content="result", tool_call_id="call-1", name="my_tool"),
+        ]
+    )
+    assert filter_orphaned_reasoning_messages(state) is None
+
+
+def test_multiple_orphans_all_removed() -> None:
+    r1 = _reasoning_msg("r1")
+    r2 = _reasoning_msg("r2")
+    state = _state([HumanMessage(content="hi"), r1, r2, HumanMessage(content="retry")])
+
+    result = filter_orphaned_reasoning_messages(state)
+
+    assert result is not None
+    removed_ids = {m.id for m in result["messages"]}
+    assert removed_ids == {"r1", "r2"}
+
+
+def test_only_human_messages_returns_none() -> None:
+    state = _state([HumanMessage(content="hi")])
+    assert filter_orphaned_reasoning_messages(state) is None
+
+
+def test_orphan_without_id_is_skipped() -> None:
+    no_id_orphan = AIMessage(
+        content=[{"type": "reasoning", "id": "rs_1", "summary": []}],
+        id=None,
+    )
+    state = _state([HumanMessage(content="hi"), no_id_orphan])
+    assert filter_orphaned_reasoning_messages(state) is None
+
+
+def test_idempotent_after_removal() -> None:
+    """Second call on a cleaned-up state returns None."""
+    orphan = _reasoning_msg("orphan-id")
+    messages = [HumanMessage(content="hi"), orphan]
+
+    result = filter_orphaned_reasoning_messages(_state(messages))
+    assert result is not None
+
+    # Simulate state update: remove the orphan
+    messages = [m for m in messages if getattr(m, "id", None) != "orphan-id"]
+
+    result = filter_orphaned_reasoning_messages(_state(messages))
+    assert result is None
+
+
+def test_complete_turn_with_reasoning_not_removed() -> None:
+    """A message with both reasoning AND text blocks is a complete turn — keep it."""
+    complete = AIMessage(
+        content=[
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {"type": "text", "text": "here is my answer"},
+        ],
+        id="complete",
+    )
+    state = _state([HumanMessage(content="hi"), complete])
+    assert filter_orphaned_reasoning_messages(state) is None


### PR DESCRIPTION
## Why

When a client aborts a streaming response mid-flight, LangGraph may persist an `AIMessage` whose content consists exclusively of `type="reasoning"` blocks with no accompanying text or tool-call output. On the next conversation turn, replaying that orphaned message causes a provider error:

```
BadRequestError: Item 'rs_...' of type 'reasoning' was provided without its required following item.
```

This is a gap in the existing `_validate_chat_history` logic, which only checks for orphaned *tool calls*, not orphaned *reasoning blocks*.

## What

Adds a public `filter_orphaned_reasoning_messages` function to `langgraph.prebuilt` that is designed to be passed directly as a `pre_model_hook` to `create_react_agent`:

```python
from langgraph.prebuilt import create_react_agent, filter_orphaned_reasoning_messages

agent = create_react_agent(
    model,
    tools,
    pre_model_hook=filter_orphaned_reasoning_messages,
)
```

The function:
- Scans `state["messages"]` for `AIMessage`s whose content is a non-empty list of only `type="reasoning"` blocks and that carry no `tool_calls`
- Returns `{"messages": [RemoveMessage(id=...), ...]}` to strip them before the model call
- Returns `None` (no-op) when no orphaned messages are present
- Skips messages without an `id` rather than raising

15 unit tests cover the full edge-case surface: empty content, mixed reasoning+text (complete turns, not orphaned), messages with `tool_calls`, multiple orphans, idempotency, and the no-id edge case.

## Notes

This pattern was first implemented in production at dbt Labs to handle stream-abort scenarios with the OpenAI Responses API (`o3`, `o4-mini`). It sits alongside the existing `_validate_chat_history` orphaned-tool-call check and is non-overlapping with it by construction — `_is_reasoning_only` returns `False` for any message carrying `tool_calls`.

Drafted by Claude Sonnet 4.6 under the direction of @alan-andrade