### PR TITLE
feat(langgraph): add node-level error handlers

### DIFF
--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -12,10 +12,9 @@ RESUME = sys.intern("__resume__")
 # for values passed to resume a node after an interrupt
 ERROR = sys.intern("__error__")
 # for errors raised by nodes
-GRAPH_ERROR_INFO = sys.intern("__graph_error_info__")
-# for graph-level error handler context: failed node names
-# value format in channel state: `Sequence[str]`
-# value format in pending writes: `(task_id, GRAPH_ERROR_INFO, node_name: str)`
+ERROR_SOURCE_NODE = sys.intern("__error_source_node__")
+# failed source node name for node-level error handlers
+# value format in pending writes: `(task_id, ERROR_SOURCE_NODE, node_name: str)`
 NO_WRITES = sys.intern("__no_writes__")
 # marker to signal node didn't write anything
 TASKS = sys.intern("__pregel_tasks")
@@ -102,6 +101,7 @@ RESERVED = {
     INTERRUPT,
     RESUME,
     ERROR,
+    ERROR_SOURCE_NODE,
     NO_WRITES,
     # reserved config.configurable keys
     CONFIG_KEY_SEND,

--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -74,6 +74,10 @@ CONFIG_KEY_RESUME_MAP = sys.intern("__pregel_resume_map")
 CONFIG_KEY_STREAM_MESSAGES_V2 = sys.intern("__pregel_stream_messages_v2")
 # when True, attach StreamMessagesHandlerV2 so content-block (v2) events
 # flow through stream_mode="messages"; set by StreamingHandler only.
+CONFIG_KEY_NODE_ERROR = sys.intern("__pregel_node_error")
+# holds a `NodeError` (failed source node + exception) for the current
+# node-level error handler invocation, injected when handler signature
+# requests `error: NodeError`
 
 # --- Other constants ---
 PUSH = sys.intern("__pregel_push")

--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -14,6 +14,8 @@ ERROR = sys.intern("__error__")
 # for errors raised by nodes
 GRAPH_ERROR_INFO = sys.intern("__graph_error_info__")
 # for graph-level error handler context: failed node names
+# value format in channel state: `Sequence[str]`
+# value format in pending writes: `(task_id, GRAPH_ERROR_INFO, node_name: str)`
 NO_WRITES = sys.intern("__no_writes__")
 # marker to signal node didn't write anything
 TASKS = sys.intern("__pregel_tasks")

--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -12,6 +12,8 @@ RESUME = sys.intern("__resume__")
 # for values passed to resume a node after an interrupt
 ERROR = sys.intern("__error__")
 # for errors raised by nodes
+GRAPH_ERROR_INFO = sys.intern("__graph_error_info__")
+# for graph-level error handler context: failed node names
 NO_WRITES = sys.intern("__no_writes__")
 # marker to signal node didn't write anything
 TASKS = sys.intern("__pregel_tasks")

--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -51,9 +51,11 @@ from langgraph._internal._config import (
 )
 from langgraph._internal._constants import (
     CONF,
+    CONFIG_KEY_NODE_ERROR,
     CONFIG_KEY_RUNTIME,
 )
 from langgraph._internal._typing import MISSING
+from langgraph.errors import NodeError
 from langgraph.types import StreamWriter
 
 try:
@@ -193,6 +195,15 @@ KWARGS_CONFIG_KEYS: tuple[tuple[str, tuple[Any, ...], str, Any], ...] = (
         # we never hit this block, we just inject runtime directly
         "N/A",
         inspect.Parameter.empty,
+    ),
+    (
+        "error",
+        (NodeError, "NodeError"),
+        # we never hit this block, we read directly from configurable
+        "N/A",
+        # default to None so non-handler nodes that happen to type a parameter
+        # `error: NodeError` don't blow up; handlers always receive a NodeError.
+        None,
     ),
 )
 """List of kwargs that can be passed to functions, and their corresponding
@@ -367,6 +378,8 @@ class RunnableCallable(Runnable):
             kw_value: Any = MISSING
             if kw == "config":
                 kw_value = config
+            elif kw == "error":
+                kw_value = config.get(CONF, {}).get(CONFIG_KEY_NODE_ERROR, MISSING)
             elif runtime:
                 if kw == "runtime":
                     kw_value = runtime
@@ -439,6 +452,8 @@ class RunnableCallable(Runnable):
             kw_value: Any = MISSING
             if kw == "config":
                 kw_value = config
+            elif kw == "error":
+                kw_value = config.get(CONF, {}).get(CONFIG_KEY_NODE_ERROR, MISSING)
             elif runtime:
                 if kw == "runtime":
                     kw_value = runtime

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 from warnings import warn
@@ -19,6 +20,7 @@ __all__ = (
     "InvalidUpdateError",
     "GraphBubbleUp",
     "GraphInterrupt",
+    "NodeError",
     "NodeInterrupt",
     "NodeTimeoutError",
     "ParentCommand",
@@ -126,6 +128,26 @@ class TaskNotFound(Exception):
     """Raised when the executor is unable to find a task (for distributed mode)."""
 
     pass
+
+
+@dataclass(frozen=True, slots=True)
+class NodeError:
+    """Failure context passed to a node-level error handler.
+
+    Inject by adding a parameter typed `NodeError` to a handler registered via
+    `StateGraph.add_node(..., error_handler=...)`:
+
+    ```python
+    def handler(state: State, error: NodeError) -> Command:
+        return Command(update={"status": f"recovered from {error.node}: {error.error}"})
+    ```
+    """
+
+    node: str
+    """Name of the node whose execution failed."""
+
+    error: BaseException
+    """Exception raised by the failed node."""
 
 
 class NodeTimeoutError(TimeoutError):

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -88,7 +88,8 @@ class StateNodeSpec(Generic[NodeInputT, ContextT]):
     input_schema: type[NodeInputT]
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None
     cache_policy: CachePolicy | None
-    is_graph_error_handler: bool = False
+    is_error_handler: bool = False
+    error_handler_node: str | None = None
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
     timeout: TimeoutPolicy | None = None

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -88,6 +88,7 @@ class StateNodeSpec(Generic[NodeInputT, ContextT]):
     input_schema: type[NodeInputT]
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None
     cache_policy: CachePolicy | None
+    is_graph_error_handler: bool = False
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
     timeout: TimeoutPolicy | None = None

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -34,7 +34,6 @@ from typing_extensions import NotRequired, Required, Self, Unpack, is_typeddict
 
 from langgraph._internal import _serde
 from langgraph._internal._constants import (
-    GRAPH_ERROR_INFO,
     INTERRUPT,
     NS_END,
     NS_SEP,
@@ -57,7 +56,6 @@ from langgraph.channels.named_barrier_value import (
     NamedBarrierValue,
     NamedBarrierValueAfterFinish,
 )
-from langgraph.channels.topic import Topic
 from langgraph.constants import END, START, TAG_HIDDEN
 from langgraph.errors import (
     ErrorCode,
@@ -246,7 +244,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.managed = {}
         self.compiled = False
         self.waiting_edges = set()
-        self.graph_error_handler_node: str | None = None
 
         self.state_schema = state_schema
         self.input_schema = cast(type[InputT], input_schema or state_schema)
@@ -305,6 +302,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         input_schema: None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
@@ -373,6 +371,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         input_schema: type[NodeInputT],
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
@@ -446,6 +445,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         input_schema: None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
@@ -514,6 +514,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         input_schema: type[NodeInputT],
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
@@ -589,6 +590,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         input_schema: type[NodeInputT] | None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
@@ -609,6 +611,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
                 If a sequence is provided, the first matching policy will be applied.
             cache_policy: The cache policy for the node.
+            error_handler: Optional node-level error handler callable for this node.
             destinations: Destinations that indicate where a node can route to.
 
                 Useful for edgeless graphs with nodes that return `Command` objects.
@@ -768,6 +771,25 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         if destinations is not None:
             ends = destinations
 
+        resolved_input_schema: type[Any] = (
+            input_schema or inferred_input_schema or self.state_schema
+        )
+        handler_node_name: str | None = None
+        if error_handler is not None:
+            handler_node_name = f"__error_handler__{node}"
+            if handler_node_name in self.nodes:
+                raise ValueError(
+                    f"Auto-generated error handler node `{handler_node_name}` already exists."
+                )
+            self.nodes[handler_node_name] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(error_handler, name=handler_node_name, trace=False),  # type: ignore[arg-type]
+                metadata=None,
+                input_schema=resolved_input_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
+
         if input_schema is not None:
             self.nodes[node] = StateNodeSpec[NodeInputT, ContextT](
                 coerce_to_runnable(action, name=node, trace=False),  # type: ignore[arg-type]
@@ -775,6 +797,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 input_schema=input_schema,
                 retry_policy=retry_policy,
                 cache_policy=cache_policy,
+                error_handler_node=handler_node_name,
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
@@ -786,6 +809,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 input_schema=inferred_input_schema,
                 retry_policy=retry_policy,
                 cache_policy=cache_policy,
+                error_handler_node=handler_node_name,
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
@@ -797,6 +821,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 input_schema=self.state_schema,
                 retry_policy=retry_policy,
                 cache_policy=cache_policy,
+                error_handler_node=handler_node_name,
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
@@ -806,86 +831,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         if input_schema is not None:
             self._add_schema(input_schema)
 
-        return self
-
-    def set_graph_error_handler(
-        self,
-        node: str | StateNode[NodeInputT, ContextT],
-        action: StateNode[NodeInputT, ContextT] | None = None,
-        *,
-        metadata: dict[str, Any] | None = None,
-        input_schema: type[NodeInputT] | None = None,
-        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-        destinations: dict[str, str] | tuple[str, ...] | None = None,
-        **kwargs: Unpack[DeprecatedKwargs],
-    ) -> Self:
-        """Set a graph-level error handler node.
-
-        When a node fails (after node retry policies are exhausted), execution
-        routes to this handler instead of failing immediately.
-
-        If the handler succeeds, graph execution continues according to normal graph
-        semantics (regular edges and/or `Command` routing). If the handler fails,
-        the graph run fails with that handler error (the handler is not recursively
-        re-handled).
-
-        In a superstep with concurrent nodes (for example A/B/C/D), if A and B fail
-        while C and D continue, the handler is triggered once in the next step and
-        receives aggregated failure context for the failed nodes.
-        Even if multiple nodes fail in the same superstep, only one handler trigger
-        is emitted for that step.
-
-        Args:
-            node: The handler function/runnable, or the handler node name.
-
-                If a string is provided, it is treated as node name and `action`
-                is used as the handler implementation. If `action` is omitted,
-                the named node must already exist.
-            action: The handler implementation when `node` is a string.
-            metadata: Metadata associated with the handler node.
-            input_schema: Input schema for the handler node.
-
-                Defaults to the graph state schema when omitted.
-            retry_policy: Retry policy for the handler node.
-
-                If a sequence is provided, the first matching policy is applied.
-            destinations: Optional destination hints for rendering.
-
-                Useful when the handler returns `Command` in edgeless graphs.
-                This only affects visualization and not execution semantics.
-
-        Returns:
-            Self: The instance of the `StateGraph`, allowing for method chaining.
-        """
-        handler_name_hint = node if isinstance(node, str) else _get_node_name(node)
-        if (
-            self.graph_error_handler_node is not None
-            and self.graph_error_handler_node != handler_name_hint
-        ):
-            raise ValueError(
-                f"Graph error handler already set to `{self.graph_error_handler_node}`."
-            )
-
-        if isinstance(node, str) and action is None:
-            if node not in self.nodes:
-                raise ValueError(f"Need to add_node `{node}` first")
-            handler_name = node
-        else:
-            cast(Any, self).add_node(
-                node,
-                action,
-                metadata=metadata,
-                input_schema=input_schema,
-                retry_policy=retry_policy,
-                destinations=destinations,
-                **kwargs,
-            )
-            handler_name = node if isinstance(node, str) else _get_node_name(node)
-
-        spec = self.nodes[handler_name]
-        spec.is_graph_error_handler = True
-
-        self.graph_error_handler_node = handler_name
         return self
 
     def add_edge(self, start_key: str | list[str], end_key: str) -> Self:
@@ -1134,14 +1079,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             for node in interrupt:
                 if node not in self.nodes:
                     raise ValueError(f"Interrupt node `{node}` not found")
-        if (
-            self.graph_error_handler_node
-            and self.graph_error_handler_node not in self.nodes
-        ):
-            raise ValueError(
-                f"Graph error handler `{self.graph_error_handler_node}` not found"
-            )
-
         self.compiled = True
         return self
 
@@ -1254,11 +1191,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
-        graph_error_trigger_channel = (
-            _CHANNEL_BRANCH_TO.format(self.graph_error_handler_node)
-            if self.graph_error_handler_node
-            else None
-        )
+        node_error_handler_map = {
+            node_name: spec.error_handler_node
+            for node_name, spec in self.nodes.items()
+            if spec.error_handler_node is not None
+        }
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
@@ -1269,11 +1206,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 **self.channels,
                 **self.managed,
                 START: EphemeralValue(self.input_schema),
-                **(
-                    {GRAPH_ERROR_INFO: Topic(Any, accumulate=False)}
-                    if self.graph_error_handler_node
-                    else {}
-                ),
             },
             input_channels=START,
             stream_mode="updates",
@@ -1286,11 +1218,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             debug=debug,
             store=store,
             cache=cache,
-            graph_error_handler_node=self.graph_error_handler_node,
-            graph_error_trigger_channel=graph_error_trigger_channel,
-            graph_error_info_channel=(
-                GRAPH_ERROR_INFO if self.graph_error_handler_node else None
-            ),
+            node_error_handler_map=node_error_handler_map,
             name=name or "LangGraph",
             stream_transformers=transformers,
         )
@@ -1465,7 +1393,8 @@ class CompiledStateGraph(
                 metadata=node.metadata,
                 retry_policy=node.retry_policy,
                 cache_policy=node.cache_policy,
-                is_graph_error_handler=node.is_graph_error_handler,
+                is_error_handler=node.is_error_handler,
+                error_handler_node=node.error_handler_node,
                 bound=node.runnable,  # type: ignore[arg-type]
                 timeout=node.timeout,
             )

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -34,6 +34,7 @@ from typing_extensions import NotRequired, Required, Self, Unpack, is_typeddict
 
 from langgraph._internal import _serde
 from langgraph._internal._constants import (
+    GRAPH_ERROR_INFO,
     INTERRUPT,
     NS_END,
     NS_SEP,
@@ -56,6 +57,7 @@ from langgraph.channels.named_barrier_value import (
     NamedBarrierValue,
     NamedBarrierValueAfterFinish,
 )
+from langgraph.channels.topic import Topic
 from langgraph.constants import END, START, TAG_HIDDEN
 from langgraph.errors import (
     ErrorCode,
@@ -244,6 +246,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.managed = {}
         self.compiled = False
         self.waiting_edges = set()
+        self.graph_error_handler_node: str | None = None
 
         self.state_schema = state_schema
         self.input_schema = cast(type[InputT], input_schema or state_schema)
@@ -805,6 +808,86 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
         return self
 
+    def set_graph_error_handler(
+        self,
+        node: str | StateNode[NodeInputT, ContextT],
+        action: StateNode[NodeInputT, ContextT] | None = None,
+        *,
+        metadata: dict[str, Any] | None = None,
+        input_schema: type[NodeInputT] | None = None,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        destinations: dict[str, str] | tuple[str, ...] | None = None,
+        **kwargs: Unpack[DeprecatedKwargs],
+    ) -> Self:
+        """Set a graph-level error handler node.
+
+        When a node fails (after node retry policies are exhausted), execution
+        routes to this handler instead of failing immediately.
+
+        If the handler succeeds, graph execution continues according to normal graph
+        semantics (regular edges and/or `Command` routing). If the handler fails,
+        the graph run fails with that handler error (the handler is not recursively
+        re-handled).
+
+        In a superstep with concurrent nodes (for example A/B/C/D), if A and B fail
+        while C and D continue, the handler is triggered once in the next step and
+        receives aggregated failure context for the failed nodes.
+        Even if multiple nodes fail in the same superstep, only one handler trigger
+        is emitted for that step.
+
+        Args:
+            node: The handler function/runnable, or the handler node name.
+
+                If a string is provided, it is treated as node name and `action`
+                is used as the handler implementation. If `action` is omitted,
+                the named node must already exist.
+            action: The handler implementation when `node` is a string.
+            metadata: Metadata associated with the handler node.
+            input_schema: Input schema for the handler node.
+
+                Defaults to the graph state schema when omitted.
+            retry_policy: Retry policy for the handler node.
+
+                If a sequence is provided, the first matching policy is applied.
+            destinations: Optional destination hints for rendering.
+
+                Useful when the handler returns `Command` in edgeless graphs.
+                This only affects visualization and not execution semantics.
+
+        Returns:
+            Self: The instance of the `StateGraph`, allowing for method chaining.
+        """
+        handler_name_hint = node if isinstance(node, str) else _get_node_name(node)
+        if (
+            self.graph_error_handler_node is not None
+            and self.graph_error_handler_node != handler_name_hint
+        ):
+            raise ValueError(
+                f"Graph error handler already set to `{self.graph_error_handler_node}`."
+            )
+
+        if isinstance(node, str) and action is None:
+            if node not in self.nodes:
+                raise ValueError(f"Need to add_node `{node}` first")
+            handler_name = node
+        else:
+            cast(Any, self).add_node(
+                node,
+                action,
+                metadata=metadata,
+                input_schema=input_schema,
+                retry_policy=retry_policy,
+                destinations=destinations,
+                **kwargs,
+            )
+            handler_name = node if isinstance(node, str) else _get_node_name(node)
+
+        spec = self.nodes[handler_name]
+        spec.is_graph_error_handler = True
+
+        self.graph_error_handler_node = handler_name
+        return self
+
     def add_edge(self, start_key: str | list[str], end_key: str) -> Self:
         """Add a directed edge from the start node (or list of start nodes) to the end node.
 
@@ -1051,6 +1134,13 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             for node in interrupt:
                 if node not in self.nodes:
                     raise ValueError(f"Interrupt node `{node}` not found")
+        if (
+            self.graph_error_handler_node
+            and self.graph_error_handler_node not in self.nodes
+        ):
+            raise ValueError(
+                f"Graph error handler `{self.graph_error_handler_node}` not found"
+            )
 
         self.compiled = True
         return self
@@ -1164,6 +1254,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
+        graph_error_trigger_channel = (
+            _CHANNEL_BRANCH_TO.format(self.graph_error_handler_node)
+            if self.graph_error_handler_node
+            else None
+        )
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
@@ -1174,6 +1269,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 **self.channels,
                 **self.managed,
                 START: EphemeralValue(self.input_schema),
+                **(
+                    {GRAPH_ERROR_INFO: Topic(Any, accumulate=False)}
+                    if self.graph_error_handler_node
+                    else {}
+                ),
             },
             input_channels=START,
             stream_mode="updates",
@@ -1186,6 +1286,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             debug=debug,
             store=store,
             cache=cache,
+            graph_error_handler_node=self.graph_error_handler_node,
+            graph_error_trigger_channel=graph_error_trigger_channel,
+            graph_error_info_channel=(
+                GRAPH_ERROR_INFO if self.graph_error_handler_node else None
+            ),
             name=name or "LangGraph",
             stream_transformers=transformers,
         )
@@ -1360,6 +1465,7 @@ class CompiledStateGraph(
                 metadata=node.metadata,
                 retry_policy=node.retry_policy,
                 cache_policy=node.cache_policy,
+                is_graph_error_handler=node.is_graph_error_handler,
                 bound=node.runnable,  # type: ignore[arg-type]
                 timeout=node.timeout,
             )

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -39,6 +39,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_CHECKPOINTER,
+    CONFIG_KEY_NODE_ERROR,
     CONFIG_KEY_READ,
     CONFIG_KEY_RESUME_MAP,
     CONFIG_KEY_RUNTIME,
@@ -67,6 +68,7 @@ from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.constants import TAG_HIDDEN
+from langgraph.errors import NodeError
 from langgraph.managed.base import ManagedValueMapping
 from langgraph.pregel._call import get_runnable_for_task, identifier
 from langgraph.pregel._io import read_channels
@@ -697,10 +699,6 @@ def prepare_single_task(
                             run_id=str(rid) if (rid := config.get("run_id")) else None,
                         ),
                     )
-                    runtime = runtime.patch_execution_info(
-                        from_node_name=None,
-                        from_node_error=None,
-                    )
                     additional_config = {
                         "metadata": metadata,
                         "tags": proc.tags,
@@ -1196,10 +1194,6 @@ def prepare_node_error_handler_task(
     runtime = runtime.override(
         store=store, previous=checkpoint["channel_values"].get(PREVIOUS, None)
     )
-    runtime = runtime.patch_execution_info(
-        from_node_name=failed_task.name,
-        from_node_error=failed_error,
-    )
     additional_config: RunnableConfig = {
         "metadata": metadata,
         "tags": proc.tags,
@@ -1239,6 +1233,9 @@ def prepare_node_error_handler_task(
                 CONFIG_KEY_CHECKPOINT_NS: task_checkpoint_ns,
                 CONFIG_KEY_SCRATCHPAD: scratchpad,
                 CONFIG_KEY_RUNTIME: runtime,
+                CONFIG_KEY_NODE_ERROR: NodeError(
+                    node=failed_task.name, error=failed_error
+                ),
             },
         ),
         PUSH_TRIGGER,

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -696,9 +696,7 @@ def prepare_single_task(
                     )
                     if proc.is_graph_error_handler:
                         failed_node_names_with_task_ids = (
-                            _read_failed_node_names_from_pending_writes(
-                                pending_writes
-                            )
+                            _read_failed_node_names_from_pending_writes(pending_writes)
                         )
                         if failed_node_names_with_task_ids:
                             names = tuple(
@@ -714,8 +712,9 @@ def prepare_single_task(
                                     ),
                                 )
                             )
-                        elif failed_node_names := _read_failed_node_names_from_graph_info_channel(
-                            channels
+                        elif (
+                            failed_node_names
+                            := _read_failed_node_names_from_graph_info_channel(channels)
                         ):
                             names = tuple(failed_node_names)
                             errors = tuple(
@@ -804,8 +803,6 @@ def _read_failed_node_names_from_graph_info_channel(
         value = channel.get()
     except EmptyChannelError:
         return []
-    if isinstance(value, str):
-        return [value]
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
         return [item for item in value if isinstance(item, str)]
     return []

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -47,7 +47,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     ERROR,
-    GRAPH_ERROR_INFO,
+    ERROR_SOURCE_NODE,
     INTERRUPT,
     NO_WRITES,
     NS_END,
@@ -67,7 +67,6 @@ from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.constants import TAG_HIDDEN
-from langgraph.errors import EmptyChannelError
 from langgraph.managed.base import ManagedValueMapping
 from langgraph.pregel._call import get_runnable_for_task, identifier
 from langgraph.pregel._io import read_channels
@@ -294,7 +293,15 @@ def apply_writes(
     pending_writes_by_channel: dict[str, list[Any]] = defaultdict(list)
     for task in tasks:
         for chan, val in task.writes:
-            if chan in (NO_WRITES, PUSH, RESUME, INTERRUPT, RETURN, ERROR):
+            if chan in (
+                NO_WRITES,
+                PUSH,
+                RESUME,
+                INTERRUPT,
+                RETURN,
+                ERROR,
+                ERROR_SOURCE_NODE,
+            ):
                 pass
             elif chan in channels:
                 pending_writes_by_channel[chan].append(val)
@@ -691,46 +698,9 @@ def prepare_single_task(
                         ),
                     )
                     runtime = runtime.patch_execution_info(
-                        from_node_names=None,
-                        from_node_errors=None,
+                        from_node_name=None,
+                        from_node_error=None,
                     )
-                    if proc.is_graph_error_handler:
-                        failed_node_names_with_task_ids = (
-                            _read_failed_node_names_from_pending_writes(pending_writes)
-                        )
-                        if failed_node_names_with_task_ids:
-                            names = tuple(
-                                node_name
-                                for _, node_name in failed_node_names_with_task_ids
-                            )
-                            errors = tuple(
-                                _read_errors_for_task_ids_from_pending_writes(
-                                    pending_writes,
-                                    tuple(
-                                        task_id
-                                        for task_id, _ in failed_node_names_with_task_ids
-                                    ),
-                                )
-                            )
-                        elif (
-                            failed_node_names
-                            := _read_failed_node_names_from_graph_info_channel(channels)
-                        ):
-                            names = tuple(failed_node_names)
-                            errors = tuple(
-                                _build_fallback_errors_for_failed_node_names(
-                                    names,
-                                    _read_errors_from_pending_writes(pending_writes),
-                                )
-                            )
-                        else:
-                            names = ()
-                            errors = ()
-                        if names:
-                            runtime = runtime.patch_execution_info(
-                                from_node_names=names,
-                                from_node_errors=errors,
-                            )
                     additional_config = {
                         "metadata": metadata,
                         "tags": proc.tags,
@@ -793,35 +763,6 @@ def prepare_single_task(
                 return PregelTask(task_id, name, task_path[:3])
 
 
-def _read_failed_node_names_from_graph_info_channel(
-    channels: Mapping[str, BaseChannel],
-) -> list[str]:
-    channel = channels.get(GRAPH_ERROR_INFO)
-    if channel is None:
-        return []
-    try:
-        value = channel.get()
-    except EmptyChannelError:
-        return []
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        return [item for item in value if isinstance(item, str)]
-    return []
-
-
-def _read_failed_node_names_from_pending_writes(
-    pending_writes: list[PendingWrite],
-) -> list[tuple[str, str]]:
-    # Returns [(task_id, node_name)] for GRAPH_ERROR_INFO writes, in original write order.
-    failed_node_names_with_task_ids: list[tuple[str, str]] = []
-    for task_id, channel, value in reversed(pending_writes):
-        if channel != GRAPH_ERROR_INFO:
-            continue
-        if isinstance(value, str):
-            failed_node_names_with_task_ids.append((task_id, value))
-    failed_node_names_with_task_ids.reverse()
-    return failed_node_names_with_task_ids
-
-
 def _coerce_pending_error(value: Any) -> BaseException:
     if isinstance(value, BaseException):
         return value
@@ -838,27 +779,24 @@ def _read_errors_from_pending_writes(
     return errors
 
 
-def _read_errors_for_task_ids_from_pending_writes(
-    pending_writes: list[PendingWrite], task_ids: tuple[str, ...]
-) -> list[BaseException]:
-    error_by_task: dict[str, BaseException] = {}
-    for task_id, channel, value in pending_writes:
-        if channel == ERROR:
-            error_by_task[task_id] = _coerce_pending_error(value)
-    return [
-        error_by_task.get(task_id, Exception(f"Error from task '{task_id}'"))
-        for task_id in task_ids
-    ]
+def _read_error_for_task_id_from_pending_writes(
+    pending_writes: list[PendingWrite], task_id: str
+) -> BaseException | None:
+    for pending_task_id, channel, value in reversed(pending_writes):
+        if pending_task_id == task_id and channel == ERROR:
+            return _coerce_pending_error(value)
+    return None
 
 
-def _build_fallback_errors_for_failed_node_names(
-    failed_node_names: tuple[str, ...], errors: list[BaseException]
-) -> list[BaseException]:
-    if len(errors) >= len(failed_node_names):
-        return errors[: len(failed_node_names)]
-    if errors:
-        return errors + [errors[-1]] * (len(failed_node_names) - len(errors))
-    return [Exception(f"Error from node '{name}'") for name in failed_node_names]
+def _read_error_source_node_from_pending_writes(
+    pending_writes: list[PendingWrite], task_id: str
+) -> str | None:
+    for pending_task_id, channel, value in reversed(pending_writes):
+        if pending_task_id == task_id and channel == ERROR_SOURCE_NODE:
+            if isinstance(value, str):
+                return value
+            return str(value)
+    return None
 
 
 def prepare_push_task_functional(
@@ -1169,6 +1107,148 @@ def prepare_push_task_send(
         )
     else:
         return PregelTask(task_id, packet.node, translated_task_path)
+
+
+def prepare_node_error_handler_task(
+    failed_task: PregelExecutableTask,
+    *,
+    handler_node_name: str,
+    failed_error: BaseException,
+    checkpoint: Checkpoint,
+    pending_writes: list[PendingWrite],
+    processes: Mapping[str, PregelNode],
+    channels: Mapping[str, BaseChannel],
+    managed: ManagedValueMapping,
+    config: RunnableConfig,
+    step: int,
+    stop: int,
+    store: BaseStore | None = None,
+    checkpointer: BaseCheckpointSaver | None = None,
+    manager: None | ParentRunManager | AsyncParentRunManager = None,
+    cache_policy: CachePolicy | None = None,
+    retry_policy: Sequence[RetryPolicy] = (),
+) -> PregelExecutableTask | None:
+    """Prepare an immediate node-level error handler task for a failed task."""
+    if handler_node_name not in processes:
+        return None
+    proc = processes[handler_node_name]
+    proc_node = proc.node
+    if proc_node is None:
+        return None
+
+    checkpoint_id_bytes = binascii.unhexlify(checkpoint["id"].replace("-", ""))
+    task_id_func = _xxhash_str if checkpoint["v"] > 1 else _uuid5_str
+    configurable = config.get(CONF, {})
+    parent_ns = configurable.get(CONFIG_KEY_CHECKPOINT_NS, "")
+    checkpoint_ns = (
+        f"{parent_ns}{NS_SEP}{handler_node_name}" if parent_ns else handler_node_name
+    )
+    task_id = task_id_func(
+        checkpoint_id_bytes,
+        checkpoint_ns,
+        str(step),
+        handler_node_name,
+        PUSH,
+        "node_error_handler",
+        failed_task.id,
+    )
+    task_checkpoint_ns = f"{checkpoint_ns}:{task_id}"
+    translated_task_path = (*failed_task.path[:3], "node_error_handler", False)
+    metadata = {
+        "langgraph_step": step,
+        "langgraph_node": handler_node_name,
+        "langgraph_triggers": PUSH_TRIGGER,
+        "langgraph_path": translated_task_path,
+        "langgraph_checkpoint_ns": task_checkpoint_ns,
+    }
+    if proc.metadata:
+        metadata.update(proc.metadata)
+    writes: deque[tuple[str, Any]] = deque()
+
+    effective_retry_policy = proc.retry_policy or retry_policy
+    effective_cache_policy = proc.cache_policy or cache_policy
+    if effective_cache_policy:
+        args_key = effective_cache_policy.key_func(failed_task.input)
+        cache_key = CacheKey(
+            (
+                CACHE_NS_WRITES,
+                (identifier(proc) or "__dynamic__"),
+                handler_node_name,
+            ),
+            xxh3_128_hexdigest(
+                args_key.encode() if isinstance(args_key, str) else args_key
+            ),
+            effective_cache_policy.ttl,
+        )
+    else:
+        cache_key = None
+
+    scratchpad = _scratchpad(
+        config[CONF].get(CONFIG_KEY_SCRATCHPAD),
+        pending_writes,
+        task_id,
+        xxh3_128_hexdigest(task_checkpoint_ns.encode()),
+        config[CONF].get(CONFIG_KEY_RESUME_MAP),
+        step,
+        stop,
+    )
+    runtime = cast(Runtime, configurable.get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME))
+    runtime = runtime.override(
+        store=store, previous=checkpoint["channel_values"].get(PREVIOUS, None)
+    )
+    runtime = runtime.patch_execution_info(
+        from_node_name=failed_task.name,
+        from_node_error=failed_error,
+    )
+    additional_config: RunnableConfig = {
+        "metadata": metadata,
+        "tags": proc.tags,
+    }
+    return PregelExecutableTask(
+        handler_node_name,
+        failed_task.input,
+        proc_node,
+        writes,
+        patch_config(
+            merge_configs(config, additional_config),
+            run_name=handler_node_name,
+            callbacks=manager.get_child(f"graph:step:{step}") if manager else None,
+            configurable={
+                CONFIG_KEY_TASK_ID: task_id,
+                CONFIG_KEY_SEND: writes.extend,
+                CONFIG_KEY_READ: partial(
+                    local_read,
+                    scratchpad,
+                    channels,
+                    managed,
+                    PregelTaskWrites(
+                        translated_task_path,
+                        handler_node_name,
+                        writes,
+                        PUSH_TRIGGER,
+                    ),
+                ),
+                CONFIG_KEY_CHECKPOINTER: (
+                    checkpointer or configurable.get(CONFIG_KEY_CHECKPOINTER)
+                ),
+                CONFIG_KEY_CHECKPOINT_MAP: {
+                    **configurable.get(CONFIG_KEY_CHECKPOINT_MAP, {}),
+                    parent_ns: checkpoint["id"],
+                },
+                CONFIG_KEY_CHECKPOINT_ID: None,
+                CONFIG_KEY_CHECKPOINT_NS: task_checkpoint_ns,
+                CONFIG_KEY_SCRATCHPAD: scratchpad,
+                CONFIG_KEY_RUNTIME: runtime,
+            },
+        ),
+        PUSH_TRIGGER,
+        effective_retry_policy,
+        cache_key,
+        task_id,
+        translated_task_path,
+        writers=proc.flat_writers,
+        subgraphs=proc.subgraphs,
+    )
 
 
 def checkpoint_null_version(

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -47,6 +47,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     ERROR,
+    GRAPH_ERROR_INFO,
     INTERRUPT,
     NO_WRITES,
     NS_END,
@@ -66,6 +67,7 @@ from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.constants import TAG_HIDDEN
+from langgraph.errors import EmptyChannelError
 from langgraph.managed.base import ManagedValueMapping
 from langgraph.pregel._call import get_runnable_for_task, identifier
 from langgraph.pregel._io import read_channels
@@ -688,6 +690,48 @@ def prepare_single_task(
                             run_id=str(rid) if (rid := config.get("run_id")) else None,
                         ),
                     )
+                    runtime = runtime.patch_execution_info(
+                        from_node_names=None,
+                        from_node_errors=None,
+                    )
+                    if proc.is_graph_error_handler:
+                        failed_node_names_with_task_ids = (
+                            _read_failed_node_names_from_pending_writes(
+                                pending_writes
+                            )
+                        )
+                        if failed_node_names_with_task_ids:
+                            names = tuple(
+                                node_name
+                                for _, node_name in failed_node_names_with_task_ids
+                            )
+                            errors = tuple(
+                                _read_errors_for_task_ids_from_pending_writes(
+                                    pending_writes,
+                                    tuple(
+                                        task_id
+                                        for task_id, _ in failed_node_names_with_task_ids
+                                    ),
+                                )
+                            )
+                        elif failed_node_names := _read_failed_node_names_from_graph_info_channel(
+                            channels
+                        ):
+                            names = tuple(failed_node_names)
+                            errors = tuple(
+                                _build_fallback_errors_for_failed_node_names(
+                                    names,
+                                    _read_errors_from_pending_writes(pending_writes),
+                                )
+                            )
+                        else:
+                            names = ()
+                            errors = ()
+                        if names:
+                            runtime = runtime.patch_execution_info(
+                                from_node_names=names,
+                                from_node_errors=errors,
+                            )
                     additional_config = {
                         "metadata": metadata,
                         "tags": proc.tags,
@@ -748,6 +792,76 @@ def prepare_single_task(
                     )
             else:
                 return PregelTask(task_id, name, task_path[:3])
+
+
+def _read_failed_node_names_from_graph_info_channel(
+    channels: Mapping[str, BaseChannel],
+) -> list[str]:
+    channel = channels.get(GRAPH_ERROR_INFO)
+    if channel is None:
+        return []
+    try:
+        value = channel.get()
+    except EmptyChannelError:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _read_failed_node_names_from_pending_writes(
+    pending_writes: list[PendingWrite],
+) -> list[tuple[str, str]]:
+    # Returns [(task_id, node_name)] for GRAPH_ERROR_INFO writes, in original write order.
+    failed_node_names_with_task_ids: list[tuple[str, str]] = []
+    for task_id, channel, value in reversed(pending_writes):
+        if channel != GRAPH_ERROR_INFO:
+            continue
+        if isinstance(value, str):
+            failed_node_names_with_task_ids.append((task_id, value))
+    failed_node_names_with_task_ids.reverse()
+    return failed_node_names_with_task_ids
+
+
+def _coerce_pending_error(value: Any) -> BaseException:
+    if isinstance(value, BaseException):
+        return value
+    return Exception(str(value))
+
+
+def _read_errors_from_pending_writes(
+    pending_writes: list[PendingWrite],
+) -> list[BaseException]:
+    errors: list[BaseException] = []
+    for _, channel, value in pending_writes:
+        if channel == ERROR:
+            errors.append(_coerce_pending_error(value))
+    return errors
+
+
+def _read_errors_for_task_ids_from_pending_writes(
+    pending_writes: list[PendingWrite], task_ids: tuple[str, ...]
+) -> list[BaseException]:
+    error_by_task: dict[str, BaseException] = {}
+    for task_id, channel, value in pending_writes:
+        if channel == ERROR:
+            error_by_task[task_id] = _coerce_pending_error(value)
+    return [
+        error_by_task.get(task_id, Exception(f"Error from task '{task_id}'"))
+        for task_id in task_ids
+    ]
+
+
+def _build_fallback_errors_for_failed_node_names(
+    failed_node_names: tuple[str, ...], errors: list[BaseException]
+) -> list[BaseException]:
+    if len(errors) >= len(failed_node_names):
+        return errors[: len(failed_node_names)]
+    if errors:
+        return errors + [errors[-1]] * (len(failed_node_names) - len(errors))
+    return [Exception(f"Error from node '{name}'") for name in failed_node_names]
 
 
 def prepare_push_task_functional(

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -50,6 +50,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     ERROR,
+    ERROR_SOURCE_NODE,
     INPUT,
     INTERRUPT,
     NS_END,
@@ -86,6 +87,7 @@ from langgraph.pregel._algo import (
     checkpoint_null_version,
     increment,
     prepare_next_tasks,
+    prepare_node_error_handler_task,
     prepare_single_task,
     sanitize_untracked_values_in_send,
     should_interrupt,
@@ -503,6 +505,16 @@ class PregelLoop:
             # return the new task, to be started if not run before
             return pushed
 
+    def schedule_error_handler(
+        self, failed_task: PregelExecutableTask, error: BaseException
+    ) -> PregelExecutableTask | None:
+        raise NotImplementedError
+
+    async def aschedule_error_handler(
+        self, failed_task: PregelExecutableTask, error: BaseException
+    ) -> PregelExecutableTask | None:
+        raise NotImplementedError
+
     def tick(self) -> bool:
         """Execute a single iteration of the Pregel loop.
 
@@ -627,7 +639,7 @@ class PregelLoop:
 
     def _match_writes(self, tasks: Mapping[str, PregelExecutableTask]) -> None:
         for tid, k, v in self.checkpoint_pending_writes:
-            if k in (ERROR, INTERRUPT, RESUME):
+            if k in (ERROR, ERROR_SOURCE_NODE, INTERRUPT, RESUME):
                 continue
             if task := tasks.get(tid):
                 task.writes.append((k, v))
@@ -1200,6 +1212,45 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
                 self.output_writes(task.id, task.writes, cached=True)
         return pushed
 
+    def schedule_error_handler(
+        self, failed_task: PregelExecutableTask, error: BaseException
+    ) -> PregelExecutableTask | None:
+        handler_node = self.nodes[failed_task.name].error_handler_node
+        if not handler_node:
+            return None
+        writes = list(failed_task.writes)
+        writes.append((ERROR_SOURCE_NODE, failed_task.name))
+        self.put_writes(
+            failed_task.id,
+            writes,
+        )
+        handler_task = prepare_node_error_handler_task(
+            failed_task,
+            handler_node_name=handler_node,
+            failed_error=error,
+            checkpoint=self.checkpoint,
+            pending_writes=self.checkpoint_pending_writes,
+            processes=self.nodes,
+            channels=self.channels,
+            managed=self.managed,
+            config=failed_task.config,
+            step=self.step,
+            stop=self.stop,
+            store=self.store,
+            checkpointer=self.checkpointer,
+            manager=self.manager,
+            retry_policy=self.retry_policy,
+            cache_policy=self.cache_policy,
+        )
+        if handler_task is None:
+            return None
+        self.tasks[handler_task.id] = handler_task
+        if not self.is_replaying:
+            self._match_writes({handler_task.id: handler_task})
+        for task in self.match_cached_writes():
+            self.output_writes(task.id, task.writes, cached=True)
+        return handler_task
+
     def put_writes(self, task_id: str, writes: WritesT) -> None:
         """Put writes for a task, to be read by the next tick."""
         super().put_writes(task_id, writes)
@@ -1398,6 +1449,45 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             for task in await self.amatch_cached_writes():
                 self.output_writes(task.id, task.writes, cached=True)
         return pushed
+
+    async def aschedule_error_handler(
+        self, failed_task: PregelExecutableTask, error: BaseException
+    ) -> PregelExecutableTask | None:
+        handler_node = self.nodes[failed_task.name].error_handler_node
+        if not handler_node:
+            return None
+        writes = list(failed_task.writes)
+        writes.append((ERROR_SOURCE_NODE, failed_task.name))
+        self.put_writes(
+            failed_task.id,
+            writes,
+        )
+        handler_task = prepare_node_error_handler_task(
+            failed_task,
+            handler_node_name=handler_node,
+            failed_error=error,
+            checkpoint=self.checkpoint,
+            pending_writes=self.checkpoint_pending_writes,
+            processes=self.nodes,
+            channels=self.channels,
+            managed=self.managed,
+            config=failed_task.config,
+            step=self.step,
+            stop=self.stop,
+            store=self.store,
+            checkpointer=self.checkpointer,
+            manager=self.manager,
+            retry_policy=self.retry_policy,
+            cache_policy=self.cache_policy,
+        )
+        if handler_task is None:
+            return None
+        self.tasks[handler_task.id] = handler_task
+        if not self.is_replaying:
+            self._match_writes({handler_task.id: handler_task})
+        for task in await self.amatch_cached_writes():
+            self.output_writes(task.id, task.writes, cached=True)
+        return handler_task
 
     def put_writes(self, task_id: str, writes: WritesT) -> None:
         """Put writes for a task, to be read by the next tick."""

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -138,8 +138,11 @@ class PregelNode:
     metadata: Mapping[str, Any] | None
     """Metadata to attach to the node for tracing."""
 
-    is_graph_error_handler: bool
-    """Whether this node is registered as a graph-level error handler."""
+    is_error_handler: bool
+    """Whether this node is registered as an error handler node."""
+
+    error_handler_node: str | None
+    """Optional handler node name for failures from this node."""
 
     subgraphs: Sequence[PregelProtocol]
     """Subgraphs used by the node."""
@@ -156,7 +159,8 @@ class PregelNode:
         bound: Runnable[Any, Any] | None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
-        is_graph_error_handler: bool = False,
+        is_error_handler: bool = False,
+        error_handler_node: str | None = None,
         subgraphs: Sequence[PregelProtocol] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
     ) -> None:
@@ -173,7 +177,8 @@ class PregelNode:
         self.timeout = coerce_timeout_policy(timeout)
         self.tags = tags
         self.metadata = metadata
-        self.is_graph_error_handler = is_graph_error_handler
+        self.is_error_handler = is_error_handler
+        self.error_handler_node = error_handler_node
         if subgraphs is not None:
             self.subgraphs = subgraphs
         elif self.bound is not DEFAULT_BOUND:

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -138,6 +138,9 @@ class PregelNode:
     metadata: Mapping[str, Any] | None
     """Metadata to attach to the node for tracing."""
 
+    is_graph_error_handler: bool
+    """Whether this node is registered as a graph-level error handler."""
+
     subgraphs: Sequence[PregelProtocol]
     """Subgraphs used by the node."""
 
@@ -153,6 +156,7 @@ class PregelNode:
         bound: Runnable[Any, Any] | None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
+        is_graph_error_handler: bool = False,
         subgraphs: Sequence[PregelProtocol] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
     ) -> None:
@@ -169,6 +173,7 @@ class PregelNode:
         self.timeout = coerce_timeout_policy(timeout)
         self.tags = tags
         self.metadata = metadata
+        self.is_graph_error_handler = is_graph_error_handler
         if subgraphs is not None:
             self.subgraphs = subgraphs
         elif self.bound is not DEFAULT_BOUND:

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -10,8 +10,10 @@ from collections.abc import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Collection,
     Iterable,
     Iterator,
+    Mapping,
     Sequence,
 )
 from functools import partial
@@ -141,42 +143,34 @@ class PregelRunner:
         put_writes: weakref.ref[Callable[[str, Sequence[tuple[str, Any]]], None]],
         use_astream: bool = False,
         node_finished: Callable[[str], None] | None = None,
-        graph_error_handler_node: str | None = None,
-        graph_error_trigger_channel: str | None = None,
-        graph_error_info_channel: str | None = None,
+        node_error_handler_map: Mapping[str, str] | None = None,
+        schedule_error_handler: Callable[
+            [PregelExecutableTask, BaseException], PregelExecutableTask | None
+        ]
+        | None = None,
+        aschedule_error_handler: Callable[
+            [PregelExecutableTask, BaseException],
+            Awaitable[PregelExecutableTask | None],
+        ]
+        | None = None,
     ) -> None:
         self.submit = submit
         self.put_writes = put_writes
         self.use_astream = use_astream
         self.node_finished = node_finished
-        self.graph_error_handler_node = graph_error_handler_node
-        self.graph_error_trigger_channel = graph_error_trigger_channel
-        self.graph_error_info_channel = graph_error_info_channel
-        if self.graph_error_handler_node is not None and (
-            self.graph_error_trigger_channel is None
-            or self.graph_error_info_channel is None
-        ):
-            raise ValueError(
-                "graph_error_handler_node requires both "
-                "graph_error_trigger_channel and graph_error_info_channel"
-            )
+        self.node_error_handler_map = dict(node_error_handler_map or {})
+        self.error_handler_nodes = set(self.node_error_handler_map.values())
+        self.schedule_error_handler = schedule_error_handler
+        self.aschedule_error_handler = aschedule_error_handler
         # Exception object ids that are already routed to graph-level error handler.
         # These ids are consulted by stop/panic checks to avoid re-raising handled
         # exceptions via the normal fatal path in the same run.
         self._handled_exception_ids: set[int] = set()
-        # Per-superstep latch to emit exactly one handler trigger write
-        # (`branch:to:<handler>`) even if multiple tasks fail in that step.
-        # Reset at the beginning of each tick/atick call.
-        self._graph_error_routed = False
 
-    def _should_route_to_graph_error_handler(self, task: PregelExecutableTask) -> bool:
-        # Route non-handler task failures to graph-level error handler when configured.
-        # Handler self-failures are intentionally excluded to avoid recursive handling.
-        if self.graph_error_handler_node is None:
+    def _should_route_to_error_handler(self, task: PregelExecutableTask) -> bool:
+        if task.name in self.error_handler_nodes:
             return False
-        if task.name == self.graph_error_handler_node:
-            return False
-        return True
+        return task.name in self.node_error_handler_map
 
     def tick(
         self,
@@ -191,7 +185,6 @@ class PregelRunner:
             PregelExecutableTask | None,
         ],
     ) -> Iterator[None]:
-        self._graph_error_routed = False
         tasks = tuple(tasks)
         futures = FuturesDict(
             callback=weakref.WeakMethod(self.commit),
@@ -208,6 +201,7 @@ class PregelRunner:
             return
         elif len(tasks) == 1 and timeout is None and get_waiter is None:
             t = tasks[0]
+            scheduled_error_handler = False
             try:
                 run_with_retry(
                     t,
@@ -226,6 +220,16 @@ class PregelRunner:
                 self.commit(t, None)
             except Exception as exc:
                 self.commit(t, exc)
+                if (
+                    not isinstance(exc, GraphBubbleUp)
+                    and self._should_route_to_error_handler(t)
+                    and self.schedule_error_handler is not None
+                ):
+                    self._handled_exception_ids.add(id(exc))
+                    if handler_task := self.schedule_error_handler(t, exc):
+                        tasks = (handler_task,)
+                        scheduled_error_handler = True
+                        # Continue to the regular scheduling path for handler execution.
                 if reraise and futures:
                     if id(exc) not in self._handled_exception_ids:
                         # will be re-raised after futures are done
@@ -241,10 +245,12 @@ class PregelRunner:
                             tb = tb.tb_next
                         exc.__traceback__ = tb
                     raise
-            if not futures:  # maybe `t` scheduled another task
+            if not futures and not scheduled_error_handler:
+                # maybe `t` scheduled another task
                 return
             else:
-                tasks = ()  # don't reschedule this task
+                if not scheduled_error_handler:
+                    tasks = ()  # don't reschedule this task
         # add waiter task if requested
         if get_waiter is not None:
             futures[get_waiter()] = None
@@ -271,6 +277,7 @@ class PregelRunner:
         # each task is independent from all other concurrent tasks
         # yield updates/debug output as each task finishes
         end_time = timeout + time.monotonic() if timeout else None
+        handled_futures: set[concurrent.futures.Future[Any]] = set()
         while len(futures) > (1 if get_waiter is not None else 0):
             done, inflight = concurrent.futures.wait(
                 futures,
@@ -287,9 +294,32 @@ class PregelRunner:
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
                 elif (
-                    task_exc := _exception(fut)
-                ) and self._should_route_to_graph_error_handler(task) and not isinstance(task_exc, GraphBubbleUp):
+                    (task_exc := _exception(fut))
+                    and self._should_route_to_error_handler(task)
+                    and not isinstance(task_exc, GraphBubbleUp)
+                ):
                     self._handled_exception_ids.add(id(task_exc))
+                    SKIP_RERAISE_SET.add(fut)
+                    handled_futures.add(fut)
+                    if self.schedule_error_handler is not None:
+                        if handler_task := self.schedule_error_handler(task, task_exc):
+                            handler_fut = self.submit()(  # type: ignore[misc]
+                                run_with_retry,
+                                handler_task,
+                                retry_policy,
+                                configurable={
+                                    CONFIG_KEY_CALL: partial(
+                                        _call,
+                                        weakref.ref(handler_task),
+                                        retry_policy=retry_policy,
+                                        futures=weakref.ref(futures),
+                                        schedule_task=schedule_task,
+                                        submit=self.submit,
+                                    ),
+                                },
+                                __reraise_on_exit__=reraise,
+                            )
+                            futures[handler_fut] = handler_task
                 else:
                     done_for_stop.add(fut)
             else:
@@ -314,6 +344,7 @@ class PregelRunner:
                 futures.done.union(f for f, t in futures.items() if t is not None),
                 panic=reraise,
                 handled_exception_ids=self._handled_exception_ids,
+                handled_futures=handled_futures,
             )
         except Exception as exc:
             if tb := exc.__traceback__:
@@ -338,7 +369,6 @@ class PregelRunner:
             Awaitable[PregelExecutableTask | None],
         ],
     ) -> AsyncIterator[None]:
-        self._graph_error_routed = False
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -360,6 +390,7 @@ class PregelRunner:
             return
         elif len(tasks) == 1 and get_waiter is None and timeout is None:
             t = tasks[0]
+            scheduled_error_handler = False
             try:
                 await arun_with_retry(
                     t,
@@ -381,6 +412,15 @@ class PregelRunner:
                 self.commit(t, None)
             except Exception as exc:
                 self.commit(t, exc)
+                if (
+                    not isinstance(exc, GraphBubbleUp)
+                    and self._should_route_to_error_handler(t)
+                    and self.aschedule_error_handler is not None
+                ):
+                    self._handled_exception_ids.add(id(exc))
+                    if handler_task := await self.aschedule_error_handler(t, exc):
+                        tasks = (handler_task,)
+                        scheduled_error_handler = True
                 if reraise and futures:
                     if id(exc) not in self._handled_exception_ids:
                         # will be re-raised after futures are done
@@ -396,10 +436,12 @@ class PregelRunner:
                             tb = tb.tb_next
                         exc.__traceback__ = tb
                     raise
-            if not futures:  # maybe `t` scheduled another task
+            if not futures and not scheduled_error_handler:
+                # maybe `t` scheduled another task
                 return
             else:
-                tasks = ()  # don't reschedule this task
+                if not scheduled_error_handler:
+                    tasks = ()  # don't reschedule this task
         # add waiter task if requested
         if get_waiter is not None:
             futures[get_waiter()] = None
@@ -434,6 +476,7 @@ class PregelRunner:
         # each task is independent from all other concurrent tasks
         # yield updates/debug output as each task finishes
         end_time = timeout + loop.time() if timeout else None
+        handled_futures: set[asyncio.Future[Any]] = set()
         while len(futures) > (1 if get_waiter is not None else 0):
             done, inflight = await asyncio.wait(
                 futures,
@@ -450,9 +493,42 @@ class PregelRunner:
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
                 elif (
-                    task_exc := _exception(fut)
-                ) and self._should_route_to_graph_error_handler(task) and not isinstance(task_exc, GraphBubbleUp):
+                    (task_exc := _exception(fut))
+                    and self._should_route_to_error_handler(task)
+                    and not isinstance(task_exc, GraphBubbleUp)
+                ):
                     self._handled_exception_ids.add(id(task_exc))
+                    SKIP_RERAISE_SET.add(fut)
+                    handled_futures.add(fut)
+                    if self.aschedule_error_handler is not None:
+                        if handler_task := await self.aschedule_error_handler(
+                            task, task_exc
+                        ):
+                            handler_fut = cast(
+                                asyncio.Future,
+                                self.submit()(  # type: ignore[misc]
+                                    arun_with_retry,
+                                    handler_task,
+                                    retry_policy,
+                                    stream=self.use_astream,
+                                    configurable={
+                                        CONFIG_KEY_CALL: partial(
+                                            _acall,
+                                            weakref.ref(handler_task),
+                                            retry_policy=retry_policy,
+                                            stream=self.use_astream,
+                                            futures=weakref.ref(futures),
+                                            schedule_task=schedule_task,
+                                            submit=self.submit,
+                                            loop=loop,
+                                        ),
+                                    },
+                                    __name__=handler_task.name,
+                                    __cancel_on_exit__=True,
+                                    __reraise_on_exit__=reraise,
+                                ),
+                            )
+                            futures[handler_fut] = handler_task
                 else:
                     done_for_stop.add(fut)
             else:
@@ -482,6 +558,7 @@ class PregelRunner:
                 timeout_exc_cls=asyncio.TimeoutError,
                 panic=reraise,
                 handled_exception_ids=self._handled_exception_ids,
+                handled_futures=handled_futures,
             )
         except Exception as exc:
             if tb := exc.__traceback__:
@@ -517,16 +594,11 @@ class PregelRunner:
             else:
                 # save error to checkpointer
                 task.writes.append((ERROR, exception))
-                if self._should_route_to_graph_error_handler(task):
-                    error_info_channel = cast(str, self.graph_error_info_channel)
-                    task.writes.append((error_info_channel, task.name))
-                    # Redundant with tick/atick path by design: commit() may run before
-                    # or after loop-side checks, so we mark here as a race-safe fallback.
+                if self._should_route_to_error_handler(task) and not isinstance(
+                    exception, GraphBubbleUp
+                ):
+                    # Mark early in commit path; loop-side routing may happen later.
                     self._handled_exception_ids.add(id(exception))
-                    if not self._graph_error_routed:
-                        trigger_channel = cast(str, self.graph_error_trigger_channel)
-                        task.writes.append((trigger_channel, None))
-                        self._graph_error_routed = True
                 self.put_writes()(task.id, task.writes)  # type: ignore[misc]
         else:
             if self.node_finished and (
@@ -580,6 +652,8 @@ def _panic_or_proceed(
     timeout_exc_cls: type[Exception] = TimeoutError,
     panic: bool = True,
     handled_exception_ids: set[int] | None = None,
+    handled_futures: Collection[concurrent.futures.Future[Any] | asyncio.Future[Any]]
+    | None = None,
 ) -> None:
     """Cancel remaining tasks if any failed, re-raise exception if panic is True."""
     done: set[concurrent.futures.Future[Any] | asyncio.Future[Any]] = set()
@@ -596,6 +670,8 @@ def _panic_or_proceed(
         # if any task failed
         fut = done.pop()
         if exc := _exception(fut):
+            if fut in (handled_futures or set()):
+                continue
             if id(exc) in (handled_exception_ids or set()):
                 continue
             # cancel all pending tasks

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -72,6 +72,10 @@ SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = 
 class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
     event: E
     callback: weakref.ref[Callable[[PregelExecutableTask, BaseException | None], None]]
+    # Stop condition is injected by PregelRunner instead of hard-coded here.
+    # This lets the runner treat graph-error-handled exceptions as non-fatal
+    # so `on_done` does not trigger an early stop for those futures.
+    should_stop: Callable[[set[F]], bool]
     counter: int
     done: set[F]
     lock: threading.Lock
@@ -82,6 +86,7 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
         callback: weakref.ref[
             Callable[[PregelExecutableTask, BaseException | None], None]
         ],
+        should_stop: Callable[[set[F]], bool],
         future_type: type[F],
         # used for generic typing, newer py supports FutureDict[...](...)
     ) -> None:
@@ -89,6 +94,7 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
         self.lock = threading.Lock()
         self.event = event
         self.callback = callback
+        self.should_stop = should_stop
         self.counter = 0
         self.done: set[F] = set()
 
@@ -109,6 +115,7 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
         task: PregelExecutableTask,
         fut: F,
     ) -> None:
+        # Called automatically by future.add_done_callback registered in __setitem__.
         try:
             if cb := self.callback():
                 cb(task, _exception(fut))
@@ -116,7 +123,9 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
             with self.lock:
                 self.done.add(fut)
                 self.counter -= 1
-                if self.counter == 0 or _should_stop_others(self.done):
+                # Wake waiter when all tracked futures are done, or when runner-level
+                # stop condition is met (for example, a non-handled fatal exception).
+                if self.counter == 0 or self.should_stop(self.done):
                     self.event.set()
 
 
@@ -132,11 +141,42 @@ class PregelRunner:
         put_writes: weakref.ref[Callable[[str, Sequence[tuple[str, Any]]], None]],
         use_astream: bool = False,
         node_finished: Callable[[str], None] | None = None,
+        graph_error_handler_node: str | None = None,
+        graph_error_trigger_channel: str | None = None,
+        graph_error_info_channel: str | None = None,
     ) -> None:
         self.submit = submit
         self.put_writes = put_writes
         self.use_astream = use_astream
         self.node_finished = node_finished
+        self.graph_error_handler_node = graph_error_handler_node
+        self.graph_error_trigger_channel = graph_error_trigger_channel
+        self.graph_error_info_channel = graph_error_info_channel
+        if self.graph_error_handler_node is not None and (
+            self.graph_error_trigger_channel is None
+            or self.graph_error_info_channel is None
+        ):
+            raise ValueError(
+                "graph_error_handler_node requires both "
+                "graph_error_trigger_channel and graph_error_info_channel"
+            )
+        # Exception object ids that are already routed to graph-level error handler.
+        # These ids are consulted by stop/panic checks to avoid re-raising handled
+        # exceptions via the normal fatal path in the same run.
+        self._handled_exception_ids: set[int] = set()
+        # Per-superstep latch to emit exactly one handler trigger write
+        # (`branch:to:<handler>`) even if multiple tasks fail in that step.
+        # Reset at the beginning of each tick/atick call.
+        self._graph_error_routed = False
+
+    def _should_route_to_graph_error_handler(self, task: PregelExecutableTask) -> bool:
+        # Route non-handler task failures to graph-level error handler when configured.
+        # Handler self-failures are intentionally excluded to avoid recursive handling.
+        if self.graph_error_handler_node is None:
+            return False
+        if task.name == self.graph_error_handler_node:
+            return False
+        return True
 
     def tick(
         self,
@@ -151,10 +191,14 @@ class PregelRunner:
             PregelExecutableTask | None,
         ],
     ) -> Iterator[None]:
+        self._graph_error_routed = False
         tasks = tuple(tasks)
         futures = FuturesDict(
             callback=weakref.WeakMethod(self.commit),
             event=threading.Event(),
+            should_stop=partial(
+                _should_stop_others, handled_exception_ids=self._handled_exception_ids
+            ),
             future_type=concurrent.futures.Future,
         )
         # give control back to the caller
@@ -183,11 +227,12 @@ class PregelRunner:
             except Exception as exc:
                 self.commit(t, exc)
                 if reraise and futures:
-                    # will be re-raised after futures are done
-                    fut: concurrent.futures.Future = concurrent.futures.Future()
-                    fut.set_exception(exc)
-                    futures.done.add(fut)
-                elif reraise:
+                    if id(exc) not in self._handled_exception_ids:
+                        # will be re-raised after futures are done
+                        fut: concurrent.futures.Future = concurrent.futures.Future()
+                        fut.set_exception(exc)
+                        futures.done.add(fut)
+                elif reraise and id(exc) not in self._handled_exception_ids:
                     if tb := exc.__traceback__:
                         while tb.tb_next is not None and any(
                             tb.tb_frame.f_code.co_filename.endswith(name)
@@ -234,17 +279,26 @@ class PregelRunner:
             )
             if not done:
                 break  # timed out
+            done_for_stop: set[concurrent.futures.Future[Any]] = set()
             for fut in done:
                 task = futures.pop(fut)
                 if task is None:
                     # waiter task finished, schedule another
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
+                elif (
+                    exc := _exception(fut)
+                ) and self._should_route_to_graph_error_handler(task):
+                    self._handled_exception_ids.add(id(exc))
+                else:
+                    done_for_stop.add(fut)
             else:
                 # remove references to loop vars
                 del fut, task
             # maybe stop other tasks
-            if _should_stop_others(done):
+            if _should_stop_others(
+                done_for_stop, handled_exception_ids=self._handled_exception_ids
+            ):
                 break
             # give control back to the caller
             yield
@@ -259,6 +313,7 @@ class PregelRunner:
             _panic_or_proceed(
                 futures.done.union(f for f, t in futures.items() if t is not None),
                 panic=reraise,
+                handled_exception_ids=self._handled_exception_ids,
             )
         except Exception as exc:
             if tb := exc.__traceback__:
@@ -283,6 +338,7 @@ class PregelRunner:
             Awaitable[PregelExecutableTask | None],
         ],
     ) -> AsyncIterator[None]:
+        self._graph_error_routed = False
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
@@ -292,6 +348,9 @@ class PregelRunner:
         futures = FuturesDict(
             callback=weakref.WeakMethod(self.commit),
             event=asyncio.Event(),
+            should_stop=partial(
+                _should_stop_others, handled_exception_ids=self._handled_exception_ids
+            ),
             future_type=asyncio.Future,
         )
         # give control back to the caller
@@ -323,11 +382,12 @@ class PregelRunner:
             except Exception as exc:
                 self.commit(t, exc)
                 if reraise and futures:
-                    # will be re-raised after futures are done
-                    fut: asyncio.Future = loop.create_future()
-                    fut.set_exception(exc)
-                    futures.done.add(fut)
-                elif reraise:
+                    if id(exc) not in self._handled_exception_ids:
+                        # will be re-raised after futures are done
+                        fut: asyncio.Future = loop.create_future()
+                        fut.set_exception(exc)
+                        futures.done.add(fut)
+                elif reraise and id(exc) not in self._handled_exception_ids:
                     if tb := exc.__traceback__:
                         while tb.tb_next is not None and any(
                             tb.tb_frame.f_code.co_filename.endswith(name)
@@ -382,17 +442,26 @@ class PregelRunner:
             )
             if not done:
                 break  # timed out
+            done_for_stop: set[asyncio.Future[Any]] = set()
             for fut in done:
                 task = futures.pop(fut)
                 if task is None:
                     # waiter task finished, schedule another
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
+                elif (
+                    exc := _exception(fut)
+                ) and self._should_route_to_graph_error_handler(task):
+                    self._handled_exception_ids.add(id(exc))
+                else:
+                    done_for_stop.add(fut)
             else:
                 # remove references to loop vars
                 del fut, task
             # maybe stop other tasks
-            if _should_stop_others(done):
+            if _should_stop_others(
+                done_for_stop, handled_exception_ids=self._handled_exception_ids
+            ):
                 break
             # give control back to the caller
             yield
@@ -412,6 +481,7 @@ class PregelRunner:
                 futures.done.union(f for f, t in futures.items() if t is not None),
                 timeout_exc_cls=asyncio.TimeoutError,
                 panic=reraise,
+                handled_exception_ids=self._handled_exception_ids,
             )
         except Exception as exc:
             if tb := exc.__traceback__:
@@ -447,6 +517,16 @@ class PregelRunner:
             else:
                 # save error to checkpointer
                 task.writes.append((ERROR, exception))
+                if self._should_route_to_graph_error_handler(task):
+                    error_info_channel = cast(str, self.graph_error_info_channel)
+                    task.writes.append((error_info_channel, task.name))
+                    # Redundant with tick/atick path by design: commit() may run before
+                    # or after loop-side checks, so we mark here as a race-safe fallback.
+                    self._handled_exception_ids.add(id(exception))
+                    if not self._graph_error_routed:
+                        trigger_channel = cast(str, self.graph_error_trigger_channel)
+                        task.writes.append((trigger_channel, None))
+                        self._graph_error_routed = True
                 self.put_writes()(task.id, task.writes)  # type: ignore[misc]
         else:
             if self.node_finished and (
@@ -462,6 +542,8 @@ class PregelRunner:
 
 def _should_stop_others(
     done: set[F],
+    *,
+    handled_exception_ids: set[int] | None = None,
 ) -> bool:
     """Check if any task failed, if so, cancel all other tasks.
     GraphInterrupts are not considered failures."""
@@ -469,7 +551,11 @@ def _should_stop_others(
         if fut.cancelled():
             continue
         elif exc := fut.exception():
-            if not isinstance(exc, GraphBubbleUp) and fut not in SKIP_RERAISE_SET:
+            if (
+                id(exc) not in (handled_exception_ids or set())
+                and not isinstance(exc, GraphBubbleUp)
+                and fut not in SKIP_RERAISE_SET
+            ):
                 return True
 
     return False
@@ -493,6 +579,7 @@ def _panic_or_proceed(
     *,
     timeout_exc_cls: type[Exception] = TimeoutError,
     panic: bool = True,
+    handled_exception_ids: set[int] | None = None,
 ) -> None:
     """Cancel remaining tasks if any failed, re-raise exception if panic is True."""
     done: set[concurrent.futures.Future[Any] | asyncio.Future[Any]] = set()
@@ -509,6 +596,8 @@ def _panic_or_proceed(
         # if any task failed
         fut = done.pop()
         if exc := _exception(fut):
+            if id(exc) in (handled_exception_ids or set()):
+                continue
             # cancel all pending tasks
             while inflight:
                 inflight.pop().cancel()

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -287,9 +287,9 @@ class PregelRunner:
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
                 elif (
-                    exc := _exception(fut)
+                    task_exc := _exception(fut)
                 ) and self._should_route_to_graph_error_handler(task):
-                    self._handled_exception_ids.add(id(exc))
+                    self._handled_exception_ids.add(id(task_exc))
                 else:
                     done_for_stop.add(fut)
             else:
@@ -450,9 +450,9 @@ class PregelRunner:
                     if inflight and get_waiter is not None:
                         futures[get_waiter()] = None
                 elif (
-                    exc := _exception(fut)
+                    task_exc := _exception(fut)
                 ) and self._should_route_to_graph_error_handler(task):
-                    self._handled_exception_ids.add(id(exc))
+                    self._handled_exception_ids.add(id(task_exc))
                 else:
                     done_for_stop.add(fut)
             else:

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -288,7 +288,7 @@ class PregelRunner:
                         futures[get_waiter()] = None
                 elif (
                     task_exc := _exception(fut)
-                ) and self._should_route_to_graph_error_handler(task):
+                ) and self._should_route_to_graph_error_handler(task) and not isinstance(task_exc, GraphBubbleUp):
                     self._handled_exception_ids.add(id(task_exc))
                 else:
                     done_for_stop.add(fut)
@@ -451,7 +451,7 @@ class PregelRunner:
                         futures[get_waiter()] = None
                 elif (
                     task_exc := _exception(fut)
-                ) and self._should_route_to_graph_error_handler(task):
+                ) and self._should_route_to_graph_error_handler(task) and not isinstance(task_exc, GraphBubbleUp):
                     self._handled_exception_ids.add(id(task_exc))
                 else:
                     done_for_stop.add(fut)

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -727,6 +727,9 @@ class Pregel(
     name: str = "LangGraph"
 
     trigger_to_nodes: Mapping[str, Sequence[str]]
+    graph_error_handler_node: str | None = None
+    graph_error_trigger_channel: str | None = None
+    graph_error_info_channel: str | None = None
 
     def __init__(
         self,
@@ -751,6 +754,9 @@ class Pregel(
         context_schema: type[ContextT] | None = None,
         config: RunnableConfig | None = None,
         trigger_to_nodes: Mapping[str, Sequence[str]] | None = None,
+        graph_error_handler_node: str | None = None,
+        graph_error_trigger_channel: str | None = None,
+        graph_error_info_channel: str | None = None,
         name: str = "LangGraph",
         stream_transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
@@ -798,6 +804,9 @@ class Pregel(
         self.context_schema = context_schema
         self.config = config
         self.trigger_to_nodes = trigger_to_nodes or {}
+        self.graph_error_handler_node = graph_error_handler_node
+        self.graph_error_trigger_channel = graph_error_trigger_channel
+        self.graph_error_info_channel = graph_error_info_channel
         self.name = name
         self.stream_transformers: tuple[Callable[[tuple[str, ...]], Any], ...] = tuple(
             stream_transformers or ()
@@ -2845,6 +2854,9 @@ class Pregel(
                     ),
                     put_writes=weakref.WeakMethod(loop.put_writes),
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
+                    graph_error_handler_node=self.graph_error_handler_node,
+                    graph_error_trigger_channel=self.graph_error_trigger_channel,
+                    graph_error_info_channel=self.graph_error_info_channel,
                 )
                 # enable subgraph streaming
                 if subgraphs:
@@ -3287,6 +3299,9 @@ class Pregel(
                     put_writes=weakref.WeakMethod(loop.put_writes),
                     use_astream=do_stream,
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
+                    graph_error_handler_node=self.graph_error_handler_node,
+                    graph_error_trigger_channel=self.graph_error_trigger_channel,
+                    graph_error_info_channel=self.graph_error_info_channel,
                 )
                 # enable subgraph streaming
                 if subgraphs:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -727,9 +727,7 @@ class Pregel(
     name: str = "LangGraph"
 
     trigger_to_nodes: Mapping[str, Sequence[str]]
-    graph_error_handler_node: str | None = None
-    graph_error_trigger_channel: str | None = None
-    graph_error_info_channel: str | None = None
+    node_error_handler_map: Mapping[str, str]
 
     def __init__(
         self,
@@ -754,9 +752,7 @@ class Pregel(
         context_schema: type[ContextT] | None = None,
         config: RunnableConfig | None = None,
         trigger_to_nodes: Mapping[str, Sequence[str]] | None = None,
-        graph_error_handler_node: str | None = None,
-        graph_error_trigger_channel: str | None = None,
-        graph_error_info_channel: str | None = None,
+        node_error_handler_map: Mapping[str, str] | None = None,
         name: str = "LangGraph",
         stream_transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
@@ -804,9 +800,7 @@ class Pregel(
         self.context_schema = context_schema
         self.config = config
         self.trigger_to_nodes = trigger_to_nodes or {}
-        self.graph_error_handler_node = graph_error_handler_node
-        self.graph_error_trigger_channel = graph_error_trigger_channel
-        self.graph_error_info_channel = graph_error_info_channel
+        self.node_error_handler_map = node_error_handler_map or {}
         self.name = name
         self.stream_transformers: tuple[Callable[[tuple[str, ...]], Any], ...] = tuple(
             stream_transformers or ()
@@ -2854,9 +2848,8 @@ class Pregel(
                     ),
                     put_writes=weakref.WeakMethod(loop.put_writes),
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
-                    graph_error_handler_node=self.graph_error_handler_node,
-                    graph_error_trigger_channel=self.graph_error_trigger_channel,
-                    graph_error_info_channel=self.graph_error_info_channel,
+                    node_error_handler_map=self.node_error_handler_map,
+                    schedule_error_handler=loop.schedule_error_handler,
                 )
                 # enable subgraph streaming
                 if subgraphs:
@@ -3299,9 +3292,8 @@ class Pregel(
                     put_writes=weakref.WeakMethod(loop.put_writes),
                     use_astream=do_stream,
                     node_finished=config[CONF].get(CONFIG_KEY_NODE_FINISHED),
-                    graph_error_handler_node=self.graph_error_handler_node,
-                    graph_error_trigger_channel=self.graph_error_trigger_channel,
-                    graph_error_info_channel=self.graph_error_info_channel,
+                    node_error_handler_map=self.node_error_handler_map,
+                    aschedule_error_handler=loop.aschedule_error_handler,
                 )
                 # enable subgraph streaming
                 if subgraphs:

--- a/libs/langgraph/langgraph/runtime.py
+++ b/libs/langgraph/langgraph/runtime.py
@@ -51,6 +51,12 @@ class ExecutionInfo:
     node_first_attempt_time: float | None = None
     """Unix timestamp (seconds) for when the first attempt started."""
 
+    from_node_names: tuple[str, ...] | None = None
+    """Failed source node names aggregated for graph-level error handler."""
+
+    from_node_errors: tuple[BaseException, ...] | None = None
+    """Failed source node exceptions aggregated for graph-level error handler."""
+
     def patch(self, **overrides: Any) -> ExecutionInfo:
         """Return a new execution info object with selected fields replaced."""
         return replace(self, **overrides)

--- a/libs/langgraph/langgraph/runtime.py
+++ b/libs/langgraph/langgraph/runtime.py
@@ -51,11 +51,11 @@ class ExecutionInfo:
     node_first_attempt_time: float | None = None
     """Unix timestamp (seconds) for when the first attempt started."""
 
-    from_node_names: tuple[str, ...] | None = None
-    """Failed source node names aggregated for graph-level error handler."""
+    from_node_name: str | None = None
+    """Failed source node name for node-level error handler."""
 
-    from_node_errors: tuple[BaseException, ...] | None = None
-    """Failed source node exceptions aggregated for graph-level error handler."""
+    from_node_error: BaseException | None = None
+    """Failed source node exception for node-level error handler."""
 
     def patch(self, **overrides: Any) -> ExecutionInfo:
         """Return a new execution info object with selected fields replaced."""

--- a/libs/langgraph/langgraph/runtime.py
+++ b/libs/langgraph/langgraph/runtime.py
@@ -51,12 +51,6 @@ class ExecutionInfo:
     node_first_attempt_time: float | None = None
     """Unix timestamp (seconds) for when the first attempt started."""
 
-    from_node_name: str | None = None
-    """Failed source node name for node-level error handler."""
-
-    from_node_error: BaseException | None = None
-    """Failed source node exception for node-level error handler."""
-
     def patch(self, **overrides: Any) -> ExecutionInfo:
         """Return a new execution info object with selected fields replaced."""
         return replace(self, **overrides)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9756,6 +9756,7 @@ async def test_graph_error_handler_async_runtime_info() -> None:
     assert isinstance(captured["from_node_error"], BaseException)
 
 
+@NEEDS_CONTEXTVARS
 async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> None:
     """When a graph error handler is configured and a node calls interrupt()
     concurrently with other nodes, the interrupt must still be raised — not

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9769,7 +9769,7 @@ async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> No
         return {"foo": f"a_{val}"}
 
     async def node_b(state: State) -> State:
-        return {"foo": "b_done"}
+        return {}
 
     async def err_handler(state: State) -> State:
         return {"foo": "handled"}

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9726,8 +9726,8 @@ async def test_graph_error_handler_async_runtime_info() -> None:
         raise ValueError("Always fails async")
 
     async def err_handler_node(state: State, runtime: Runtime) -> State:
-        captured["from_node_names"] = runtime.execution_info.from_node_names
-        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        captured["from_node_name"] = runtime.execution_info.from_node_name
+        captured["from_node_error"] = runtime.execution_info.from_node_error
         return {"foo": "handled_async"}
 
     graph = (
@@ -9741,8 +9741,8 @@ async def test_graph_error_handler_async_runtime_info() -> None:
                 jitter=False,
                 retry_on=ValueError,
             ),
+            error_handler=err_handler_node,
         )
-        .set_graph_error_handler("err_handler", err_handler_node)
         .add_edge(START, "always_failing")
         .compile()
     )
@@ -9752,10 +9752,8 @@ async def test_graph_error_handler_async_runtime_info() -> None:
 
     assert attempts == 2
     assert result["foo"] == "handled_async"
-    assert captured["from_node_names"] == ("always_failing",)
-    assert isinstance(captured["from_node_errors"], tuple)
-    assert len(captured["from_node_errors"]) == 1
-    assert isinstance(captured["from_node_errors"][0], BaseException)
+    assert captured["from_node_name"] == "always_failing"
+    assert isinstance(captured["from_node_error"], BaseException)
 
 
 async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> None:
@@ -9779,9 +9777,8 @@ async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> No
     checkpointer = InMemorySaver()
     graph = (
         StateGraph(State)
-        .add_node("node_a", node_a)
+        .add_node("node_a", node_a, error_handler=err_handler)
         .add_node("node_b", node_b)
-        .set_graph_error_handler("err_handler", err_handler)
         .add_edge(START, "node_a")
         .add_edge(START, "node_b")
         .compile(checkpointer=checkpointer)
@@ -9789,15 +9786,12 @@ async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> No
 
     config = {"configurable": {"thread_id": "test-interrupt-concurrent-async"}}
 
-    result = await graph.ainvoke({"foo": ""}, config)
+    await graph.ainvoke({"foo": ""}, config)
 
     state = await graph.aget_state(config)
     assert len(state.tasks) > 0
 
-    interrupts = [
-        t for t in state.tasks
-        if hasattr(t, 'interrupts') and t.interrupts
-    ]
+    interrupts = [t for t in state.tasks if hasattr(t, "interrupts") and t.interrupts]
     assert len(interrupts) > 0, (
         "GraphInterrupt was swallowed — interrupt() in node_a "
         "should have paused execution"

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9756,3 +9756,49 @@ async def test_graph_error_handler_async_runtime_info() -> None:
     assert isinstance(captured["from_node_errors"], tuple)
     assert len(captured["from_node_errors"]) == 1
     assert isinstance(captured["from_node_errors"][0], BaseException)
+
+
+async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> None:
+    """When a graph error handler is configured and a node calls interrupt()
+    concurrently with other nodes, the interrupt must still be raised — not
+    silently swallowed."""
+
+    class State(TypedDict):
+        foo: str
+
+    async def node_a(state: State) -> State:
+        val = interrupt("need human input")
+        return {"foo": f"a_{val}"}
+
+    async def node_b(state: State) -> State:
+        return {"foo": "b_done"}
+
+    async def err_handler(state: State) -> State:
+        return {"foo": "handled"}
+
+    checkpointer = InMemorySaver()
+    graph = (
+        StateGraph(State)
+        .add_node("node_a", node_a)
+        .add_node("node_b", node_b)
+        .set_graph_error_handler("err_handler", err_handler)
+        .add_edge(START, "node_a")
+        .add_edge(START, "node_b")
+        .compile(checkpointer=checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "test-interrupt-concurrent-async"}}
+
+    result = await graph.ainvoke({"foo": ""}, config)
+
+    state = await graph.aget_state(config)
+    assert len(state.tasks) > 0
+
+    interrupts = [
+        t for t in state.tasks
+        if hasattr(t, 'interrupts') and t.interrupts
+    ]
+    assert len(interrupts) > 0, (
+        "GraphInterrupt was swallowed — interrupt() in node_a "
+        "should have paused execution"
+    )

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -49,6 +49,7 @@ from langgraph.channels.topic import Topic
 from langgraph.errors import (
     GraphRecursionError,
     InvalidUpdateError,
+    NodeError,
     ParentCommand,
 )
 from langgraph.func import entrypoint, task
@@ -57,7 +58,6 @@ from langgraph.graph.message import MessagesState, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._loop import AsyncPregelLoop
 from langgraph.pregel._runner import PregelRunner
-from langgraph.runtime import Runtime
 from langgraph.types import (
     CachePolicy,
     Command,
@@ -9725,9 +9725,9 @@ async def test_graph_error_handler_async_runtime_info() -> None:
         attempts += 1
         raise ValueError("Always fails async")
 
-    async def err_handler_node(state: State, runtime: Runtime) -> State:
-        captured["from_node_name"] = runtime.execution_info.from_node_name
-        captured["from_node_error"] = runtime.execution_info.from_node_error
+    async def err_handler_node(state: State, error: NodeError) -> State:
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
         return {"foo": "handled_async"}
 
     graph = (
@@ -9797,3 +9797,40 @@ async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> No
         "GraphInterrupt was swallowed — interrupt() in node_a "
         "should have paused execution"
     )
+
+
+async def test_node_error_handler_handles_subgraph_internal_failure_async() -> None:
+    class SubState(TypedDict):
+        foo: str
+
+    class ParentState(TypedDict):
+        foo: str
+
+    captured: dict[str, object] = {}
+
+    async def sub_fail_node(state: SubState) -> SubState:
+        raise ValueError("async subgraph boom")
+
+    async def parent_handler(state: ParentState, error: NodeError) -> ParentState:
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
+        return {"foo": "handled_async_subgraph"}
+
+    subgraph = (
+        StateGraph(SubState)
+        .add_node("sub_fail_node", sub_fail_node)
+        .add_edge(START, "sub_fail_node")
+        .compile()
+    )
+
+    parent_graph = (
+        StateGraph(ParentState)
+        .add_node("subgraph_node", subgraph, error_handler=parent_handler)
+        .add_edge(START, "subgraph_node")
+        .compile()
+    )
+
+    result = await parent_graph.ainvoke({"foo": ""})
+    assert result["foo"] == "handled_async_subgraph"
+    assert captured["from_node_name"] == "subgraph_node"
+    assert isinstance(captured["from_node_error"], BaseException)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -16,6 +16,7 @@ from typing import (
     Literal,
     Optional,
 )
+from unittest.mock import patch
 from uuid import UUID
 
 import pytest
@@ -56,6 +57,7 @@ from langgraph.graph.message import MessagesState, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._loop import AsyncPregelLoop
 from langgraph.pregel._runner import PregelRunner
+from langgraph.runtime import Runtime
 from langgraph.types import (
     CachePolicy,
     Command,
@@ -9709,3 +9711,48 @@ async def test_fork_does_not_apply_pending_writes(
 
     # 1 (input) + 20 (forked node_a) + 100 (node_b) = 121
     assert result == {"value": 121}
+
+
+async def test_graph_error_handler_async_runtime_info() -> None:
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+    captured: dict[str, object] = {}
+
+    async def always_failing_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("Always fails async")
+
+    async def err_handler_node(state: State, runtime: Runtime) -> State:
+        captured["from_node_names"] = runtime.execution_info.from_node_names
+        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        return {"foo": "handled_async"}
+
+    graph = (
+        StateGraph(State)
+        .add_node(
+            "always_failing",
+            always_failing_node,
+            retry_policy=RetryPolicy(
+                max_attempts=2,
+                initial_interval=0.01,
+                jitter=False,
+                retry_on=ValueError,
+            ),
+        )
+        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_edge(START, "always_failing")
+        .compile()
+    )
+
+    with patch("asyncio.sleep"):
+        result = await graph.ainvoke({"foo": ""})
+
+    assert attempts == 2
+    assert result["foo"] == "handled_async"
+    assert captured["from_node_names"] == ("always_failing",)
+    assert isinstance(captured["from_node_errors"], tuple)
+    assert len(captured["from_node_errors"]) == 1
+    assert isinstance(captured["from_node_errors"][0], BaseException)

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import operator
 import sys
 import threading
 import time
@@ -34,7 +35,7 @@ from langgraph._internal._runnable import RunnableCallable
 from langgraph._internal._timeout import coerce_timeout_policy
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
-from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
+from langgraph.errors import GraphInterrupt, NodeError, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
@@ -1769,9 +1770,9 @@ def test_graph_error_handler_runs_after_retry_exhaustion():
         attempts += 1
         raise ValueError("Always fails")
 
-    def err_handler_node(state: State, runtime: Runtime) -> Command:
-        captured["from_node_name"] = runtime.execution_info.from_node_name
-        captured["from_node_error"] = runtime.execution_info.from_node_error
+    def err_handler_node(state: State, error: NodeError) -> Command:
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
         return Command(update={"foo": "handled"}, goto="after_handler")
 
     def after_handler(state: State) -> State:
@@ -1882,11 +1883,11 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
     def sub_fail_node(state: SubState) -> SubState:
         raise ValueError("subgraph boom")
 
-    def parent_handler(state: ParentState, runtime: Runtime) -> ParentState:
+    def parent_handler(state: ParentState, error: NodeError) -> ParentState:
         nonlocal parent_handler_called
         parent_handler_called = True
-        captured["from_node_name"] = runtime.execution_info.from_node_name
-        captured["from_node_error"] = runtime.execution_info.from_node_error
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
         return {"foo": "handled_by_parent"}
 
     subgraph = (
@@ -1919,9 +1920,9 @@ def test_graph_error_handler_error_context_survives_checkpoint_resume():
     def always_failing_node(state: State) -> State:
         raise RuntimeError("failed before handler")
 
-    def err_handler_node(state: State, runtime: Runtime) -> State:
-        captured["from_node_name"] = runtime.execution_info.from_node_name
-        captured["from_node_error"] = runtime.execution_info.from_node_error
+    def err_handler_node(state: State, error: NodeError) -> State:
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
         return {"foo": "handled_after_resume"}
 
     checkpointer = InMemorySaver()
@@ -1992,3 +1993,64 @@ def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
         "GraphInterrupt was swallowed — interrupt() in node_a "
         "should have paused execution"
     )
+
+
+
+def test_node_error_handlers_route_to_matching_handler():
+    class State(TypedDict):
+        route: str
+        foo: Annotated[list[str], operator.add]
+
+    def route_node(state: State) -> State:
+        return {"foo": []}
+
+    def choose_node(state: State) -> str:
+        return state["route"]
+
+    def fail_a(state: State) -> State:
+        raise ValueError("a failed")
+
+    def fail_b(state: State) -> State:
+        raise RuntimeError("b failed")
+
+    def handler_a(state: State, error: NodeError) -> State:
+        assert error.node == "fail_a"
+        return {"foo": ["handled_a"]}
+
+    def handler_b(state: State, error: NodeError) -> State:
+        assert error.node == "fail_b"
+        return {"foo": ["handled_b"]}
+
+    graph = (
+        StateGraph(State)
+        .add_node("route_node", route_node)
+        .add_node("fail_a", fail_a, error_handler=handler_a)
+        .add_node("fail_b", fail_b, error_handler=handler_b)
+        .add_edge(START, "route_node")
+        .add_conditional_edges("route_node", choose_node, path_map=["fail_a", "fail_b"])
+        .compile()
+    )
+
+    result_a = graph.invoke({"route": "fail_a", "foo": []})
+    result_b = graph.invoke({"route": "fail_b", "foo": []})
+    assert result_a["foo"] == ["handled_a"]
+    assert result_b["foo"] == ["handled_b"]
+
+
+def test_node_without_error_handler_still_fails_run():
+    class State(TypedDict):
+        foo: str
+
+    def fail_without_handler(state: State) -> State:
+        raise ValueError("no handler")
+
+    graph = (
+        StateGraph(State)
+        .add_node("fail_without_handler", fail_without_handler)
+        .add_edge(START, "fail_without_handler")
+        .compile()
+    )
+
+    with pytest.raises(ValueError, match="no handler"):
+        graph.invoke({"foo": ""})
+

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -29,8 +29,6 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
-    ERROR,
-    GRAPH_ERROR_INFO,
 )
 from langgraph._internal._runnable import RunnableCallable
 from langgraph._internal._timeout import coerce_timeout_policy
@@ -40,10 +38,6 @@ from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
-from langgraph.pregel._algo import (
-    _read_errors_for_task_ids_from_pending_writes,
-    _read_failed_node_names_from_pending_writes,
-)
 from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
@@ -1775,10 +1769,10 @@ def test_graph_error_handler_runs_after_retry_exhaustion():
         attempts += 1
         raise ValueError("Always fails")
 
-    def err_handler_node(state: State, runtime: Runtime) -> State:
-        captured["from_node_names"] = runtime.execution_info.from_node_names
-        captured["from_node_errors"] = runtime.execution_info.from_node_errors
-        return {"foo": "handled"}
+    def err_handler_node(state: State, runtime: Runtime) -> Command:
+        captured["from_node_name"] = runtime.execution_info.from_node_name
+        captured["from_node_error"] = runtime.execution_info.from_node_error
+        return Command(update={"foo": "handled"}, goto="after_handler")
 
     def after_handler(state: State) -> State:
         return {"foo": f"{state['foo']}_after"}
@@ -1792,11 +1786,14 @@ def test_graph_error_handler_runs_after_retry_exhaustion():
 
     graph = (
         StateGraph(State)
-        .add_node("always_failing", always_failing_node, retry_policy=retry_policy)
-        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_node(
+            "always_failing",
+            always_failing_node,
+            retry_policy=retry_policy,
+            error_handler=err_handler_node,
+        )
         .add_node("after_handler", after_handler)
         .add_edge(START, "always_failing")
-        .add_edge("err_handler", "after_handler")
         .compile()
     )
 
@@ -1805,10 +1802,8 @@ def test_graph_error_handler_runs_after_retry_exhaustion():
 
     assert attempts == 2
     assert result["foo"] == "handled_after"
-    assert captured["from_node_names"] == ("always_failing",)
-    assert isinstance(captured["from_node_errors"], tuple)
-    assert len(captured["from_node_errors"]) == 1
-    assert isinstance(captured["from_node_errors"][0], BaseException)
+    assert captured["from_node_name"] == "always_failing"
+    assert isinstance(captured["from_node_error"], BaseException)
 
 
 def test_graph_error_handler_can_route_with_command():
@@ -1837,11 +1832,11 @@ def test_graph_error_handler_can_route_with_command():
 
     graph = (
         StateGraph(State)
-        .add_node("always_failing", always_failing_node, retry_policy=retry_policy)
-        .set_graph_error_handler(
-            "err_handler",
-            err_handler_node,
-            destinations=("next_node",),
+        .add_node(
+            "always_failing",
+            always_failing_node,
+            retry_policy=retry_policy,
+            error_handler=err_handler_node,
         )
         .add_node("next_node", next_node)
         .add_edge(START, "always_failing")
@@ -1865,8 +1860,7 @@ def test_graph_error_handler_failure_fails_run():
 
     graph = (
         StateGraph(State)
-        .add_node("always_failing", always_failing_node)
-        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_node("always_failing", always_failing_node, error_handler=err_handler_node)
         .add_edge(START, "always_failing")
         .compile()
     )
@@ -1891,8 +1885,8 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
     def parent_handler(state: ParentState, runtime: Runtime) -> ParentState:
         nonlocal parent_handler_called
         parent_handler_called = True
-        captured["from_node_names"] = runtime.execution_info.from_node_names
-        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        captured["from_node_name"] = runtime.execution_info.from_node_name
+        captured["from_node_error"] = runtime.execution_info.from_node_error
         return {"foo": "handled_by_parent"}
 
     subgraph = (
@@ -1904,8 +1898,7 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
 
     parent_graph = (
         StateGraph(ParentState)
-        .add_node("subgraph_node", subgraph)
-        .set_graph_error_handler("parent_handler", parent_handler)
+        .add_node("subgraph_node", subgraph, error_handler=parent_handler)
         .add_edge(START, "subgraph_node")
         .compile()
     )
@@ -1913,10 +1906,8 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
     result = parent_graph.invoke({"foo": ""})
     assert result["foo"] == "handled_by_parent"
     assert parent_handler_called is True
-    assert captured["from_node_names"] == ("subgraph_node",)
-    assert isinstance(captured["from_node_errors"], tuple)
-    assert len(captured["from_node_errors"]) == 1
-    assert isinstance(captured["from_node_errors"][0], BaseException)
+    assert captured["from_node_name"] == "subgraph_node"
+    assert isinstance(captured["from_node_error"], BaseException)
 
 
 def test_graph_error_handler_error_context_survives_checkpoint_resume():
@@ -1929,18 +1920,20 @@ def test_graph_error_handler_error_context_survives_checkpoint_resume():
         raise RuntimeError("failed before handler")
 
     def err_handler_node(state: State, runtime: Runtime) -> State:
-        captured["from_node_names"] = runtime.execution_info.from_node_names
-        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        captured["from_node_name"] = runtime.execution_info.from_node_name
+        captured["from_node_error"] = runtime.execution_info.from_node_error
         return {"foo": "handled_after_resume"}
 
     checkpointer = InMemorySaver()
     config = {"configurable": {"thread_id": "graph-error-resume"}}
     graph = (
         StateGraph(State)
-        .add_node("always_failing", always_failing_node)
-        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_node("always_failing", always_failing_node, error_handler=err_handler_node)
         .add_edge(START, "always_failing")
-        .compile(checkpointer=checkpointer, interrupt_before=["err_handler"])
+        .compile(
+            checkpointer=checkpointer,
+            interrupt_before=["__error_handler__always_failing"],
+        )
     )
 
     # First run pauses before handler, after failure context is checkpointed.
@@ -1949,35 +1942,15 @@ def test_graph_error_handler_error_context_survives_checkpoint_resume():
     result = graph.invoke(None, config)
 
     assert result["foo"] == "handled_after_resume"
-    assert captured["from_node_names"] == ("always_failing",)
-    assert isinstance(captured["from_node_errors"], tuple)
-    assert len(captured["from_node_errors"]) == 1
-    assert isinstance(captured["from_node_errors"][0], BaseException)
-
-
-def test_graph_error_info_supports_multiple_failures_from_pending_writes():
-    pending_writes = [
-        ("task_a", GRAPH_ERROR_INFO, "fail_a"),
-        ("task_b", GRAPH_ERROR_INFO, "fail_b"),
-        ("task_a", ERROR, ValueError("a failed")),
-        ("task_b", ERROR, KeyError("b failed")),
-    ]
-
-    failed_node_names = _read_failed_node_names_from_pending_writes(pending_writes)
-    assert failed_node_names == [("task_a", "fail_a"), ("task_b", "fail_b")]
-    errors = _read_errors_for_task_ids_from_pending_writes(
-        pending_writes, tuple(task_id for task_id, _ in failed_node_names)
-    )
-    assert len(errors) == 2
-    assert isinstance(errors[0], ValueError)
-    assert isinstance(errors[1], KeyError)
+    assert captured["from_node_name"] == "always_failing"
+    assert isinstance(captured["from_node_error"], BaseException)
 
 
 def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
     """When a graph error handler is configured and a node calls interrupt()
     concurrently with other nodes, the interrupt must still be raised — not
     silently swallowed."""
-    from langgraph.types import interrupt, Send
+    from langgraph.types import interrupt
 
     class State(TypedDict):
         foo: str
@@ -1996,9 +1969,8 @@ def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
     checkpointer = InMemorySaver()
     graph = (
         StateGraph(State)
-        .add_node("node_a", node_a)
+        .add_node("node_a", node_a, error_handler=err_handler)
         .add_node("node_b", node_b)
-        .set_graph_error_handler("err_handler", err_handler)
         # Fan-out: both node_a and node_b run concurrently
         .add_edge(START, "node_a")
         .add_edge(START, "node_b")
@@ -2008,17 +1980,14 @@ def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
     config = {"configurable": {"thread_id": "test-interrupt-concurrent"}}
 
     # First invoke should pause at the interrupt, not silently complete
-    result = graph.invoke({"foo": ""}, config)
+    graph.invoke({"foo": ""}, config)
 
     # The graph should have an interrupt pending
     state = graph.get_state(config)
     assert len(state.tasks) > 0
 
     # There should be a pending interrupt from node_a
-    interrupts = [
-        t for t in state.tasks
-        if hasattr(t, 'interrupts') and t.interrupts
-    ]
+    interrupts = [t for t in state.tasks if hasattr(t, "interrupts") and t.interrupts]
     assert len(interrupts) > 0, (
         "GraphInterrupt was swallowed — interrupt() in node_a "
         "should have paused execution"

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1961,7 +1961,7 @@ def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
         return {"foo": f"a_{val}"}
 
     def node_b(state: State) -> State:
-        return {"foo": "b_done"}
+        return {}
 
     def err_handler(state: State) -> State:
         return {"foo": "handled"}

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1971,3 +1971,55 @@ def test_graph_error_info_supports_multiple_failures_from_pending_writes():
     assert len(errors) == 2
     assert isinstance(errors[0], ValueError)
     assert isinstance(errors[1], KeyError)
+
+
+def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
+    """When a graph error handler is configured and a node calls interrupt()
+    concurrently with other nodes, the interrupt must still be raised — not
+    silently swallowed."""
+    from langgraph.types import interrupt, Send
+
+    class State(TypedDict):
+        foo: str
+
+    def node_a(state: State) -> State:
+        # This node uses interrupt() which raises GraphInterrupt
+        val = interrupt("need human input")
+        return {"foo": f"a_{val}"}
+
+    def node_b(state: State) -> State:
+        return {"foo": "b_done"}
+
+    def err_handler(state: State) -> State:
+        return {"foo": "handled"}
+
+    checkpointer = InMemorySaver()
+    graph = (
+        StateGraph(State)
+        .add_node("node_a", node_a)
+        .add_node("node_b", node_b)
+        .set_graph_error_handler("err_handler", err_handler)
+        # Fan-out: both node_a and node_b run concurrently
+        .add_edge(START, "node_a")
+        .add_edge(START, "node_b")
+        .compile(checkpointer=checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "test-interrupt-concurrent"}}
+
+    # First invoke should pause at the interrupt, not silently complete
+    result = graph.invoke({"foo": ""}, config)
+
+    # The graph should have an interrupt pending
+    state = graph.get_state(config)
+    assert len(state.tasks) > 0
+
+    # There should be a pending interrupt from node_a
+    interrupts = [
+        t for t in state.tasks
+        if hasattr(t, 'interrupts') and t.interrupts
+    ]
+    assert len(interrupts) > 0, (
+        "GraphInterrupt was swallowed — interrupt() in node_a "
+        "should have paused execution"
+    )

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1883,13 +1883,16 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
         foo: str
 
     parent_handler_called = False
+    captured: dict[str, object] = {}
 
     def sub_fail_node(state: SubState) -> SubState:
         raise ValueError("subgraph boom")
 
-    def parent_handler(state: ParentState) -> ParentState:
+    def parent_handler(state: ParentState, runtime: Runtime) -> ParentState:
         nonlocal parent_handler_called
         parent_handler_called = True
+        captured["from_node_names"] = runtime.execution_info.from_node_names
+        captured["from_node_errors"] = runtime.execution_info.from_node_errors
         return {"foo": "handled_by_parent"}
 
     subgraph = (
@@ -1910,6 +1913,10 @@ def test_graph_error_handler_handles_subgraph_internal_failure():
     result = parent_graph.invoke({"foo": ""})
     assert result["foo"] == "handled_by_parent"
     assert parent_handler_called is True
+    assert captured["from_node_names"] == ("subgraph_node",)
+    assert isinstance(captured["from_node_errors"], tuple)
+    assert len(captured["from_node_errors"]) == 1
+    assert isinstance(captured["from_node_errors"][0], BaseException)
 
 
 def test_graph_error_handler_error_context_survives_checkpoint_resume():

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -15,7 +15,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import RunnableLambda, RunnableParallel
-from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.memory import InMemorySaver, MemorySaver
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from typing_extensions import TypedDict
 
@@ -29,6 +29,8 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
+    ERROR,
+    GRAPH_ERROR_INFO,
 )
 from langgraph._internal._runnable import RunnableCallable
 from langgraph._internal._timeout import coerce_timeout_policy
@@ -38,6 +40,10 @@ from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
+from langgraph.pregel._algo import (
+    _read_errors_for_task_ids_from_pending_writes,
+    _read_failed_node_names_from_pending_writes,
+)
 from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
@@ -1755,3 +1761,206 @@ async def test_arun_with_retry_timeout_observer_treats_bubble_up_as_non_error():
     assert finish.status == "success"
     assert finish.error_type is None
     assert finish.error_message is None
+
+
+def test_graph_error_handler_runs_after_retry_exhaustion():
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+    captured: dict[str, object] = {}
+
+    def always_failing_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("Always fails")
+
+    def err_handler_node(state: State, runtime: Runtime) -> State:
+        captured["from_node_names"] = runtime.execution_info.from_node_names
+        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        return {"foo": "handled"}
+
+    def after_handler(state: State) -> State:
+        return {"foo": f"{state['foo']}_after"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.01,
+        jitter=False,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing_node, retry_policy=retry_policy)
+        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_node("after_handler", after_handler)
+        .add_edge(START, "always_failing")
+        .add_edge("err_handler", "after_handler")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert attempts == 2
+    assert result["foo"] == "handled_after"
+    assert captured["from_node_names"] == ("always_failing",)
+    assert isinstance(captured["from_node_errors"], tuple)
+    assert len(captured["from_node_errors"]) == 1
+    assert isinstance(captured["from_node_errors"][0], BaseException)
+
+
+def test_graph_error_handler_can_route_with_command():
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+
+    def always_failing_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("Always fails")
+
+    def err_handler_node(state: State) -> Command:
+        return Command(update={"foo": "handled"}, goto="next_node")
+
+    def next_node(state: State) -> State:
+        return {"foo": f"{state['foo']}_next"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=1,
+        initial_interval=0.01,
+        jitter=False,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing_node, retry_policy=retry_policy)
+        .set_graph_error_handler(
+            "err_handler",
+            err_handler_node,
+            destinations=("next_node",),
+        )
+        .add_node("next_node", next_node)
+        .add_edge(START, "always_failing")
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert attempts == 1
+    assert result["foo"] == "handled_next"
+
+
+def test_graph_error_handler_failure_fails_run():
+    class State(TypedDict):
+        foo: str
+
+    def always_failing_node(state: State) -> State:
+        raise ValueError("Always fails")
+
+    def err_handler_node(state: State) -> State:
+        raise RuntimeError("handler failed")
+
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing_node)
+        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_edge(START, "always_failing")
+        .compile()
+    )
+
+    with pytest.raises(RuntimeError, match="handler failed"):
+        graph.invoke({"foo": ""})
+
+
+def test_graph_error_handler_handles_subgraph_internal_failure():
+    class SubState(TypedDict):
+        foo: str
+
+    class ParentState(TypedDict):
+        foo: str
+
+    parent_handler_called = False
+
+    def sub_fail_node(state: SubState) -> SubState:
+        raise ValueError("subgraph boom")
+
+    def parent_handler(state: ParentState) -> ParentState:
+        nonlocal parent_handler_called
+        parent_handler_called = True
+        return {"foo": "handled_by_parent"}
+
+    subgraph = (
+        StateGraph(SubState)
+        .add_node("sub_fail_node", sub_fail_node)
+        .add_edge(START, "sub_fail_node")
+        .compile()
+    )
+
+    parent_graph = (
+        StateGraph(ParentState)
+        .add_node("subgraph_node", subgraph)
+        .set_graph_error_handler("parent_handler", parent_handler)
+        .add_edge(START, "subgraph_node")
+        .compile()
+    )
+
+    result = parent_graph.invoke({"foo": ""})
+    assert result["foo"] == "handled_by_parent"
+    assert parent_handler_called is True
+
+
+def test_graph_error_handler_error_context_survives_checkpoint_resume():
+    class State(TypedDict):
+        foo: str
+
+    captured: dict[str, object] = {}
+
+    def always_failing_node(state: State) -> State:
+        raise RuntimeError("failed before handler")
+
+    def err_handler_node(state: State, runtime: Runtime) -> State:
+        captured["from_node_names"] = runtime.execution_info.from_node_names
+        captured["from_node_errors"] = runtime.execution_info.from_node_errors
+        return {"foo": "handled_after_resume"}
+
+    checkpointer = InMemorySaver()
+    config = {"configurable": {"thread_id": "graph-error-resume"}}
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing_node)
+        .set_graph_error_handler("err_handler", err_handler_node)
+        .add_edge(START, "always_failing")
+        .compile(checkpointer=checkpointer, interrupt_before=["err_handler"])
+    )
+
+    # First run pauses before handler, after failure context is checkpointed.
+    graph.invoke({"foo": ""}, config)
+    # Resume should execute handler and recover serialized error context.
+    result = graph.invoke(None, config)
+
+    assert result["foo"] == "handled_after_resume"
+    assert captured["from_node_names"] == ("always_failing",)
+    assert isinstance(captured["from_node_errors"], tuple)
+    assert len(captured["from_node_errors"]) == 1
+    assert isinstance(captured["from_node_errors"][0], BaseException)
+
+
+def test_graph_error_info_supports_multiple_failures_from_pending_writes():
+    pending_writes = [
+        ("task_a", GRAPH_ERROR_INFO, "fail_a"),
+        ("task_b", GRAPH_ERROR_INFO, "fail_b"),
+        ("task_a", ERROR, ValueError("a failed")),
+        ("task_b", ERROR, KeyError("b failed")),
+    ]
+
+    failed_node_names = _read_failed_node_names_from_pending_writes(pending_writes)
+    assert failed_node_names == [("task_a", "fail_a"), ("task_b", "fail_b")]
+    errors = _read_errors_for_task_ids_from_pending_writes(
+        pending_writes, tuple(task_id for task_id, _ in failed_node_names)
+    )
+    assert len(errors) == 2
+    assert isinstance(errors[0], ValueError)
+    assert isinstance(errors[1], KeyError)


### PR DESCRIPTION
## Why this matters

Today, an unhandled exception in a node aborts the whole graph run, even if the failure is recoverable. The only built-in recovery is `RetryPolicy`, which can't compensate, fan out to a recovery branch, or surface a structured error to downstream logic.

Wrapping the node body in `try/except` isn't a real substitute either: most fallible nodes want to **retry on retryable errors first** (with backoff, jitter, classification) and **only then handle the residual failure**. Reimplementing `RetryPolicy` semantics inside every fallible node — and keeping it in sync as the policy evolves — is exactly the boilerplate `RetryPolicy` was meant to remove. A handler that runs *after* the configured retry policy is exhausted is the missing piece.

This PR adds first-class node-level error handlers so failure handling is colocated with the failing node configuration:

- `graph.add_node("name", func, error_handler=handler_func, retry_policy=...)`
- handler runs only after `retry_policy` is exhausted, so retry and handling stay decoupled
- handler receives the failed node's name and exception via a typed `error: NodeError` parameter
- handler can update state and route via `Command(goto=...)` for Saga / compensation flows

## What changed

- Added node-level handler binding on `StateGraph.add_node(..., error_handler=...)`.
- Introduced `langgraph.errors.NodeError(node, error)`, a frozen dataclass injected into handler signatures by type annotation (`error: NodeError`). Keeps per-task failure context out of the long-lived `Runtime` object.
- Plumbed failure context through a dedicated `CONFIG_KEY_NODE_ERROR` configurable key.
- Added task-scoped reserved write key `ERROR_SOURCE_NODE` for checkpointed failure provenance, so handlers see the same context after resume.
- Added per-node `node_error_handler_map` wiring through Pregel compile/runtime.
- Added sync/async tests covering retry exhaustion, `Command` routing, handler-side failures, subgraph failures, checkpoint resume, and concurrent-with-`interrupt()` safety.

## Intended usage

```python
from typing_extensions import TypedDict
from langgraph.errors import NodeError
from langgraph.graph import START, StateGraph
from langgraph.types import Command, RetryPolicy


class State(TypedDict):
    status: str


def reserve_inventory(state: State) -> State:
    return {"status": "reserved"}


def charge_payment(state: State) -> State:
    raise RuntimeError("payment timeout")


def payment_error_handler(state: State, error: NodeError) -> Command:
    # per-task failure context, injected by type annotation;
    # only invoked after `retry_policy` is exhausted
    return Command(
        update={"status": f"compensated_after_{error.node}: {error.error}"},
        goto="finalize",
    )


def finalize(state: State) -> State:
    return state


graph = (
    StateGraph(State)
    .add_node("reserve_inventory", reserve_inventory)
    .add_node(
        "charge_payment",
        charge_payment,
        retry_policy=RetryPolicy(max_attempts=3, retry_on=ConnectionError),
        error_handler=payment_error_handler,
    )
    .add_node("finalize", finalize)
    .add_edge(START, "reserve_inventory")
    .add_edge("reserve_inventory", "charge_payment")
    .compile()
)
```

The `error: NodeError` parameter is opt-in: handlers that don't need failure context can keep the simpler `(state)` or `(state, runtime)` signatures.

## Validation

Executed in `libs/langgraph`:

- `make format`
- `make lint`
- `make test`

All passing.