### PR TITLE
feat: add restart-safety coverage for put_writes idempotency

### DIFF
--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put_writes.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put_writes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import traceback
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
 from uuid import uuid4
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -263,6 +263,75 @@ async def test_put_writes_cleared_on_next_checkpoint(
     assert len(writes) == 0
 
 
+async def test_put_writes_idempotent_across_restart(
+    saver: BaseCheckpointSaver,
+    saver_factory: Callable[[], AsyncGenerator[BaseCheckpointSaver, None]] | None = None,
+) -> None:
+    """Duplicate (task_id, idx) doesn't duplicate writes after saver restart.
+
+    This test verifies the retry-safe contract survives process restarts,
+    not just same-instance duplicates. If no saver_factory is provided,
+    the test falls back to same-instance verification (matching
+    test_put_writes_idempotent behavior).
+    """
+    tid = str(uuid4())
+    config = generate_config(tid)
+    cp = generate_checkpoint()
+    stored = await saver.aput(config, cp, generate_metadata(), {})
+
+    task_id = str(uuid4())
+    await saver.aput_writes(stored, [("ch", "val")], task_id)
+
+    # Verify write exists before restart
+    tup_before = await saver.aget_tuple(stored)
+    assert tup_before is not None
+    assert tup_before.pending_writes is not None
+    pre_count = len(tup_before.pending_writes)
+    assert pre_count == 1, f"Expected 1 write before restart, got {pre_count}"
+
+    if saver_factory is not None:
+        # Re-open the saver — simulates process restart
+        gen = saver_factory()
+        saver2 = await gen.__anext__()
+        try:
+            # Replay the exact same write on the fresh instance
+            await saver2.aput_writes(stored, [("ch", "val")], task_id)
+
+            tup_after = await saver2.aget_tuple(stored)
+            assert tup_after is not None
+            assert tup_after.pending_writes is not None
+            post_count = len(tup_after.pending_writes)
+            assert post_count == 1, (
+                f"Expected 1 write after restart replay, got {post_count} "
+                f"(restart duplicated writes)"
+            )
+            matching = [
+                w
+                for w in tup_after.pending_writes
+                if w[0] == task_id and w[1] == "ch"
+            ]
+            assert len(matching) == 1, (
+                f"Expected 1 matching write, got {len(matching)}"
+            )
+            assert matching[0][2] == "val", f"Value mismatch: {matching[0][2]!r}"
+        finally:
+            try:
+                await gen.__anext__()
+            except StopAsyncIteration:
+                pass
+    else:
+        # Fallback: same-instance replay (weaker guarantee, matches existing test)
+        await saver.aput_writes(stored, [("ch", "val")], task_id)
+
+        tup_after = await saver.aget_tuple(stored)
+        assert tup_after is not None
+        assert tup_after.pending_writes is not None
+        post_count = len(tup_after.pending_writes)
+        assert post_count == 1, (
+            f"Expected 1 write after replay, got {post_count}"
+        )
+
+
 ALL_PUT_WRITES_TESTS = [
     test_put_writes_basic,
     test_put_writes_multiple_writes_same_task,
@@ -274,20 +343,34 @@ ALL_PUT_WRITES_TESTS = [
     test_put_writes_special_channels,
     test_put_writes_across_namespaces,
     test_put_writes_cleared_on_next_checkpoint,
+    # Restart-safety test — requires factory for full coverage
+    test_put_writes_idempotent_across_restart,
 ]
 
 
 async def run_put_writes_tests(
     saver: BaseCheckpointSaver,
     on_test_result: Callable[[str, str, bool, str | None], None] | None = None,
+    saver_factory: Callable[[], AsyncGenerator[BaseCheckpointSaver, None]] | None = None,
 ) -> tuple[int, int, list[str]]:
-    """Run all put_writes tests. Returns (passed, failed, failure_names)."""
+    """Run all put_writes tests. Returns (passed, failed, failure_names).
+
+    Args:
+        saver: The checkpointer instance to test.
+        on_test_result: Optional callback for per-test results.
+        saver_factory: Optional factory for creating fresh saver instances.
+            When provided, enables restart-safety tests that verify
+            idempotency across saver restarts (process/network failure).
+    """
     passed = 0
     failed = 0
     failures: list[str] = []
     for test_fn in ALL_PUT_WRITES_TESTS:
         try:
-            await test_fn(saver)
+            if test_fn is test_put_writes_idempotent_across_restart:
+                await test_fn(saver, saver_factory=saver_factory)
+            else:
+                await test_fn(saver)
             passed += 1
             if on_test_result:
                 on_test_result("put_writes", test_fn.__name__, True, None)

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put_writes.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put_writes.py
@@ -290,6 +290,14 @@ async def test_put_writes_idempotent_across_restart(
     assert pre_count == 1, f"Expected 1 write before restart, got {pre_count}"
 
     if saver_factory is not None:
+        # Close the original saver first to simulate a true restart —
+        # persistent backends should flush/release their connections
+        # before a second instance opens.
+        if hasattr(saver, "__aexit__"):
+            await saver.__aexit__(None, None, None)
+        elif hasattr(saver, "aclose"):
+            await saver.aclose()
+
         # Re-open the saver — simulates process restart
         gen = saver_factory()
         saver2 = await gen.__anext__()

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from langgraph.checkpoint.conformance.capabilities import (
     Capability,
     DetectedCapabilities,
@@ -97,9 +99,15 @@ async def validate(
                     if progress and progress.on_capability_start:
                         progress.on_capability_start(cap.value, True)
 
+                    runner_kwargs: dict[str, Any] = {
+                        "on_test_result": progress.on_test_result if progress else None,
+                    }
+                    # Pass factory for restart-safety tests
+                    if cap == Capability.PUT_WRITES:
+                        runner_kwargs["saver_factory"] = registered.factory
                     passed, failed, failures = await runner(
                         saver,
-                        on_test_result=progress.on_test_result if progress else None,
+                        **runner_kwargs,
                     )
 
                     if progress and progress.on_capability_end:

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
@@ -8,7 +8,10 @@ from langgraph.checkpoint.conformance.capabilities import (
     Capability,
     DetectedCapabilities,
 )
-from langgraph.checkpoint.conformance.initializer import RegisteredCheckpointer
+from langgraph.checkpoint.conformance.initializer import (
+    RegisteredCheckpointer,
+    _noop_lifespan,
+)
 from langgraph.checkpoint.conformance.report import (
     CapabilityReport,
     CapabilityResult,
@@ -102,9 +105,19 @@ async def validate(
                     runner_kwargs: dict[str, Any] = {
                         "on_test_result": progress.on_test_result if progress else None,
                     }
-                    # Pass factory for restart-safety tests
+                    # Pass factory for restart-safety tests only when the
+                    # checkpointer persists state externally (indicated by a
+                    # custom lifespan, e.g. a database).  In-memory savers use
+                    # the default noop lifespan; their factory returns a fresh
+                    # empty instance each time, so the restart branch would
+                    # produce false failures.
                     if cap == Capability.PUT_WRITES:
-                        runner_kwargs["saver_factory"] = registered.factory
+                        has_persistent_storage = (
+                            registered.lifespan is not _noop_lifespan
+                        )
+                        runner_kwargs["saver_factory"] = (
+                            registered.factory if has_persistent_storage else None
+                        )
                     passed, failed, failures = await runner(
                         saver,
                         **runner_kwargs,


### PR DESCRIPTION
## Summary

Adds `test_put_writes_idempotent_across_restart` to the checkpoint conformance suite, closing the contract-validation gap described in #7201.

### What changed

**`libs/checkpoint-conformance/.../spec/test_put_writes.py`**
- New test: `test_put_writes_idempotent_across_restart` — creates a checkpoint, writes pending data, re-opens the saver via factory, replays the exact same write, and asserts no duplication
- Graceful fallback: when no factory is available, falls back to same-instance verification (matching existing `test_put_writes_idempotent`)
- `run_put_writes_tests` now accepts optional `saver_factory` parameter

**`libs/checkpoint-conformance/.../validate.py`**
- Passes `registered.factory` to the put_writes runner when running PUT_WRITES capability tests

### Design decisions

- **Backward compatible**: The new `saver_factory` parameter is optional. Existing runners that don't pass it still work — the test falls back to same-instance verification.
- **Minimal interface change**: Only the put_writes runner signature changes (new optional kwarg). No new capabilities, no new test files.
- **Factory reuse**: Uses the same factory from `RegisteredCheckpointer` that `validate()` already has access to, rather than introducing a new abstraction.

## Addresses

Closes #7201

## Test Plan

- [ ] Existing conformance tests pass unchanged (no factory = fallback mode)
- [ ] InMemorySaver: restart test passes (stateless, so replay is a no-op)
- [ ] PostgresSaver: restart test verifies ON CONFLICT idempotency across connections
- [ ] SQLiteSaver: restart test verifies UPSERT idempotency across file reopens