### PR TITLE
fix: get_subgraphs prefix matching with shared node name prefixes

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -959,9 +959,11 @@ class Pregel(
             An iterator of the `(namespace, subgraph)` pairs.
         """
         for name, node in self.nodes.items():
-            # filter by prefix
+            # filter by prefix (must match full segment, not just any prefix)
             if namespace is not None:
-                if not namespace.startswith(name):
+                if namespace != name and not namespace.startswith(
+                    name + NS_SEP
+                ):
                     continue
 
             # find the subgraph, if any


### PR DESCRIPTION
## Summary

Fixes a bug in Pregel.get_subgraphs() where nodes sharing a common name prefix cause incorrect namespace resolution.

## Problem

When looking up namespace common_prefix_2|child_subgraph, the startswith check incorrectly matches node common_prefix, corrupting the namespace.

## Root Cause

The prefix filter used namespace.startswith(name) without checking the separator boundary.

## Fix

Changed the filter to verify the full segment boundary.

Closes #6924