### PR TITLE
fix(langgraph): catch CancelledError in AsyncBackgroundExecutor.__aexit__ during task cleanup

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -197,7 +197,15 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
                 task.cancel(self.sentinel)
         # wait for all tasks to finish
         if tasks:
-            await asyncio.wait(tasks)
+            try:
+                await asyncio.wait(tasks)
+            except asyncio.CancelledError:
+                # If the outer coroutine is cancelled while waiting for tasks,
+                # suppress the CancelledError here so that task exceptions can
+                # still be inspected below.  The CancelledError will propagate
+                # naturally if `exc_type` is already set (the `__aexit__`
+                # protocol handles re-raising).
+                pass
         # if there's already an exception being raised, don't raise another one
         if exc_type is None:
             # re-raise the first exception that occurred in a task

--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -196,16 +196,22 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
             if cancel:
                 task.cancel(self.sentinel)
         # wait for all tasks to finish
+        cancelled_error: asyncio.CancelledError | None = None
         if tasks:
-            try:
-                await asyncio.wait(tasks)
-            except asyncio.CancelledError:
-                # If the outer coroutine is cancelled while waiting for tasks,
-                # suppress the CancelledError here so that task exceptions can
-                # still be inspected below.  The CancelledError will propagate
-                # naturally if `exc_type` is already set (the `__aexit__`
-                # protocol handles re-raising).
-                pass
+            while True:
+                try:
+                    await asyncio.wait(tasks)
+                    break
+                except asyncio.CancelledError as exc:
+                    if cancelled_error is not None:
+                        raise
+                    # Finish waiting for child cleanup before propagating the
+                    # outer cancellation. A subsequent wait is still required
+                    # because the first one may have been interrupted while
+                    # children were pending.
+                    cancelled_error = exc
+        if cancelled_error is not None:
+            raise cancelled_error
         # if there's already an exception being raised, don't raise another one
         if exc_type is None:
             # re-raise the first exception that occurred in a task


### PR DESCRIPTION
## Summary

When `AsyncBackgroundExecutor.__aexit__` is cancelled while waiting for background tasks, finish the in-progress child cleanup and then re-raise the original `CancelledError` instead of swallowing it.

## Root Cause

The original `await asyncio.wait(tasks)` lets outer cancellation interrupt cleanup. The first version of this PR caught that exception but dropped it, which could leave the outer task uncancelled and could inspect a child with `task.exception()` before the child reached a terminal state.

## Fix

- capture the first `CancelledError` raised while waiting;
- wait again until all copied child tasks finish before inspecting them;
- re-raise the captured cancellation before child exceptions can override it;
- treat a second cancellation as a forced abort instead of making cleanup cancellation-resistant forever.

## Verification

- `python3 -m py_compile` on the updated module
- standalone async regression: one cancellation waits for finite child cleanup and then propagates with its original message
- standalone async regression: a second cancellation aborts cleanup while a child remains blocked
- two-round adversarial Codex review, final verdict `approve`

Fixes #6950
