### PR TITLE
chore: extract reusable `uv_setup` composite action

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,13 +2,13 @@ blank_issues_enabled: false
 version: 2.1
 contact_links:
   - name: 💬 LangChain Forum
-    url:  https://forum.langchain.com/
+    url: https://forum.langchain.com/
     about: General community discussions and support
   - name: 📚 LangGraph Documentation
     url: https://docs.langchain.com/oss/python/langgraph/overview
     about: View the official LangGraph documentation
   - name: 📚 API Reference Documentation
-    url: https://reference.langchain.com/python/
+    url: https://reference.langchain.com/python/langgraph/
     about: View the official LangGraph API reference documentation
   - name: 📚 Documentation issue
     url: https://github.com/langchain-ai/docs/issues/new?template=02-langgraph.yml

--- a/.github/ISSUE_TEMPLATE/privileged.yml
+++ b/.github/ISSUE_TEMPLATE/privileged.yml
@@ -1,22 +1,21 @@
-name: 🔒 Privileged
-description: You are a LangGraph maintainer, or was asked directly by a maintainer to create an issue here. If not, check the other options.
+name: "\U0001F512 Privileged"
+description: You are a LangGraph maintainer. If not, check the other options.
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your interest in LangGraph! 🚀
+        > **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).
 
-        If you are not a LangGraph maintainer or were not asked directly by a maintainer to create an issue, then please start the conversation on the [LangChain Forum](https://forum.langchain.com/) instead.
+        If you are not a LangGraph maintainer, employee, or were not asked directly by a maintainer to create an issue, then please start the conversation on the [LangChain Forum](https://forum.langchain.com/) instead.
 
-        You are a LangGraph maintainer if you maintain any of the packages inside of the LangGraph repository 
-        or are a regular contributor to LangGraph with previous merged merged pull requests.
+        **Note:** Do not begin work on a PR unless explicitly assigned to this issue by a maintainer.
   - type: checkboxes
     id: privileged
     attributes:
       label: Privileged issue
       description: Confirm that you are allowed to create an issue here.
       options:
-        - label: I am a LangGraph maintainer, or was asked directly by a LangGraph maintainer to create an issue here.
+        - label: I am a LangGraph maintainer.
           required: true
   - type: textarea
     id: content
@@ -26,4 +25,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        Community members should **NOT** work on Privileged issues unless these issues have been explicitly marked with a "help-wanted" tag.
+        Please do not begin work on a PR unless explicitly assigned to this issue by a maintainer.

--- a/.github/actions/uv_setup/action.yml
+++ b/.github/actions/uv_setup/action.yml
@@ -1,0 +1,35 @@
+# Helper to set up Python and uv with caching
+
+name: uv-install
+description: Set up Python and uv with caching
+
+inputs:
+  python-version:
+    description: Python version, supporting MAJOR.MINOR only
+    required: true
+  enable-cache:
+    description: Enable caching for uv dependencies
+    required: false
+    default: "true"
+  cache-suffix:
+    description: Custom cache key suffix for cache invalidation
+    required: false
+    default: ""
+  working-directory:
+    description: Working directory for cache glob scoping
+    required: false
+    default: "**"
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv and set the python version
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        enable-cache: ${{ inputs.enable-cache }}
+        cache-dependency-glob: |
+          ${{ inputs.working-directory }}/pyproject.toml
+          ${{ inputs.working-directory }}/uv.lock
+          ${{ inputs.working-directory }}/requirements*.txt
+        cache-suffix: ${{ inputs.cache-suffix }}

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -46,12 +46,11 @@ jobs:
           filter: "libs/cli/**"
       - name: Set up Python ${{ matrix.python-version }}
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
           cache-suffix: "cli-integration-test"
-          ignore-nothing-to-cache: true
+          working-directory: libs/cli
       - name: Install cli globally
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
         run: pip install -e .

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -40,11 +40,11 @@ jobs:
           filter: "${{ inputs.working-directory }}/**"
       - name: Set up Python ${{ matrix.python-version }}
         if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
           cache-suffix: lint-${{ inputs.working-directory }}
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Install dependencies
         if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,11 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
           cache-suffix: test-${{ inputs.working-directory }}
+          working-directory: ${{ inputs.working-directory }}
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/_test_langgraph.yml
+++ b/.github/workflows/_test_langgraph.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: true
           cache-suffix: "test-langgraph"
+          working-directory: libs/langgraph
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python $${ env.PYTHON_VERSION }}
-        uses: astral-sh/setup-uv@v7
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
           cache-suffix: "release"
+          working-directory: ${{ inputs.working-directory }}
 
       # We want to keep this build stage *separate* from the release stage,
       # so that there's no sharing of permissions between them.

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -20,11 +20,11 @@ jobs:
       - uses: actions/checkout@v6
       - run: SHA=$(git rev-parse HEAD) && echo "SHA=$SHA" >> $GITHUB_ENV
       - name: Set up Python 3.11
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: "3.11"
-          enable-cache: true
           cache-suffix: "bench"
+          working-directory: libs/langgraph
       - name: Install dependencies
         run: uv sync --group test
       - name: Run benchmarks

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,11 +22,11 @@ jobs:
         with:
           format: json
       - name: Set up Python 3.11
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: "3.11"
-          enable-cache: true
           cache-suffix: "bench"
+          working-directory: libs/langgraph
       - name: Install dependencies
         run: uv sync --group test
       - name: Download baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: "3.13"
-          enable-cache: true
           cache-suffix: "schema-check-cli"
+          working-directory: libs/cli
       - name: Install CLI dependencies
         run: |
           cd libs/cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
           cache-suffix: "release"
+          working-directory: ${{ inputs.working-directory }}
 
       # We want to keep this build stage *separate* from the release stage,
       # so that there's no sharing of permissions between them.
@@ -173,10 +173,11 @@ jobs:
       #   used in the real world.
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
+          enable-cache: false
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Import published package
         shell: bash
@@ -263,11 +264,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
           cache-suffix: "release"
+          working-directory: ${{ inputs.working-directory }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -304,11 +305,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          enable-cache: true
           cache-suffix: "release"
+          working-directory: ${{ inputs.working-directory }}
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/uv_lock_ugprade.yml
+++ b/.github/workflows/uv_lock_ugprade.yml
@@ -19,11 +19,9 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: ./.github/actions/uv_setup
         with:
-          # use minimum supported Python version
           python-version: "3.10"
-          enable-cache: true
           cache-suffix: "uv-lock-upgrade"
           
       - name: Run uv lock --upgrade in all Python packages


### PR DESCRIPTION
Extract a composite GitHub Action for Python + uv setup, replacing 12 scattered `astral-sh/setup-uv@v7` calls with a single reusable `uv_setup` action that scopes cache dependency globs per library. Also tightens issue template language and fixes a broken expression in the release-test workflow.

## Changes

- Add `.github/actions/uv_setup/action.yml` — composite action wrapping `astral-sh/setup-uv@v7` with a `working-directory` input that scopes `cache-dependency-glob` to `<dir>/pyproject.toml`, `<dir>/uv.lock`, and `<dir>/requirements*.txt`
- Migrate all workflow files (`_test.yml`, `_lint.yml`, `_test_langgraph.yml`, `_integration_test.yml`, `baseline.yml`, `bench.yml`, `ci.yml`, `release.yml`, `_test_release.yml`, `uv_lock_ugprade.yml`) from inline `astral-sh/setup-uv@v7` to `./.github/actions/uv_setup`, passing library-specific `working-directory` for cache scoping
- Fix typo in `_test_release.yml` step name: `$${ env.PYTHON_VERSION }}` → `${{ env.PYTHON_VERSION }}`
- Disable uv cache for the release smoke-test job (`enable-cache: false`) since it installs from PyPI, not the local lockfile
- Update `config.yml` API reference URL to point to `/python/langgraph/` instead of `/python/`
- Tighten `privileged.yml` — shorter description, add English language policy link, add "do not begin work unless assigned" notice