### PR TITLE
fix: initialize resume_is_map=False to prevent UnboundLocalError on Command(resume=None)

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -672,6 +672,7 @@ class PregelLoop:
 
         # map command to writes
         if input_is_command:
+            resume_is_map = False
             if (resume := cast(Command, self.input).resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -3,7 +3,7 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict
 
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Durability
+from langgraph.types import Command, Durability, interrupt
 
 pytestmark = pytest.mark.anyio
 
@@ -90,3 +90,77 @@ async def test_interruption_without_state_updates_async(
     assert (await graph.aget_state(thread)).next == ()
     n_checkpoints = len([c async for c in graph.aget_state_history(thread)])
     assert n_checkpoints == (5 if durability != "exit" else 3)
+
+
+def test_command_resume_none_no_unbound_error(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Regression test for https://github.com/langchain-ai/langgraph/issues/7034.
+
+    Command(resume=None) used to raise UnboundLocalError because `resume_is_map`
+    was only assigned inside the `if resume is not None` block but referenced
+    unconditionally afterwards.  It should instead raise EmptyInputError (or
+    succeed) without an UnboundLocalError.
+    """
+    from langgraph.errors import EmptyInputError
+
+    class State(TypedDict):
+        result: str
+
+    def checkpoint_node(state: State):
+        interrupt(None)
+        return {}
+
+    def work_node(state: State):
+        return {"result": "done"}
+
+    builder = StateGraph(State)
+    builder.add_node("checkpoint", checkpoint_node)
+    builder.add_node("work", work_node)
+    builder.add_edge(START, "checkpoint")
+    builder.add_edge("checkpoint", "work")
+    builder.add_edge("work", END)
+
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "resume-none-test"}}
+
+    # First invocation — runs until the interrupt
+    graph.invoke({"result": ""}, config)
+
+    # Second invocation with Command(resume=None) — must NOT raise UnboundLocalError.
+    # resume=None is the sentinel for "no resume value provided", so it should
+    # raise EmptyInputError rather than an unrelated UnboundLocalError.
+    with pytest.raises(EmptyInputError):
+        graph.invoke(Command(resume=None), config)
+
+
+async def test_command_resume_none_no_unbound_error_async(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Async variant of test_command_resume_none_no_unbound_error (issue #7034)."""
+    from langgraph.errors import EmptyInputError
+
+    class State(TypedDict):
+        result: str
+
+    async def checkpoint_node(state: State):
+        interrupt(None)
+        return {}
+
+    async def work_node(state: State):
+        return {"result": "done"}
+
+    builder = StateGraph(State)
+    builder.add_node("checkpoint", checkpoint_node)
+    builder.add_node("work", work_node)
+    builder.add_edge(START, "checkpoint")
+    builder.add_edge("checkpoint", "work")
+    builder.add_edge("work", END)
+
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "resume-none-test-async"}}
+
+    await graph.ainvoke({"result": ""}, config)
+
+    with pytest.raises(EmptyInputError):
+        await graph.ainvoke(Command(resume=None), config)


### PR DESCRIPTION
## Summary

Fixes #7034.

In `PregelLoop._first()` (`langgraph/pregel/_loop.py`), `resume_is_map` was only assigned inside the `if (resume := ...) is not None:` block but referenced unconditionally on the two lines that follow:

```python
# resume_is_map only set here (when resume is not None)
if (resume := cast(Command, self.input).resume) is not None:
    ...
    if resume_is_map := (...):
        ...

# referenced unconditionally — UnboundLocalError when resume is None
for tid, c, v in map_command(cmd=cast(Command, self.input)):
    if not (c == RESUME and resume_is_map):   # crash
        writes[tid].append((c, v))
if not writes and not resume_is_map:          # crash
    raise EmptyInputError(...)
```

Passing `Command(resume=None)` (the default sentinel for "no resume value provided") skips the `if` block entirely, leaving `resume_is_map` unbound and raising an `UnboundLocalError` instead of the expected `EmptyInputError("Received empty Command input")`.

**Fix:** Add `resume_is_map = False` before the conditional block (one line change).

## Changes

- `libs/langgraph/langgraph/pregel/_loop.py`: initialize `resume_is_map = False` before the `if resume is not None` block
- `libs/langgraph/tests/test_interruption.py`: add sync + async regression tests reproducing the exact repro from the issue

## Test plan

- [x] Manual verification: `Command(resume=None)` now raises `EmptyInputError` instead of `UnboundLocalError`
- [x] Sync regression test: `test_command_resume_none_no_unbound_error`
- [x] Async regression test: `test_command_resume_none_no_unbound_error_async`

🤖 Generated with [Claude Code](https://claude.com/claude-code)