### PR TITLE
fix(pregel): get_subgraphs fails when node names share a common prefix

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -959,9 +959,14 @@ class Pregel(
             An iterator of the `(namespace, subgraph)` pairs.
         """
         for name, node in self.nodes.items():
-            # filter by prefix
+            # filter by exact first token match
+            remainder_namespace: str | None = None
+
             if namespace is not None:
-                if not namespace.startswith(name):
+                first_namespace_token, _, remainder_namespace = namespace.partition(
+                    NS_SEP
+                )
+                if name != first_namespace_token:
                     continue
 
             # find the subgraph, if any
@@ -975,12 +980,10 @@ class Pregel(
                 if namespace is None:
                     yield name, graph
                 if recurse and isinstance(graph, Pregel):
-                    if namespace is not None:
-                        namespace = namespace[len(name) + 1 :]
                     yield from (
                         (f"{name}{NS_SEP}{n}", s)
                         for n, s in graph.get_subgraphs(
-                            namespace=namespace, recurse=recurse
+                            namespace=remainder_namespace, recurse=recurse
                         )
                     )
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -9301,6 +9301,60 @@ def test_overwrite_parallel_error(
         graph.invoke({"messages": ["START"]}, config)
 
 
+def test_get_subgraphs_with_common_prefix() -> None:
+    """Test that get_subgraphs works correctly when node names share a common prefix.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/6924.
+    The old implementation used startswith() to match namespaces, which caused
+    incorrect behaviour when one node name was a prefix of another node name.
+    """
+
+    class State(TypedDict):
+        do_not_care: str
+
+    def generic_node(state: State) -> State:
+        # Just need a properly typed node; we will not be running this graph
+        return state
+
+    grandchild_graph_builder = StateGraph(State)
+    grandchild_graph_builder.add_node("grandchild", generic_node)
+    grandchild_graph_builder.set_entry_point("grandchild")
+    grandchild_graph_builder.add_edge("grandchild", END)
+    grandchild_graph = grandchild_graph_builder.compile()
+
+    child_graph_builder = StateGraph(State)
+    child_graph_builder.add_node("child_subgraph", grandchild_graph)
+    child_graph_builder.set_entry_point("child_subgraph")
+    child_graph_builder.add_edge("child_subgraph", END)
+    child_graph = child_graph_builder.compile()
+
+    parent_graph_builder = StateGraph(State)
+    parent_graph_builder.add_node("common_prefix", child_graph)
+    parent_graph_builder.add_node("common_prefix_2", child_graph)
+    parent_graph_builder.set_entry_point("common_prefix")
+    parent_graph_builder.add_edge("common_prefix", "common_prefix_2")
+    parent_graph_builder.add_edge("common_prefix_2", END)
+
+    parent_graph = parent_graph_builder.compile()
+
+    # It's pretty intricate to get this to fail against the previous
+    # implementation of get_subgraphs. You need the following conditions:
+    # * A parent graph with 2 subgraphs
+    # * Subgraph A added before subgraph B
+    # * Subgraph A's name is a prefix of subgraph B's name
+    # * Subgraph B must also contain a subgraph (call it subgraph C)
+    # * You must call get_subgraphs with the namespace 'subgraph_b|subgraph_c'
+    #
+    # The old implementation used prefix matching to find subgraphs,
+    # so it would chop off subgraph A's name from subgraph B's name and
+    # look for subgraph C under the chopped-off name, which would fail.
+    subgraphs = parent_graph.get_subgraphs(
+        namespace="common_prefix_2|child_subgraph",
+        recurse=True,
+    )
+    assert len(list(subgraphs)) == 1
+
+
 def test_fork_does_not_apply_pending_writes(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #6924.

`Pregel.get_subgraphs()` used `startswith()` to match a `namespace` string against node names. This created a subtle bug when two node names shared a common prefix (e.g. `common_prefix` and `common_prefix_2`):

1. The first matching node (`common_prefix`) would be found via `namespace.startswith("common_prefix")` — which is `True` even when the intended target is `common_prefix_2`.
2. Its name length would be stripped from `namespace` (mutating the loop variable), leaving a corrupted remainder.
3. Recursion would proceed with the wrong namespace, returning incorrect results.

## Fix

Replace the `startswith` check with an **exact token match** on the first `NS_SEP`-delimited segment of the namespace:

```python
first_namespace_token, _, remainder_namespace = namespace.partition(NS_SEP)
if name != first_namespace_token:
    continue
```

The `remainder_namespace` (everything after the first separator) is computed once per node and passed down to recursive calls. This also eliminates the mutation of the `namespace` loop variable that made the old code hard to follow.

## Test

Added `test_get_subgraphs_with_common_prefix` in `tests/test_pregel.py` that reproduces the exact scenario from the issue report (parent graph with `common_prefix` and `common_prefix_2` nodes, both wrapping a child subgraph, queried via `get_subgraphs(namespace="common_prefix_2|child_subgraph", recurse=True)`).

## Test plan

- [x] New test `test_get_subgraphs_with_common_prefix` passes
- [x] Existing `get_subgraphs` / subgraph tests unaffected
- [x] Fix verified by running the reproduction script from the issue directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)