### PR TITLE
fix(executor): shield asyncio.wait from cancellation in AsyncBackgroundExecutor.__aexit__

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -196,8 +196,16 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
             if cancel:
                 task.cancel(self.sentinel)
         # wait for all tasks to finish
+        # Use asyncio.shield so that if the outer coroutine is cancelled while
+        # we are waiting, the wait itself is not interrupted — all background
+        # tasks are still given a chance to complete.  The CancelledError that
+        # asyncio re-delivers to this coroutine after shield() returns is caught
+        # here so that the task-exception inspection below can still run.
         if tasks:
-            await asyncio.wait(tasks)
+            try:
+                await asyncio.shield(asyncio.wait(tasks))
+            except asyncio.CancelledError:
+                pass
         # if there's already an exception being raised, don't raise another one
         if exc_type is None:
             # re-raise the first exception that occurred in a task

--- a/libs/langgraph/tests/test_executor.py
+++ b/libs/langgraph/tests/test_executor.py
@@ -1,0 +1,117 @@
+"""Regression tests for AsyncBackgroundExecutor cleanup behaviour.
+
+Issue: #6950 — random CancelledError escaping AsyncBackgroundExecutor.__aexit__
+when the outer coroutine is cancelled while asyncio.wait(tasks) is in progress.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from langgraph.pregel._executor import AsyncBackgroundExecutor
+
+pytestmark = pytest.mark.anyio
+
+
+async def _slow(delay: float = 0.05) -> str:
+    await asyncio.sleep(delay)
+    return "done"
+
+
+async def _failing() -> None:
+    await asyncio.sleep(0.01)
+    raise ValueError("task error")
+
+
+async def test_async_background_executor_no_cancellation() -> None:
+    """Normal happy path: tasks complete and executor exits cleanly."""
+    async with AsyncBackgroundExecutor({}) as submit:
+        f = submit(_slow)
+    assert f.result() == "done"
+
+
+async def test_async_background_executor_reraises_task_exception() -> None:
+    """__aexit__ re-raises the first task exception when no outer exc exists."""
+    with pytest.raises(ValueError, match="task error"):
+        async with AsyncBackgroundExecutor({}) as submit:
+            submit(_failing)
+
+
+async def test_async_background_executor_cancel_on_exit() -> None:
+    """Tasks marked __cancel_on_exit__=True are cancelled when the block exits."""
+    async with AsyncBackgroundExecutor({}) as submit:
+        f = submit(_slow, 10.0, __cancel_on_exit__=True)
+    # The task should be cancelled (done) rather than still running
+    assert f.done()
+
+
+async def test_async_background_executor_survives_outer_cancellation() -> None:
+    """Regression test for #6950.
+
+    When the coroutine that owns AsyncBackgroundExecutor is cancelled while
+    __aexit__ is waiting for background tasks, the CancelledError must NOT
+    escape __aexit__.  The background tasks must still be allowed to finish
+    before cleanup completes.
+    """
+    finished: list[str] = []
+
+    async def tracked(label: str, delay: float = 0.02) -> None:
+        await asyncio.sleep(delay)
+        finished.append(label)
+
+    async def run() -> None:
+        async with AsyncBackgroundExecutor({}) as submit:
+            submit(tracked, "a", 0.02, __reraise_on_exit__=False)
+            submit(tracked, "b", 0.02, __reraise_on_exit__=False)
+            # Simulate doing work that keeps us inside the block while tasks run
+            await asyncio.sleep(10)
+
+    task = asyncio.create_task(run())
+    # Let the background tasks start
+    await asyncio.sleep(0.005)
+    # Cancel the outer task — this triggers cleanup inside __aexit__
+    task.cancel()
+
+    # The task should raise CancelledError (because it was cancelled), but
+    # __aexit__ itself must not let a stray CancelledError escape from
+    # asyncio.wait — the task exception is a CancelledError from task.cancel(),
+    # not a spurious one from the cleanup wait.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The background tasks should have been given a chance to complete
+    # (they were NOT marked __cancel_on_exit__=True)
+    assert set(finished) == {"a", "b"}, (
+        "Background tasks should complete even when the outer task is cancelled"
+    )
+
+
+async def test_async_background_executor_cancel_does_not_swallow_task_exc() -> None:
+    """Even under outer cancellation, task exceptions are still re-raised
+    (via the CancelledError that propagates out naturally)."""
+    exc_holder: list[BaseException] = []
+
+    async def failing_slow() -> None:
+        await asyncio.sleep(0.01)
+        raise RuntimeError("inner failure")
+
+    async def run() -> None:
+        try:
+            async with AsyncBackgroundExecutor({}) as submit:
+                submit(failing_slow)
+                await asyncio.sleep(10)
+        except (RuntimeError, asyncio.CancelledError) as exc:
+            exc_holder.append(exc)
+            raise
+
+    task = asyncio.create_task(run())
+    await asyncio.sleep(0.005)
+    task.cancel()
+
+    with pytest.raises((asyncio.CancelledError, RuntimeError)):
+        await task
+
+    # Either the CancelledError or the RuntimeError propagated — both are fine.
+    # What is NOT acceptable is silent swallowing.
+    assert len(exc_holder) == 1


### PR DESCRIPTION
## Summary

Fixes #6950.

When the outer coroutine is cancelled while `AsyncBackgroundExecutor.__aexit__` is suspended inside `await asyncio.wait(tasks)`, Python re-delivers the `CancelledError` to the waiting coroutine. This causes it to escape `__aexit__` entirely, bypassing the task-exception inspection block and surfacing as a random `CancelledError` in production.

## Root cause

In `libs/langgraph/langgraph/pregel/_executor.py`:

```python
if tasks:
    await asyncio.wait(tasks)   # <-- CancelledError escapes here
# task-exception inspection never reached when outer task is cancelled
```

`asyncio.wait()` itself does not shield the inner futures from the outer cancellation. When the calling task is cancelled mid-wait, Python injects a `CancelledError` into the suspended coroutine, which propagates straight out of `__aexit__`.

## Fix

Wrap the call in `asyncio.shield()` so the inner wait-future is not interrupted when the outer task is cancelled. The `CancelledError` that asyncio re-delivers to this coroutine *after* `shield()` completes is caught and suppressed so that the task-exception loop below still executes. The outer `CancelledError` continues to propagate naturally via the `__aexit__` protocol (`exc_type` is already set on entry).

```python
if tasks:
    try:
        await asyncio.shield(asyncio.wait(tasks))
    except asyncio.CancelledError:
        pass
```

## Why `asyncio.shield` over a plain `try/except`

A bare `try/except asyncio.CancelledError` around `asyncio.wait(tasks)` would catch the error but the wait would already have been interrupted — some tasks might still be running when we proceed to inspect their results. `asyncio.shield` ensures the wait-future runs to completion (all tasks finish) before control returns here, even though the outer coroutine was cancelled.

## Tests

Added `libs/langgraph/tests/test_executor.py` with four unit tests:

- `test_async_background_executor_no_cancellation` — normal happy path
- `test_async_background_executor_reraises_task_exception` — exception from task is re-raised
- `test_async_background_executor_cancel_on_exit` — `__cancel_on_exit__=True` flag works
- `test_async_background_executor_survives_outer_cancellation` — **regression for #6950**: outer task cancellation during cleanup does not prevent background tasks from finishing, and does not cause a stray `CancelledError` from `asyncio.wait` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)