### PR TITLE
fix(checkpoint-postgres): avoid shared async lock for pooled async savers

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -37,6 +37,12 @@ from langgraph.checkpoint.postgres.shallow import AsyncShallowPostgresSaver
 Conn = _ainternal.Conn  # For backward compatibility
 
 
+@asynccontextmanager
+async def _noop_async_lock() -> AsyncIterator[None]:
+    """No-op async context manager used when locking is unnecessary."""
+    yield
+
+
 class AsyncPostgresSaver(BasePostgresSaver):
     """Asynchronous checkpointer that stores checkpoints in a Postgres database."""
 
@@ -371,13 +377,21 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the AsyncPostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
-        async with self.lock, _ainternal.get_connection(self.conn) as conn:
+        is_pooled_conn = isinstance(self.conn, AsyncConnectionPool)
+        # With AsyncConnectionPool, each _cursor() call checks out its own connection.
+        # The pool does not hand out the same connection concurrently, so a shared lock
+        # across calls is unnecessary here.
+        lock_cm = _noop_async_lock() if is_pooled_conn else self.lock
+        async with _ainternal.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    async with (
+                        lock_cm,
+                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                    ):
                         yield cur
                 finally:
                     if pipeline:
@@ -387,6 +401,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     async with (
+                        lock_cm,
                         conn.pipeline(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
@@ -394,12 +409,16 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     async with (
+                        lock_cm,
                         conn.transaction(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
                         yield cur
             else:
-                async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                async with (
+                    lock_cm,
+                    conn.cursor(binary=True, row_factory=dict_row) as cur,
+                ):
                     yield cur
 
     async def aget_delta_channel_history(

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -387,15 +387,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
-                try:
-                    async with (
-                        lock_cm,
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
-                    ):
-                        yield cur
-                finally:
-                    if pipeline:
-                        await self.pipe.sync()
+                async with lock_cm:
+                    try:
+                        async with conn.cursor(
+                            binary=True, row_factory=dict_row
+                        ) as cur:
+                            yield cur
+                    finally:
+                        if pipeline:
+                            await self.pipe.sync()
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -81,6 +81,13 @@ MIGRATIONS = [
     """,
 ]
 
+
+@asynccontextmanager
+async def _noop_async_lock() -> AsyncIterator[None]:
+    """No-op async context manager used when locking is unnecessary."""
+    yield
+
+
 SELECT_SQL = f"""
 select
     thread_id,
@@ -831,13 +838,21 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the AsyncShallowPostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
+        is_pooled_conn = isinstance(self.conn, AsyncConnectionPool)
+        # With AsyncConnectionPool, each _cursor() call checks out its own connection.
+        # The pool does not hand out the same connection concurrently, so a shared lock
+        # across calls is unnecessary here.
+        lock_cm = _noop_async_lock() if is_pooled_conn else self.lock
         async with _ainternal.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    async with (
+                        lock_cm,
+                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                    ):
                         yield cur
                 finally:
                     if pipeline:
@@ -847,7 +862,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     async with (
-                        self.lock,
+                        lock_cm,
                         conn.pipeline(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
@@ -855,14 +870,14 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     async with (
-                        self.lock,
+                        lock_cm,
                         conn.transaction(),
                         conn.cursor(binary=True, row_factory=dict_row) as cur,
                     ):
                         yield cur
             else:
                 async with (
-                    self.lock,
+                    lock_cm,
                     conn.cursor(binary=True, row_factory=dict_row) as cur,
                 ):
                     yield cur

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -848,15 +848,15 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
-                try:
-                    async with (
-                        lock_cm,
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
-                    ):
-                        yield cur
-                finally:
-                    if pipeline:
-                        await self.pipe.sync()
+                async with lock_cm:
+                    try:
+                        async with conn.cursor(
+                            binary=True, row_factory=dict_row
+                        ) as cur:
+                            yield cur
+                    finally:
+                        if pipeline:
+                            await self.pipe.sync()
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -29,6 +29,26 @@ def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
 
 
+class _ExplodingAsyncLock:
+    async def __aenter__(self):
+        raise AssertionError("instance lock should not be used in pool mode")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _TrackingAsyncLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    async def __aenter__(self):
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 @asynccontextmanager
 async def _pool_saver():
     """Fixture for pool mode testing."""
@@ -129,6 +149,32 @@ async def _shallow_saver():
             row_factory=dict_row,
         ) as conn:
             checkpointer = AsyncShallowPostgresSaver(conn)
+            await checkpointer.setup()
+            yield checkpointer
+    finally:
+        # drop unique db
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
+@asynccontextmanager
+async def _shallow_pool_saver():
+    """Fixture for shallow saver pool mode testing."""
+    database = f"test_{uuid4().hex[:16]}"
+    # create unique db
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with AsyncConnectionPool(
+            DEFAULT_POSTGRES_URI + database,
+            max_size=10,
+            kwargs={"autocommit": True, "row_factory": dict_row},
+        ) as pool:
+            checkpointer = AsyncShallowPostgresSaver(pool)
             await checkpointer.setup()
             yield checkpointer
     finally:
@@ -415,3 +461,44 @@ async def test_delta_channel_chain_reconstruction(saver_name: str) -> None:
         assert msgs[1].content == "reply-1"
         assert msgs[2].content == "there"
         assert msgs[3].content == "reply-3"
+
+
+async def test_pool_saver_does_not_use_instance_lock(test_data) -> None:
+    async with _pool_saver() as saver:
+        saver.lock = _ExplodingAsyncLock()  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None
+
+
+async def test_base_saver_uses_instance_lock(test_data) -> None:
+    async with _base_saver() as saver:
+        tracking_lock = _TrackingAsyncLock()
+        saver.lock = tracking_lock  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None
+        assert tracking_lock.enter_count >= 2
+
+
+async def test_shallow_pool_saver_does_not_use_instance_lock(test_data) -> None:
+    async with _shallow_pool_saver() as saver:
+        saver.lock = _ExplodingAsyncLock()  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -504,3 +504,18 @@ async def test_shallow_pool_saver_does_not_use_instance_lock(test_data) -> None:
         )
         checkpoint = await saver.aget_tuple(config)
         assert checkpoint is not None
+
+
+async def test_shallow_base_saver_uses_instance_lock(test_data) -> None:
+    async with _shallow_saver() as saver:
+        tracking_lock = _TrackingAsyncLock()
+        saver.lock = tracking_lock  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None
+        assert tracking_lock.enter_count >= 2

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -29,6 +29,26 @@ def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
 
 
+class _ExplodingAsyncLock:
+    async def __aenter__(self):
+        raise AssertionError("instance lock should not be used in pool mode")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _TrackingAsyncLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    async def __aenter__(self):
+        self.enter_count += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 @asynccontextmanager
 async def _pool_saver():
     """Fixture for pool mode testing."""
@@ -129,6 +149,32 @@ async def _shallow_saver():
             row_factory=dict_row,
         ) as conn:
             checkpointer = AsyncShallowPostgresSaver(conn)
+            await checkpointer.setup()
+            yield checkpointer
+    finally:
+        # drop unique db
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
+@asynccontextmanager
+async def _shallow_pool_saver():
+    """Fixture for shallow saver pool mode testing."""
+    database = f"test_{uuid4().hex[:16]}"
+    # create unique db
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with AsyncConnectionPool(
+            DEFAULT_POSTGRES_URI + database,
+            max_size=10,
+            kwargs={"autocommit": True, "row_factory": dict_row},
+        ) as pool:
+            checkpointer = AsyncShallowPostgresSaver(pool)
             await checkpointer.setup()
             yield checkpointer
     finally:
@@ -417,3 +463,44 @@ async def test_delta_channel_chain_reconstruction(saver_name: str) -> None:
         assert msgs[1].content == "reply-1"
         assert msgs[2].content == "there"
         assert msgs[3].content == "reply-3"
+
+
+async def test_pool_saver_does_not_use_instance_lock(test_data) -> None:
+    async with _pool_saver() as saver:
+        saver.lock = _ExplodingAsyncLock()  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None
+
+
+async def test_base_saver_uses_instance_lock(test_data) -> None:
+    async with _base_saver() as saver:
+        tracking_lock = _TrackingAsyncLock()
+        saver.lock = tracking_lock  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None
+        assert tracking_lock.enter_count >= 2
+
+
+async def test_shallow_pool_saver_does_not_use_instance_lock(test_data) -> None:
+    async with _shallow_pool_saver() as saver:
+        saver.lock = _ExplodingAsyncLock()  # type: ignore[assignment]
+        config = await saver.aput(
+            test_data["configs"][0],
+            test_data["checkpoints"][0],
+            test_data["metadata"][0],
+            {},
+        )
+        checkpoint = await saver.aget_tuple(config)
+        assert checkpoint is not None


### PR DESCRIPTION
Fixes #7259

This updates async Postgres checkpointers to avoid using the instance-level shared lock when running with `AsyncConnectionPool`, while preserving lock-based safety for single-connection usage. It also adds async coverage to verify pooled savers (including shallow pooled saver) do not rely on the instance lock, while single-connection behavior remains lock-safe.

Verified with `make format` and `make lint`, and with full test suite runs against pgvector Postgres 15 and 16 (`uv run pytest .` in `libs/checkpoint-postgres`), both passing (220 tests each). Reproduction script and benchmark output: https://gist.github.com/jitokim/b5b2f380d35cde72fd4db4615f310e21

No breaking changes.

```
=== Issue #7259 Reproduction Benchmark ===
normal (pool-aware lock strategy): ops=26501, elapsed=20.23s, ops/sec=1310.26
serialized (legacy shared lock patch): ops=9888, elapsed=20.45s, ops/sec=483.61
improvement ratio (normal / serialized): 2.71x
```