### PR TITLE
perf(checkpoint-sqlite): fix N+1 query pattern in SqliteSaver.list()

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -332,50 +332,76 @@ class SqliteSaver(BaseCheckpointSaver[str]):
         if limit is not None:
             query += " LIMIT ?"
             param_values = (*param_values, limit)
-        with self.cursor(transaction=False) as cur, closing(self.conn.cursor()) as wcur:
+        with self.cursor(transaction=False) as cur:
             cur.execute(query, param_values)
-            for (
-                thread_id,
-                checkpoint_ns,
-                checkpoint_id,
-                parent_checkpoint_id,
-                type,
-                checkpoint,
-                metadata,
-            ) in cur:
-                wcur.execute(
-                    "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
-                    (thread_id, checkpoint_ns, checkpoint_id),
+            checkpoints = list(cur)
+
+        if not checkpoints:
+            return
+
+        # Collect all (thread_id, checkpoint_ns, checkpoint_id) tuples for batched writes query
+        checkpoint_keys = [
+            (row[0], row[1], row[2])  # (thread_id, checkpoint_ns, checkpoint_id)
+            for row in checkpoints
+        ]
+
+        # Batch query: single query for all writes (fixes N+1 pattern)
+        with self.cursor(transaction=False) as wcur:
+            # Build conditions for each checkpoint key
+            conditions = " OR ".join(
+                "(thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ?)"
+                for _ in checkpoint_keys
+            )
+            flat_keys = [item for keys in checkpoint_keys for item in keys]
+            wcur.execute(
+                f"""SELECT thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value
+                FROM writes
+                WHERE {conditions}
+                ORDER BY thread_id, checkpoint_ns, checkpoint_id, task_id, idx""",
+                flat_keys,
+            )
+            # Group writes by checkpoint key
+            writes_by_key: dict[tuple, list[tuple]] = {key: [] for key in checkpoint_keys}
+            for thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value in wcur:
+                writes_by_key[(thread_id, checkpoint_ns, checkpoint_id)].append(
+                    (task_id, channel, self.serde.loads_typed((type, value)))
                 )
-                yield CheckpointTuple(
+
+        for (
+            thread_id,
+            checkpoint_ns,
+            checkpoint_id,
+            parent_checkpoint_id,
+            type,
+            checkpoint,
+            metadata,
+        ) in checkpoints:
+            yield CheckpointTuple(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": checkpoint_id,
+                    }
+                },
+                self.serde.loads_typed((type, checkpoint)),
+                cast(
+                    CheckpointMetadata,
+                    json.loads(metadata) if metadata is not None else {},
+                ),
+                (
                     {
                         "configurable": {
                             "thread_id": thread_id,
                             "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": checkpoint_id,
+                            "checkpoint_id": parent_checkpoint_id,
                         }
-                    },
-                    self.serde.loads_typed((type, checkpoint)),
-                    cast(
-                        CheckpointMetadata,
-                        json.loads(metadata) if metadata is not None else {},
-                    ),
-                    (
-                        {
-                            "configurable": {
-                                "thread_id": thread_id,
-                                "checkpoint_ns": checkpoint_ns,
-                                "checkpoint_id": parent_checkpoint_id,
-                            }
-                        }
-                        if parent_checkpoint_id
-                        else None
-                    ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        for task_id, channel, type, value in wcur
-                    ],
-                )
+                    }
+                    if parent_checkpoint_id
+                    else None
+                ),
+                writes_by_key[(thread_id, checkpoint_ns, checkpoint_id)],
+            )
 
     def put(
         self,

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -428,53 +428,76 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         if limit is not None:
             query += " LIMIT ?"
             params = (*params, limit)
-        async with (
-            self.lock,
-            self.conn.execute(query, params) as cur,
-            self.conn.cursor() as wcur,
-        ):
-            async for (
-                thread_id,
-                checkpoint_ns,
-                checkpoint_id,
-                parent_checkpoint_id,
-                type,
-                checkpoint,
-                metadata,
-            ) in cur:
+        async with self.lock:
+            async with self.conn.execute(query, params) as cur:
+                checkpoints = [row async for row in cur]
+
+        if not checkpoints:
+            return
+
+        # Collect all (thread_id, checkpoint_ns, checkpoint_id) tuples for batched writes query
+        checkpoint_keys = [
+            (row[0], row[1], row[2])  # (thread_id, checkpoint_ns, checkpoint_id)
+            for row in checkpoints
+        ]
+
+        # Batch query: single query for all writes (fixes N+1 pattern)
+        async with self.lock:
+            conditions = " OR ".join(
+                "(thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ?)"
+                for _ in checkpoint_keys
+            )
+            flat_keys = [item for keys in checkpoint_keys for item in keys]
+            async with self.conn.cursor() as wcur:
                 await wcur.execute(
-                    "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
-                    (thread_id, checkpoint_ns, checkpoint_id),
+                    f"""SELECT thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value
+                    FROM writes
+                    WHERE {conditions}
+                    ORDER BY thread_id, checkpoint_ns, checkpoint_id, task_id, idx""",
+                    flat_keys,
                 )
-                yield CheckpointTuple(
+                # Group writes by checkpoint key
+                writes_by_key: dict[tuple, list[tuple]] = {key: [] for key in checkpoint_keys}
+                async for thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value in wcur:
+                    writes_by_key[(thread_id, checkpoint_ns, checkpoint_id)].append(
+                        (task_id, channel, self.serde.loads_typed((type, value)))
+                    )
+
+        for (
+            thread_id,
+            checkpoint_ns,
+            checkpoint_id,
+            parent_checkpoint_id,
+            type,
+            checkpoint,
+            metadata,
+        ) in checkpoints:
+            yield CheckpointTuple(
+                {
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": checkpoint_id,
+                    }
+                },
+                self.serde.loads_typed((type, checkpoint)),
+                cast(
+                    CheckpointMetadata,
+                    (json.loads(metadata) if metadata is not None else {}),
+                ),
+                (
                     {
                         "configurable": {
                             "thread_id": thread_id,
                             "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": checkpoint_id,
+                            "checkpoint_id": parent_checkpoint_id,
                         }
-                    },
-                    self.serde.loads_typed((type, checkpoint)),
-                    cast(
-                        CheckpointMetadata,
-                        (json.loads(metadata) if metadata is not None else {}),
-                    ),
-                    (
-                        {
-                            "configurable": {
-                                "thread_id": thread_id,
-                                "checkpoint_ns": checkpoint_ns,
-                                "checkpoint_id": parent_checkpoint_id,
-                            }
-                        }
-                        if parent_checkpoint_id
-                        else None
-                    ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        async for task_id, channel, type, value in wcur
-                    ],
-                )
+                    }
+                    if parent_checkpoint_id
+                    else None
+                ),
+                writes_by_key[(thread_id, checkpoint_ns, checkpoint_id)],
+            )
 
     async def aput(
         self,

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -307,3 +307,49 @@ class TestSqliteSaver:
             # Nested digit-starting key via dotted path
             results = list(saver.list(None, filter={"user.123abc": "ok2"}))
             assert len(results) == 1
+
+
+def test_list_no_n_plus_one_queries() -> None:
+    """Verify SqliteSaver.list() uses 2 queries total (1 checkpoints + 1 writes), not N+1.
+    
+    Refs: https://github.com/langchain-ai/langgraph/issues/7263
+    """
+    from langgraph.checkpoint.sqlite import SqliteSaver
+
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        saver.setup()
+
+        # Insert 10 checkpoints with writes
+        for i in range(10):
+            checkpoint_id = f"{i:032}.0"
+            config = {
+                "configurable": {
+                    "thread_id": "1",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": checkpoint_id,
+                }
+            }
+            checkpoint = empty_checkpoint()
+            metadata: CheckpointMetadata = {"step": i}
+            saver.put(config, checkpoint, metadata, {})
+
+        # Count queries using a trace callback
+        query_count = [0]
+
+        def count_queries(sql: str) -> None:
+            query_count[0] += 1
+
+        saver.conn.set_trace_callback(count_queries)
+        results = list(saver.list({"configurable": {"thread_id": "1"}}))
+
+        # With 10 checkpoints, N+1 pattern would produce 11 queries
+        # Fixed version should produce exactly 2 queries:
+        #   1. SELECT checkpoints ...
+        #   2. SELECT writes WHERE ... IN (VALUES ...) ...
+        assert len(results) == 10, f"Expected 10 checkpoints, got {len(results)}"
+        assert query_count[0] == 2, (
+            f"Expected exactly 2 queries (N+1 fix), got {query_count[0]}. "
+            f"Queries: N+1 pattern still present."
+        )
+
+        saver.conn.set_trace_callback(None)


### PR DESCRIPTION
## Performance Fix: N+1 Query Pattern in SqliteSaver.list()

**Issue:** #7263

### Problem

`SqliteSaver.list()` and `AsyncSqliteSaver.alist()` executed N+1 queries:
1. 1 query to fetch all checkpoints
2. N additional queries (one per checkpoint) to fetch writes

This caused linear performance degradation as checkpoint count grew.

### Fix

1. Collect all checkpoint keys in memory
2. Issue a single batched writes query using OR conditions for all keys

**Before (N+1):**
```python
for checkpoint in checkpoints:
    wcur.execute("SELECT ... FROM writes WHERE thread_id=? AND checkpoint_id=?", ...)
```

**After (constant 2 queries):**
```python
conditions = " OR ".join("(thread_id=? AND checkpoint_ns=? AND checkpoint_id=?)" for _ in checkpoints)
wcur.execute(f"SELECT ... FROM writes WHERE {conditions}", flat_keys)
```

### Testing

- Added `test_list_no_n_plus_one_queries` verifying exactly 2 queries for 10 checkpoints
- All existing sync tests pass (9/9)

---

Fixes #7263