### PR TITLE
fix(sdk-py): validate cron schedules for impossible dates before creation

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/cron.py
+++ b/libs/sdk-py/langgraph_sdk/_async/cron.py
@@ -8,7 +8,7 @@ from datetime import datetime, tzinfo
 from typing import Any
 
 from langgraph_sdk._async.http import HttpClient
-from langgraph_sdk._shared.utilities import _resolve_timezone
+from langgraph_sdk._shared.utilities import _resolve_timezone, _validate_cron_schedule
 from langgraph_sdk.schema import (
     All,
     Config,
@@ -135,6 +135,8 @@ class CronClient:
             )
             ```
         """
+        _validate_cron_schedule(schedule)
+
         if checkpoint_during is not None:
             warnings.warn(
                 "`checkpoint_during` is deprecated and will be removed in a future version. Use `durability` instead.",
@@ -253,6 +255,8 @@ class CronClient:
             ```
 
         """
+        _validate_cron_schedule(schedule)
+
         if checkpoint_during is not None:
             warnings.warn(
                 "`checkpoint_during` is deprecated and will be removed in a future version. Use `durability` instead.",
@@ -381,6 +385,9 @@ class CronClient:
             ```
 
         """
+        if schedule is not None:
+            _validate_cron_schedule(schedule)
+
         payload = {
             "schedule": schedule,
             "end_time": end_time.isoformat() if end_time else None,

--- a/libs/sdk-py/langgraph_sdk/_shared/utilities.py
+++ b/libs/sdk-py/langgraph_sdk/_shared/utilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 import functools
 import os
 import re
@@ -180,3 +181,81 @@ def get_asgi_transport() -> type[httpx.ASGITransport]:
     except ImportError:
         # Older versions of the server
         return httpx.ASGITransport
+
+
+def _parse_cron_field(field: str, min_val: int, max_val: int) -> list[int] | None:
+    """Parse a single cron field into a sorted list of integer values.
+
+    Returns None if the field is '*' (meaning all values).
+    """
+    if field == "*":
+        return None
+
+    values: set[int] = set()
+    for part in field.split(","):
+        if "/" in part:
+            range_part, step_str = part.split("/", 1)
+            step = int(step_str)
+            if range_part == "*":
+                start, end = min_val, max_val
+            elif "-" in range_part:
+                start, end = (int(x) for x in range_part.split("-", 1))
+            else:
+                start = int(range_part)
+                end = max_val
+            values.update(range(start, end + 1, step))
+        elif "-" in part:
+            start, end = (int(x) for x in part.split("-", 1))
+            values.update(range(start, end + 1))
+        else:
+            values.add(int(part))
+
+    return sorted(v for v in values if min_val <= v <= max_val)
+
+
+def _validate_cron_schedule(schedule: str) -> None:
+    """Validate that a cron schedule can produce at least one valid trigger time.
+
+    Raises ValueError for cron expressions that specify month/day combinations
+    which never exist (e.g., ``0 23 31 2 *`` for February 31st).
+
+    The Go cron library used by the LangGraph server silently returns a zero-value
+    time (``0001-01-01T00:00:00``) for such schedules, which causes the
+    scheduler's ``WHERE next_run_date <= NOW()`` condition to always be true,
+    triggering the cron job in an infinite loop every few seconds.
+    """
+    parts = schedule.strip().split()
+    if len(parts) != 5:
+        return  # non-standard format, let the server validate
+
+    _, _, day_field, month_field, _ = parts
+
+    # Only validate when both day-of-month and month are constrained
+    if day_field == "*" or month_field == "*":
+        return
+
+    try:
+        days = _parse_cron_field(day_field, 1, 31)
+        months = _parse_cron_field(month_field, 1, 12)
+    except (ValueError, IndexError):
+        return  # malformed, let the server validate
+
+    if not days or not months:
+        return
+
+    # Check across a full leap-year cycle (4 years) to account for Feb 29
+    for month in months:
+        max_day_in_month = max(
+            calendar.monthrange(year, month)[1] for year in range(2024, 2028)
+        )
+        for day in days:
+            if day <= max_day_in_month:
+                return  # at least one valid (month, day) combination exists
+
+    raise ValueError(
+        f"Cron schedule '{schedule}' specifies date(s) that never exist "
+        f"(day {day_field} in month {month_field}). "
+        f"The server's Go cron library would return a zero-value time for this "
+        f"schedule, causing the scheduler to trigger continuously in an infinite "
+        f"loop. See: https://github.com/langchain-ai/langgraph/issues/XXXX"
+    )

--- a/libs/sdk-py/langgraph_sdk/_sync/cron.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/cron.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, tzinfo
 from typing import Any
 
-from langgraph_sdk._shared.utilities import _resolve_timezone
+from langgraph_sdk._shared.utilities import _resolve_timezone, _validate_cron_schedule
 from langgraph_sdk._sync.http import SyncHttpClient
 from langgraph_sdk.schema import (
     All,
@@ -126,6 +126,8 @@ class SyncCronClient:
             )
             ```
         """
+        _validate_cron_schedule(schedule)
+
         if checkpoint_during is not None:
             warnings.warn(
                 "`checkpoint_during` is deprecated and will be removed in a future version. Use `durability` instead.",
@@ -243,6 +245,8 @@ class SyncCronClient:
             ```
 
         """
+        _validate_cron_schedule(schedule)
+
         if checkpoint_during is not None:
             warnings.warn(
                 "`checkpoint_during` is deprecated and will be removed in a future version. Use `durability` instead.",
@@ -370,6 +374,9 @@ class SyncCronClient:
             ```
 
         """
+        if schedule is not None:
+            _validate_cron_schedule(schedule)
+
         payload = {
             "schedule": schedule,
             "end_time": end_time.isoformat() if end_time else None,

--- a/libs/sdk-py/tests/test_crons_client.py
+++ b/libs/sdk-py/tests/test_crons_client.py
@@ -8,6 +8,10 @@ from datetime import datetime, timezone
 import httpx
 import pytest
 
+from langgraph_sdk._shared.utilities import (
+    _parse_cron_field,
+    _validate_cron_schedule,
+)
 from langgraph_sdk.client import (
     CronClient,
     HttpClient,
@@ -483,5 +487,222 @@ def test_sync_update_with_enabled_parameter(enabled_value):
             cron_id="cron_456",
             enabled=enabled_value,
         )
+
+    assert result == cron
+
+
+# ---------------------------------------------------------------------------
+# Schedule validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCronField:
+    """Tests for _parse_cron_field helper."""
+
+    def test_wildcard_returns_none(self):
+        assert _parse_cron_field("*", 1, 12) is None
+
+    def test_single_value(self):
+        assert _parse_cron_field("5", 1, 31) == [5]
+
+    def test_comma_list(self):
+        assert _parse_cron_field("1,15,28", 1, 31) == [1, 15, 28]
+
+    def test_range(self):
+        assert _parse_cron_field("3-6", 1, 12) == [3, 4, 5, 6]
+
+    def test_step(self):
+        assert _parse_cron_field("*/3", 1, 12) == [1, 4, 7, 10]
+
+    def test_range_with_step(self):
+        assert _parse_cron_field("1-10/3", 1, 31) == [1, 4, 7, 10]
+
+    def test_out_of_range_filtered(self):
+        assert _parse_cron_field("30,31", 1, 12) == []
+
+
+class TestValidateCronSchedule:
+    """Tests for _validate_cron_schedule."""
+
+    # --- impossible schedules that should raise ValueError ---
+
+    def test_feb_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 23 31 2 *")
+
+    def test_feb_30(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 30 2 *")
+
+    def test_feb_30_and_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 30,31 2 *")
+
+    def test_apr_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 31 4 *")
+
+    def test_jun_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 31 6 *")
+
+    def test_sep_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 31 9 *")
+
+    def test_nov_31(self):
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 31 11 *")
+
+    def test_31st_in_all_30day_months(self):
+        """Day 31 in months 4,6,9,11 — none of these months have 31 days."""
+        with pytest.raises(ValueError, match="never exist"):
+            _validate_cron_schedule("0 0 31 4,6,9,11 *")
+
+    # --- valid schedules that should NOT raise ---
+
+    def test_valid_every_minute(self):
+        _validate_cron_schedule("* * * * *")  # should not raise
+
+    def test_valid_daily(self):
+        _validate_cron_schedule("0 0 * * *")
+
+    def test_valid_monthly_15th(self):
+        _validate_cron_schedule("0 0 15 * *")
+
+    def test_valid_jan_31(self):
+        _validate_cron_schedule("0 0 31 1 *")  # Jan has 31 days
+
+    def test_valid_mar_31(self):
+        _validate_cron_schedule("0 0 31 3 *")  # Mar has 31 days
+
+    def test_valid_feb_29(self):
+        """Feb 29 is valid — it occurs in leap years."""
+        _validate_cron_schedule("0 0 29 2 *")
+
+    def test_valid_feb_28(self):
+        _validate_cron_schedule("0 0 28 2 *")
+
+    def test_wildcard_day(self):
+        _validate_cron_schedule("0 0 * 2 *")
+
+    def test_wildcard_month(self):
+        _validate_cron_schedule("0 0 31 * *")
+
+    def test_day_range_with_some_valid(self):
+        """Day 28-31 in Feb: 28 and 29 are valid, so this should pass."""
+        _validate_cron_schedule("0 0 28-31 2 *")
+
+    def test_multiple_months_some_valid(self):
+        """Day 31 in months 1,2: Jan 31 is valid even though Feb 31 is not."""
+        _validate_cron_schedule("0 0 31 1,2 *")
+
+    def test_non_standard_format_ignored(self):
+        """Non 5-field expressions are passed through to server."""
+        _validate_cron_schedule("@daily")  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_async_create_rejects_impossible_schedule():
+    """Async create should raise ValueError for impossible schedules."""
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = CronClient(HttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            await cron_client.create(
+                assistant_id="asst_123",
+                schedule="0 23 31 2 *",
+            )
+
+
+@pytest.mark.asyncio
+async def test_async_create_for_thread_rejects_impossible_schedule():
+    """Async create_for_thread should raise ValueError for impossible schedules."""
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = CronClient(HttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            await cron_client.create_for_thread(
+                thread_id="thread_123",
+                assistant_id="asst_123",
+                schedule="0 23 31 2 *",
+            )
+
+
+@pytest.mark.asyncio
+async def test_async_update_rejects_impossible_schedule():
+    """Async update should raise ValueError for impossible schedules."""
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = CronClient(HttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            await cron_client.update(
+                cron_id="cron_123",
+                schedule="0 0 31 4 *",
+            )
+
+
+def test_sync_create_rejects_impossible_schedule():
+    """Sync create should raise ValueError for impossible schedules."""
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = SyncCronClient(SyncHttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            cron_client.create(
+                assistant_id="asst_456",
+                schedule="0 0 30 2 *",
+            )
+
+
+def test_sync_create_for_thread_rejects_impossible_schedule():
+    """Sync create_for_thread should raise ValueError for impossible schedules."""
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = SyncCronClient(SyncHttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            cron_client.create_for_thread(
+                thread_id="thread_123",
+                assistant_id="asst_123",
+                schedule="0 0 30 2 *",
+            )
+
+
+def test_sync_update_rejects_impossible_schedule():
+    """Sync update should raise ValueError for impossible schedules."""
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = SyncCronClient(SyncHttpClient(client))
+        with pytest.raises(ValueError, match="never exist"):
+            cron_client.update(
+                cron_id="cron_456",
+                schedule="0 0 31 6 *",
+            )
+
+
+def test_sync_update_no_schedule_skips_validation():
+    """Sync update without schedule should not trigger validation."""
+    cron = _cron_response()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=cron)
+
+    with httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://example.com",
+    ) as client:
+        cron_client = SyncCronClient(SyncHttpClient(client))
+        result = cron_client.update(cron_id="cron_456", enabled=False)
 
     assert result == cron


### PR DESCRIPTION
## Problem

The Go cron library used by the LangGraph server silently returns a zero-value time (`0001-01-01T00:00:00`) for cron expressions that specify dates which never exist, such as `0 23 31 2 *` (February 31st).

This causes the scheduler's `WHERE next_run_date <= NOW()` condition to **always be true**, triggering the cron job in an **infinite loop every ~5 seconds**. In production, this consumed **$150 in API credits** before being detected.

### Root cause chain

1. Go cron library computes `next_run_date` for impossible date → returns `time.Time{}` (zero value `0001-01-01`)
2. LangGraph scheduler: `WHERE next_run_date <= NOW() AND enabled = true` → zero value always ≤ current time → always triggers
3. After each trigger, Go tries to advance `next_run_date` → still cannot compute → stays at zero value → triggers again in ~5s

## Solution

Add **client-side validation** in the Python SDK that detects impossible day/month combinations **before** the request is sent to the server. The validation:

- Uses only the Python **standard library** (`calendar` module) — no new dependencies
- Checks across a full **4-year leap-year cycle** to correctly allow Feb 29
- Raises `ValueError` with a clear message explaining why the schedule is invalid
- Applied to **both async and sync** `CronClient` methods: `create`, `create_for_thread`, `update`

### Schedules that are now rejected

| Schedule | Reason |
|----------|--------|
| `0 23 31 2 *` | February never has 31 days |
| `0 0 30 2 *` | February never has 30 days |
| `0 0 31 4 *` | April never has 31 days |
| `0 0 31 4,6,9,11 *` | None of these months have 31 days |

### Valid edge cases preserved

| Schedule | Reason |
|----------|--------|
| `0 0 29 2 *` | Feb 29 is valid in leap years |
| `0 0 31 1,2 *` | Jan 31 is valid (even though Feb 31 is not) |
| `0 0 28-31 2 *` | Feb 28 and 29 are valid days |
| `0 0 31 * *` | Wildcard month = some months have 31 days |
| `@daily` | Non-standard format passed through to server |

## Test plan

Added 30+ test cases covering:
- `_parse_cron_field` utility (wildcards, ranges, steps, comma lists)
- `_validate_cron_schedule` (impossible dates, valid dates, edge cases)
- Integration tests for all 6 SDK methods (async/sync × create/create_for_thread/update)
- Update without schedule parameter skips validation

```
======================== 50 passed in 0.06s ========================
```

## Note on server-side fix

This is a client-side defense. The root cause is in the Go cron library / LangGraph scheduler server-side, which ideally should:
1. Reject impossible cron schedules at creation time (return 400)
2. Or detect zero-value `next_run_date` and disable the cron

This SDK fix provides immediate protection for all Python SDK users.
