### PR TITLE
ci: SHA-pin all third-party GitHub Actions

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         if: github.event_name != 'workflow_dispatch'
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           filter: "libs/cli/**"
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         if: github.event_name != 'workflow_dispatch'
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           filter: "${{ inputs.working-directory }}/**"
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -33,7 +33,7 @@ jobs:
           cache-suffix: test-${{ inputs.working-directory }}
           working-directory: ${{ inputs.working-directory }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/_test_langgraph.yml
+++ b/.github/workflows/_test_langgraph.yml
@@ -31,7 +31,7 @@ jobs:
           cache-suffix: "test-langgraph"
           working-directory: libs/langgraph
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -82,7 +82,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish to test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - id: files
         name: Get changed files
-        uses: Ana06/get-changed-files@v2.3.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           format: json
       - name: Set up Python 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       deps: ${{ steps.filter.outputs.deps || 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         if: github.event_name != 'workflow_dispatch'
         id: filter
         with:

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR Title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true
@@ -317,7 +317,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Create Tag
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/uv_lock_ugprade.yml
+++ b/.github/workflows/uv_lock_ugprade.yml
@@ -28,7 +28,7 @@ jobs:
         run: make lock-upgrade
           
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(deps): upgrade dependencies with `uv lock --upgrade`"


### PR DESCRIPTION
## Summary

- SHA-pins 7 distinct third-party actions across 10 workflow files to full commit SHAs
- Prevents supply chain attacks via tag hijacking (mutable tags can be force-pushed by a compromised maintainer account)
- Tag retained as an inline comment for readability

| Action | Before | After |
|--------|--------|-------|
| `dorny/paths-filter` | `@v4` | `@fbd0ab8...` |
| `Ana06/get-changed-files` | `@v2.3.0` | `@25f79e6...` |
| `docker/login-action` | `@v4` | `@b45d80f...` |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `@ed0c539...` |
| `ncipollo/release-action` | `@v1` | `@339a818...` |
| `amannn/action-semantic-pull-request` | `@v6` | `@48f2562...` |
| `peter-evans/create-pull-request` | `@v8` | `@c0f553f...` |

## Test plan

- [x] CI passes on this PR
- [x] Verify each pinned action still functions (no behaviour change, only ref format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)