### PR TITLE
Fix add_messages(format="langchain-openai") stripping message IDs (#7272)

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -321,7 +321,7 @@ def _format_messages(messages: Sequence[BaseMessage]) -> list[BaseMessage]:
         warnings.warn(msg)
         return list(messages)
     else:
-        return convert_to_messages(convert_to_openai_messages(messages))
+        return convert_to_messages(convert_to_openai_messages(messages, include_id=True))
 
 
 def push_message(

--- a/libs/langgraph/tests/test_messages_state.py
+++ b/libs/langgraph/tests/test_messages_state.py
@@ -208,6 +208,21 @@ def test_messages_state(state_schema):
     condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
     reason="Requires langchain_core>=0.3.11.",
 )
+def test_add_messages_format_openai_preserves_ids():
+    """Regression test: add_messages(format="langchain-openai") must preserve message IDs."""
+    left = [HumanMessage(content="hello", id="msg-1")]
+    right = [AIMessage(content="world", id="msg-2")]
+
+    result = add_messages(left, right, format="langchain-openai")
+
+    assert result[0].id == "msg-1", f"Expected 'msg-1', got {result[0].id!r}"
+    assert result[1].id == "msg-2", f"Expected 'msg-2', got {result[1].id!r}"
+
+
+@pytest.mark.skipif(
+    condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
+    reason="Requires langchain_core>=0.3.11.",
+)
 def test_messages_state_format_openai():
     class State(TypedDict):
         messages: Annotated[list[AnyMessage], add_messages(format="langchain-openai")]


### PR DESCRIPTION
## Summary

When `add_messages(..., format="langchain-openai")` was called, message IDs were silently lost in the round-trip conversion.

## Root Cause

`_format_messages()` called `convert_to_openai_messages()` without `include_id=True`. By default this function strips IDs from the output dicts.

## Fix

Pass `include_id=True` to `convert_to_openai_messages()` in `_format_messages()`:

```python
# Before (buggy)
return convert_to_messages(convert_to_openai_messages(messages))

# After (fixed)
return convert_to_messages(convert_to_openai_messages(messages, include_id=True))
```

## Testing

Added regression test `test_add_messages_format_openai_preserves_ids` that verifies message IDs are preserved through the round-trip.

Fixes #7272