### PR TITLE
fix(langgraph): get_subgraphs fails when nodes share a common prefix

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -959,9 +959,10 @@ class Pregel(
             An iterator of the `(namespace, subgraph)` pairs.
         """
         for name, node in self.nodes.items():
-            # filter by prefix
+            # filter by exact match on the first namespace segment
             if namespace is not None:
-                if not namespace.startswith(name):
+                ns_parts = namespace.split(NS_SEP, 1)
+                if ns_parts[0] != name:
                     continue
 
             # find the subgraph, if any
@@ -975,12 +976,14 @@ class Pregel(
                 if namespace is None:
                     yield name, graph
                 if recurse and isinstance(graph, Pregel):
+                    remaining_ns: str | None = None
                     if namespace is not None:
-                        namespace = namespace[len(name) + 1 :]
+                        ns_parts = namespace.split(NS_SEP, 1)
+                        remaining_ns = ns_parts[1] if len(ns_parts) > 1 else None
                     yield from (
                         (f"{name}{NS_SEP}{n}", s)
                         for n, s in graph.get_subgraphs(
-                            namespace=namespace, recurse=recurse
+                            namespace=remaining_ns, recurse=recurse
                         )
                     )
 

--- a/libs/langgraph/tests/test_get_subgraphs.py
+++ b/libs/langgraph/tests/test_get_subgraphs.py
@@ -1,0 +1,87 @@
+"""Tests for Pregel.get_subgraphs with common-prefix node names.
+
+Regression test for https://github.com/langchain-ai/langgraph/issues/6924
+"""
+
+from typing import TypedDict
+
+from langgraph.graph import END, StateGraph
+
+
+class State(TypedDict):
+    value: str
+
+
+def _node(state: State) -> State:
+    return state
+
+
+def _make_parent_graph():
+    """Build a parent graph with two subgraph nodes sharing a common prefix."""
+    grandchild_builder = StateGraph(State)
+    grandchild_builder.add_node("grandchild", _node)
+    grandchild_builder.set_entry_point("grandchild")
+    grandchild_builder.add_edge("grandchild", END)
+    grandchild_graph = grandchild_builder.compile()
+
+    child_builder = StateGraph(State)
+    child_builder.add_node("child_subgraph", grandchild_graph)
+    child_builder.set_entry_point("child_subgraph")
+    child_builder.add_edge("child_subgraph", END)
+    child_graph = child_builder.compile()
+
+    parent_builder = StateGraph(State)
+    parent_builder.add_node("common_prefix", child_graph)
+    parent_builder.add_node("common_prefix_2", child_graph)
+    parent_builder.set_entry_point("common_prefix")
+    parent_builder.add_edge("common_prefix", "common_prefix_2")
+    parent_builder.add_edge("common_prefix_2", END)
+    return parent_builder.compile()
+
+
+def test_get_subgraphs_common_prefix_recursive_namespace():
+    """get_subgraphs must not confuse nodes whose names share a common prefix."""
+    graph = _make_parent_graph()
+    result = list(
+        graph.get_subgraphs(
+            namespace="common_prefix_2|child_subgraph", recurse=True
+        )
+    )
+    assert len(result) == 1
+    assert result[0][0] == "common_prefix_2|child_subgraph"
+
+
+def test_get_subgraphs_first_node_recursive():
+    graph = _make_parent_graph()
+    result = list(
+        graph.get_subgraphs(
+            namespace="common_prefix|child_subgraph", recurse=True
+        )
+    )
+    assert len(result) == 1
+    assert result[0][0] == "common_prefix|child_subgraph"
+
+
+def test_get_subgraphs_no_namespace():
+    graph = _make_parent_graph()
+    result = list(graph.get_subgraphs())
+    assert len(result) == 2
+
+
+def test_get_subgraphs_exact_namespace():
+    graph = _make_parent_graph()
+    for name in ("common_prefix", "common_prefix_2"):
+        result = list(graph.get_subgraphs(namespace=name))
+        assert len(result) == 1
+        assert result[0][0] == name
+
+
+def test_get_subgraphs_recurse_no_namespace():
+    graph = _make_parent_graph()
+    result = list(graph.get_subgraphs(recurse=True))
+    names = [n for n, _ in result]
+    assert len(result) == 4
+    assert "common_prefix" in names
+    assert "common_prefix_2" in names
+    assert "common_prefix|child_subgraph" in names
+    assert "common_prefix_2|child_subgraph" in names


### PR DESCRIPTION
## Summary

Fixes #6924

`Pregel.get_subgraphs()` used `startswith` to match node names against namespaces, which caused false matches when two node names share a common prefix (e.g. `common_prefix` and `common_prefix_2`). The algorithm would match the shorter node name first, strip too few characters from the namespace, and recurse with a broken remaining namespace.

## Fix

Replace `startswith`-based prefix matching with an exact match on the first segment of the namespace (split by `NS_SEP`). This ensures `common_prefix` only matches itself, never `common_prefix_2`.

**Before:**
```python
if not namespace.startswith(name):
    continue
# ...
namespace = namespace[len(name) + 1:]
```

**After:**
```python
ns_parts = namespace.split(NS_SEP, 1)
if ns_parts[0] != name:
    continue
# ...
remaining_ns = ns_parts[1] if len(ns_parts) > 1 else None
```

## Tests

Added 5 tests in `test_get_subgraphs.py` covering the exact bug scenario from the issue plus regressions for basic enumeration, exact namespace match, and recursive traversal.

> ⚠️ This reopens #7079 which was accidentally closed due to fork deletion.