### PR TITLE
fix: merge multiple Command.PARENT from parallel tool calls

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1545,9 +1545,11 @@ def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
             if isinstance(cmd, Command):
                 commands.append(cmd)
     rtn: list[tuple[str, Any]] = []
+    parent_commands: list[Command] = []
     for command in commands:
         if command.graph == Command.PARENT:
-            raise ParentCommand(command)
+            parent_commands.append(command)
+            continue
 
         goto_targets = (
             [command.goto] if isinstance(command.goto, (Send, str)) else command.goto
@@ -1560,6 +1562,45 @@ def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
                 # END is a special case, it's not actually a node in a practical sense
                 # but rather a special terminal node that we don't need to branch to
                 rtn.append((_CHANNEL_BRANCH_TO.format(go), None))
+    if parent_commands:
+        if len(parent_commands) == 1:
+            raise ParentCommand(parent_commands[0])
+        # Merge multiple parent commands (e.g. from parallel tool calls)
+        # into a single Command so all updates and gotos are preserved.
+        merged_update: dict[str, Any] = {}
+        merged_goto: list[Send | str] = []
+        merged_resume: dict[str, Any] = {}
+        for cmd in parent_commands:
+            if cmd.update is not None:
+                if isinstance(cmd.update, dict):
+                    merged_update.update(cmd.update)
+                else:
+                    merged_update.update(dict(cmd._update_as_tuples()))
+            goto = cmd.goto
+            if isinstance(goto, (Send, str)):
+                if goto not in merged_goto:
+                    merged_goto.append(goto)
+            elif goto:
+                for g in goto:
+                    if g not in merged_goto:
+                        merged_goto.append(g)
+            if isinstance(cmd.resume, dict):
+                merged_resume.update(cmd.resume)
+        final_goto: Send | list[Send | str] | str | tuple[()]
+        if len(merged_goto) == 1:
+            final_goto = merged_goto[0]
+        elif merged_goto:
+            final_goto = merged_goto
+        else:
+            final_goto = ()
+        raise ParentCommand(
+            Command(
+                graph=Command.PARENT,
+                update=merged_update or None,
+                goto=final_goto,
+                resume=merged_resume or None,
+            )
+        )
     return rtn
 
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8371,6 +8371,117 @@ def test_parent_command_goto_deeply_nested(
     }
 
 
+def test_parallel_parent_commands_merged() -> None:
+    """Test that multiple Command.PARENT from parallel tool calls are merged.
+
+    When multiple tools return Command.PARENT in parallel, all updates and gotos
+    should be merged into a single ParentCommand instead of only the first being
+    processed (see https://github.com/langchain-ai/langgraph/issues/7129).
+    """
+    from langgraph.graph.state import _control_branch
+
+    # Single parent command should still work as before
+    single = Command(graph=Command.PARENT, goto="node_a", update={"a": True})
+    with pytest.raises(ParentCommand) as exc_info:
+        _control_branch(single)
+    assert exc_info.value.args[0].goto == "node_a"
+    assert exc_info.value.args[0].update == {"a": True}
+
+    # Multiple parent commands in a list should be merged
+    cmds = [
+        Command(graph=Command.PARENT, goto="result", update={"a": True}),
+        Command(graph=Command.PARENT, goto="result", update={"b": True}),
+        Command(graph=Command.PARENT, goto="result", update={"c": True}),
+    ]
+    with pytest.raises(ParentCommand) as exc_info:
+        _control_branch(cmds)
+    merged = exc_info.value.args[0]
+    assert merged.graph == Command.PARENT
+    # All updates should be present
+    assert merged.update == {"a": True, "b": True, "c": True}
+    # Duplicate gotos should be deduplicated
+    assert merged.goto == "result"
+
+    # Multiple parent commands with different gotos
+    cmds_diff_goto = [
+        Command(graph=Command.PARENT, goto="node_x", update={"x": 1}),
+        Command(graph=Command.PARENT, goto="node_y", update={"y": 2}),
+    ]
+    with pytest.raises(ParentCommand) as exc_info:
+        _control_branch(cmds_diff_goto)
+    merged = exc_info.value.args[0]
+    assert merged.update == {"x": 1, "y": 2}
+    assert set(merged.goto) == {"node_x", "node_y"}
+
+    # Mixed: some parent commands, some local commands
+    mixed = [
+        Command(goto="local_node"),
+        Command(graph=Command.PARENT, goto="parent_node", update={"p": True}),
+    ]
+    with pytest.raises(ParentCommand) as exc_info:
+        result = _control_branch(mixed)
+    merged = exc_info.value.args[0]
+    assert merged.update == {"p": True}
+    assert merged.goto == "parent_node"
+
+
+@pytest.mark.parametrize("subgraph_persist", [True, False])
+def test_parent_command_parallel_tool_calls(
+    sync_checkpointer: BaseCheckpointSaver,
+    subgraph_persist: bool,
+) -> None:
+    """Integration test: parallel tool calls each returning Command.PARENT.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/7129.
+    When a tool node invokes multiple tools in parallel and each returns
+    Command(graph=Command.PARENT), all updates must be applied to the parent
+    state, not just the first one.
+    """
+
+    class ParentState(TypedDict):
+        a: bool
+        b: bool
+        c: bool
+
+    class ChildState(TypedDict):
+        values: Annotated[list[str], operator.add]
+
+    def child_tools(state: ChildState) -> list[Command]:
+        # Simulate parallel tool calls that all return Command.PARENT
+        return [
+            Command(graph=Command.PARENT, goto="result_node", update={"a": True}),
+            Command(graph=Command.PARENT, goto="result_node", update={"b": True}),
+            Command(graph=Command.PARENT, goto="result_node", update={"c": True}),
+        ]
+
+    child_builder = StateGraph(ChildState)
+    child_builder.add_node("tools", child_tools)
+    child_builder.add_edge(START, "tools")
+    child_graph = child_builder.compile(checkpointer=subgraph_persist)
+
+    def result_node(state: ParentState) -> ParentState:
+        return state
+
+    parent_builder = StateGraph(ParentState)
+    parent_builder.add_node(
+        "child", child_graph, destinations=("result_node",)
+    )
+    parent_builder.add_node("result_node", result_node)
+    parent_builder.add_edge(START, "child")
+
+    graph = parent_builder.compile(checkpointer=sync_checkpointer)
+
+    config = {"configurable": {"thread_id": "parallel_parent"}}
+    result = graph.invoke(
+        {"a": False, "b": False, "c": False}, config=config
+    )
+
+    # All three updates should have been applied
+    assert result["a"] is True
+    assert result["b"] is True
+    assert result["c"] is True
+
+
 @pytest.mark.parametrize("with_timeout", [True, False])
 def test_timeout_with_parent_command(
     sync_checkpointer: BaseCheckpointSaver, with_timeout: bool


### PR DESCRIPTION
## Problem

When multiple tools return `Command(graph=Command.PARENT)` in parallel, only the **first** command's update is applied to the parent state — all subsequent commands are silently discarded.

**Root cause:** `_control_branch()` in `state.py` raises `ParentCommand` on the **first** `Command.PARENT` it encounters (L1550), which exits the loop immediately and skips all remaining commands.

### Reproduction (from #7129)

```python
@tool
def fetch_file_info(sha256: str) -> Command:
    return Command(graph=Command.PARENT, goto="result_node", update={"a": True})

@tool
def fetch_file_sources(sha256: str) -> Command:
    return Command(graph=Command.PARENT, goto="result_node", update={"b": True})

@tool
def fetch_file_relations(sha256: str) -> Command:
    return Command(graph=Command.PARENT, goto="result_node", update={"c": True})

# When all 3 tools are called in parallel:
# Expected: a=True, b=True, c=True
# Actual:   only one of a/b/c is True
```

## Fix

`_control_branch()` now **collects** all `Command.PARENT` commands instead of raising on the first one. After processing all commands, it merges their updates and gotos into a single `Command` and raises a single `ParentCommand`:

- **Updates** are merged via `dict.update()` (last-write-wins per key, consistent with state update semantics)
- **Gotos** are deduplicated (same goto target from multiple tools → single goto)
- **Resume** dicts are merged similarly
- Single parent command still takes the fast path (no merge overhead)

## Tests

- **Unit test** (`test_parallel_parent_commands_merged`): Tests `_control_branch()` directly with single, multiple same-goto, multiple different-goto, and mixed local+parent commands
- **Integration test** (`test_parent_command_parallel_tool_calls`): End-to-end test with a subgraph returning 3 parallel `Command.PARENT` — verifies all 3 updates reach the parent state

All 65 existing `parent_command` tests pass without modification.

Closes #7129

> ⚠️ This reopens #7149 which was accidentally closed due to fork deletion.