### PR TITLE
feat(checkpoint-postgres): add `pool_config` support to `AsyncPostgresSaver.from_conn_string()`

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -25,6 +25,7 @@ from psycopg_pool import AsyncConnectionPool
 from langgraph.checkpoint.postgres import _ainternal
 from langgraph.checkpoint.postgres.base import BasePostgresSaver
 from langgraph.checkpoint.postgres.shallow import AsyncShallowPostgresSaver
+from langgraph.store.postgres.base import PoolConfig
 
 Conn = _ainternal.Conn  # For backward compatibility
 
@@ -60,24 +61,48 @@ class AsyncPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        pool_config: PoolConfig | None = None,
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
-            pipeline: whether to use AsyncPipeline
+            pipeline: whether to use AsyncPipeline. Ignored when `pool_config` is provided.
+            serde: The serializer to use for serializing and deserializing checkpoints.
+            pool_config: Configuration for the connection pool. If provided, a
+                `psycopg_pool.AsyncConnectionPool` is created and used instead of a
+                single connection. This overrides the `pipeline` argument.
 
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
-            else:
-                yield cls(conn=conn, serde=serde)
+        if pool_config is not None:
+            pc = pool_config.copy()
+            async with cast(
+                AsyncConnectionPool[AsyncConnection[DictRow]],
+                AsyncConnectionPool(
+                    conn_string,
+                    min_size=pc.pop("min_size", 1),
+                    max_size=pc.pop("max_size", None),
+                    kwargs={
+                        "autocommit": True,
+                        "prepare_threshold": 0,
+                        "row_factory": dict_row,
+                        **(pc.pop("kwargs", None) or {}),
+                    },
+                    **cast(dict, pc),
+                ),
+            ) as pool:
+                yield cls(conn=pool, serde=serde)
+        else:
+            async with await AsyncConnection.connect(
+                conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            ) as conn:
+                if pipeline:
+                    async with conn.pipeline() as pipe:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
+                else:
+                    yield cls(conn=conn, serde=serde)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -3,7 +3,7 @@ import threading
 import warnings
 from collections.abc import AsyncIterator, Iterator, Sequence
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -31,6 +31,7 @@ from psycopg_pool import AsyncConnectionPool, ConnectionPool
 
 from langgraph.checkpoint.postgres import _ainternal, _internal
 from langgraph.checkpoint.postgres.base import BasePostgresSaver
+from langgraph.store.postgres.base import PoolConfig
 
 """
 To add a new migration, add a new string to the MIGRATIONS list.
@@ -574,24 +575,48 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        pool_config: PoolConfig | None = None,
     ) -> AsyncIterator["AsyncShallowPostgresSaver"]:
         """Create a new AsyncShallowPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
-            pipeline: whether to use AsyncPipeline
+            pipeline: whether to use AsyncPipeline. Ignored when `pool_config` is provided.
+            serde: The serializer to use for serializing and deserializing checkpoints.
+            pool_config: Configuration for the connection pool. If provided, a
+                `psycopg_pool.AsyncConnectionPool` is created and used instead of a
+                single connection. This overrides the `pipeline` argument.
 
         Returns:
             AsyncShallowPostgresSaver: A new AsyncShallowPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
-            else:
-                yield cls(conn=conn, serde=serde)
+        if pool_config is not None:
+            pc = pool_config.copy()
+            async with cast(
+                AsyncConnectionPool[AsyncConnection[DictRow]],
+                AsyncConnectionPool(
+                    conn_string,
+                    min_size=pc.pop("min_size", 1),
+                    max_size=pc.pop("max_size", None),
+                    kwargs={
+                        "autocommit": True,
+                        "prepare_threshold": 0,
+                        "row_factory": dict_row,
+                        **(pc.pop("kwargs", None) or {}),
+                    },
+                    **cast(dict, pc),
+                ),
+            ) as pool:
+                yield cls(conn=pool, serde=serde)
+        else:
+            async with await AsyncConnection.connect(
+                conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            ) as conn:
+                if pipeline:
+                    async with conn.pipeline() as pipe:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
+                else:
+                    yield cls(conn=conn, serde=serde)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
Fixes #7304

Add `pool_config` parameter to `AsyncPostgresSaver.from_conn_string()` and `AsyncShallowPostgresSaver.from_conn_string()`, consistent with the existing `pool_config` support already present in `AsyncPostgresStore.from_conn_string()`. This allows users to configure connection pool settings (e.g. `max_idle`, `max_lifetime`, pool sizing) to handle cloud-hosted Postgres instances with idle connection timeouts.

**Changes in `libs/checkpoint-postgres/`:**

- `langgraph/checkpoint/postgres/aio.py` — added `pool_config: PoolConfig | None = None` to `AsyncPostgresSaver.from_conn_string()`. When provided, an `AsyncConnectionPool` is created using the given config (mirrors the pattern in `AsyncPostgresStore`); when `None`, existing single-connection + pipeline behaviour is unchanged.

- `langgraph/checkpoint/postgres/shallow.py` — same change applied to `AsyncShallowPostgresSaver.from_conn_string()` for consistency.

**Usage after this change:**

```python
from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
from langgraph.store.postgres import PoolConfig

async with AsyncPostgresSaver.from_conn_string(
    conn_string,
    pool_config=PoolConfig(min_size=1, max_size=5),
) as saver:
    await saver.setup()
```

**How did you verify your code works?**

- `make format` — all 16 files left unchanged.
- `make lint` — `ruff check`, `ruff format --diff`, `ruff check --select I`, and `mypy` all pass with no issues.
- Manual import + signature check confirms both classes expose `pool_config`:
  ```
  AsyncPostgresSaver.from_conn_string params: ['cls', 'conn_string', 'pipeline', 'serde', 'pool_config']
  AsyncShallowPostgresSaver.from_conn_string params: ['cls', 'conn_string', 'pipeline', 'serde', 'pool_config']
  ```
- Integration tests (`make test`) require a live Postgres instance; CI will validate these.

**Scope:** Single package (`libs/checkpoint-postgres`). No new dependencies, no `pyproject.toml` / `uv.lock` changes. No breaking changes — `pool_config` defaults to `None` and existing behaviour is fully preserved.