### PR TITLE
docs: add governed NL-to-SQL agent example with policy validation

### DIFF
--- a/examples/multi_agent/governed-nl-to-sql-agent.ipynb
+++ b/examples/multi_agent/governed-nl-to-sql-agent.ipynb
@@ -1,0 +1,338 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Governed NL-to-SQL Agent with Query Validation\n",
+        "\n",
+        "This example shows how to build a multi-step NL-to-SQL agent using LangGraph where generated SQL must pass a **policy validation gate** before execution. This pattern is essential for production analytics systems where not all generated SQL should be executed directly.\n",
+        "\n",
+        "## Architecture\n",
+        "\n",
+        "```\n",
+        "User Question\n",
+        "     |\n",
+        "     v\n",
+        "[parse_question] --> [generate_sql] --> [validate_query] --allow--> [execute_query]\n",
+        "                                              |                          |\n",
+        "                                           deny/review                   v\n",
+        "                                              |                    [format_result]\n",
+        "                                              v\n",
+        "                                       [reject_query]\n",
+        "```\n",
+        "\n",
+        "Key features:\n",
+        "- **Policy engine** with deny/review/allow decisions\n",
+        "- **Audit trail** tracking every step\n",
+        "- **Conditional routing** based on validation results"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%%capture --no-stderr\n",
+        "%pip install -U langgraph langchain-openai"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import re\n",
+        "import sqlite3\n",
+        "from datetime import datetime\n",
+        "from typing import Annotated, Literal, TypedDict\n",
+        "\n",
+        "from langchain_openai import ChatOpenAI\n",
+        "from langgraph.graph import END, StateGraph\n",
+        "from langgraph.graph.message import add_messages"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Define State\n",
+        "\n",
+        "The state tracks the question, generated SQL, policy decision, query results, and a full audit trail."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "class AgentState(TypedDict):\n",
+        "    question: str\n",
+        "    sql: str\n",
+        "    policy_decision: Literal[\"allow\", \"deny\", \"review\"]\n",
+        "    policy_reason: str\n",
+        "    results: list[dict]\n",
+        "    error: str\n",
+        "    audit_trail: list[dict]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Set Up Demo Database"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def setup_demo_db() -> sqlite3.Connection:\n",
+        "    conn = sqlite3.connect(\":memory:\")\n",
+        "    conn.execute(\n",
+        "        \"CREATE TABLE sales (id INTEGER PRIMARY KEY, region TEXT, \"\n",
+        "        \"product TEXT, amount REAL, sale_date TEXT)\"\n",
+        "    )\n",
+        "    rows = [\n",
+        "        (1, \"APAC\", \"Widget\", 1200.0, \"2026-01-15\"),\n",
+        "        (2, \"EMEA\", \"Gadget\", 850.0, \"2026-01-20\"),\n",
+        "        (3, \"APAC\", \"Widget\", 2300.0, \"2026-02-01\"),\n",
+        "        (4, \"NA\", \"Gadget\", 1750.0, \"2026-02-10\"),\n",
+        "        (5, \"EMEA\", \"Widget\", 900.0, \"2026-03-01\"),\n",
+        "    ]\n",
+        "    conn.executemany(\"INSERT INTO sales VALUES (?,?,?,?,?)\", rows)\n",
+        "    conn.commit()\n",
+        "    return conn\n",
+        "\n",
+        "db = setup_demo_db()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Define Policy Engine\n",
+        "\n",
+        "The policy engine inspects generated SQL and decides whether to **allow**, **deny**, or flag for **review**."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DANGEROUS_PATTERNS = [\n",
+        "    (r\"\\bDROP\\b\", \"DROP statements are not allowed\"),\n",
+        "    (r\"\\bDELETE\\b\", \"DELETE statements are not allowed\"),\n",
+        "    (r\"\\bINSERT\\b\", \"INSERT statements are not allowed\"),\n",
+        "    (r\"\\bUPDATE\\b\", \"UPDATE statements are not allowed\"),\n",
+        "    (r\"\\bALTER\\b\", \"ALTER statements are not allowed\"),\n",
+        "    (r\"\\bTRUNCATE\\b\", \"TRUNCATE statements are not allowed\"),\n",
+        "]\n",
+        "\n",
+        "REVIEW_PATTERNS = [\n",
+        "    (r\"SELECT\\s+\\*\", \"SELECT * queries should specify columns explicitly\"),\n",
+        "    (r\"\\bJOIN\\b.*\\bJOIN\\b\", \"Multi-join queries require review\"),\n",
+        "]\n",
+        "\n",
+        "\n",
+        "def check_policy(sql: str) -> tuple[str, str]:\n",
+        "    \"\"\"Returns (decision, reason) where decision is allow/deny/review.\"\"\"\n",
+        "    sql_upper = sql.upper()\n",
+        "    for pattern, reason in DANGEROUS_PATTERNS:\n",
+        "        if re.search(pattern, sql_upper):\n",
+        "            return \"deny\", reason\n",
+        "    for pattern, reason in REVIEW_PATTERNS:\n",
+        "        if re.search(pattern, sql_upper):\n",
+        "            return \"review\", reason\n",
+        "    return \"allow\", \"Query passed all policy checks\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Define Graph Nodes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)\n",
+        "\n",
+        "\n",
+        "def generate_sql(state: AgentState) -> AgentState:\n",
+        "    \"\"\"Translate natural language question to SQL.\"\"\"\n",
+        "    prompt = (\n",
+        "        f\"Given a table `sales` with columns: id, region, product, amount, sale_date\\n\"\n",
+        "        f\"Write a SQL SELECT query for: {state['question']}\\n\"\n",
+        "        f\"Return ONLY the SQL query, no explanation.\"\n",
+        "    )\n",
+        "    response = llm.invoke(prompt)\n",
+        "    sql = response.content.strip().strip(\"`\").removeprefix(\"sql\").strip()\n",
+        "    audit_entry = {\n",
+        "        \"step\": \"generate_sql\",\n",
+        "        \"timestamp\": datetime.now().isoformat(),\n",
+        "        \"input\": state[\"question\"],\n",
+        "        \"output\": sql,\n",
+        "    }\n",
+        "    return {**state, \"sql\": sql, \"audit_trail\": state.get(\"audit_trail\", []) + [audit_entry]}\n",
+        "\n",
+        "\n",
+        "def validate_query(state: AgentState) -> AgentState:\n",
+        "    \"\"\"Run the generated SQL through the policy engine.\"\"\"\n",
+        "    decision, reason = check_policy(state[\"sql\"])\n",
+        "    audit_entry = {\n",
+        "        \"step\": \"validate_query\",\n",
+        "        \"timestamp\": datetime.now().isoformat(),\n",
+        "        \"decision\": decision,\n",
+        "        \"reason\": reason,\n",
+        "    }\n",
+        "    return {\n",
+        "        **state,\n",
+        "        \"policy_decision\": decision,\n",
+        "        \"policy_reason\": reason,\n",
+        "        \"audit_trail\": state.get(\"audit_trail\", []) + [audit_entry],\n",
+        "    }\n",
+        "\n",
+        "\n",
+        "def execute_query(state: AgentState) -> AgentState:\n",
+        "    \"\"\"Execute the validated SQL against the database.\"\"\"\n",
+        "    try:\n",
+        "        cursor = db.execute(state[\"sql\"])\n",
+        "        columns = [desc[0] for desc in cursor.description]\n",
+        "        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]\n",
+        "        audit_entry = {\n",
+        "            \"step\": \"execute_query\",\n",
+        "            \"timestamp\": datetime.now().isoformat(),\n",
+        "            \"row_count\": len(rows),\n",
+        "        }\n",
+        "        return {**state, \"results\": rows, \"audit_trail\": state.get(\"audit_trail\", []) + [audit_entry]}\n",
+        "    except Exception as e:\n",
+        "        return {**state, \"error\": str(e), \"results\": []}\n",
+        "\n",
+        "\n",
+        "def reject_query(state: AgentState) -> AgentState:\n",
+        "    \"\"\"Handle rejected or review-flagged queries.\"\"\"\n",
+        "    audit_entry = {\n",
+        "        \"step\": \"reject_query\",\n",
+        "        \"timestamp\": datetime.now().isoformat(),\n",
+        "        \"decision\": state[\"policy_decision\"],\n",
+        "        \"reason\": state[\"policy_reason\"],\n",
+        "    }\n",
+        "    return {\n",
+        "        **state,\n",
+        "        \"results\": [],\n",
+        "        \"error\": f\"Query {state['policy_decision']}: {state['policy_reason']}\",\n",
+        "        \"audit_trail\": state.get(\"audit_trail\", []) + [audit_entry],\n",
+        "    }"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Build the Graph\n",
+        "\n",
+        "The conditional edge after `validate_query` routes to either `execute_query` (allowed) or `reject_query` (denied/review)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def route_after_validation(state: AgentState) -> str:\n",
+        "    if state[\"policy_decision\"] == \"allow\":\n",
+        "        return \"execute_query\"\n",
+        "    return \"reject_query\"\n",
+        "\n",
+        "\n",
+        "workflow = StateGraph(AgentState)\n",
+        "\n",
+        "workflow.add_node(\"generate_sql\", generate_sql)\n",
+        "workflow.add_node(\"validate_query\", validate_query)\n",
+        "workflow.add_node(\"execute_query\", execute_query)\n",
+        "workflow.add_node(\"reject_query\", reject_query)\n",
+        "\n",
+        "workflow.set_entry_point(\"generate_sql\")\n",
+        "workflow.add_edge(\"generate_sql\", \"validate_query\")\n",
+        "workflow.add_conditional_edges(\"validate_query\", route_after_validation)\n",
+        "workflow.add_edge(\"execute_query\", END)\n",
+        "workflow.add_edge(\"reject_query\", END)\n",
+        "\n",
+        "app = workflow.compile()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Run: Safe Query (Allowed)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result = app.invoke({\"question\": \"Show total sales amount by region\"})\n",
+        "\n",
+        "print(f\"SQL: {result['sql']}\")\n",
+        "print(f\"Policy: {result['policy_decision']} - {result['policy_reason']}\")\n",
+        "print(f\"Results: {result['results']}\")\n",
+        "print(f\"\\nAudit trail ({len(result['audit_trail'])} entries):\")\n",
+        "for entry in result[\"audit_trail\"]:\n",
+        "    print(f\"  [{entry['step']}] {entry.get('decision', entry.get('output', entry.get('row_count', '')))}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Run: Dangerous Query (Denied)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "result = app.invoke({\"question\": \"Delete all sales records from EMEA region\"})\n",
+        "\n",
+        "print(f\"SQL: {result['sql']}\")\n",
+        "print(f\"Policy: {result['policy_decision']} - {result['policy_reason']}\")\n",
+        "print(f\"Error: {result.get('error', 'None')}\")\n",
+        "print(f\"\\nAudit trail ({len(result['audit_trail'])} entries):\")\n",
+        "for entry in result[\"audit_trail\"]:\n",
+        "    print(f\"  [{entry['step']}] {entry.get('decision', entry.get('output', ''))}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a new multi-agent example demonstrating a **governed NL-to-SQL agent** with policy-based query validation using LangGraph.

### What this example shows

- Multi-node LangGraph workflow: `generate_sql` → `validate_query` → `execute_query` / `reject_query`
- **Policy engine** with deny/review/allow decisions (blocks DROP, DELETE, INSERT, flags SELECT *)
- **Conditional routing** based on validation results
- **Audit trail** state tracking every step with timestamps
- Two demo runs: a safe query (allowed) and a dangerous query (denied)

### Motivation

Production NL-to-SQL systems need governance — not every generated query should be executed. This example shows how to implement policy gates as LangGraph nodes with conditional edges, a pattern that is missing from the current examples.

Based on patterns from [Nexus-Hive](https://github.com/KIM3310/Nexus-Hive), a governed NL-to-SQL copilot with Snowflake and Databricks adapters.

### Checklist

- [x] Follows existing notebook example conventions
- [x] Self-contained with SQLite in-memory database
- [x] Only requires `langgraph` and `langchain-openai` dependencies