### PR TITLE
fix(sdk-py): add missing `previous` and `context` fields to server runtime classes

### DIFF
--- a/libs/sdk-py/langgraph_sdk/runtime.py
+++ b/libs/sdk-py/langgraph_sdk/runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 if sys.version_info >= (3, 13):
     ContextT = TypeVar("ContextT", default=None)
@@ -162,6 +162,12 @@ class _ExecutionRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
     Only available during `threads.create_run`.
     """
 
+    previous: Any = field(default=None)
+    """The previous return value for the given thread.
+
+    Only available with the functional API when a checkpointer is provided.
+    """
+
 
 @dataclass(kw_only=True, slots=True, frozen=True)
 class _ReadRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
@@ -173,6 +179,18 @@ class _ReadRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
 
     !!! warning "Beta"
         This API is in beta and may change in future releases.
+    """
+
+    context: Any = field(default=None)
+    """Placeholder for compatibility with ``runtime_to_proto``.
+
+    Always ``None`` for non-execution contexts.
+    """
+
+    previous: Any = field(default=None)
+    """Placeholder for compatibility with ``runtime_to_proto``.
+
+    Always ``None`` for non-execution contexts.
     """
 
 


### PR DESCRIPTION
## Summary

- `_ExecutionRuntime` is missing `previous` and `_ReadRuntime` is missing both `context` and `previous`, causing `GetGraph` introspection to crash with `AttributeError` in LangGraph Cloud deployments
- Adds the missing dataclass fields with `default=None` to match the `Runtime` protocol that `runtime_to_proto` expects
- Agent execution is unaffected — only graph schema serialization (`GetGraph`) breaks

Fixes #7315

## Test plan

- [ ] `runtime_to_proto(_ExecutionRuntime(...))` no longer raises `AttributeError`
- [ ] `runtime_to_proto(_ReadRuntime(...))` no longer raises `AttributeError`
- [ ] `_ExecutionRuntime.context` still works with real values (instance slot takes precedence)
- [ ] `GetGraph` succeeds in a LangGraph Cloud deployment