### PR TITLE
fix: merge_configs now preserves recursion_limit when equal to DEFAULT_RECURSION_LIMIT

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -139,8 +139,7 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
                 else:
                     raise NotImplementedError
             elif key == "recursion_limit":
-                if config["recursion_limit"] != DEFAULT_RECURSION_LIMIT:
-                    base["recursion_limit"] = config["recursion_limit"]
+                base["recursion_limit"] = config["recursion_limit"]
             else:
                 base[key] = config[key]  # type: ignore[literal-required]
     if CONF not in base:

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -17,7 +17,12 @@ import langsmith
 import pytest
 from typing_extensions import NotRequired, Required, TypedDict
 
-from langgraph._internal._config import _is_not_empty, ensure_config
+from langgraph._internal._config import (
+    DEFAULT_RECURSION_LIMIT,
+    _is_not_empty,
+    ensure_config,
+    merge_configs,
+)
 from langgraph._internal._fields import (
     _is_optional_type,
     get_enhanced_type_hints,
@@ -317,3 +322,33 @@ def test_configurable_metadata():
     metadata = merged["metadata"]
     assert metadata.keys() == expected
     assert metadata["nooverride"] == 18
+
+
+def test_merge_configs_recursion_limit() -> None:
+    """Test that merge_configs preserves recursion_limit, including when it equals DEFAULT_RECURSION_LIMIT.
+
+    This is a regression test for a bug where merge_configs silently dropped
+    recursion_limit when it was explicitly set to DEFAULT_RECURSION_LIMIT (10000).
+    See: https://github.com/langchain-ai/langgraph/issues/7314
+    """
+    # Test merging recursion_limit with explicit DEFAULT_RECURSION_LIMIT value
+    result = merge_configs(
+        {"configurable": {}}, {"recursion_limit": DEFAULT_RECURSION_LIMIT}
+    )
+    assert "recursion_limit" in result
+    assert result["recursion_limit"] == DEFAULT_RECURSION_LIMIT
+
+    # Test merging recursion_limit with a different value
+    result = merge_configs({"configurable": {}}, {"recursion_limit": 9999})
+    assert "recursion_limit" in result
+    assert result["recursion_limit"] == 9999
+
+    # Test that recursion_limit from second config overrides first
+    result = merge_configs({"recursion_limit": 25}, {"recursion_limit": 100})
+    assert result["recursion_limit"] == 100
+
+    # Test that explicit DEFAULT_RECURSION_LIMIT overrides a different value
+    result = merge_configs(
+        {"recursion_limit": 25}, {"recursion_limit": DEFAULT_RECURSION_LIMIT}
+    )
+    assert result["recursion_limit"] == DEFAULT_RECURSION_LIMIT


### PR DESCRIPTION
## Summary

- Fix a bug in `merge_configs` that silently dropped `recursion_limit` when its value was equal to `DEFAULT_RECURSION_LIMIT` (10000)
- Remove the condition `!= DEFAULT_RECURSION_LIMIT` that was causing explicit `recursion_limit=10000` values to be discarded
- Add comprehensive tests for `merge_configs` with `recursion_limit` values

## Problem

Previously, calling `merge_configs` with `recursion_limit=10000` would silently drop the key:

```python
from langgraph._internal._config import merge_configs

result = merge_configs({"configurable": {}}, {"recursion_limit": 10000})
print("recursion_limit" in result)  # False — the config was silently ignored!
```

This caused real bugs when `create_agent(...).with_config({"recursion_limit": 10000})` was used to propagate recursion limits to sub-agents. The sub-agent would end up with no stored `recursion_limit`, falling back to the nested Pregel context's default (25), causing `GraphRecursionError` on multi-step tasks.

## Fix

The fix removes the unnecessary check for `!= DEFAULT_RECURSION_LIMIT` and always copies the `recursion_limit` value when present:

```python
# Before
elif key == "recursion_limit":
    if config["recursion_limit"] != DEFAULT_RECURSION_LIMIT:
        base["recursion_limit"] = config["recursion_limit"]

# After
elif key == "recursion_limit":
    base["recursion_limit"] = config["recursion_limit"]
```

## Test Plan

- [x] Added `test_merge_configs_recursion_limit()` test that verifies:
  - `recursion_limit=DEFAULT_RECURSION_LIMIT` is preserved
  - Other `recursion_limit` values are preserved
  - Later configs override earlier ones
  - Explicit `DEFAULT_RECURSION_LIMIT` overrides smaller values
- [x] `make format` passed
- [x] `make lint` passed
- [x] Test passes locally

Fixes #7314

🤖 Generated with [Claude Code](https://claude.com/claude-code)