### PR TITLE
fix(langgraph): use sentinel int subclass for DEFAULT_RECURSION_LIMIT

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -28,7 +28,16 @@ from langgraph._internal._constants import (
     NS_SEP,
 )
 
-DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10000"))
+class _DefaultRecursionLimit(int):
+    """Sentinel int subclass to distinguish LangGraph's default recursion
+    limit from a user-provided value of the same magnitude."""
+
+    pass
+
+
+DEFAULT_RECURSION_LIMIT = _DefaultRecursionLimit(
+    int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10000"))
+)
 
 
 def recast_checkpoint_ns(ns: str) -> str:
@@ -139,7 +148,7 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
                 else:
                     raise NotImplementedError
             elif key == "recursion_limit":
-                if config["recursion_limit"] != DEFAULT_RECURSION_LIMIT:
+                if not isinstance(config["recursion_limit"], _DefaultRecursionLimit):
                     base["recursion_limit"] = config["recursion_limit"]
             else:
                 base[key] = config[key]  # type: ignore[literal-required]
@@ -293,7 +302,7 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
             {
                 k: v.copy() if k in COPIABLE_KEYS else v  # type: ignore[attr-defined]
                 for k, v in var_config.items()
-                if _is_not_empty(v)
+                if _is_not_empty(v) and k != "recursion_limit"
             },
         )
     for config in configs:

--- a/libs/sdk-py/langgraph_sdk/schema.py
+++ b/libs/sdk-py/langgraph_sdk/schema.py
@@ -183,7 +183,7 @@ class Config(TypedDict, total=False):
 
     recursion_limit: int
     """
-    Maximum number of times a call can recurse. If not provided, defaults to 25.
+    Maximum number of times a call can recurse. If not provided, defaults to 10000.
     """
 
     configurable: dict[str, Any]


### PR DESCRIPTION
Fixes #7313

Replace the plain `int` magic number (10000) for `DEFAULT_RECURSION_LIMIT` with a `_DefaultRecursionLimit` int subclass sentinel, so `merge_configs()` can distinguish LangGraph's default from a user-provided value of the same magnitude.

## Problem

`DEFAULT_RECURSION_LIMIT` was a plain `int(10000)`. In `merge_configs()`, a value-equality check (`!= DEFAULT_RECURSION_LIMIT`) was used to decide whether to propagate `recursion_limit`. This meant:

- A user who explicitly set `recursion_limit=10000` had their value silently dropped (it matched the magic number).
- langchain_core's default of `25` could then leak through `var_child_runnable_config` in `ensure_config()`, causing the graph to run with only 25 steps.

## Solution

1. **`_DefaultRecursionLimit(int)` sentinel class** — An `int` subclass that satisfies the `RunnableConfig` type constraint, works in arithmetic, but is distinguishable via `isinstance()`.

2. **`merge_configs()`** — Changed from value comparison to `isinstance` check. Only sentinel defaults are dropped; plain `int` values (even `10000`) always propagate.

3. **`ensure_config()`** — Skip `recursion_limit` from `var_child_runnable_config` to prevent langchain_core's default (25) from overwriting LangGraph's sentinel default.

4. **SDK docstring** — Corrected `recursion_limit` default from 25 to 10000 in `langgraph_sdk/schema.py`.

## How I verified

Ran a standalone validation script covering:
- Sentinel type is `int` subclass with correct value
- User-set values propagate through `merge_configs`
- Two sentinel defaults merged produce no `recursion_limit` key
- User-set `10000` (plain int) propagates correctly (the bug fix)
- `ensure_config` returns sentinel default
- `ensure_config` respects user overrides

> Note: `make format`/`make lint`/`make test` could not run locally due to `uvloop` not supporting Windows. CI will validate on Linux.