### PR TITLE
fix(prebuilt): handle empty messages in route_tool_responses

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -968,6 +968,7 @@ def create_react_agent(
     )
 
     def route_tool_responses(state: StateSchema) -> str:
+        m = None
         for m in reversed(_get_state_value(state, "messages")):
             if not isinstance(m, ToolMessage):
                 break
@@ -976,7 +977,7 @@ def create_react_agent(
 
         # handle a case of parallel tool calls where
         # the tool w/ `return_direct` was executed in a different `Send`
-        if isinstance(m, AIMessage) and m.tool_calls:
+        if m is not None and isinstance(m, AIMessage) and m.tool_calls:
             if any(call["name"] in should_return_direct for call in m.tool_calls):
                 return END
 


### PR DESCRIPTION
## Summary
- Fixes `UnboundLocalError` in `route_tool_responses` when the messages list is empty
- Initializes loop variable `m` to `None` and adds a guard before the post-loop `isinstance` check

## Issue
Closes #7017

## Changes
In `libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py`, the `route_tool_responses` function uses the loop variable `m` after a `for` loop without guaranteeing it was assigned. If the messages list is empty, the loop body never executes and the subsequent `isinstance(m, AIMessage)` raises `UnboundLocalError`.

Fix: initialize `m = None` before the loop and check `m is not None` before the `isinstance` call.

## Test plan
- [x] Existing `test_return_direct` tests pass
- [x] `make lint` passes (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)