### PR TITLE
fix(prebuilt): guard against non-class types in _infer_handled_types

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -486,7 +486,9 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
                 raise ValueError(msg)
 
             exception_type = type_hints[first_param.name]
-            if Exception in exception_type.__mro__:
+            if isinstance(exception_type, type) and issubclass(
+                exception_type, Exception
+            ):
                 return (exception_type,)
             msg = (
                 f"Arbitrary types are not supported in the error handler "


### PR DESCRIPTION
## Summary
- Fixes `AttributeError` when `_infer_handled_types` encounters non-class type annotations (e.g., `TypeVar`, generic aliases)
- Replaces direct `__mro__` access with `isinstance(exception_type, type)` and `issubclass` check

## Issue
Closes #7016

## Changes
In `libs/prebuilt/langgraph/prebuilt/tool_node.py`, the `_infer_handled_types` function accesses `exception_type.__mro__` without verifying that `exception_type` is actually a class. Non-class type hints like `TypeVar` or generic aliases crash with `AttributeError`.

Fix: replace `Exception in exception_type.__mro__` with `isinstance(exception_type, type) and issubclass(exception_type, Exception)`.

## Test plan
- [x] `ruff check` and `ruff format` pass
- [x] Pre-existing mypy errors only (not introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)