### PR TITLE
fix(graph): use Mapping for path_map type in add_conditional_edges

### DIFF
--- a/libs/langgraph/langgraph/graph/_branch.py
+++ b/libs/langgraph/langgraph/graph/_branch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Hashable, Sequence
+from collections.abc import Awaitable, Callable, Hashable, Mapping, Sequence
 from inspect import (
     isfunction,
     ismethod,
@@ -89,14 +89,14 @@ class BranchSpec(NamedTuple):
     def from_path(
         cls,
         path: Runnable[Any, Hashable | list[Hashable]],
-        path_map: dict[Hashable, str] | list[str] | None,
+        path_map: Mapping[Hashable, str] | list[str] | None,
         infer_schema: bool = False,
     ) -> BranchSpec:
         # coerce path_map to a dictionary
         path_map_: dict[Hashable, str] | None = None
         try:
-            if isinstance(path_map, dict):
-                path_map_ = path_map.copy()
+            if isinstance(path_map, Mapping):
+                path_map_ = dict(path_map)
             elif isinstance(path_map, list):
                 path_map_ = {name: name for name in path_map}
             else:

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -5,7 +5,7 @@ import logging
 import typing
 import warnings
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Hashable, Sequence
+from collections.abc import Awaitable, Callable, Hashable, Mapping, Sequence
 from dataclasses import is_dataclass
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
@@ -845,7 +845,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         path: Callable[..., Hashable | Sequence[Hashable]]
         | Callable[..., Awaitable[Hashable | Sequence[Hashable]]]
         | Runnable[Any, Hashable | Sequence[Hashable]],
-        path_map: dict[Hashable, str] | list[str] | None = None,
+        path_map: Mapping[Hashable, str] | list[str] | None = None,
     ) -> Self:
         """Add a conditional edge from the starting node to any number of destination nodes.
 


### PR DESCRIPTION
## Summary
- Changes `path_map` parameter type from `dict[Hashable, str]` to `Mapping[Hashable, str]`
- Fixes pyright type error when passing `dict[str, str]` as `path_map`

## Issue
Closes #6540

## Changes
`dict` is invariant in its key type, so `dict[str, str]` is not assignable to `dict[Hashable, str]` under strict type checking. `Mapping` is covariant, so `Mapping[Hashable, str]` accepts `dict[str, str]`.

Updated in two places:
- `StateGraph.add_conditional_edges` in `libs/langgraph/langgraph/graph/state.py`
- `BranchSpec.from_path` in `libs/langgraph/langgraph/graph/_branch.py`

The `isinstance(path_map, dict)` check in `from_path` is updated to `isinstance(path_map, Mapping)` with `dict(path_map)` to ensure the internal representation remains a `dict`.

## Test plan
- [x] Verified the reproduction from the issue works without type errors
- [x] `ruff check` and `ruff format` pass
- [x] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)