### PR TITLE
fix(cli): validate deployment name before build

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -852,6 +852,13 @@ def _deploy(
         default_name = _normalize_image_name(pathlib.Path.cwd().name)
         name = click.prompt("Deployment name", default=default_name)
 
+    if name and not re.fullmatch(r"[a-zA-Z][a-zA-Z0-9-]+", name):
+        raise click.UsageError(
+            f"Invalid deployment name '{name}'. "
+            "Names must start with a letter and contain only letters, numbers, and hyphens. "
+            "Tip: replace underscores with hyphens (e.g. 'my-deployment')."
+        )
+
     secrets = _secrets_from_env(env_vars)
 
     # Use buildx to cross-compile for amd64 when running on a non-x86_64 host


### PR DESCRIPTION
## Summary
* `langgraph deploy` auto-generates the deployment name from the working directory, which can contain underscores
* Deployment names only allow `[a-zA-Z0-9-]` but this was never validated client-side
* A name like `test_deploy_graph` passed through, started a full Docker build, then hit a 500 from GCP Artifact Registry deep in the backend

## Fix
Add a `re.fullmatch` check immediately after the name is resolved, covering all sources (`--name` flag, `LANGSMITH_DEPLOYMENT_NAME` env var, interactive prompt). Fails fast with a clear message before any build or network calls.

## Test plan
- [x] Verified `langgraph deploy --name my_bad_name` exits with a clear UsageError before building
- [x] Verified `langgraph deploy --name my-good-name` proceeds past validation normally
- [x] All 34 existing CLI unit tests pass

## Release Notes
`langgraph deploy` now validates the deployment name upfront and shows a clear error if it contains invalid characters (e.g. underscores) instead of failing with a cryptic 500.