### PR TITLE
Batch sqlite checkpoint writes in list paths

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -5,6 +5,7 @@ import random
 import sqlite3
 import threading
 from collections.abc import AsyncIterator, Iterator, Sequence
+from itertools import chain
 from contextlib import closing, contextmanager
 from typing import Any, cast
 
@@ -23,6 +24,32 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 from langgraph.checkpoint.sqlite.utils import search_where
+
+
+def _search_writes_query(keys: Sequence[tuple[str, str, str]]) -> tuple[str, tuple[str, ...]]:
+    clauses = " OR ".join(
+        "(thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ?)"
+        for _ in keys
+    )
+    params = tuple(chain.from_iterable(keys))
+    query = (
+        "SELECT thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value "
+        "FROM writes WHERE " + clauses + " ORDER BY thread_id, checkpoint_ns, checkpoint_id, task_id, idx"
+    )
+    return query, params
+
+
+def _group_pending_writes(
+    rows: Sequence[tuple[str, str, str, str, str, str, bytes]],
+    serde: SerializerProtocol,
+) -> dict[tuple[str, str, str], list[tuple[str, str, Any]]]:
+    grouped: dict[tuple[str, str, str], list[tuple[str, str, Any]]] = {}
+    for thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type_, value in rows:
+        grouped.setdefault((thread_id, checkpoint_ns, checkpoint_id), []).append(
+            (task_id, channel, serde.loads_typed((type_, value)))
+        )
+    return grouped
+
 
 _AIO_ERROR_MSG = (
     "The SqliteSaver does not support async methods. "
@@ -333,7 +360,25 @@ class SqliteSaver(BaseCheckpointSaver[str]):
             query += " LIMIT ?"
             param_values = (*param_values, limit)
         with self.cursor(transaction=False) as cur, closing(self.conn.cursor()) as wcur:
-            cur.execute(query, param_values)
+            rows = list(cur.execute(query, param_values))
+            keys = [
+                (thread_id, checkpoint_ns, checkpoint_id)
+                for (
+                    thread_id,
+                    checkpoint_ns,
+                    checkpoint_id,
+                    _,
+                    _,
+                    _,
+                    _,
+                ) in rows
+            ]
+            grouped_writes: dict[tuple[str, str, str], list[tuple[str, str, Any]]] = {}
+            if keys:
+                writes_query, writes_params = _search_writes_query(keys)
+                wcur.execute(writes_query, writes_params)
+                grouped_writes = _group_pending_writes(list(wcur), self.serde)
+
             for (
                 thread_id,
                 checkpoint_ns,
@@ -342,11 +387,7 @@ class SqliteSaver(BaseCheckpointSaver[str]):
                 type,
                 checkpoint,
                 metadata,
-            ) in cur:
-                wcur.execute(
-                    "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
-                    (thread_id, checkpoint_ns, checkpoint_id),
-                )
+            ) in rows:
                 yield CheckpointTuple(
                     {
                         "configurable": {
@@ -371,10 +412,7 @@ class SqliteSaver(BaseCheckpointSaver[str]):
                         if parent_checkpoint_id
                         else None
                     ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        for task_id, channel, type, value in wcur
-                    ],
+                    grouped_writes.get((thread_id, checkpoint_ns, checkpoint_id), []),
                 )
 
     def put(

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -5,6 +5,7 @@ import json
 import random
 import threading
 from collections.abc import AsyncIterator, Callable, Iterator, Sequence
+from itertools import chain
 from contextlib import asynccontextmanager
 from typing import Any, TypeVar, cast
 
@@ -24,6 +25,32 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 from langgraph.checkpoint.sqlite.utils import search_where
+
+
+def _search_writes_query(keys: Sequence[tuple[str, str, str]]) -> tuple[str, tuple[str, ...]]:
+    clauses = " OR ".join(
+        "(thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ?)"
+        for _ in keys
+    )
+    params = tuple(chain.from_iterable(keys))
+    query = (
+        "SELECT thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type, value "
+        "FROM writes WHERE " + clauses + " ORDER BY thread_id, checkpoint_ns, checkpoint_id, task_id, idx"
+    )
+    return query, params
+
+
+def _group_pending_writes(
+    rows: Sequence[tuple[str, str, str, str, str, str, bytes]],
+    serde: SerializerProtocol,
+) -> dict[tuple[str, str, str], list[tuple[str, str, Any]]]:
+    grouped: dict[tuple[str, str, str], list[tuple[str, str, Any]]] = {}
+    for thread_id, checkpoint_ns, checkpoint_id, task_id, channel, type_, value in rows:
+        grouped.setdefault((thread_id, checkpoint_ns, checkpoint_id), []).append(
+            (task_id, channel, serde.loads_typed((type_, value)))
+        )
+    return grouped
+
 
 T = TypeVar("T", bound=Callable)
 
@@ -433,7 +460,28 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             self.conn.execute(query, params) as cur,
             self.conn.cursor() as wcur,
         ):
-            async for (
+            rows = [row async for row in cur]
+            keys = [
+                (thread_id, checkpoint_ns, checkpoint_id)
+                for (
+                    thread_id,
+                    checkpoint_ns,
+                    checkpoint_id,
+                    _,
+                    _,
+                    _,
+                    _,
+                ) in rows
+            ]
+            grouped_writes: dict[tuple[str, str, str], list[tuple[str, str, Any]]] = {}
+            if keys:
+                writes_query, writes_params = _search_writes_query(keys)
+                await wcur.execute(writes_query, writes_params)
+                grouped_writes = _group_pending_writes(
+                    [row async for row in wcur], self.serde
+                )
+
+            for (
                 thread_id,
                 checkpoint_ns,
                 checkpoint_id,
@@ -441,11 +489,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                 type,
                 checkpoint,
                 metadata,
-            ) in cur:
-                await wcur.execute(
-                    "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
-                    (thread_id, checkpoint_ns, checkpoint_id),
-                )
+            ) in rows:
                 yield CheckpointTuple(
                     {
                         "configurable": {
@@ -470,10 +514,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                         if parent_checkpoint_id
                         else None
                     ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        async for task_id, channel, type, value in wcur
-                    ],
+                    grouped_writes.get((thread_id, checkpoint_ns, checkpoint_id), []),
                 )
 
     async def aput(

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,59 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+
+    async def test_alist_batches_pending_writes_queries(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            for index in range(4):
+                config: RunnableConfig = {
+                    "configurable": {
+                        "thread_id": "thread-batch",
+                        "checkpoint_ns": "",
+                    }
+                }
+                metadata: CheckpointMetadata = {"index": index}
+                saved = await saver.aput(
+                    config,
+                    create_checkpoint(empty_checkpoint(), {}, index + 1),
+                    metadata,
+                    {},
+                )
+                await saver.aput_writes(
+                    saved,
+                    [("messages", [f"message-{index}"])],
+                    task_id=f"task-{index}",
+                )
+
+            queries: list[str] = []
+            await saver.conn.set_trace_callback(
+                lambda query: queries.append(query)
+            )
+            results = [
+                checkpoint
+                async for checkpoint in saver.alist(
+                    {"configurable": {"thread_id": "thread-batch"}}
+                )
+            ]
+
+            writes_queries = [query for query in queries if "FROM writes" in query]
+            checkpoint_queries = [
+                query for query in queries if "FROM checkpoints" in query
+            ]
+
+            assert len(results) == 4
+            assert len(checkpoint_queries) == 1
+            assert len(writes_queries) == 1
+            assert all(result.pending_writes for result in results)
+            assert [result.pending_writes[0][0] for result in results] == [
+                "task-3",
+                "task-2",
+                "task-1",
+                "task-0",
+            ]
+            assert [result.pending_writes[0][2] for result in results] == [
+                ["message-3"],
+                ["message-2"],
+                ["message-1"],
+                ["message-0"],
+            ]

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -307,3 +307,54 @@ class TestSqliteSaver:
             # Nested digit-starting key via dotted path
             results = list(saver.list(None, filter={"user.123abc": "ok2"}))
             assert len(results) == 1
+
+
+    def test_list_batches_pending_writes_queries(self) -> None:
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            for index in range(4):
+                config: RunnableConfig = {
+                    "configurable": {
+                        "thread_id": "thread-batch",
+                        "checkpoint_ns": "",
+                    }
+                }
+                metadata: CheckpointMetadata = {"index": index}
+                saved = saver.put(
+                    config,
+                    create_checkpoint(empty_checkpoint(), {}, index + 1),
+                    metadata,
+                    {},
+                )
+                saver.put_writes(
+                    saved,
+                    [("messages", [f"message-{index}"])],
+                    task_id=f"task-{index}",
+                )
+
+            queries: list[str] = []
+            saver.conn.set_trace_callback(lambda query: queries.append(query))
+            results = list(
+                saver.list({"configurable": {"thread_id": "thread-batch"}})
+            )
+
+            writes_queries = [query for query in queries if "FROM writes" in query]
+            checkpoint_queries = [
+                query for query in queries if "FROM checkpoints" in query
+            ]
+
+            assert len(results) == 4
+            assert len(checkpoint_queries) == 1
+            assert len(writes_queries) == 1
+            assert all(result.pending_writes for result in results)
+            assert [result.pending_writes[0][0] for result in results] == [
+                "task-3",
+                "task-2",
+                "task-1",
+                "task-0",
+            ]
+            assert [result.pending_writes[0][2] for result in results] == [
+                ["message-3"],
+                ["message-2"],
+                ["message-1"],
+                ["message-0"],
+            ]


### PR DESCRIPTION
## Summary
- batch pending-write loading in `SqliteSaver.list()` and `AsyncSqliteSaver.alist()` instead of querying `writes` once per checkpoint
- keep checkpoint ordering and pending-write decoding behavior unchanged while reducing the SQLite query count from `N+1` to `2`
- add sync and async regression coverage that verifies listed checkpoints still return the right writes and only issue a single `writes` query

## Why this fix
`SqliteSaver.list()` and `AsyncSqliteSaver.alist()` currently fetch checkpoint rows first and then run a separate `writes` query for every checkpoint returned. That creates a classic N+1 query pattern on the checkpoint listing path.

This patch collects the listed checkpoint keys, loads all matching writes in one ordered query, groups them by `(thread_id, checkpoint_ns, checkpoint_id)`, and then reattaches the grouped writes while yielding checkpoint tuples.

Closes #7263.

## Validation
- `PYTHONPATH=libs/checkpoint;libs/checkpoint-sqlite python -m pytest libs/checkpoint-sqlite/tests/test_sqlite.py::TestSqliteSaver::test_list_batches_pending_writes_queries -q` -> `1 passed`
- `PYTHONPATH=libs/checkpoint;libs/checkpoint-sqlite` async verification script against `AsyncSqliteSaver.alist()` -> `async-ok`
- `python -c "from pathlib import Path; files = [Path('libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py'), Path('libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py'), Path('libs/checkpoint-sqlite/tests/test_sqlite.py'), Path('libs/checkpoint-sqlite/tests/test_aiosqlite.py')]; [compile(p.read_text(encoding='utf-8'), str(p), 'exec') for p in files]; print('compile-ok')"` -> `compile-ok`

## Notes
- I also tried running the full SQLite test modules locally, but this environment is missing the async pytest plugin configuration required by the repo's existing async tests. The new async logic was validated with a direct `AsyncSqliteSaver` script instead of changing unrelated test infrastructure.