### PR TITLE
fix(prebuilt): prevent ToolNode.ainvoke hangs on MCP sse_read_timeout

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -115,6 +115,8 @@ TOOL_INVOCATION_ERROR_TEMPLATE = (
     " {error}\n"
     " Please fix the error and try again."
 )
+TOOL_CALL_TIMEOUT_CONFIG_KEY = "__tool_call_timeout"
+DEFAULT_MCP_TOOL_CALL_TIMEOUT_S = 15.0
 
 
 class _ToolCallRequestOverrides(TypedDict, total=False):
@@ -379,12 +381,110 @@ class ToolInvocationError(ToolException):
 def _default_handle_tool_errors(e: Exception) -> str:
     """Default error handler for tool errors.
 
-    If the tool is a tool invocation error, return its message.
-    Otherwise, raise the error.
+    Handles:
+    - ToolInvocationError: Invalid arguments provided by the model
+    - asyncio.TimeoutError: Tool execution timeout (e.g., MCP stream timeout)
+    - ConnectionError: Network/connection failures during tool execution
+
+    Other exceptions are re-raised to propagate to the caller.
     """
     if isinstance(e, ToolInvocationError):
         return e.message
+    if isinstance(e, (asyncio.TimeoutError, ConnectionError)):
+        return TOOL_CALL_ERROR_TEMPLATE.format(error=repr(e))
     raise e
+
+
+def _is_mcp_tool(tool: BaseTool) -> bool:
+    """Return True if the tool appears to be backed by langchain-mcp-adapters."""
+    if tool.__class__.__module__.startswith("langchain_mcp_adapters."):
+        return True
+
+    for attr in ("coroutine", "func"):
+        candidate = getattr(tool, attr, None)
+        module = getattr(candidate, "__module__", "")
+        if isinstance(module, str) and module.startswith("langchain_mcp_adapters."):
+            return True
+
+    return False
+
+
+def _coerce_positive_timeout(value: Any) -> float | None:
+    """Convert a timeout-like value to positive seconds if possible."""
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+
+    total_seconds = getattr(value, "total_seconds", None)
+    if callable(total_seconds):
+        try:
+            seconds = float(total_seconds())
+        except (TypeError, ValueError):
+            return None
+        if seconds > 0:
+            return seconds
+
+    return None
+
+
+def _get_mcp_sse_read_timeout(tool: BaseTool) -> float | None:
+    """Best-effort extraction of MCP sse_read_timeout from tool closure state."""
+    for attr in ("coroutine", "func"):
+        candidate = getattr(tool, attr, None)
+        if candidate is None:
+            continue
+
+        try:
+            closure_vars = inspect.getclosurevars(candidate)
+        except TypeError:
+            continue
+
+        connection = closure_vars.nonlocals.get("connection")
+        if not isinstance(connection, dict):
+            continue
+
+        inferred = _coerce_positive_timeout(connection.get("sse_read_timeout"))
+        if inferred is not None:
+            return inferred
+
+    return None
+
+
+def _get_tool_call_timeout(
+    config: RunnableConfig,
+    *,
+    tool: BaseTool | None = None,
+) -> float | None:
+    """Extract and validate tool call timeout from config.
+
+    Args:
+        config: The RunnableConfig containing optional timeout configuration.
+
+    Returns:
+        The timeout in seconds as a float, or None if no timeout is configured.
+        For MCP tools, prefers `sse_read_timeout` from tool configuration when
+        available, with a default fallback when it cannot be inferred.
+
+    Raises:
+        ValueError: If the timeout value is not a positive number.
+    """
+    configurable = config.get("configurable") if config else None
+    timeout_value = (
+        configurable.get(TOOL_CALL_TIMEOUT_CONFIG_KEY) if configurable else None
+    )
+    if timeout_value is not None:
+        timeout = _coerce_positive_timeout(timeout_value)
+        if timeout is not None:
+            return timeout
+
+        msg = f"Tool call timeout must be a positive number, got {timeout_value}"
+        raise ValueError(msg)
+
+    if tool and _is_mcp_tool(tool):
+        if inferred_mcp_timeout := _get_mcp_sse_read_timeout(tool):
+            return inferred_mcp_timeout
+        return DEFAULT_MCP_TOOL_CALL_TIMEOUT_S
+
+    return None
 
 
 def _handle_tool_error(
@@ -1080,7 +1180,13 @@ class ToolNode(RunnableCallable):
 
         try:
             try:
-                response = await tool.ainvoke(call_args, config)
+                timeout = _get_tool_call_timeout(config, tool=tool)
+                if timeout is not None:
+                    response = await asyncio.wait_for(
+                        tool.ainvoke(call_args, config), timeout=timeout
+                    )
+                else:
+                    response = await tool.ainvoke(call_args, config)
             except ValidationError as exc:
                 # Filter out errors for injected arguments
                 injected = self._injected_args.get(call["name"])

--- a/libs/prebuilt/manual_repro/repro_toolnode_hang.py
+++ b/libs/prebuilt/manual_repro/repro_toolnode_hang.py
@@ -1,8 +1,10 @@
-from langchain_core.messages import AIMessage
-from langchain_mcp_adapters.client import MultiServerMCPClient
-from langgraph.prebuilt import ToolNode
 import asyncio
 from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from langgraph.prebuilt import ToolNode
 
 
 async def main() -> None:

--- a/libs/prebuilt/manual_repro/slow_mcp_server.py
+++ b/libs/prebuilt/manual_repro/slow_mcp_server.py
@@ -1,18 +1,16 @@
 import anyio
 from mcp.server.fastmcp import FastMCP
 
-
 mcp = FastMCP("slow-server", host="127.0.0.1", port=8099)
 
 
 @mcp.tool()
 async def slow_tool(q: str) -> str:
-	# Intentionally exceed client sse_read_timeout.
-	await anyio.sleep(60)
-	return f"done: {q}"
+    # Intentionally exceed client sse_read_timeout.
+    await anyio.sleep(60)
+    return f"done: {q}"
 
 
 if __name__ == "__main__":
-	# Streamable HTTP MCP endpoint.
-	mcp.run(transport="streamable-http")
-
+    # Streamable HTTP MCP endpoint.
+    mcp.run(transport="streamable-http")

--- a/libs/prebuilt/tests/test_tool_node_mcp_timeout.py
+++ b/libs/prebuilt/tests/test_tool_node_mcp_timeout.py
@@ -9,8 +9,8 @@ propagate the timeout exception, causing the async task to hang indefinitely.
 """
 
 import asyncio
-from unittest.mock import Mock
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from langchain_core.messages import AIMessage, ToolMessage
@@ -52,6 +52,7 @@ async def tool_with_read_timeout_error() -> str:
     # Simulate httpx ReadTimeout
     try:
         import httpx
+
         raise httpx.ReadTimeout("Read timeout")
     except ImportError:
         # httpx not available, use OSError as fallback
@@ -77,15 +78,15 @@ async def slow_async_tool(delay_seconds: int) -> str:
 async def test_tool_node_handles_asyncio_timeout() -> None:
     """
     Test that ToolNode properly catches AsyncTimeoutError from MCP tools.
-    
+
     This test reproduces the bug where ToolNode doesn't propagate timeout
     exceptions, causing ainvoke to hang instead of returning an error message.
-    
+
     Expected (with fix): ToolMessage with error content
     Current (bug): Hangs indefinitely (caught by outer asyncio.wait_for)
     """
     tool_node = ToolNode([tool_with_timeout])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -100,7 +101,7 @@ async def test_tool_node_handles_asyncio_timeout() -> None:
             )
         ]
     }
-    
+
     # Wrap with timeout to prevent infinite hang during test
     # Without fix, this test times out after 10 seconds
     try:
@@ -114,23 +115,26 @@ async def test_tool_node_handles_asyncio_timeout() -> None:
             "BUG REPRODUCED: ToolNode.ainvoke hanged despite MCP timeout. "
             "The timeout exception was not properly propagated from the tool."
         )
-    
-    # Verify result contains error message about timeout
-    assert len(result["messages"]) >= 2
+
+    # Verify result contains the tool error message
+    assert len(result["messages"]) >= 1
     tool_message: ToolMessage = result["messages"][-1]
     assert tool_message.type == "tool"
     # Should contain error information, not hang
-    assert "timeout" in tool_message.content.lower() or "error" in tool_message.content.lower()
+    assert (
+        "timeout" in tool_message.content.lower()
+        or "error" in tool_message.content.lower()
+    )
 
 
 async def test_tool_node_handles_connection_error() -> None:
     """
     Test that ToolNode properly handles connection errors from MCP tools.
-    
+
     Connection errors can occur when MCP server is unreachable after timeout.
     """
     tool_node = ToolNode([tool_with_connection_error])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -145,7 +149,7 @@ async def test_tool_node_handles_connection_error() -> None:
             )
         ]
     }
-    
+
     try:
         result = await asyncio.wait_for(
             tool_node.ainvoke(state, config=_create_config_with_runtime()),
@@ -156,9 +160,9 @@ async def test_tool_node_handles_connection_error() -> None:
             "ToolNode.ainvoke hanged handling connection error. "
             "Connection errors should be caught and returned as ToolMessage."
         )
-    
+
     # Should return a ToolMessage with error content
-    assert len(result["messages"]) >= 2
+    assert len(result["messages"]) >= 1
     tool_message: ToolMessage = result["messages"][-1]
     assert tool_message.type == "tool"
 
@@ -166,12 +170,12 @@ async def test_tool_node_handles_connection_error() -> None:
 async def test_tool_node_multiple_tools_one_timeout() -> None:
     """
     Test that ToolNode handles timeout in one tool when running multiple tools.
-    
+
     This scenario is common: LLM generates multiple tool calls, one times out.
     The other calls should still complete and the timeout should be reported.
     """
     tool_node = ToolNode([slow_async_tool, tool_with_timeout])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -191,7 +195,7 @@ async def test_tool_node_multiple_tools_one_timeout() -> None:
             )
         ]
     }
-    
+
     try:
         result = await asyncio.wait_for(
             tool_node.ainvoke(state, config=_create_config_with_runtime()),
@@ -202,19 +206,21 @@ async def test_tool_node_multiple_tools_one_timeout() -> None:
             "ToolNode.ainvoke hanged when one of multiple tools timed out. "
             "Should complete with mixed results (success + error)."
         )
-    
-    # Should have 3 messages: original + 2 tool results
-    assert len(result["messages"]) >= 3
-    
+
+    # Should have 2 tool results (one ToolMessage per tool call)
+    assert len(result["messages"]) >= 2
+
     # Verify we got both tool messages
     tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
     assert len(tool_messages) == 2
-    
+
     # One should succeed, one should have error
     contents = [msg.content for msg in tool_messages]
     has_success = any("Completed" in str(c) for c in contents)
-    has_error = any("error" in str(c).lower() or "timeout" in str(c).lower() for c in contents)
-    
+    has_error = any(
+        "error" in str(c).lower() or "timeout" in str(c).lower() for c in contents
+    )
+
     assert has_success, "Expected at least one tool to succeed"
     assert has_error, "Expected timeout error to be reported"
 
@@ -222,11 +228,11 @@ async def test_tool_node_multiple_tools_one_timeout() -> None:
 async def test_tool_node_timeout_propagates_to_caller() -> None:
     """
     Test that extreme timeouts in tools are properly caught and reported.
-    
+
     The fix should prevent ToolNode from indefinitely waiting when a tool times out.
     """
     tool_node = ToolNode([tool_with_timeout])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -241,7 +247,7 @@ async def test_tool_node_timeout_propagates_to_caller() -> None:
             )
         ]
     }
-    
+
     # Set a moderate timeout (5 seconds)
     # Without fix: This will timeout (bug is present)
     # With fix: Should return quickly with error ToolMessage
@@ -251,10 +257,10 @@ async def test_tool_node_timeout_propagates_to_caller() -> None:
             timeout=5,
         )
         # If we get here without timeout, check the result contains error info
-        assert len(result["messages"]) >= 2
+        assert len(result["messages"]) >= 1
         tool_message: ToolMessage = result["messages"][-1]
         assert tool_message.type == "tool"
-        
+
     except TimeoutError:
         # This is the bug: ToolNode hung instead of returning error
         pytest.fail(
@@ -267,15 +273,16 @@ async def test_tool_node_timeout_propagates_to_caller() -> None:
 async def test_tool_node_sync_tool_not_affected() -> None:
     """
     Test that synchronous tools still work correctly.
-    
+
     Ensure our timeout handling doesn't break sync tools.
     """
+
     def sync_tool(value: int) -> str:
         """A simple synchronous tool."""
         return f"sync result: {value}"
-    
+
     tool_node = ToolNode([sync_tool])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -290,10 +297,10 @@ async def test_tool_node_sync_tool_not_affected() -> None:
             )
         ]
     }
-    
+
     result = await tool_node.ainvoke(state, config=_create_config_with_runtime())
-    
-    assert len(result["messages"]) >= 2
+
+    assert len(result["messages"]) >= 1
     tool_message: ToolMessage = result["messages"][-1]
     assert tool_message.type == "tool"
     assert tool_message.content == "sync result: 42"
@@ -302,16 +309,17 @@ async def test_tool_node_sync_tool_not_affected() -> None:
 async def test_tool_node_timeout_with_decorated_tool() -> None:
     """
     Test timeout handling with @tool decorated async function.
-    
+
     Ensures timeout handling works with langchain's tool decorator.
     """
+
     @dec_tool
     async def decorated_timeout_tool() -> str:
         """A decorated tool that times out."""
         raise asyncio.TimeoutError("MCP timeout")
-    
+
     tool_node = ToolNode([decorated_timeout_tool])
-    
+
     state = {
         "messages": [
             AIMessage(
@@ -326,7 +334,7 @@ async def test_tool_node_timeout_with_decorated_tool() -> None:
             )
         ]
     }
-    
+
     try:
         result = await asyncio.wait_for(
             tool_node.ainvoke(state, config=_create_config_with_runtime()),
@@ -336,8 +344,8 @@ async def test_tool_node_timeout_with_decorated_tool() -> None:
         pytest.fail(
             "ToolNode.ainvoke hanged with @tool decorated async function that timed out."
         )
-    
+
     # Verify error was caught
-    assert len(result["messages"]) >= 2
+    assert len(result["messages"]) >= 1
     tool_message: ToolMessage = result["messages"][-1]
     assert tool_message.type == "tool"


### PR DESCRIPTION
Fixes #6412 

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->
This modification will ensure the ToolNode.ainvoke does not hang in case MCP tools go beyond the sse_read_timeout by retrieving the timeout value of MCP settings and applying it when executing the tool asynchronously. It also modifies default tool error handling to have TimeoutError and ConnectionError re-throw error ToolMessages rather than stall, with an error fallback time is used where MCP timeout is not present.

How I verified:

1. Ran make format, make lint and make test in libs/prebuilt.
2. Added and executed targeted MCP timeout regression tests.
3. Re-ran existing ToolNode tests to confirm no regressions.
4. Ran the manual reproduction scenario for the original hang.
5. Confirmed timeout/connection failures now return error ToolMessages instead of hanging.

## Social handles
<!-- If you'd like a shoutout on release, add your socials below -->
LinkedIn: https://www.linkedin.com/in/sanila-wijesekara/