### PR TITLE
fix(langgraph): remove deprecated Pydantic v1 __fields__ fallbacks

### DIFF
--- a/libs/langgraph/langgraph/_internal/_pydantic.py
+++ b/libs/langgraph/langgraph/_internal/_pydantic.py
@@ -44,9 +44,6 @@ def get_fields(
     """Get the field names of a Pydantic model."""
     if hasattr(model, "model_fields"):
         return model.model_fields
-
-    if hasattr(model, "__fields__"):
-        return model.__fields__
     msg = f"Expected a Pydantic model. Got {type(model)}"
     raise TypeError(msg)
 

--- a/libs/langgraph/langgraph/_internal/_serde.py
+++ b/libs/langgraph/langgraph/_internal/_serde.py
@@ -244,10 +244,4 @@ def _pydantic_field_types(typ: type[Any]) -> list[Any]:
             for field in typ.model_fields.values()
             if getattr(field, "annotation", None) is not None
         ]
-    if hasattr(typ, "__fields__"):
-        return [
-            field.outer_type_
-            for field in typ.__fields__.values()
-            if getattr(field, "outer_type_", None) is not None
-        ]
     return []


### PR DESCRIPTION
Fixes #6333

Remove deprecated `__fields__` fallbacks in `_pydantic.py` and `_serde.py`. Since langgraph requires `pydantic>=2.7.4`, all Pydantic models have the `model_fields` attribute. The `__fields__` codepaths were unreachable for v2 models and triggered `DeprecationWarning` on Pydantic v2.11+.

Two files changed:
- `_pydantic.py:get_fields()` — removed `__fields__` fallback
- `_serde.py:_pydantic_field_types()` — removed `__fields__` fallback with `outer_type_` access

Verified by searching the codebase for all `__fields__` references — no other occurrences remain in `libs/langgraph/`.