### PR TITLE
fix(langgraph): avoid recursion limit default sentinel collision

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -28,7 +28,7 @@ from langgraph._internal._constants import (
     NS_SEP,
 )
 
-DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10000"))
+DEFAULT_RECURSION_LIMIT = int(getenv("LANGGRAPH_DEFAULT_RECURSION_LIMIT", "10007"))
 
 
 def recast_checkpoint_ns(ns: str) -> str:


### PR DESCRIPTION
This changes the fallback `DEFAULT_RECURSION_LIMIT` from `10000` to `10007`. Today `merge_configs()` treats the default recursion limit as a proxy for "not explicitly set", so using a round number like `10000` creates possible collision risk with user-supplied values. Moving the fallback to `10007` slightly reduces the chance that an explicitly chosen recursion limit is mistaken for the implicit default while we keep the current merge semantics.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview) using gpt-5.4 (provider: openai).
