### PR TITLE
docs(checkpoint-postgres): add thread_id length warning for Postgres btree index limit

### DIFF
--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -28,6 +28,22 @@ By default `langgraph-checkpoint-postgres` installs `psycopg` (Psycopg 3) withou
 >     # TypeError: tuple indices must be integers or slices, not str
 > ```
 
+> [!WARNING]
+> **`thread_id` length limits:** PostgreSQL's `bpchar` index has a maximum key size (typically 2704 bytes for btree version 4). If `thread_id` exceeds this limit, you will encounter:
+> ```
+> Postgres error: Index row size exceeds btree maximum
+> ```
+> **Recommendation:** Use UUIDs or short hashes for `thread_id` values:
+> ```python
+> import uuid
+> thread_id = str(uuid.uuid4())  # Recommended — always 36 characters
+>
+> # Or a short hash for meaningful identifiers
+> import hashlib
+> thread_id = hashlib.sha256(user_id.encode()).hexdigest()[:16]  # 16-char hex
+> ```
+> If you need longer human-readable identifiers, consider encoding them (e.g., base62) or storing a mapping in a separate table.
+
 ```python
 from langgraph.checkpoint.postgres import PostgresSaver
 


### PR DESCRIPTION
## Summary

Adds a `[!WARNING]` block in `libs/checkpoint-postgres/README.md` documenting that PostgreSQL's `bpchar` btree index has a maximum key size (typically 2704 bytes for btree version 4). When `thread_id` exceeds this limit, users encounter:

```
Postgres error: Index row size exceeds btree maximum
```

Also provides practical alternatives:
- `uuid.uuid4()` for unique identifiers
- `sha256` hash truncated for meaningful identifiers
- base62 encoding or lookup tables for longer human-readable strings

## Motivation

This addresses [langgraph issue #6239](https://github.com/langchain-ai/langgraph/issues/6239), where users using long `thread_id` values get cryptic PostgreSQL errors without understanding the root cause. A collaborator (`@eyurtsev`) already approved adding a warning for this.

## Testing

- [x] Readable documentation rendered correctly
- [x] Code examples are syntactically correct Python

## Checklist

- [x] docs only change
- [ ] tests added (N/A — docs only)
