### PR TITLE
fix(prebuilt): strip extended thinking before with_structured_output to avoid Anthropic tool_choice error

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -240,6 +240,23 @@ def _get_model(model: LanguageModelLike) -> BaseChatModel:
     return model
 
 
+def _strip_thinking_if_enabled(model: BaseChatModel) -> BaseChatModel:
+    """Strip thinking/reasoning from a model if it is enabled.
+
+    Some providers (e.g. Anthropic extended thinking) set a `thinking` parameter
+    on the model that enables reasoning prior to the response.  When thinking is
+    active the provider does not allow `tool_choice` to force tool use
+    (i.e. `tool_choice="any"` or `tool_choice="tool"`), which is the default
+    behaviour of `with_structured_output`.  For the separate structured-response
+    generation call we therefore disable thinking so that `with_structured_output`
+    can bind tools without hitting an API error.
+    """
+    thinking = getattr(model, "thinking", None)
+    if isinstance(thinking, dict) and thinking.get("type") not in (None, "disabled"):
+        return model.model_copy(update={"thinking": {"type": "disabled"}})
+    return model
+
+
 def _validate_chat_history(
     messages: Sequence[BaseMessage],
 ) -> None:
@@ -758,8 +775,8 @@ def create_react_agent(
             messages = [SystemMessage(content=system_prompt)] + list(messages)
 
         resolved_model = _resolve_model(state, runtime)
-        model_with_structured_output = _get_model(
-            resolved_model
+        model_with_structured_output = _strip_thinking_if_enabled(
+            _get_model(resolved_model)
         ).with_structured_output(
             cast(StructuredResponseSchema, structured_response_schema)
         )
@@ -776,8 +793,8 @@ def create_react_agent(
             messages = [SystemMessage(content=system_prompt)] + list(messages)
 
         resolved_model = await _aresolve_model(state, runtime)
-        model_with_structured_output = _get_model(
-            resolved_model
+        model_with_structured_output = _strip_thinking_if_enabled(
+            _get_model(resolved_model)
         ).with_structured_output(
             cast(StructuredResponseSchema, structured_response_schema)
         )

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -11,7 +11,7 @@ from typing import (
 from unittest.mock import Mock
 
 import pytest
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.messages import (
     AIMessage,
     AnyMessage,
@@ -22,7 +22,7 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
-from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.runnables import Runnable, RunnableConfig, RunnableLambda
 from langchain_core.tools import InjectedToolCallId, ToolException
 from langchain_core.tools import tool as dec_tool
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -46,8 +46,10 @@ from langgraph.prebuilt.chat_agent_executor import (
     AgentState,
     AgentStatePydantic,
     StateSchemaType,
+    StructuredResponse,
     _get_model,
     _should_bind_tools,
+    _strip_thinking_if_enabled,
     _validate_chat_history,
 )
 from langgraph.prebuilt.tool_node import (
@@ -1549,6 +1551,89 @@ def test_get_model() -> None:
 
     with pytest.raises(TypeError):
         _get_model(RunnableLambda(lambda message: message))
+
+
+class FakeThinkingModel(FakeToolCallingModel):
+    """Fake model that simulates Anthropic extended thinking."""
+
+    thinking: dict | None = None
+
+    def with_structured_output(
+        self, schema: type[BaseModel], **kwargs
+    ) -> Runnable[LanguageModelInput, StructuredResponse]:
+        # Simulate Anthropic's restriction: raise an error if thinking is enabled
+        # and tool_choice would force tool use (the default with_structured_output
+        # behaviour for Anthropic models).
+        if isinstance(self.thinking, dict) and self.thinking.get("type") not in (
+            None,
+            "disabled",
+        ):
+            raise ValueError(
+                "Thinking may not be enabled when tool_choice forces tool use."
+            )
+        return super().with_structured_output(schema, **kwargs)
+
+
+def test_strip_thinking_if_enabled() -> None:
+    """_strip_thinking_if_enabled should disable thinking when it is active."""
+    # Model without thinking - returned unchanged
+    plain_model = FakeToolCallingModel(tool_calls=[])
+    assert _strip_thinking_if_enabled(plain_model) is plain_model
+
+    # Model with thinking explicitly disabled - returned unchanged
+    model_thinking_disabled = FakeThinkingModel(
+        tool_calls=[], thinking={"type": "disabled"}
+    )
+    assert (
+        _strip_thinking_if_enabled(model_thinking_disabled) is model_thinking_disabled
+    )
+
+    # Model with thinking=None - returned unchanged
+    model_thinking_none = FakeThinkingModel(tool_calls=[], thinking=None)
+    assert _strip_thinking_if_enabled(model_thinking_none) is model_thinking_none
+
+    # Model with thinking enabled - should return a copy with thinking disabled
+    model_thinking_enabled = FakeThinkingModel(
+        tool_calls=[], thinking={"type": "enabled", "budget_tokens": 1024}
+    )
+    stripped = _strip_thinking_if_enabled(model_thinking_enabled)
+    assert stripped is not model_thinking_enabled
+    assert stripped.thinking == {"type": "disabled"}  # type: ignore[attr-defined]
+
+    # Adaptive thinking variant
+    model_adaptive = FakeThinkingModel(tool_calls=[], thinking={"type": "adaptive"})
+    stripped_adaptive = _strip_thinking_if_enabled(model_adaptive)
+    assert stripped_adaptive is not model_adaptive
+    assert stripped_adaptive.thinking == {"type": "disabled"}  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+def test_react_agent_structured_response_strips_thinking(version: str) -> None:
+    """create_react_agent should strip extended thinking before calling
+    with_structured_output so that Anthropic's tool_choice restriction is not hit.
+    """
+
+    class WeatherResponse(BaseModel):
+        temperature: float = Field(description="The temperature in fahrenheit")
+
+    expected_structured_response = WeatherResponse(temperature=75)
+    # Model that has thinking enabled and raises if with_structured_output
+    # is called without stripping thinking first.
+    model = FakeThinkingModel(
+        tool_calls=[[]],
+        structured_response=expected_structured_response,
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    )
+
+    agent = create_react_agent(
+        model,
+        [],  # no tools - goes straight to generate_structured_response
+        response_format=WeatherResponse,
+        version=version,
+    )
+    # Should NOT raise "Thinking may not be enabled when tool_choice forces tool use."
+    response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+    assert response["structured_response"] == expected_structured_response
 
 
 @pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)


### PR DESCRIPTION
Fixes langchain-ai/langchain#36418

When Anthropic extended thinking is enabled on a model (`thinking.type == "enabled"` or `"adaptive"`), the Anthropic API rejects `tool_choice="any"` or `tool_choice="tool"`. `with_structured_output` uses `tool_choice="any"` by default for Anthropic models, causing a 400 error:

```
Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error',
'message': 'Thinking may not be enabled when tool_choice forces tool use.'}}
```

This surfaces whenever `response_format` is used together with a thinking-enabled `ChatAnthropic` model in `create_react_agent` (and the new `create_agent` in `langchain`).

## Changes

**`libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py`**

- Added `_strip_thinking_if_enabled(model: BaseChatModel) -> BaseChatModel` helper.  
  It checks for a `thinking` dict attribute whose `type` is not `None`/`"disabled"`, and returns a `model_copy(update={"thinking": {"type": "disabled"}})` in that case. Models without thinking are returned unchanged (same object, no copy made).

- Applied the helper in both `generate_structured_response` and `agenerate_structured_response` before calling `.with_structured_output(...)`. The structured-response call is a separate LLM invocation that occurs *after* the main tool-use loop, so thinking is not needed there and stripping it avoids the API constraint.

**`libs/prebuilt/tests/test_react_agent.py`**

- `FakeThinkingModel` — test-double that raises the Anthropic error string when `with_structured_output` is called while `thinking` is enabled.
- `test_strip_thinking_if_enabled` — unit tests for all thinking states (absent, `None`, `"disabled"`, `"enabled"`, `"adaptive"`).
- `test_react_agent_structured_response_strips_thinking[v1/v2]` — end-to-end test verifying the fix.

## Verification

```
# All new tests pass, no regressions in existing structured-output tests
python -m pytest \
  tests/test_react_agent.py::test_strip_thinking_if_enabled \
  "tests/test_react_agent.py::test_react_agent_structured_response_strips_thinking[v1]" \
  "tests/test_react_agent.py::test_react_agent_structured_response_strips_thinking[v2]" \
  tests/test_react_agent.py::test_react_agent_with_structured_response \
  tests/test_react_agent.py::test_get_model \
  tests/test_react_agent.py::test_dynamic_model_with_structured_response \
  tests/test_react_agent.py::test_post_model_hook_with_structured_output
# 9 passed
```

`ruff check` and `ruff format --check` both pass.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/