### PR TITLE
enforce codespell across all libraries

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -87,6 +87,16 @@ jobs:
             ${{ inputs.working-directory }}/.mypy_cache_test
           key: mypy-test-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ inputs.working-directory }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory)) }}
 
+      - name: Spell check with codespell
+        if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if make spell_check > /dev/null 2>&1; then
+            make spell_check
+          else
+            echo "spell_check command not found, skipping step"
+          fi
+
       - name: Analysing tests with our lint
         if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'
         working-directory: ${{ inputs.working-directory }}

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,26 @@ lock-upgrade:
 		fi; \
 	done
 
+# Spell check all projects
+.PHONY: spell_check
+spell_check:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ]; then \
+			echo "Running spell_check in $$dir"; \
+			$(MAKE) -C $$dir spell_check; \
+		fi; \
+	done
+
+# Spell fix all projects
+.PHONY: spell_fix
+spell_fix:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ]; then \
+			echo "Running spell_fix in $$dir"; \
+			$(MAKE) -C $$dir spell_fix; \
+		fi; \
+	done
+
 # Test all projects
 .PHONY: test
 test:

--- a/libs/checkpoint-conformance/Makefile
+++ b/libs/checkpoint-conformance/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test
+.PHONY: format lint test spell_check spell_fix
 
 format:
 	uv run ruff format .
@@ -7,6 +7,12 @@ format:
 lint:
 	uv run ruff check .
 	uv run ty check
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w
 
 test:
 	uv run pytest $(TEST)

--- a/libs/checkpoint-conformance/pyproject.toml
+++ b/libs/checkpoint-conformance/pyproject.toml
@@ -24,6 +24,7 @@ test = [
 ]
 lint = [
   "ruff",
+  "codespell",
   "ty",
 ]
 dev = [
@@ -57,6 +58,9 @@ lint.select = [
 ]
 lint.ignore = ["E501", "B008"]
 target-version = "py310"
+
+[tool.codespell]
+ignore-words-list = "langgraph,langchain,checkpointer,checkpointing"
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -67,3 +67,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -79,6 +79,9 @@ warn_redundant_casts = "True"
 allow_redefinition = "True"
 disable_error_code = "typeddict-item, return-value"
 
+[tool.codespell]
+ignore-words-list = "langgraph,langchain,checkpointer,checkpointing"
+
 [tool.pytest-watcher]
 now = true
 delay = 0.1

--- a/libs/checkpoint-sqlite/Makefile
+++ b/libs/checkpoint-sqlite/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-sqlite/pyproject.toml
+++ b/libs/checkpoint-sqlite/pyproject.toml
@@ -82,3 +82,6 @@ warn_unused_ignores = "True"
 warn_redundant_casts = "True"
 allow_redefinition = "True"
 disable_error_code = "typeddict-item, return-value"
+
+[tool.codespell]
+ignore-words-list = "langgraph,langchain,checkpointer,checkpointing"

--- a/libs/checkpoint/Makefile
+++ b/libs/checkpoint/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,9 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -79,3 +79,6 @@ warn_unused_ignores = "True"
 warn_redundant_casts = "True"
 allow_redefinition = "True"
 disable_error_code = "typeddict-item, return-value"
+
+[tool.codespell]
+ignore-words-list = "langgraph,langchain,checkpointer,checkpointing"

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint type format test-integration update-schema bump-version
+.PHONY: test lint type format test-integration spell_check spell_fix update-schema bump-version
 
 ######################
 # TESTING AND COVERAGE
@@ -35,6 +35,12 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w
 
 update-schema:
 	uv run python generate_schema.py

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -74,3 +74,6 @@ lint.select = [
 ]
 lint.ignore = ["E501", "B008"]
 target-version = "py310"
+
+[tool.codespell]
+ignore-words-list = "langgraph,langchain"

--- a/libs/sdk-py/Makefile
+++ b/libs/sdk-py/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint type format test
+.PHONY: lint type format test spell_check spell_fix
 
 test:
 	uv run pytest tests
@@ -25,3 +25,9 @@ type:
 format format_diff:
 	uv run ruff check --select I --fix $(PYTHON_FILES)
 	uv run ruff format $(PYTHON_FILES)
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -81,5 +81,8 @@ ignore = [
 ]
 per-file-ignores = { "tests/**" = ["S101", "B017"] }
 
+[tool.codespell]
+ignore-words-list = "langgraph,langchain"
+
 [tool.ty.rules]
 no-matching-overload = "ignore"


### PR DESCRIPTION
Closes #5021

## Summary

- Added `spell_check` and `spell_fix` Makefile targets to every library that was missing them (cli, checkpoint, checkpoint-sqlite, checkpoint-postgres, checkpoint-conformance, sdk-py)
- Wired up `[tool.codespell]` config in each library's `pyproject.toml` with appropriate ignore lists
- Added unified root-level `spell_check` / `spell_fix` targets that iterate over all libs
- Added a codespell step to the CI lint workflow so typos get caught automatically on PRs

## Motivation

As mentioned in #5021, having codespell enforced repo-wide should cut down on the constant stream of docs typo fix PRs. Two libraries (langgraph, prebuilt) already had this set up — this brings the rest in line.

## Test plan

- [ ] Run `make spell_check` from the repo root to verify it iterates all libs correctly
- [ ] Confirm CI lint workflow picks up the new codespell step
- [ ] Check that existing code passes without false positives (ignore lists tuned per library)