### PR TITLE
fix(langgraph): preserve openai-formatted message metadata

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 import warnings
 from collections.abc import Callable, Sequence
+from copy import deepcopy
 from functools import partial
 from typing import (
     Annotated,
@@ -321,7 +322,26 @@ def _format_messages(messages: Sequence[BaseMessage]) -> list[BaseMessage]:
         warnings.warn(msg)
         return list(messages)
     else:
-        return convert_to_messages(convert_to_openai_messages(messages))
+        additional_kwargs_by_id = {
+            m.id: deepcopy(m.additional_kwargs)
+            for m in messages
+            if m.id is not None and m.additional_kwargs
+        }
+        formatted_messages = convert_to_messages(
+            convert_to_openai_messages(messages, include_id=True)
+        )
+        for m in formatted_messages:
+            if m.id is None:
+                continue
+            original_additional_kwargs = additional_kwargs_by_id.get(m.id)
+            if not original_additional_kwargs:
+                continue
+            if not m.additional_kwargs:
+                m.additional_kwargs = original_additional_kwargs
+            else:
+                for key, value in original_additional_kwargs.items():
+                    m.additional_kwargs.setdefault(key, value)
+        return formatted_messages
 
 
 def push_message(

--- a/libs/langgraph/tests/test_messages_state.py
+++ b/libs/langgraph/tests/test_messages_state.py
@@ -208,6 +208,50 @@ def test_messages_state(state_schema):
     condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
     reason="Requires langchain_core>=0.3.11.",
 )
+def test_add_messages_format_openai_preserves_ids():
+    initial = add_messages(
+        [], [HumanMessage(content="hello", id="msg-1")], format="langchain-openai"
+    )
+
+    result = add_messages(
+        initial,
+        [HumanMessage(content="hello again", id="msg-1")],
+        format="langchain-openai",
+    )
+
+    assert result == [HumanMessage(content="hello again", id="msg-1")]
+
+
+@pytest.mark.skipif(
+    condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
+    reason="Requires langchain_core>=0.3.11.",
+)
+def test_add_messages_format_openai_preserves_additional_kwargs():
+    result = add_messages(
+        [],
+        [
+            AIMessage(
+                content="hello",
+                id="msg-1",
+                additional_kwargs={"widgets": [{"type": "carousel"}]},
+            )
+        ],
+        format="langchain-openai",
+    )
+
+    assert result == [
+        AIMessage(
+            content="hello",
+            id="msg-1",
+            additional_kwargs={"widgets": [{"type": "carousel"}]},
+        )
+    ]
+
+
+@pytest.mark.skipif(
+    condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
+    reason="Requires langchain_core>=0.3.11.",
+)
 def test_messages_state_format_openai():
     class State(TypedDict):
         messages: Annotated[list[AnyMessage], add_messages(format="langchain-openai")]


### PR DESCRIPTION
## Summary
- preserve message IDs when `add_messages(format="langchain-openai")` round-trips through OpenAI message dicts
- restore custom `additional_kwargs` that are not represented in the OpenAI wire format
- add focused regression tests for ID-based updates and custom kwargs preservation

## Why
OpenAI-format conversion was dropping message `id` values and custom `additional_kwargs`, which broke ID-based overwrites and removed metadata that callers attached to the original messages.

## Impact
This keeps `add_messages(format="langchain-openai")` safe to use in append-or-update flows and preserves caller-provided message metadata across the formatting round-trip.

## Verification
- reproduced the bug locally with a minimal `add_messages(format="langchain-openai")` example
- verified that message IDs are preserved across formatting round-trips
- verified that custom `additional_kwargs` are preserved across formatting round-trips
- verified the existing OpenAI-format graph behavior still matches the current expected output
