### PR TITLE
fix: extract default from Pydantic model_fields for Annotated fields

### DIFF
--- a/libs/langgraph/langgraph/_internal/_fields.py
+++ b/libs/langgraph/langgraph/_internal/_fields.py
@@ -101,6 +101,16 @@ def get_field_default(name: str, type_: Any, schema: type[Any]) -> Any:
             return ...
         # Handle NotRequired[<type>] for earlier versions of python
         return None
+    # Pydantic BaseModel - extract default from model_fields
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        if hasattr(schema, "model_fields") and name in schema.model_fields:
+            field = schema.model_fields[name]
+            if hasattr(field, "default_factory") and field.default_factory is not None:
+                return field.default_factory()
+            elif hasattr(field, "default") and field.default is not None:
+                from pydantic import PydanticUndefined
+                if field.default is not PydanticUndefined:
+                    return field.default
     if dataclasses.is_dataclass(schema):
         field_info = next(
             (f for f in dataclasses.fields(schema) if f.name == name), None


### PR DESCRIPTION
## Summary

When a Pydantic BaseModel state schema has a field annotated with both a reducer function (e.g., `Annotated[list[str], extend_list]`) and a `Field(default_factory=...)`, the `get_field_default` function was not extracting the default value. It would return `...` (required) instead of the actual default.

## Root Cause

The `get_field_default` function in `libs/langgraph/langgraph/_internal/_fields.py` only handled:
1. TypedDict required/optional keys
2. Dataclass defaults
3. Optional type annotations

It did **not** check `model_fields` on Pydantic BaseModels before falling through to the final `return ...`.

## Fix

Added Pydantic BaseModel handling before the dataclass check to extract `default`/`default_factory` from `model_fields`:



## Reproduction

```python
from typing import Annotated
from pydantic import BaseModel, Field

def extend_list(original, new):
    original.extend(new)
    return original

class OverallState(BaseModel):
    variable: Annotated[list[str], extend_list] = Field(default_factory=lambda: ['default'])

# Before fix: get_field_default returns ... (required)
# After fix:  get_field_default returns ['default']
```

Fixes langchain-ai/langgraph#5225