### PR TITLE
feat: add declarative A2A agent card support

### DIFF
--- a/docs/docs/how-tos/a2a.md
+++ b/docs/docs/how-tos/a2a.md
@@ -1,0 +1,103 @@
+# Serve a LangGraph agent as an A2A endpoint
+
+This guide shows how to attach a declarative **A2A Agent Card** to a LangGraph
+graph and serve it as an [Agent-to-Agent (A2A)](https://github.com/google/A2A)
+compatible endpoint.
+
+## Prerequisites
+
+```bash
+pip install langgraph[a2a]
+```
+
+## 1. Build your agent
+
+```python
+from langgraph.prebuilt import create_react_agent
+
+agent = create_react_agent(model, tools=[search, calculator])
+```
+
+## 2. Declare the Agent Card
+
+```python
+from langgraph.a2a import AgentCard, AgentSkill
+
+card = AgentCard(
+    name="Research Assistant",
+    description="Searches the web and performs calculations.",
+    url="https://research.mycompany.com",
+    org="My Company",
+    skills=[
+        AgentSkill(
+            id="web-search",
+            name="Web Search",
+            description="Search the web for current information.",
+            tags=["search", "research"],
+            examples=["What happened in AI this week?"],
+        ),
+        AgentSkill(
+            id="calculator",
+            name="Calculator",
+            description="Perform arithmetic and unit conversions.",
+            tags=["math"],
+            examples=["Convert 42 miles to kilometers"],
+        ),
+    ],
+)
+```
+
+## 3. Attach the card
+
+```python
+agent = agent.with_agent_card(card)
+```
+
+The card is now accessible at `agent.agent_card` and can be serialized:
+
+```python
+import json
+print(json.dumps(agent.agent_card.to_dict(), indent=2))
+```
+
+## 4. Serve the A2A endpoint
+
+```python
+agent.serve_a2a(host="0.0.0.0", port=8080)
+```
+
+This starts a Starlette server exposing:
+
+| Route | Method | Description |
+|---|---|---|
+| `/.well-known/agent.json` | GET | Agent Card discovery |
+| `/` | POST | A2A `tasks/send` endpoint |
+
+## 5. Verify with curl
+
+**Discover the agent:**
+
+```bash
+curl http://localhost:8080/.well-known/agent.json | jq .
+```
+
+**Send a task:**
+
+```bash
+curl -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "task-001",
+    "message": {
+      "role": "user",
+      "parts": {"text": "What happened in AI this week?"}
+    }
+  }'
+```
+
+## API reference
+
+- `AgentCard` — declarative metadata (name, description, url, skills, auth)
+- `AgentSkill` — individual skill with id, name, description, tags, examples
+- `graph.with_agent_card(card)` — attach a card (fluent, returns self)
+- `graph.serve_a2a(host, port, config)` — start the A2A server

--- a/libs/langgraph/langgraph/a2a/__init__.py
+++ b/libs/langgraph/langgraph/a2a/__init__.py
@@ -1,0 +1,3 @@
+from langgraph.a2a.types import AgentCard, AgentSkill
+
+__all__ = ("AgentCard", "AgentSkill")

--- a/libs/langgraph/langgraph/a2a/server.py
+++ b/libs/langgraph/langgraph/a2a/server.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_server(
+    graph: Any,
+    *,
+    host: str,
+    port: int,
+    config: dict[str, Any],
+) -> None:
+    """Wire *graph* + its `agent_card` into an A2A-compliant Starlette app.
+
+    Only imported when the ``langgraph[a2a]`` extra is installed.
+    """
+    import uvicorn
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response
+    from starlette.routing import Route
+
+    card_dict = graph.agent_card.to_dict()
+
+    async def agent_card_endpoint(request: Request) -> Response:
+        return JSONResponse(card_dict)
+
+    async def task_endpoint(request: Request) -> Response:
+        body = await request.json()
+        user_message = _extract_user_message(body)
+        thread_id = body.get("id", "default")
+
+        run_config: dict[str, Any] = {**config}
+        if graph.checkpointer is not None:
+            run_config.setdefault("configurable", {})["thread_id"] = thread_id
+
+        result_parts: list[str] = []
+        async for event in graph.astream(
+            {"messages": [{"role": "user", "content": user_message}]},
+            config=run_config,
+            stream_mode="values",
+        ):
+            msgs = event.get("messages", [])
+            if msgs:
+                last = msgs[-1]
+                content = getattr(last, "content", "")
+                if content:
+                    result_parts.append(str(content))
+
+        return JSONResponse(_build_a2a_response(body.get("id"), result_parts))
+
+    app = Starlette(
+        routes=[
+            Route(
+                "/.well-known/agent.json",
+                agent_card_endpoint,
+                methods=["GET"],
+            ),
+            Route("/", task_endpoint, methods=["POST"]),
+        ]
+    )
+
+    uvicorn.run(app, host=host, port=port)
+
+
+def _extract_user_message(body: dict[str, Any]) -> str:
+    """Extract text from an A2A ``tasks/send`` request body."""
+    try:
+        return str(body["message"]["parts"]["text"])
+    except (KeyError, IndexError, TypeError):
+        return str(body)
+
+
+def _build_a2a_response(task_id: str | None, parts: list[str]) -> dict[str, Any]:
+    return {
+        "id": task_id,
+        "status": {"state": "completed"},
+        "artifacts": [{"parts": [{"type": "text", "text": p} for p in parts]}],
+    }

--- a/libs/langgraph/langgraph/a2a/types.py
+++ b/libs/langgraph/langgraph/a2a/types.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class AgentSkill:
+    """A skill that an A2A agent can perform."""
+
+    id: str
+    """Slug identifier, e.g. ``web-search``."""
+    name: str
+    """Human-readable label, e.g. ``Web Search``."""
+    description: str
+    """What this skill does."""
+    tags: list[str] = field(default_factory=list)
+    """Freeform tags for categorisation."""
+    examples: list[str] = field(default_factory=list)
+    """Sample user messages that trigger this skill."""
+
+
+@dataclass
+class AgentCard:
+    """Declarative metadata describing an A2A-compatible agent.
+
+    Attach an `AgentCard` to a compiled LangGraph graph via
+    `graph.with_agent_card(card)` so it can be served as an A2A endpoint.
+    """
+
+    name: str
+    """Agent display name."""
+    description: str
+    """Short description (recommended <= 200 chars)."""
+    url: str
+    """Base URL where this agent is hosted."""
+    version: str = "1.0.0"
+    """Semantic version of the agent."""
+    org: str = ""
+    """Organisation name (shown under ``provider``)."""
+    org_url: str = ""
+    """Organisation URL."""
+    skills: list[AgentSkill] = field(default_factory=list)
+    """Capabilities this agent exposes."""
+    auth_scheme: Literal["apiKey", "bearer", "none"] = "apiKey"
+    """Authentication scheme advertised in the card."""
+    streaming: bool = True
+    """Whether streaming is supported (always True for LangGraph)."""
+    push_notifications: bool = False
+    """Whether push notifications are supported."""
+    state_transition_history: bool = False
+    """Whether state transition history is supported."""
+
+    def to_dict(self) -> dict:
+        """Serialize to the canonical A2A agent card JSON shape."""
+        card: dict = {
+            "name": self.name,
+            "description": self.description,
+            "url": self.url,
+            "version": self.version,
+            "capabilities": {
+                "streaming": self.streaming,
+                "pushNotifications": self.push_notifications,
+                "stateTransitionHistory": self.state_transition_history,
+            },
+            "defaultInputModes": ["text/plain", "application/json"],
+            "defaultOutputModes": ["text/plain", "application/json"],
+            "skills": [
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "description": s.description,
+                    "tags": s.tags,
+                    "examples": s.examples,
+                }
+                for s in self.skills
+            ],
+        }
+        if self.org:
+            card["provider"] = {"organization": self.org, "url": self.org_url}
+        if self.auth_scheme != "none":
+            card["securitySchemes"] = (
+                {"apiKey": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}
+                if self.auth_scheme == "apiKey"
+                else {"bearer": {"type": "http", "scheme": "bearer"}}
+            )
+            card["security"] = (
+                [{"apiKey": []}] if self.auth_scheme == "apiKey" else [{"bearer": []}]
+            )
+        return card

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -20,6 +20,7 @@ from dataclasses import is_dataclass
 from functools import partial
 from inspect import isclass
 from typing import (
+    TYPE_CHECKING,
     Any,
     Generic,
     Literal,
@@ -27,6 +28,9 @@ from typing import (
     get_type_hints,
     overload,
 )
+
+if TYPE_CHECKING:
+    from langgraph.a2a.types import AgentCard
 from uuid import UUID, uuid5
 
 from langchain_core.globals import get_debug
@@ -3520,6 +3524,47 @@ class Pregel(
             return latest
         else:
             return chunks
+
+    # -- A2A card support --------------------------------------------------
+
+    def with_agent_card(self, card: AgentCard) -> Self:
+        """Attach an A2A `AgentCard` to this compiled graph.
+
+        Returns `self` so it can be chained at compile time::
+
+            graph = builder.compile().with_agent_card(card)
+
+        The card is accessible as `graph.agent_card` and is serialized to
+        ``/.well-known/agent.json`` when `serve_a2a` is called.
+        """
+        self.agent_card = card
+        return self
+
+    def serve_a2a(
+        self,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+        config: dict | None = None,
+    ) -> None:
+        """Start a standards-compliant A2A server for this graph.
+
+        Requires ``pip install langgraph[a2a]``.
+        The graph must have an `AgentCard` attached via `with_agent_card` first.
+
+        Exposes:
+            - ``GET  /.well-known/agent.json`` — the AgentCard JSON
+            - ``POST /`` — A2A task endpoint (``tasks/send``)
+        """
+        if not hasattr(self, "agent_card"):
+            raise RuntimeError(
+                "No AgentCard attached. Call graph.with_agent_card(card) first."
+            )
+        try:
+            from langgraph.a2a.server import run_server
+        except ImportError:
+            raise ImportError("A2A server support requires: pip install langgraph[a2a]")
+        run_server(self, host=host, port=port, config=config or {})
 
     def clear_cache(self, nodes: Sequence[str] | None = None) -> None:
         """Clear the cache for the given nodes."""

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -42,6 +42,12 @@ Twitter = "https://x.com/LangChain"
 Slack = "https://www.langchain.com/join-community"
 Reddit = "https://www.reddit.com/r/LangChain/"
 
+[project.optional-dependencies]
+a2a = [
+    "uvicorn>=0.29",
+    "starlette>=0.37",
+]
+
 [dependency-groups]
 test = [
     "pytest",

--- a/libs/langgraph/tests/test_a2a.py
+++ b/libs/langgraph/tests/test_a2a.py
@@ -1,0 +1,160 @@
+"""Tests for the declarative A2A card attachment system."""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+
+import pytest
+
+from langgraph.a2a.types import AgentCard, AgentSkill
+from langgraph.graph import END, START, StateGraph
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_graph():
+    """Return a minimal compiled StateGraph."""
+
+    class State(dict):
+        messages: Annotated[list, lambda a, b: a + b]
+
+    def noop(state: State) -> State:
+        return state
+
+    builder = StateGraph(State)
+    builder.add_node("noop", noop)
+    builder.add_edge(START, "noop")
+    builder.add_edge("noop", END)
+    return builder.compile()
+
+
+@pytest.fixture
+def simple_graph():
+    return _make_graph()
+
+
+# ---------------------------------------------------------------------------
+# with_agent_card
+# ---------------------------------------------------------------------------
+
+
+def test_with_agent_card_attaches_card(simple_graph):
+    card = AgentCard(name="Test", description="desc", url="http://localhost")
+    g = simple_graph.with_agent_card(card)
+    assert g.agent_card is card
+
+
+def test_with_agent_card_returns_self(simple_graph):
+    card = AgentCard(name="Test", description="desc", url="http://localhost")
+    assert simple_graph.with_agent_card(card) is simple_graph
+
+
+# ---------------------------------------------------------------------------
+# serve_a2a pre-condition
+# ---------------------------------------------------------------------------
+
+
+def test_serve_a2a_raises_without_card(simple_graph):
+    with pytest.raises(RuntimeError, match="with_agent_card"):
+        simple_graph.serve_a2a()
+
+
+# ---------------------------------------------------------------------------
+# AgentCard.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_agent_card_to_dict_shape():
+    skill = AgentSkill(
+        id="s1",
+        name="Search",
+        description="Searches web",
+        tags=["search"],
+        examples=["find X"],
+    )
+    card = AgentCard(
+        name="MyAgent",
+        description="Does things",
+        url="https://agent.example.com",
+        skills=[skill],
+    )
+    d = card.to_dict()
+    assert d["name"] == "MyAgent"
+    assert d["capabilities"]["streaming"] is True
+    assert len(d["skills"]) == 1
+    assert d["skills"][0]["id"] == "s1"
+    assert "/.well-known" not in str(d)
+
+
+def test_agent_card_no_auth():
+    card = AgentCard(name="X", description="Y", url="Z", auth_scheme="none")
+    d = card.to_dict()
+    assert "securitySchemes" not in d
+    assert "security" not in d
+
+
+def test_agent_card_bearer_auth():
+    card = AgentCard(name="X", description="Y", url="Z", auth_scheme="bearer")
+    d = card.to_dict()
+    assert "bearer" in d["securitySchemes"]
+    assert d["security"] == [{"bearer": []}]
+
+
+def test_agent_card_apikey_auth():
+    card = AgentCard(name="X", description="Y", url="Z", auth_scheme="apiKey")
+    d = card.to_dict()
+    assert "apiKey" in d["securitySchemes"]
+    assert d["security"] == [{"apiKey": []}]
+
+
+def test_agent_card_provider_present():
+    card = AgentCard(
+        name="X",
+        description="Y",
+        url="Z",
+        org="Acme",
+        org_url="https://acme.com",
+    )
+    d = card.to_dict()
+    assert d["provider"]["organization"] == "Acme"
+    assert d["provider"]["url"] == "https://acme.com"
+
+
+def test_agent_card_provider_absent():
+    card = AgentCard(name="X", description="Y", url="Z")
+    d = card.to_dict()
+    assert "provider" not in d
+
+
+def test_state_transition_history_flag():
+    card = AgentCard(
+        name="X",
+        description="Y",
+        url="Z",
+        state_transition_history=True,
+    )
+    d = card.to_dict()
+    assert d["capabilities"]["stateTransitionHistory"] is True
+
+
+def test_default_io_modes():
+    card = AgentCard(name="X", description="Y", url="Z")
+    d = card.to_dict()
+    assert "text/plain" in d["defaultInputModes"]
+    assert "application/json" in d["defaultOutputModes"]
+
+
+# ---------------------------------------------------------------------------
+# serve_a2a import error
+# ---------------------------------------------------------------------------
+
+
+def test_serve_a2a_import_error(simple_graph, monkeypatch):
+    card = AgentCard(name="X", description="Y", url="Z")
+    simple_graph.with_agent_card(card)
+    monkeypatch.setitem(sys.modules, "langgraph.a2a.server", None)
+    with pytest.raises(ImportError, match=r"pip install langgraph\[a2a\]"):
+        simple_graph.serve_a2a()

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -384,7 +384,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -1378,6 +1378,12 @@ dependencies = [
     { name = "xxhash" },
 ]
 
+[package.optional-dependencies]
+a2a = [
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
@@ -1444,8 +1450,11 @@ requires-dist = [
     { name = "langgraph-prebuilt", editable = "../prebuilt" },
     { name = "langgraph-sdk", editable = "../sdk-py" },
     { name = "pydantic", specifier = ">=2.7.4" },
+    { name = "starlette", marker = "extra == 'a2a'", specifier = ">=0.37" },
+    { name = "uvicorn", marker = "extra == 'a2a'", specifier = ">=0.29" },
     { name = "xxhash", specifier = ">=3.5.0" },
 ]
+provides-extras = ["a2a"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3497,8 +3506,8 @@ name = "starlette"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/65/5a1fadcc40c5fdc7df421a7506b79633af8f5d5e3a95c3e72acacec644b9/starlette-0.51.0.tar.gz", hash = "sha256:4c4fda9b1bc67f84037d3d14a5112e523509c369d9d47b111b2f984b0cc5ba6c", size = 2647658, upload-time = "2026-01-10T20:23:15.043Z" }
 wheels = [
@@ -3744,8 +3753,9 @@ name = "uvicorn"
 version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "h11", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [


### PR DESCRIPTION
Closes #7398

## Summary

- Add `AgentCard` and `AgentSkill` dataclasses in `langgraph.a2a` for declaring A2A-compatible agent metadata
- Add `Pregel.with_agent_card(card)` fluent method to attach a card to any compiled graph
- Add `Pregel.serve_a2a()` to start a Starlette-based A2A server (gated behind `pip install langgraph[a2a]`)
- Expose `GET /.well-known/agent.json` (discovery) and `POST /` (tasks/send) endpoints

## Design

The developer declares everything explicitly — no inference, no magic. This follows the same pattern as `@app.route()` metadata in Flask or `openapi_extra` in FastAPI:

```python
from langgraph.a2a import AgentCard, AgentSkill

card = AgentCard(
    name="Research Assistant",
    description="Searches the web and performs calculations.",
    url="https://research.mycompany.com",
    skills=[AgentSkill(id="web-search", name="Web Search", ...)],
)

graph = builder.compile().with_agent_card(card)
graph.serve_a2a(port=8080)
```

## Files changed

| File | What |
|---|---|
| `libs/langgraph/langgraph/a2a/__init__.py` | Re-exports `AgentCard`, `AgentSkill` |
| `libs/langgraph/langgraph/a2a/types.py` | Dataclasses with `to_dict()` serialization |
| `libs/langgraph/langgraph/a2a/server.py` | Starlette server glue (lazy-imported) |
| `libs/langgraph/langgraph/pregel/main.py` | `with_agent_card()` and `serve_a2a()` on `Pregel` |
| `libs/langgraph/pyproject.toml` | `[project.optional-dependencies] a2a` extra |
| `libs/langgraph/uv.lock` | Lock file update for new optional deps |
| `libs/langgraph/tests/test_a2a.py` | 12 tests covering card attachment, serialization, error handling |
| `docs/docs/how-tos/a2a.md` | How-to guide with full usage example |

## Test plan

- [x] `make format` — clean
- [x] `make lint` (ruff + mypy) — clean
- [x] `TEST=tests/test_a2a.py make test` — 12/12 pass
- [ ] Verify no regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)