### PR TITLE
ci: re-run `require_issue_link` check after PR reopen, close stale comments

### DIFF
--- a/.github/workflows/reopen_on_assignment.yml
+++ b/.github/workflows/reopen_on_assignment.yml
@@ -21,6 +21,7 @@ jobs:
   reopen-linked-prs:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       pull-requests: write
 
     steps:
@@ -157,5 +158,38 @@ jobs:
                 }
               } catch (e) {
                 core.warning(`Could not minimize stale comment on PR #${prNumber}: ${e.message}`);
+              }
+
+              // Re-run the failed require_issue_link check so it picks up the
+              // new assignment.  The re-run uses the original event payload but
+              // fetches live issue data, so the assignment check will pass.
+              //
+              // Limitation: we look up runs by the PR's current head SHA.  If the
+              // contributor pushed new commits while the PR was closed, head.sha
+              // won't match the SHA of the original failed run and the query will
+              // return 0 results.  This is acceptable because any push after reopen
+              // triggers a fresh require_issue_link run against the new SHA.
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner, repo, pull_number: prNumber,
+                });
+                const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                  owner, repo,
+                  workflow_id: 'require_issue_link.yml',
+                  head_sha: pr.head.sha,
+                  status: 'failure',
+                  per_page: 1,
+                });
+                if (runs.workflow_runs.length > 0) {
+                  await github.rest.actions.reRunWorkflowFailedJobs({
+                    owner, repo,
+                    run_id: runs.workflow_runs[0].id,
+                  });
+                  console.log(`Re-ran failed require_issue_link run ${runs.workflow_runs[0].id} for PR #${prNumber}`);
+                } else {
+                  console.log(`No failed require_issue_link runs found for PR #${prNumber} — skipping re-run`);
+                }
+              } catch (e) {
+                core.warning(`Could not re-run require_issue_link check for PR #${prNumber} (HTTP ${e.status ?? 'unknown'}): ${e.message}`);
               }
             }


### PR DESCRIPTION
Combined:

(1)

After reopening a PR and removing the `missing-issue-link` label, the `require_issue_link` check still shows as failed on the PR. Because the default `GITHUB_TOKEN` suppresses event-driven re-triggers, the old red check persists until the contributor pushes again. This adds a best-effort re-run of the failed check so the PR's status clears automatically on assignment.

(2)

When the `require_issue_link` workflow closes a PR and posts an enforcement comment, that comment was never cleaned up after the situation resolved — leaving a stale "automatically closed" message visible on reopened PRs. Now all three resolution paths (maintainer bypass, author fixing the issue link, and contributor assignment) minimize the enforcement comment as outdated via GraphQL. The cleanup is best-effort: failures log a warning but never block the primary workflow logic (label removal, bypass, reopen).