### PR TITLE
ci: add unified spell_check targets across the monorepo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,26 @@ lock-upgrade:
 		fi; \
 	done
 
+# Spell check all projects
+.PHONY: spell_check
+spell_check:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ] && grep -q spell_check $$dir/Makefile; then \
+			echo "Running spell_check in $$dir"; \
+			$(MAKE) -C $$dir spell_check; \
+		fi; \
+	done
+
+# Spell fix all projects
+.PHONY: spell_fix
+spell_fix:
+	@for dir in $(LIBS_DIRS); do \
+		if [ -f $$dir/Makefile ] && grep -q spell_fix $$dir/Makefile; then \
+			echo "Running spell_fix in $$dir"; \
+			$(MAKE) -C $$dir spell_fix; \
+		fi; \
+	done
+
 # Test all projects
 .PHONY: test
 test:

--- a/libs/checkpoint-conformance/Makefile
+++ b/libs/checkpoint-conformance/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test
+.PHONY: format lint test spell_check spell_fix
 
 format:
 	uv run ruff format .
@@ -10,3 +10,13 @@ lint:
 
 test:
 	uv run pytest $(TEST)
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -67,3 +67,13 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint-sqlite/Makefile
+++ b/libs/checkpoint-sqlite/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,13 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --select I --fix $(PYTHON_FILES)
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/checkpoint/Makefile
+++ b/libs/checkpoint/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_watch lint type format
+.PHONY: test test_watch lint type format spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -38,3 +38,13 @@ type:
 format format_diff:
 	uv run ruff format $(PYTHON_FILES)
 	uv run ruff check --fix $(PYTHON_FILES)
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint type format test-integration update-schema bump-version
+.PHONY: test lint type format test-integration update-schema bump-version spell_check spell_fix
 
 ######################
 # TESTING AND COVERAGE
@@ -41,3 +41,13 @@ update-schema:
 
 bump-version:
 	uv run hatch version patch
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w

--- a/libs/sdk-py/Makefile
+++ b/libs/sdk-py/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint type format test
+.PHONY: lint type format test spell_check spell_fix
 
 test:
 	uv run pytest tests
@@ -25,3 +25,13 @@ type:
 format format_diff:
 	uv run ruff check --select I --fix $(PYTHON_FILES)
 	uv run ruff format $(PYTHON_FILES)
+
+######################
+# SPELL CHECK
+######################
+
+spell_check:
+	uv run codespell --toml pyproject.toml
+
+spell_fix:
+	uv run codespell --toml pyproject.toml -w


### PR DESCRIPTION
Fixes #5021

## Summary

Adds `spell_check` and `spell_fix` Makefile targets to all Python libraries that were missing them, plus root-level targets that iterate over all sub-projects.

### Changes

- **Root `Makefile`**: Added `spell_check` and `spell_fix` targets that loop over all `libs/` sub-directories (same pattern as existing `lint`, `format`, `test` targets)
- **6 sub-project `Makefile`s**: Added `spell_check` and `spell_fix` targets to `checkpoint`, `checkpoint-postgres`, `checkpoint-sqlite`, `cli`, `sdk-py`, and `checkpoint-conformance`

All targets use the same convention already established in `libs/langgraph` and `libs/prebuilt`:

```makefile
spell_check:
	uv run codespell --toml pyproject.toml

spell_fix:
	uv run codespell --toml pyproject.toml -w
```

### Usage

```bash
# Check spelling across all libraries
make spell_check

# Auto-fix spelling across all libraries
make spell_fix

# Or per-library
cd libs/checkpoint && make spell_check
```

## Test plan

- [x] Verified `spell_check` and `spell_fix` targets exist in all 8 Python library Makefiles
- [x] Root `make spell_check` iterates only over sub-projects that have the target (via `grep -q` guard)
- [x] No changes to existing `libs/langgraph` or `libs/prebuilt` Makefiles (already had these targets)