### PR TITLE
fix: missing f-string prefix and sync SDK docstring examples

### DIFF
--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -901,7 +901,7 @@ def get_build_tools_to_uninstall(config: Config) -> tuple[str]:
     else:
         raise ValueError(
             f"Invalid value for keep_pkg_tools: {keep_pkg_tools}."
-            " Expected True or a list containing any of {expected}."
+            f" Expected True or a list containing any of {expected}."
         )
 
 

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -266,7 +266,7 @@ class SyncRunsClient:
 
             ```python
             client = get_sync_client(url="http://localhost:2024")
-            async for chunk in client.runs.stream(
+            for chunk in client.runs.stream(
                 thread_id=None,
                 assistant_id="agent",
                 input={"messages": [{"role": "user", "content": "how are you?"}]},

--- a/libs/sdk-py/langgraph_sdk/_sync/threads.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/threads.py
@@ -586,7 +586,7 @@ class SyncThreadsClient:
 
             ```python
 
-            response = await client.threads.update_state(
+            response = client.threads.update_state(
                 thread_id="my_thread_id",
                 values={"messages":[{"role": "user", "content": "hello!"}]},
                 as_node="my_node",


### PR DESCRIPTION
## Summary
- Add missing `f` prefix in CLI config error message where `{expected}` was printed as literal text
- Fix `async for` → `for` in sync client `runs.stream()` docstring example
- Fix `await` removal in sync client `threads.update_state()` docstring example

## Test plan
- [ ] Verify error message correctly interpolates the expected values
- [ ] Verify docstring examples match sync client usage patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)