### PR TITLE
fix(checkpoint): preserve created_at on InMemoryStore update

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,12 +407,14 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                now = datetime.now(timezone.utc)
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
-                    updated_at=datetime.now(timezone.utc),
+                    created_at=existing.created_at if existing else now,
+                    updated_at=now,
                 )
 
     def _extract_texts(

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1045,3 +1045,30 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_put_preserves_created_at_on_update() -> None:
+    """Test that updating an existing key preserves the original created_at."""
+    import time
+
+    store = InMemoryStore()
+    ns = ("test",)
+
+    # Initial put
+    store.put(ns, "key", {"v": 1})
+    item1 = store.get(ns, "key")
+    assert item1 is not None
+    original_created_at = item1.created_at
+
+    # Brief wait so timestamps differ
+    time.sleep(0.01)
+
+    # Update same key
+    store.put(ns, "key", {"v": 2})
+    item2 = store.get(ns, "key")
+    assert item2 is not None
+
+    # created_at should be preserved, updated_at should be newer
+    assert item2.created_at == original_created_at
+    assert item2.updated_at > original_created_at
+    assert item2.value == {"v": 2}


### PR DESCRIPTION
Fixes #7411

## Changes

**`libs/checkpoint/langgraph/store/memory/__init__.py`:**
- `_apply_put_ops` now checks if the key already exists before creating the `Item`. If it does, the original `created_at` is preserved. `updated_at` is always set to the current time. This matches the PostgresStore behavior where `ON CONFLICT DO UPDATE` only sets `updated_at`.

**`libs/checkpoint/tests/test_store.py`:**
- Added `test_put_preserves_created_at_on_update` — puts a value, records `created_at`, updates the same key, asserts `created_at` is unchanged while `updated_at` is newer.

## Test plan

- [x] All existing checkpoint tests pass
- [x] New test verifies the fix