### PR TITLE
fix: correct f-string prefix, sync docstrings, and malformed URLs in SDK examples

### DIFF
--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -901,7 +901,7 @@ def get_build_tools_to_uninstall(config: Config) -> tuple[str]:
     else:
         raise ValueError(
             f"Invalid value for keep_pkg_tools: {keep_pkg_tools}."
-            " Expected True or a list containing any of {expected}."
+            f" Expected True or a list containing any of {expected}."
         )
 
 

--- a/libs/sdk-py/langgraph_sdk/_async/cron.py
+++ b/libs/sdk-py/langgraph_sdk/_async/cron.py
@@ -35,7 +35,7 @@ class CronClient:
     ???+ example "Example Usage"
 
         ```python
-        client = get_client(url="http://localhost:2024"))
+        client = get_client(url="http://localhost:2024")
         cron_job = await client.crons.create_for_thread(
             thread_id="thread_123",
             assistant_id="asst_456",

--- a/libs/sdk-py/langgraph_sdk/_async/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_async/runs.py
@@ -266,7 +266,7 @@ class RunsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost:2024)
+            client = get_client(url="http://localhost:2024")
             async for chunk in client.runs.stream(
                 thread_id=None,
                 assistant_id="agent",

--- a/libs/sdk-py/langgraph_sdk/_async/threads.py
+++ b/libs/sdk-py/langgraph_sdk/_async/threads.py
@@ -34,7 +34,7 @@ class ThreadsClient:
     ???+ example "Example"
 
         ```python
-        client = get_client(url="http://localhost:2024"))
+        client = get_client(url="http://localhost:2024")
         new_thread = await client.threads.create(metadata={"user_id": "123"})
         ```
     """
@@ -239,7 +239,7 @@ class ThreadsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost2024)
+            client = get_client(url="http://localhost:2024")
             await client.threads.delete(
                 thread_id="my_thread_id"
             )
@@ -381,7 +381,7 @@ class ThreadsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost:2024)
+            client = get_client(url="http://localhost:2024")
             await client.threads.copy(
                 thread_id="my_thread_id"
             )
@@ -459,7 +459,7 @@ class ThreadsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost:2024)
+            client = get_client(url="http://localhost:2024")
             thread_state = await client.threads.get_state(
                 thread_id="my_thread_id",
                 checkpoint_id="my_checkpoint_id"
@@ -597,7 +597,7 @@ class ThreadsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost:2024)
+            client = get_client(url="http://localhost:2024")
             response = await client.threads.update_state(
                 thread_id="my_thread_id",
                 values={"messages":[{"role": "user", "content": "hello!"}]},
@@ -660,7 +660,7 @@ class ThreadsClient:
         ???+ example "Example Usage"
 
             ```python
-            client = get_client(url="http://localhost:2024)
+            client = get_client(url="http://localhost:2024")
             thread_state = await client.threads.get_history(
                 thread_id="my_thread_id",
                 limit=5,

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -266,7 +266,7 @@ class SyncRunsClient:
 
             ```python
             client = get_sync_client(url="http://localhost:2024")
-            async for chunk in client.runs.stream(
+            for chunk in client.runs.stream(
                 thread_id=None,
                 assistant_id="agent",
                 input={"messages": [{"role": "user", "content": "how are you?"}]},

--- a/libs/sdk-py/langgraph_sdk/_sync/store.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/store.py
@@ -24,7 +24,7 @@ class SyncStoreClient:
     ???+ example "Example"
 
         ```python
-        client = get_sync_client(url="http://localhost:2024"))
+        client = get_sync_client(url="http://localhost:2024")
         client.store.put_item(["users", "profiles"], "user123", {"name": "Alice", "age": 30})
         ```
     """

--- a/libs/sdk-py/langgraph_sdk/_sync/threads.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/threads.py
@@ -586,7 +586,7 @@ class SyncThreadsClient:
 
             ```python
 
-            response = await client.threads.update_state(
+            response = client.threads.update_state(
                 thread_id="my_thread_id",
                 values={"messages":[{"role": "user", "content": "hello!"}]},
                 as_node="my_node",


### PR DESCRIPTION
## Summary
- Add missing `f` prefix in CLI config error message where `{expected}` is printed literally
- Fix `async for` → `for` and remove `await` in sync client docstring examples
- Fix 6 missing closing quotes on `url="http://localhost:2024` in async SDK docstrings
- Fix missing colon in `localhost2024` → `localhost:2024`
- Fix 3 extra closing parentheses in SDK docstring examples

## Test plan
- [ ] Verify error message correctly interpolates expected values
- [ ] Verify SDK docstring examples have valid Python syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)