### PR TITLE
feat(checkpoint-postgres): configurable stateless postgres schema sup…

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -17,7 +17,7 @@ from langgraph.checkpoint.base import (
     get_serializable_checkpoint_metadata,
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
-from psycopg import Capabilities, Connection, Cursor, Pipeline
+from psycopg import Capabilities, Connection, Cursor, Pipeline, sql
 from psycopg.rows import DictRow, dict_row
 from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
@@ -39,8 +39,15 @@ class PostgresSaver(BasePostgresSaver):
         conn: _internal.Conn,
         pipe: Pipeline | None = None,
         serde: SerializerProtocol | None = None,
+        schema: str = "public",
     ) -> None:
         super().__init__(serde=serde)
+        if not schema or not isinstance(schema, str):
+            raise ValueError("Invalid schema")
+
+        self.schema = schema
+        self._setup_queries(schema)
+
         if isinstance(conn, ConnectionPool) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single Connection, not ConnectionPool."
@@ -54,7 +61,7 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls, conn_string: str, *, pipeline: bool = False, schema: str = "public"
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
@@ -70,9 +77,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, schema=schema)
             else:
-                yield cls(conn)
+                yield cls(conn, schema=schema)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -82,9 +89,16 @@ class PostgresSaver(BasePostgresSaver):
         the first time checkpointer is used.
         """
         with self._cursor() as cur:
+            cur.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                    sql.Identifier(self.schema)
+                )
+            )
             cur.execute(self.MIGRATIONS[0])
             results = cur.execute(
-                "SELECT v FROM checkpoint_migrations ORDER BY v DESC LIMIT 1"
+                sql.SQL("SELECT v FROM {} ORDER BY v DESC LIMIT 1").format(
+                    sql.Identifier(self.schema, "checkpoint_migrations")
+                )
             )
             row = results.fetchone()
             if row is None:
@@ -97,7 +111,12 @@ class PostgresSaver(BasePostgresSaver):
                 strict=False,
             ):
                 cur.execute(migration)
-                cur.execute("INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,))
+                cur.execute(
+                    sql.SQL("INSERT INTO {} (v) VALUES (%s)").format(
+                        sql.Identifier(self.schema, "checkpoint_migrations")
+                    ),
+                    (v,),
+                )
         if self.pipe:
             self.pipe.sync()
 
@@ -378,15 +397,21 @@ class PostgresSaver(BasePostgresSaver):
         """
         with self._cursor(pipeline=True) as cur:
             cur.execute(
-                "DELETE FROM checkpoints WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoints")
+                ),
                 (str(thread_id),),
             )
             cur.execute(
-                "DELETE FROM checkpoint_blobs WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoint_blobs")
+                ),
                 (str(thread_id),),
             )
             cur.execute(
-                "DELETE FROM checkpoint_writes WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoint_writes")
+                ),
                 (str(thread_id),),
             )
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -17,7 +17,7 @@ from langgraph.checkpoint.base import (
     get_serializable_checkpoint_metadata,
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
-from psycopg import AsyncConnection, AsyncCursor, AsyncPipeline, Capabilities
+from psycopg import AsyncConnection, AsyncCursor, AsyncPipeline, Capabilities, sql
 from psycopg.rows import DictRow, dict_row
 from psycopg.types.json import Jsonb
 from psycopg_pool import AsyncConnectionPool
@@ -39,8 +39,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
         conn: _ainternal.Conn,
         pipe: AsyncPipeline | None = None,
         serde: SerializerProtocol | None = None,
+        schema: str = "public",
     ) -> None:
         super().__init__(serde=serde)
+        if not schema or not isinstance(schema, str):
+            raise ValueError("Invalid schema")
+
+        self.schema = schema
+        self._setup_queries(schema)
+
         if isinstance(conn, AsyncConnectionPool) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single AsyncConnection, not AsyncConnectionPool."
@@ -60,6 +67,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        schema: str = "public",
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
@@ -75,9 +83,9 @@ class AsyncPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                    yield cls(conn=conn, pipe=pipe, serde=serde, schema=schema)
             else:
-                yield cls(conn=conn, serde=serde)
+                yield cls(conn=conn, serde=serde, schema=schema)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -87,9 +95,16 @@ class AsyncPostgresSaver(BasePostgresSaver):
         the first time checkpointer is used.
         """
         async with self._cursor() as cur:
+            await cur.execute(
+                sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                    sql.Identifier(self.schema)
+                )
+            )
             await cur.execute(self.MIGRATIONS[0])
             results = await cur.execute(
-                "SELECT v FROM checkpoint_migrations ORDER BY v DESC LIMIT 1"
+                sql.SQL("SELECT v FROM {} ORDER BY v DESC LIMIT 1").format(
+                    sql.Identifier(self.schema, "checkpoint_migrations")
+                )
             )
             row = await results.fetchone()
             if row is None:
@@ -103,7 +118,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
             ):
                 await cur.execute(migration)
                 await cur.execute(
-                    "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
+                    sql.SQL("INSERT INTO {} (v) VALUES (%s)").format(
+                        sql.Identifier(self.schema, "checkpoint_migrations")
+                    ),
+                    (v,),
                 )
         if self.pipe:
             await self.pipe.sync()
@@ -337,15 +355,21 @@ class AsyncPostgresSaver(BasePostgresSaver):
         """
         async with self._cursor(pipeline=True) as cur:
             await cur.execute(
-                "DELETE FROM checkpoints WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoints")
+                ),
                 (str(thread_id),),
             )
             await cur.execute(
-                "DELETE FROM checkpoint_blobs WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoint_blobs")
+                ),
                 (str(thread_id),),
             )
             await cur.execute(
-                "DELETE FROM checkpoint_writes WHERE thread_id = %s",
+                sql.SQL("DELETE FROM {} WHERE thread_id = %s").format(
+                    sql.Identifier(self.schema, "checkpoint_writes")
+                ),
                 (str(thread_id),),
             )
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -14,6 +14,7 @@ from langgraph.checkpoint.base import (
     get_checkpoint_id,
 )
 from langgraph.checkpoint.serde.types import TASKS
+from psycopg import sql
 from psycopg.types.json import Jsonb
 
 MetadataInput = dict[str, Any] | None
@@ -34,11 +35,25 @@ except Exception:
 To add a new migration, add a new string to the MIGRATIONS list.
 The position of the migration in the list is the version number.
 """
-MIGRATIONS = [
-    """CREATE TABLE IF NOT EXISTS checkpoint_migrations (
-    v INTEGER PRIMARY KEY
-);""",
-    """CREATE TABLE IF NOT EXISTS checkpoints (
+
+
+class BasePostgresSaver(BaseCheckpointSaver[str]):
+    MIGRATIONS: list[sql.Composed]
+    SELECT_SQL: sql.Composed
+    SELECT_PENDING_SENDS_SQL: sql.Composed
+    UPSERT_CHECKPOINT_BLOBS_SQL: sql.Composed
+    UPSERT_CHECKPOINTS_SQL: sql.Composed
+    UPSERT_CHECKPOINT_WRITES_SQL: sql.Composed
+    INSERT_CHECKPOINT_WRITES_SQL: sql.Composed
+
+    supports_pipeline: bool
+
+    def _setup_queries(self, schema: str) -> None:
+        self.MIGRATIONS = [
+            sql.SQL(
+                "CREATE TABLE IF NOT EXISTS {} (\n    v INTEGER PRIMARY KEY\n);"
+            ).format(sql.Identifier(schema, "checkpoint_migrations")),
+            sql.SQL("""CREATE TABLE IF NOT EXISTS {} (
     thread_id TEXT NOT NULL,
     checkpoint_ns TEXT NOT NULL DEFAULT '',
     checkpoint_id TEXT NOT NULL,
@@ -47,8 +62,8 @@ MIGRATIONS = [
     checkpoint JSONB NOT NULL,
     metadata JSONB NOT NULL DEFAULT '{}',
     PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
-);""",
-    """CREATE TABLE IF NOT EXISTS checkpoint_blobs (
+);""").format(sql.Identifier(schema, "checkpoints")),
+            sql.SQL("""CREATE TABLE IF NOT EXISTS {} (
     thread_id TEXT NOT NULL,
     checkpoint_ns TEXT NOT NULL DEFAULT '',
     channel TEXT NOT NULL,
@@ -56,8 +71,8 @@ MIGRATIONS = [
     type TEXT NOT NULL,
     blob BYTEA,
     PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
-);""",
-    """CREATE TABLE IF NOT EXISTS checkpoint_writes (
+);""").format(sql.Identifier(schema, "checkpoint_blobs")),
+            sql.SQL("""CREATE TABLE IF NOT EXISTS {} (
     thread_id TEXT NOT NULL,
     checkpoint_ns TEXT NOT NULL DEFAULT '',
     checkpoint_id TEXT NOT NULL,
@@ -67,24 +82,26 @@ MIGRATIONS = [
     type TEXT,
     blob BYTEA NOT NULL,
     PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
-);""",
-    "ALTER TABLE checkpoint_blobs ALTER COLUMN blob DROP not null;",
-    # NOTE: this is a no-op migration to ensure that the versions in the migrations table are correct.
-    # This is necessary due to an empty migration previously added to the list.
-    "SELECT 1;",
-    """
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoints_thread_id_idx ON checkpoints(thread_id);
-    """,
-    """
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_blobs_thread_id_idx ON checkpoint_blobs(thread_id);
-    """,
-    """
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_writes_thread_id_idx ON checkpoint_writes(thread_id);
-    """,
-    """ALTER TABLE checkpoint_writes ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';""",
-]
+);""").format(sql.Identifier(schema, "checkpoint_writes"), TASKS=sql.SQL(TASKS)),
+            sql.SQL("ALTER TABLE {} ALTER COLUMN blob DROP not null;").format(
+                sql.Identifier(schema, "checkpoint_blobs")
+            ),
+            sql.SQL("SELECT 1;"),
+            sql.SQL(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoints_thread_id_idx ON {}(thread_id);"
+            ).format(sql.Identifier(schema, "checkpoints")),
+            sql.SQL(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_blobs_thread_id_idx ON {}(thread_id);"
+            ).format(sql.Identifier(schema, "checkpoint_blobs")),
+            sql.SQL(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS checkpoint_writes_thread_id_idx ON {}(thread_id);"
+            ).format(sql.Identifier(schema, "checkpoint_writes")),
+            sql.SQL(
+                "ALTER TABLE {} ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';"
+            ).format(sql.Identifier(schema, "checkpoint_writes")),
+        ]
 
-SELECT_SQL = """
+        self.SELECT_SQL = sql.SQL("""
 select
     thread_id,
     checkpoint,
@@ -95,74 +112,66 @@ select
     (
         select array_agg(array[bl.channel::bytea, bl.type::bytea, bl.blob])
         from jsonb_each_text(checkpoint -> 'channel_versions')
-        inner join checkpoint_blobs bl
-            on bl.thread_id = checkpoints.thread_id
-            and bl.checkpoint_ns = checkpoints.checkpoint_ns
+        inner join {checkpoint_blobs} bl
+            on bl.thread_id = {checkpoints}.thread_id
+            and bl.checkpoint_ns = {checkpoints}.checkpoint_ns
             and bl.channel = jsonb_each_text.key
             and bl.version = jsonb_each_text.value
     ) as channel_values,
     (
         select
         array_agg(array[cw.task_id::text::bytea, cw.channel::bytea, cw.type::bytea, cw.blob] order by cw.task_id, cw.idx)
-        from checkpoint_writes cw
-        where cw.thread_id = checkpoints.thread_id
-            and cw.checkpoint_ns = checkpoints.checkpoint_ns
-            and cw.checkpoint_id = checkpoints.checkpoint_id
+        from {checkpoint_writes} cw
+        where cw.thread_id = {checkpoints}.thread_id
+            and cw.checkpoint_ns = {checkpoints}.checkpoint_ns
+            and cw.checkpoint_id = {checkpoints}.checkpoint_id
     ) as pending_writes
-from checkpoints """
+from {checkpoints} """).format(
+            checkpoint_blobs=sql.Identifier(schema, "checkpoint_blobs"),
+            checkpoint_writes=sql.Identifier(schema, "checkpoint_writes"),
+            checkpoints=sql.Identifier(schema, "checkpoints"),
+        )
 
-SELECT_PENDING_SENDS_SQL = f"""
+        self.SELECT_PENDING_SENDS_SQL = sql.SQL("""
 select
     checkpoint_id,
     array_agg(array[type::bytea, blob] order by task_path, task_id, idx) as sends
-from checkpoint_writes
+from {}
 where thread_id = %s
     and checkpoint_id = any(%s)
     and channel = '{TASKS}'
 group by checkpoint_id
-"""
+""").format(sql.Identifier(schema, "checkpoint_writes"), TASKS=sql.SQL(TASKS))
 
-UPSERT_CHECKPOINT_BLOBS_SQL = """
-    INSERT INTO checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
+        self.UPSERT_CHECKPOINT_BLOBS_SQL = sql.SQL("""
+    INSERT INTO {} (thread_id, checkpoint_ns, channel, version, type, blob)
     VALUES (%s, %s, %s, %s, %s, %s)
     ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
-"""
+""").format(sql.Identifier(schema, "checkpoint_blobs"))
 
-UPSERT_CHECKPOINTS_SQL = """
-    INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+        self.UPSERT_CHECKPOINTS_SQL = sql.SQL("""
+    INSERT INTO {} (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
     VALUES (%s, %s, %s, %s, %s, %s)
     ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
     DO UPDATE SET
         checkpoint = EXCLUDED.checkpoint,
         metadata = EXCLUDED.metadata;
-"""
+""").format(sql.Identifier(schema, "checkpoints"))
 
-UPSERT_CHECKPOINT_WRITES_SQL = """
-    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob)
+        self.UPSERT_CHECKPOINT_WRITES_SQL = sql.SQL("""
+    INSERT INTO {} (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob)
     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
     ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
         channel = EXCLUDED.channel,
         type = EXCLUDED.type,
         blob = EXCLUDED.blob;
-"""
+""").format(sql.Identifier(schema, "checkpoint_writes"), TASKS=sql.SQL(TASKS))
 
-INSERT_CHECKPOINT_WRITES_SQL = """
-    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob)
+        self.INSERT_CHECKPOINT_WRITES_SQL = sql.SQL("""
+    INSERT INTO {} (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob)
     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
     ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
-"""
-
-
-class BasePostgresSaver(BaseCheckpointSaver[str]):
-    SELECT_SQL = SELECT_SQL
-    SELECT_PENDING_SENDS_SQL = SELECT_PENDING_SENDS_SQL
-    MIGRATIONS = MIGRATIONS
-    UPSERT_CHECKPOINT_BLOBS_SQL = UPSERT_CHECKPOINT_BLOBS_SQL
-    UPSERT_CHECKPOINTS_SQL = UPSERT_CHECKPOINTS_SQL
-    UPSERT_CHECKPOINT_WRITES_SQL = UPSERT_CHECKPOINT_WRITES_SQL
-    INSERT_CHECKPOINT_WRITES_SQL = INSERT_CHECKPOINT_WRITES_SQL
-
-    supports_pipeline: bool
+""").format(sql.Identifier(schema, "checkpoint_writes"), TASKS=sql.SQL(TASKS))
 
     def _migrate_pending_sends(
         self,

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -371,3 +371,62 @@ async def test_get_checkpoint_no_channel_values(
 
         checkpoint = await saver.aget_tuple(config)
         assert checkpoint.checkpoint["channel_values"] == {}
+
+
+@pytest.mark.asyncio
+async def test_custom_schema() -> None:
+    """Test that explicit schema handling works for both new and existing schemas."""
+    database = f"test_{uuid4().hex[:16]}"
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI + database,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as conn:
+            # 1. Custom schema that does not exist yet
+            saver = AsyncPostgresSaver(conn, schema="tenant_a")
+            await saver.setup()
+
+            config = {
+                "configurable": {
+                    "thread_id": "1",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": "",
+                }
+            }
+            chkpnt = empty_checkpoint()
+            chkpnt["id"] = "chk_1"
+            await saver.aput(config, chkpnt, {}, {})
+
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT count(*) as count FROM tenant_a.checkpoints")
+                row = await cur.fetchone()
+                assert row["count"] == 1
+
+            # 2. Existing schema
+            async with conn.cursor() as cur:
+                await cur.execute("CREATE SCHEMA IF NOT EXISTS tenant_b")
+
+            saver_b = AsyncPostgresSaver(conn, schema="tenant_b")
+            await saver_b.setup()  # Should run safely
+
+            await saver_b.aput(config, chkpnt, {}, {})
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT count(*) as count FROM tenant_b.checkpoints")
+                row = await cur.fetchone()
+                assert row["count"] == 1
+
+                # Check isolation
+                await cur.execute("SELECT count(*) as count FROM tenant_a.checkpoints")
+                row = await cur.fetchone()
+                assert row["count"] == 1
+    finally:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -358,3 +358,54 @@ def test_get_checkpoint_no_channel_values(
 
         checkpoint = saver.get_tuple(config)
         assert checkpoint.checkpoint["channel_values"] == {}
+
+
+def test_custom_schema() -> None:
+    """Test that explicit schema handling works for both new and existing schemas."""
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+    try:
+        with Connection.connect(
+            DEFAULT_POSTGRES_URI + database,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as conn:
+            # 1. Custom schema that does not exist yet
+            saver = PostgresSaver(conn, schema="tenant_a")
+            saver.setup()
+
+            config = {
+                "configurable": {
+                    "thread_id": "1",
+                    "checkpoint_ns": "",
+                    "checkpoint_id": "",
+                }
+            }
+            chkpnt = empty_checkpoint()
+            chkpnt["id"] = "chk_1"
+            saver.put(config, chkpnt, {}, {})
+
+            with conn.cursor() as cur:
+                cur.execute("SELECT count(*) as count FROM tenant_a.checkpoints")
+                assert cur.fetchone()["count"] == 1
+
+            # 2. Existing schema
+            with conn.cursor() as cur:
+                cur.execute("CREATE SCHEMA IF NOT EXISTS tenant_b")
+
+            saver_b = PostgresSaver(conn, schema="tenant_b")
+            saver_b.setup()  # Should run safely
+
+            saver_b.put(config, chkpnt, {}, {})
+            with conn.cursor() as cur:
+                cur.execute("SELECT count(*) as count FROM tenant_b.checkpoints")
+                assert cur.fetchone()["count"] == 1
+
+                # Check isolation
+                cur.execute("SELECT count(*) as count FROM tenant_a.checkpoints")
+                assert cur.fetchone()["count"] == 1
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")


### PR DESCRIPTION
This change removes reliance on connection state by making all PostgreSQL checkpoint queries schema-explicit and stateless, with safe identifier handling through psycopg.sql.Identifier and full sync/async parity. Resolves #7345