### PR TITLE
fix(langgraph): gracefully init exec info when None (ref: #7420)

### DIFF
--- a/libs/langgraph/langgraph/runtime.py
+++ b/libs/langgraph/langgraph/runtime.py
@@ -210,8 +210,16 @@ class Runtime(Generic[ContextT]):
     def patch_execution_info(self, **overrides: Any) -> Runtime[ContextT]:
         """Return a new runtime with selected execution_info fields replaced."""
         if self.execution_info is None:
-            msg = "Cannot patch execution_info before it has been set"
-            raise RuntimeError(msg)
+            defaults: dict[str, Any] = {
+                "checkpoint_id": "",
+                "checkpoint_ns": "",
+                "task_id": "",
+            }
+            defaults.update(overrides)
+            return replace(
+                self,
+                execution_info=ExecutionInfo(**defaults),
+            )
         return replace(
             self,
             execution_info=self.execution_info.patch(**overrides),

--- a/libs/langgraph/tests/test_runtime.py
+++ b/libs/langgraph/tests/test_runtime.py
@@ -418,6 +418,34 @@ def test_execution_info_defaults_and_patch() -> None:
         info.thread_id = "t2"  # type: ignore[misc]
 
 
+def test_patch_execution_info_initializes_when_none() -> None:
+    """patch_execution_info creates a default ExecutionInfo when execution_info is None."""
+    rt = Runtime()
+    assert rt.execution_info is None
+
+    patched_rt = rt.patch_execution_info(node_first_attempt_time=123.0)
+    assert patched_rt.execution_info is not None
+    assert patched_rt.execution_info.checkpoint_id == ""
+    assert patched_rt.execution_info.checkpoint_ns == ""
+    assert patched_rt.execution_info.task_id == ""
+    assert patched_rt.execution_info.node_first_attempt_time == 123.0
+    assert patched_rt.execution_info.node_attempt == 1
+
+    # overrides can include identity fields too
+    patched_rt2 = rt.patch_execution_info(
+        checkpoint_id="c1", task_id="t1", node_attempt=2
+    )
+    assert patched_rt2.execution_info.checkpoint_id == "c1"
+    assert patched_rt2.execution_info.task_id == "t1"
+    assert patched_rt2.execution_info.node_attempt == 2
+
+    # can be re-patched after initialization from None
+    repatched = patched_rt.patch_execution_info(node_attempt=3)
+    assert repatched.execution_info.node_attempt == 3
+    assert repatched.execution_info.node_first_attempt_time == 123.0
+    assert repatched.execution_info.checkpoint_id == ""
+
+
 # --- ServerInfo / Runtime unit tests ---
 
 


### PR DESCRIPTION
Fixes #7420                                                                                                                                                 
- `patch_execution_info()` now inits a default `ExecutionInfo` instead of raising `RuntimeError` when `execution_info` is `None`. Unblocks LangGraph Cloud executor 0.7.96.
- ran `make format`, `make lint`, `make test` .. all passing (40/40 tests).

verified by adding `test_patch_execution_info_initializes_when_none` covering init from None, identity field overrides, and re-patching.