### PR TITLE
fix(checkpoint): preserve created_at in InMemoryStore.put() on update

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,12 +407,14 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                now = datetime.now(timezone.utc)
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
-                    updated_at=datetime.now(timezone.utc),
+                    created_at=existing.created_at if existing else now,
+                    updated_at=now,
                 )
 
     def _extract_texts(

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1045,3 +1045,21 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_put_preserves_created_at_on_update() -> None:
+    """Test that put() preserves created_at when updating an existing key."""
+    store = InMemoryStore()
+    store.put(("ns",), "key", {"v": 1})
+    item1 = store.get(("ns",), "key")
+    assert item1 is not None
+
+    store.put(("ns",), "key", {"v": 2})
+    item2 = store.get(("ns",), "key")
+    assert item2 is not None
+
+    assert item2.value == {"v": 2}
+    assert item1.created_at == item2.created_at, (
+        f"created_at changed on update: {item1.created_at} -> {item2.created_at}"
+    )
+    assert item2.updated_at >= item1.updated_at


### PR DESCRIPTION
## Summary

- `InMemoryStore._apply_put_ops` unconditionally set `created_at=datetime.now(timezone.utc)` on every `put()`, even when updating an existing key. This made `created_at` always identical to `updated_at` after an update, which is inconsistent with PostgresStore behavior (which preserves `created_at` via `ON CONFLICT DO UPDATE`).
- Fix: check for an existing item before creating the new `Item` and preserve its `created_at` if present.
- Added a test covering `created_at` preservation on update.

Fixes #7411

## Test plan

- [x] Added `test_put_preserves_created_at_on_update` in `libs/checkpoint/tests/test_store.py`
- [ ] Existing tests pass (no behavioral change for new keys or deletes)