### PR TITLE
chore: bump langgraph version to 1.1.5 in CI and examples

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -116,8 +116,8 @@ jobs:
           timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
           echo "Finished starting up langgraph-test-h"
           LANGGRAPH_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langgraph'); print(v);")
-          if [ "$LANGGRAPH_VERSION" != "1.1.2" ]; then
-            echo "LANGGRAPH_VERSION != 1.1.2; $LANGGRAPH_VERSION"
+          if [ "$LANGGRAPH_VERSION" != "1.1.5" ]; then
+            echo "LANGGRAPH_VERSION != 1.1.5; $LANGGRAPH_VERSION"
             exit 1
           fi
           LANGCHAIN_OPENAI_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langchain-openai'); print(v);")

--- a/libs/cli/examples/graph_prerelease_reqs/deps/additional_deps/pyproject.toml
+++ b/libs/cli/examples/graph_prerelease_reqs/deps/additional_deps/pyproject.toml
@@ -5,5 +5,5 @@ description = "Test for prerelease stuff"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "langgraph==1.1.2"
+  "langgraph==1.1.5"
 ]

--- a/libs/cli/examples/graph_prerelease_reqs/pyproject.toml
+++ b/libs/cli/examples/graph_prerelease_reqs/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "langchain-openai==1.0.0a2",
   "langchain-anthropic==1.0.0a5",
-  "langgraph==1.1.2"
+  "langgraph==1.1.5"
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Bump `langgraph` version from `1.1.2` to `1.1.5` in the CI integration test workflow version check
- Bump `langgraph` version from `1.1.2` to `1.1.5` in the prerelease example `pyproject.toml` files

## Test plan
- [ ] CI integration tests pass with the updated version expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)