### PR TITLE
fix: coerce non-string namespace labels to strings in store validatio…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ dmypy.json
 .turbo
 .editorconfig
 .scratch
+
+.turbo-quant/

--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -908,7 +908,7 @@ class BaseStore(ABC):
             store.put(("docs",), "report", {"memory": "Will likes ai"}, index=["memory"])
             ```
         """
-        _validate_namespace(namespace)
+        namespace = _validate_namespace(namespace)
         if ttl not in (NOT_PROVIDED, None) and not self.supports_ttl:
             raise NotImplementedError(
                 f"TTL is not supported by {self.__class__.__name__}. "
@@ -1169,7 +1169,7 @@ class BaseStore(ABC):
             )
             ```
         """
-        _validate_namespace(namespace)
+        namespace = _validate_namespace(namespace)
         if ttl not in (NOT_PROVIDED, None) and not self.supports_ttl:
             raise NotImplementedError(
                 f"TTL is not supported by {self.__class__.__name__}. "
@@ -1252,15 +1252,15 @@ class BaseStore(ABC):
         return (await self.abatch([op]))[0]
 
 
-def _validate_namespace(namespace: tuple[str, ...]) -> None:
+def _validate_namespace(namespace: tuple[str, ...]) -> tuple[str, ...]:
     if not namespace:
         raise InvalidNamespaceError("Namespace cannot be empty.")
+    coerced = False
+    labels: list[str] = []
     for label in namespace:
         if not isinstance(label, str):
-            raise InvalidNamespaceError(
-                f"Invalid namespace label '{label}' found in {namespace}. Namespace labels"
-                f" must be strings, but got {type(label).__name__}."
-            )
+            label = str(label)
+            coerced = True
         if "." in label:
             raise InvalidNamespaceError(
                 f"Invalid namespace label '{label}' found in {namespace}. Namespace labels cannot contain periods ('.')."
@@ -1269,10 +1269,13 @@ def _validate_namespace(namespace: tuple[str, ...]) -> None:
             raise InvalidNamespaceError(
                 f"Namespace labels cannot be empty strings. Got {label} in {namespace}"
             )
-    if namespace[0] == "langgraph":
+        labels.append(label)
+    result = tuple(labels) if coerced else namespace
+    if result[0] == "langgraph":
         raise InvalidNamespaceError(
-            f'Root label for namespace cannot be "langgraph". Got: {namespace}'
+            f'Root label for namespace cannot be "langgraph". Got: {result}'
         )
+    return result
 
 
 def _ensure_refresh(

--- a/libs/checkpoint/langgraph/store/base/batch.py
+++ b/libs/checkpoint/langgraph/store/base/batch.py
@@ -138,7 +138,7 @@ class AsyncBatchedBaseStore(BaseStore):
         ttl: float | None | NotProvided = NOT_PROVIDED,
     ) -> None:
         self._ensure_task()
-        _validate_namespace(namespace)
+        namespace = _validate_namespace(namespace)
         fut = self._loop.create_future()
         self._aqueue.put_nowait(
             (
@@ -236,7 +236,7 @@ class AsyncBatchedBaseStore(BaseStore):
         *,
         ttl: float | None | NotProvided = NOT_PROVIDED,
     ) -> None:
-        _validate_namespace(namespace)
+        namespace = _validate_namespace(namespace)
         asyncio.run_coroutine_threadsafe(
             self.aput(
                 namespace,

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -515,6 +515,35 @@ async def test_cannot_put_empty_namespace() -> None:
     assert (await async_store.aget(("valid", "namespace"), "key")) is None
 
 
+async def test_namespace_non_string_labels_coerced() -> None:
+    """Non-string namespace labels (e.g. int user IDs) are coerced to strings.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/7427.
+    """
+    store = InMemoryStore()
+    doc = {"memory": "likes ai"}
+
+    # int label should be coerced to str, not raise
+    store.put(("rag-agent", 1, "memories"), "k1", doc)
+    assert store.get(("rag-agent", "1", "memories"), "k1").value == doc  # type: ignore[union-attr]
+
+    # async path
+    await store.aput(("app", 42, "data"), "k2", doc)
+    assert (await store.aget(("app", "42", "data"), "k2")).value == doc  # type: ignore[union-attr]
+
+    # AsyncBatchedBaseStore path
+    async_store = MockAsyncBatchedStore()
+    await async_store.aput(("agent", 7, "ctx"), "k3", doc)
+    val = await async_store.aget(("agent", "7", "ctx"), "k3")
+    assert val is not None
+    assert val.value == doc
+
+    # search works with the coerced namespace
+    results = store.search(("rag-agent", "1", "memories"))
+    assert len(results) == 1
+    assert results[0].value == doc
+
+
 async def test_async_batch_store_deduplication(mocker: MockerFixture) -> None:
     abatch = mocker.spy(InMemoryStore, "batch")
     store = MockAsyncBatchedStore()


### PR DESCRIPTION
Title: fix(checkpoint): coerce non-string namespace labels to strings

  Body:                                                                                                                   
  Fixes #7427                                                                                                          
  
  Non-string namespace labels (e.g. integer user IDs from template substitution) now get coerced to `str()` instead of
  raising `InvalidNamespaceError`.

  ## What changed

  - `_validate_namespace()` converts non-string labels to strings and returns the cleaned tuple
  - Updated 4 call sites in `BaseStore.put`, `BaseStore.aput`, `AsyncBatchedBaseStore.aput`, and
  `AsyncBatchedBaseStore.put`
  - Added `test_namespace_non_string_labels_coerced` covering sync, async, and batched store paths

  ## Verification

  - `make test` from `libs/checkpoint` — 25/25 passed
  
  https://www.linkedin.com/in/prathmesh-kunturwar/