### PR TITLE
fix(langgraph): copy copiable keys in ensure_config to prevent metadata mutation

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -304,7 +304,7 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
                 if k == CONF:
                     empty[k] = cast(dict, v).copy()
                 else:
-                    empty[k] = v  # type: ignore[literal-required]
+                    empty[k] = v.copy() if k in COPIABLE_KEYS else v  # type: ignore[attr-defined]
         for k, v in config.items():
             if _is_not_empty(v) and k not in CONFIG_KEYS:
                 empty[CONF][k] = v

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -317,3 +317,15 @@ def test_configurable_metadata():
     metadata = merged["metadata"]
     assert metadata.keys() == expected
     assert metadata["nooverride"] == 18
+
+
+def test_ensure_config_does_not_mutate_input_metadata():
+    original_config = {"metadata": {"user": "alice"}}
+    new_config = {"configurable": {"thread_id": "thread-1"}}
+
+    ensure_config(original_config, new_config)
+
+    assert original_config["metadata"] == {"user": "alice"}, (
+        "ensure_config mutated the original "
+        f"metadata dict: {original_config['metadata']}"
+    )


### PR DESCRIPTION
Fixes #7441

Copy copiable keys (e.g. `metadata`) by value instead of by reference in the `for config in configs` loop of `ensure_config`, preventing mutation of the original config's metadata dict across invocations.
