### PR TITLE
chore(checkpoint-conformance): remove test_list_global_search, bump to 0.0.2

### DIFF
--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_list.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_list.py
@@ -339,36 +339,6 @@ async def test_list_metadata_custom_keys(
     assert results[0].metadata["run_id"] == "run-abc"
 
 
-async def test_list_global_search(
-    saver: BaseCheckpointSaver,
-) -> None:
-    """alist(None, filter=...) searches across all threads."""
-    tid1, tid2 = str(uuid4()), str(uuid4())
-
-    # Use a unique marker so we don't collide with other tests' data
-    marker = str(uuid4())
-
-    cfg1 = generate_config(tid1)
-    cp1 = generate_checkpoint()
-    await saver.aput(cfg1, cp1, generate_metadata(source="input", marker=marker), {})
-
-    cfg2 = generate_config(tid2)
-    cp2 = generate_checkpoint()
-    await saver.aput(cfg2, cp2, generate_metadata(source="loop", marker=marker), {})
-
-    # Search across all threads with filter
-    results = []
-    async for tup in saver.alist(None, filter={"source": "input", "marker": marker}):
-        results.append(tup)
-    assert len(results) == 1
-    assert results[0].config["configurable"]["thread_id"] == tid1
-
-    # Search with marker only — should find both
-    results = []
-    async for tup in saver.alist(None, filter={"marker": marker}):
-        results.append(tup)
-    assert len(results) == 2
-
 
 ALL_LIST_TESTS = [
     test_list_all,
@@ -380,7 +350,6 @@ ALL_LIST_TESTS = [
     test_list_metadata_filter_multiple_keys,
     test_list_metadata_filter_no_match,
     test_list_metadata_custom_keys,
-    test_list_global_search,
     test_list_before,
     test_list_limit,
     test_list_limit_plus_before,

--- a/libs/checkpoint-conformance/pyproject.toml
+++ b/libs/checkpoint-conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint-conformance"
-version = "0.0.1"
+version = "0.0.2"
 description = "Conformance test suite for LangGraph checkpointer implementations."
 authors = [{name = "William FH", email = "13333726+hinthornw@users.noreply.github.com"}]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Remove `test_list_global_search` from the conformance test suite. This test required cross-thread `alist(None, filter=...)` support that not all checkpointer implementations provide.
- Remove the corresponding entry from `ALL_LIST_TESTS`.
- Bump `langgraph-checkpoint-conformance` version from 0.0.1 to 0.0.2.

## Test plan
- [x] Verify `test_list_global_search` function definition is fully removed
- [x] Verify `test_list_global_search` is removed from `ALL_LIST_TESTS`
- [x] Verify version bumped to 0.0.2 in pyproject.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)