### PR TITLE
fix(config): copy copiable keys to prevent shared metadata mutation in ensure_config

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -301,8 +301,8 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
             continue
         for k, v in config.items():
             if _is_not_empty(v) and k in CONFIG_KEYS:
-                if k == CONF:
-                    empty[k] = cast(dict, v).copy()
+                if k in COPIABLE_KEYS:
+                    empty[k] = v.copy()  # type: ignore[attr-defined]
                 else:
                     empty[k] = v  # type: ignore[literal-required]
         for k, v in config.items():

--- a/libs/langgraph/tests/test_config_async.py
+++ b/libs/langgraph/tests/test_config_async.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.callbacks import AsyncCallbackManager
 
-from langgraph._internal._config import get_async_callback_manager_for_config
+from langgraph._internal._config import ensure_config, get_async_callback_manager_for_config
 
 pytestmark = pytest.mark.anyio
 
@@ -17,3 +17,24 @@ def test_new_async_manager_merges_tags_with_config() -> None:
     config = {"callbacks": None, "tags": ["a"]}
     manager = get_async_callback_manager_for_config(config, tags=["b"])
     assert manager.inheritable_tags == ["a", "b"]
+
+
+def test_ensure_config_does_not_mutate_shared_metadata() -> None:
+    original_config = {"metadata": {"ls_integration": "langchain_create_agent"}}
+    new_config = {"configurable": {"thread_id": "thread-1"}}
+    ensure_config(original_config, new_config)
+
+    assert original_config == {"metadata": {"ls_integration": "langchain_create_agent"}}, (
+        f"ensure_config mutated original config: {original_config}"
+    )
+
+
+def test_ensure_config_does_not_mutate_shared_metadata_multiple_invocations() -> None:
+    original_config = {"metadata": {"ls_integration": "langchain_create_agent"}}
+
+    ensure_config(original_config, {"configurable": {"thread_id": "thread-1"}})
+    ensure_config(original_config, {"configurable": {"thread_id": "thread-2"}})
+
+    assert original_config == {"metadata": {"ls_integration": "langchain_create_agent"}}, (
+        f"ensure_config mutated original config after multiple invocations: {original_config}"
+    )


### PR DESCRIPTION
## Summary
Fixes #7441

`ensure_config` assigned `metadata` (and other `COPIABLE_KEYS`) by reference instead of copying them. When configurable values like `thread_id` were later written into `_empty_metadata`, they mutated the caller's original config dict. Subsequent invocations would then see stale configurable values injected into their metadata.

## Root Cause

In the loop over user-provided configs, `configurable` (CONF) was correctly copied with `.copy()`, but `metadata` and other `COPIABLE_KEYS` were assigned by reference:

```python
# Before — metadata assigned by reference, gets mutated later
if k == CONF:
    empty[k] = cast(dict, v).copy()
else:
    empty[k] = v

# After — all COPIABLE_KEYS are copied consistently
if k in COPIABLE_KEYS:
    empty[k] = v.copy()
else:
    empty[k] = v
```

The subsequent block writes configurable keys into `_empty_metadata`, which was the same object as the caller's original `metadata` dict. After the fix each call gets its own copy.

## Changes
- `libs/langgraph/langgraph/_internal/_config.py`: Check `k in COPIABLE_KEYS` instead of `k == CONF`, consistent with how `var_child_runnable_config` is already handled in the same function.
- `libs/langgraph/tests/test_config_async.py`: Two tests covering single and multiple invocations.

## How to Test
```bash
pytest libs/langgraph/tests/test_config_async.py::test_ensure_config_does_not_mutate_shared_metadata -v
pytest libs/langgraph/tests/test_config_async.py::test_ensure_config_does_not_mutate_shared_metadata_multiple_invocations -v
```