### PR TITLE
fix(channels): unwrap Overwrite and track seen_overwrite when initial value is MISSING

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -102,10 +102,15 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
-            self.value = values[0]
-            values = values[1:]
         seen_overwrite: bool = False
+        if self.value is MISSING:
+            is_overwrite, overwrite_value = _get_overwrite(values[0])
+            if is_overwrite:
+                self.value = overwrite_value
+                seen_overwrite = True
+            else:
+                self.value = values[0]
+            values = values[1:]
         for value in values:
             is_overwrite, overwrite_value = _get_overwrite(value)
             if is_overwrite:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,5 +1,6 @@
 import operator
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import pytest
 
@@ -9,6 +10,7 @@ from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
+from langgraph.types import Overwrite
 
 pytestmark = pytest.mark.anyio
 
@@ -88,6 +90,44 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_overwrite_on_missing_initial_value() -> None:
+    """Overwrite on a channel with no default constructor must unwrap the value."""
+
+    @dataclass
+    class Metrics:
+        count: int
+
+        def __add__(self, other: "Metrics") -> "Metrics":
+            return Metrics(self.count + other.count)
+
+    # Bug 1: Overwrite on MISSING initial value must unwrap, not store the wrapper.
+    channel: BinaryOperatorAggregate[Metrics] = BinaryOperatorAggregate(
+        Metrics, operator.add
+    )
+    assert channel.value is MISSING
+    channel.update([Overwrite(Metrics(count=42))])
+    assert channel.get() == Metrics(count=42), (
+        "Overwrite on MISSING channel stored the wrapper instead of the value"
+    )
+
+    # Bug 2: A second Overwrite in the same super-step must still raise.
+    channel2: BinaryOperatorAggregate[Metrics] = BinaryOperatorAggregate(
+        Metrics, operator.add
+    )
+    with pytest.raises(InvalidUpdateError):
+        channel2.update([Overwrite(Metrics(1)), Overwrite(Metrics(2))])
+
+    # Normal accumulation still works after an Overwrite resets an initialised channel.
+    channel3: BinaryOperatorAggregate[Metrics] = BinaryOperatorAggregate(
+        Metrics, operator.add
+    )
+    channel3.update([Metrics(count=10)])
+    channel3.update([Overwrite(Metrics(count=5))])
+    assert channel3.get() == Metrics(count=5)
+    channel3.update([Metrics(count=3)])
+    assert channel3.get() == Metrics(count=8)
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary

Fixes #6909

`BinaryOperatorAggregate.update()` had a fast-path for when the channel starts with no value (`self.value is MISSING`) that assigned `values[0]` directly without checking whether it was an `Overwrite` wrapper. This caused two bugs for types with no zero-arg constructor (where `self.value` starts as `MISSING`):

**Bug 1 — wrapper stored instead of unwrapped value:**
```python
channel.update([Overwrite(Metrics(count=42))])
channel.get()  # returns Overwrite(value=Metrics(count=42)) — wrong
               # expected: Metrics(count=42)
```

**Bug 2 — duplicate Overwrite guard skipped:**
```python
channel.update([Overwrite(Metrics(1)), Overwrite(Metrics(2))])
# No error raised — the seen_overwrite flag was never set in the MISSING path
```

## Root Cause

The MISSING fast-path bypassed the `_get_overwrite` helper that runs for all other values:

```python
# Before
if self.value is MISSING:
    self.value = values[0]  # skips _get_overwrite — stores the wrapper as-is
    values = values[1:]
seen_overwrite: bool = False
```

## Fix

Run `_get_overwrite` on `values[0]` in the MISSING branch and set `seen_overwrite = True` when it is an `Overwrite`, matching the behaviour of the general loop:

```python
# After
seen_overwrite: bool = False
if self.value is MISSING:
    is_overwrite, overwrite_value = _get_overwrite(values[0])
    if is_overwrite:
        self.value = overwrite_value
        seen_overwrite = True
    else:
        self.value = values[0]
    values = values[1:]
```

## Tests

Added `test_binop_overwrite_on_missing_initial_value` to `tests/test_channels.py` covering both bugs and verifying that normal accumulation still works after an Overwrite resets an already-initialised channel.