### PR TITLE
Add retry control for self-RAG and refactor deprecated APIs

### DIFF
--- a/examples/rag/langgraph_self_rag.ipynb
+++ b/examples/rag/langgraph_self_rag.ipynb
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "1fafad21-60cc-483e-92a3-6a7edb1838e3",
    "metadata": {},
    "outputs": [
@@ -185,9 +185,8 @@
     "\n",
     "\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_core.pydantic_v1 import BaseModel, Field\n",
+    "from pydantic import BaseModel, Field\n",
     "from langchain_openai import ChatOpenAI\n",
-    "\n",
     "\n",
     "# Data model\n",
     "class GradeDocuments(BaseModel):\n",
@@ -216,14 +215,14 @@
     "\n",
     "retrieval_grader = grade_prompt | structured_llm_grader\n",
     "question = \"agent memory\"\n",
-    "docs = retriever.get_relevant_documents(question)\n",
+    "docs = retriever.inoke(question)\n",
     "doc_txt = docs[1].page_content\n",
     "print(retrieval_grader.invoke({\"question\": question, \"document\": doc_txt}))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "dcd77cc1-4587-40ec-b633-5364eab9e1ec",
    "metadata": {},
    "outputs": [
@@ -238,11 +237,12 @@
    "source": [
     "### Generate\n",
     "\n",
-    "from langchain import hub\n",
+    "from langsmith import Client\n",
     "from langchain_core.output_parsers import StrOutputParser\n",
     "\n",
     "# Prompt\n",
-    "prompt = hub.pull(\"rlm/rag-prompt\")\n",
+    "client = Client()\n",
+    "prompt = client.pull_prompt(\"rlm/rag-prompt\")\n",
     "\n",
     "# LLM\n",
     "llm = ChatOpenAI(model_name=\"gpt-3.5-turbo\", temperature=0)\n",
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "f1617e9e-66a8-4c1a-a1fe-cc936284c085",
    "metadata": {},
    "outputs": [],
@@ -433,12 +433,14 @@
     "\n",
     "    question: str\n",
     "    generation: str\n",
-    "    documents: List[str]"
+    "    documents: List[str]\n",
+    "    retries: int\n",
+    "    max_retries: int"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "add509d8-6682-4127-8d95-13dd37d79702",
    "metadata": {},
    "outputs": [],
@@ -460,7 +462,7 @@
     "    question = state[\"question\"]\n",
     "\n",
     "    # Retrieval\n",
-    "    documents = retriever.get_relevant_documents(question)\n",
+    "    documents = retriever.inoke(question)\n",
     "    return {\"documents\": documents, \"question\": question}\n",
     "\n",
     "\n",
@@ -551,6 +553,12 @@
     "    print(\"---ASSESS GRADED DOCUMENTS---\")\n",
     "    state[\"question\"]\n",
     "    filtered_documents = state[\"documents\"]\n",
+    "    retries = state[\"retries\"]\n",
+    "    max_retries = state[\"max_retries\"]\n",
+    "\n",
+    "    if retries >= max_retries:\n",
+    "        print(\"---DECISION: MAX RETRIES REACHED, RETURN FALLBACK RESPONSE---\")\n",
+    "        return \"max_retries_reached\"\n",
     "\n",
     "    if not filtered_documents:\n",
     "        # All documents have been filtered check_relevance\n",
@@ -601,7 +609,24 @@
     "            return \"not useful\"\n",
     "    else:\n",
     "        pprint(\"---DECISION: GENERATION IS NOT GROUNDED IN DOCUMENTS, RE-TRY---\")\n",
-    "        return \"not supported\""
+    "        return \"not supported\"\n",
+    "    \n",
+    "\n",
+    "def max_retries_reached(state):\n",
+    "    \"\"\"\n",
+    "    Returns a fallback response when the maximum number of retries is reached.\n",
+    "\n",
+    "    This function is triggered when the self-RAG pipeline exceeds the allowed\n",
+    "    retry limit. It generates a user-friendly message indicating that no\n",
+    "    relevant answer could be found within the specified number of attempts.\n",
+    "\n",
+    "    Args:\n",
+    "        state (dict): Contains the current pipeline state, including 'max_retries'.\n",
+    "\n",
+    "    Returns:\n",
+    "        dict: A response containing the fallback generation message.\n",
+    "    \"\"\"\n",
+    "    return {\"generation\": f\"Sorry, I could not find a relevant answer after {state['max_retries']} attempts.\"}"
    ]
   },
   {
@@ -616,7 +641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "0e09ca9f-e36d-4ef4-a0d5-79fdbada9fe0",
    "metadata": {},
    "outputs": [],
@@ -630,6 +655,7 @@
     "workflow.add_node(\"grade_documents\", grade_documents)  # grade documents\n",
     "workflow.add_node(\"generate\", generate)  # generate\n",
     "workflow.add_node(\"transform_query\", transform_query)  # transform_query\n",
+    "workflow.add_node(\"max_retries_reached\", max_retries_reached)  # max retries reached\n",
     "\n",
     "# Build graph\n",
     "workflow.add_edge(START, \"retrieve\")\n",
@@ -640,6 +666,7 @@
     "    {\n",
     "        \"transform_query\": \"transform_query\",\n",
     "        \"generate\": \"generate\",\n",
+    "        \"max_retries_reached\": \"max_retries_reached\",\n",
     "    },\n",
     ")\n",
     "workflow.add_edge(\"transform_query\", \"retrieve\")\n",
@@ -652,6 +679,7 @@
     "        \"not useful\": \"transform_query\",\n",
     "    },\n",
     ")\n",
+    "workflow.add_edge(\"max_retries_reached\", END)\n",
     "\n",
     "# Compile\n",
     "app = workflow.compile()"
@@ -659,7 +687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "fb69dbb9-91ee-4868-8c3c-93af3cd885be",
    "metadata": {},
    "outputs": [
@@ -698,7 +726,7 @@
     "from pprint import pprint\n",
     "\n",
     "# Run\n",
-    "inputs = {\"question\": \"Explain how the different types of agent memory work?\"}\n",
+    "inputs = {\"question\": \"Explain how the different types of agent memory work?\", \"retries\": 0, \"max_retries\": 3}\n",
     "for output in app.stream(inputs):\n",
     "    for key, value in output.items():\n",
     "        # Node\n",
@@ -713,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "4138bc51-8c84-4b8a-8d24-f7f470721f6f",
    "metadata": {},
    "outputs": [
@@ -750,7 +778,7 @@
     }
    ],
    "source": [
-    "inputs = {\"question\": \"Explain how chain of thought prompting works?\"}\n",
+    "inputs = {\"question\": \"Explain how chain of thought prompting works?\", \"retries\": 0, \"max_retries\": 3}\n",
     "for output in app.stream(inputs):\n",
     "    for key, value in output.items():\n",
     "        # Node\n",


### PR DESCRIPTION
- Add configurable max retry limit in self-RAG with fallback response when exceeded
- Replace langchain.pydantic_v1 with pydantic
- Replace deprecated retriever.get_relevant_documents() with retriever.invoke()
- Replace deprecated hub.pull() with langsmith.Client.pull_prompt()