### PR TITLE
fix: typo in comment (medata -> metadata)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1664,7 +1664,7 @@ def _get_channel(
 def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
-        # Search through all annotated medata to find channel annotations
+        # Search through all annotated metadata to find channel annotations
         for item in meta:
             if isinstance(item, BaseChannel):
                 return item


### PR DESCRIPTION
Fixes #7479 
Corrected a typo in a comment in libs/langgraph/langgraph/graph/state.py, changing medata to metadata. This is a documentation-only change and does not affect runtime behavior.

How did you verify your code works?

This change only updates a comment, so it does not change any functionality. I verified that the typo was corrected in the target file.