### PR TITLE
fix(cli): add missing typing_extensions dependency

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
+    "typing_extensions>=4.0.0",
 ]
 [tool.hatch.version]
 path = "langgraph_cli/__init__.py"

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -1003,6 +1003,7 @@ dependencies = [
     { name = "pathspec" },
     { name = "python-dotenv" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1046,6 +1047,7 @@ requires-dist = [
     { name = "pathspec", specifier = ">=0.11.0" },
     { name = "python-dotenv", specifier = ">=0.8.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["inmem"]
 


### PR DESCRIPTION
## Summary

`langgraph-cli` 0.4.21 imports `typing_extensions.Required` in `langgraph_cli/schemas.py` but does not declare `typing_extensions` as a dependency. This causes `ModuleNotFoundError` on clean environments where `typing_extensions` is not pulled in transitively.

Closes #7462

## Failing scenario

```
pip install langgraph-cli
python -c "from langgraph_cli import schemas"
# ModuleNotFoundError: No module named 'typing_extensions'
```

## Fix

Add `typing_extensions>=4.0.0` to `dependencies` in `libs/cli/pyproject.toml`. The dependency is unconditional to match the unconditional import in `schemas.py`.

## Validation

- Reproduced: fresh venv + `pip install --no-deps ./libs/cli` → `ModuleNotFoundError`
- Verified: fresh venv + `pip install ./libs/cli` (with fix) → import succeeds
- Unit tests: 254 passed (5 pre-existing failures unrelated to this change)