### PR TITLE
docs(managed): add docstrings to ManagedValue, IsLastStep, and RemainingSteps

### DIFF
--- a/libs/langgraph/langgraph/managed/base.py
+++ b/libs/langgraph/langgraph/managed/base.py
@@ -16,16 +16,67 @@ __all__ = ("ManagedValueSpec", "ManagedValueMapping")
 
 
 class ManagedValue(ABC, Generic[V]):
+    """Abstract base class for managed graph values.
+
+    Managed values are read-only values injected into graph nodes at runtime.
+    They are not part of the graph state and are not checkpointed. Instead,
+    they are computed fresh on each step from the current `PregelScratchpad`.
+
+    To create a custom managed value, subclass `ManagedValue` and implement
+    the `get` static method:
+
+    ```python
+    from typing import Annotated
+    from langgraph.managed.base import ManagedValue
+    from langgraph._internal._scratchpad import PregelScratchpad
+
+    class CurrentStepManager(ManagedValue[int]):
+        @staticmethod
+        def get(scratchpad: PregelScratchpad) -> int:
+            return scratchpad.step
+
+    CurrentStep = Annotated[int, CurrentStepManager]
+    ```
+    """
+
     @staticmethod
     @abstractmethod
-    def get(scratchpad: PregelScratchpad) -> V: ...
+    def get(scratchpad: PregelScratchpad) -> V:
+        """Compute and return the managed value for the current step.
+
+        Args:
+            scratchpad: The current Pregel execution scratchpad, containing
+                step counters and other runtime state.
+
+        Returns:
+            The computed value for this managed value type.
+        """
+        ...
 
 
 ManagedValueSpec = type[ManagedValue]
+"""Type alias for a class (not instance) that is a subclass of `ManagedValue`.
+
+Used in type annotations to indicate that a value is a managed value
+specification, i.e. a class object that implements `ManagedValue.get`.
+"""
 
 
 def is_managed_value(value: Any) -> TypeGuard[ManagedValueSpec]:
+    """Return `True` if `value` is a `ManagedValue` subclass, `False` otherwise.
+
+    Args:
+        value: The object to check.
+
+    Returns:
+        `True` if `value` is a class that subclasses `ManagedValue`.
+    """
     return isclass(value) and issubclass(value, ManagedValue)
 
 
 ManagedValueMapping = dict[str, ManagedValueSpec]
+"""Type alias for a mapping from state key names to `ManagedValue` subclasses.
+
+Used internally by the graph runtime to look up and inject managed values
+into node invocations.
+"""

--- a/libs/langgraph/langgraph/managed/is_last_step.py
+++ b/libs/langgraph/langgraph/managed/is_last_step.py
@@ -7,18 +7,107 @@ __all__ = ("IsLastStep", "RemainingStepsManager")
 
 
 class IsLastStepManager(ManagedValue[bool]):
+    """Managed value that indicates whether the current step is the last step.
+
+    Inject `IsLastStep` into a node's type annotations to receive a boolean
+    flag that is `True` only when the graph is on its final allowed step
+    (i.e. one step before the recursion limit).
+
+    This is useful for gracefully handling the recursion limit — for example,
+    by returning a final response instead of invoking more tools.
+
+    Example:
+        ```python
+        from typing import Annotated
+        from langgraph.managed import IsLastStep
+
+        def my_node(state: State, is_last_step: IsLastStep) -> dict:
+            if is_last_step:
+                return {"messages": [{"role": "assistant", "content": "Stopping here."}]}
+            # ... normal processing
+        ```
+    """
+
     @staticmethod
     def get(scratchpad: PregelScratchpad) -> bool:
+        """Return `True` if the current step is the last permitted step.
+
+        Args:
+            scratchpad: The current Pregel execution scratchpad.
+
+        Returns:
+            `True` if `scratchpad.step == scratchpad.stop - 1`, else `False`.
+        """
         return scratchpad.step == scratchpad.stop - 1
 
 
 IsLastStep = Annotated[bool, IsLastStepManager]
+"""Managed value annotation that resolves to `True` on the graph's final step.
+
+Use this as a type annotation for a node parameter to receive a boolean
+indicating whether the current step is the last step before the recursion
+limit is reached.
+
+Example:
+    ```python
+    from langgraph.managed import IsLastStep
+
+    def call_model(state: State, is_last_step: IsLastStep) -> dict:
+        if is_last_step:
+            # Force a final response without further tool calls
+            ...
+    ```
+"""
 
 
 class RemainingStepsManager(ManagedValue[int]):
+    """Managed value that reports the number of steps remaining before the recursion limit.
+
+    Inject `RemainingSteps` into a node's type annotations to receive an
+    integer count of how many more steps the graph may execute.
+
+    A value of `1` means the current step is the last permitted step.
+    A value of `0` would indicate the limit has been reached (not normally
+    observable in practice, since execution stops beforehand).
+
+    Example:
+        ```python
+        from langgraph.managed import RemainingSteps
+
+        def my_node(state: State, remaining_steps: RemainingSteps) -> dict:
+            if remaining_steps < 3:
+                # Wrap up early
+                ...
+        ```
+    """
+
     @staticmethod
     def get(scratchpad: PregelScratchpad) -> int:
+        """Return the number of steps remaining before the recursion limit.
+
+        Args:
+            scratchpad: The current Pregel execution scratchpad.
+
+        Returns:
+            The number of remaining steps, computed as
+            `scratchpad.stop - scratchpad.step`.
+        """
         return scratchpad.stop - scratchpad.step
 
 
 RemainingSteps = Annotated[int, RemainingStepsManager]
+"""Managed value annotation that resolves to the number of steps remaining.
+
+Use this as a type annotation for a node parameter to receive the count of
+steps the graph may still execute before hitting the recursion limit.
+
+Example:
+    ```python
+    from langgraph.managed import RemainingSteps
+
+    def call_model(state: State, remaining_steps: RemainingSteps) -> dict:
+        if remaining_steps < 5:
+            # Not enough steps left for more tool calls — respond directly
+            ...
+    ```
+"""


### PR DESCRIPTION
Fixes #5019 (partial — covers managed/ module)

## Summary

Adds Google-style docstrings to all public classes, methods, and type aliases in libs/langgraph/langgraph/managed/, which previously had no documentation at all.

**Files changed:**

- managed/base.py — ManagedValue abstract base class (with a custom-value usage example), ManagedValue.get abstract method, ManagedValueSpec type alias, is_managed_value() helper, ManagedValueMapping type alias
- managed/is_last_step.py — IsLastStepManager and RemainingStepsManager classes with get() method docs, plus IsLastStep and RemainingSteps annotated type alias docs with usage examples

All docstrings follow the Google-style conventions used elsewhere in the repo, and use single backticks for inline code per AGENTS.md.

## Test plan

- [x] make format passes (ruff format + ruff check)
- [x] make lint passes (ruff + mypy — 67 source files, no issues)
- [x] make test passes (1321 passed, 4 skipped)
- [x] Documentation-only change — no behavior changes