### PR TITLE
docs: add Chart Library edge-mining StateGraph example

### DIFF
--- a/examples/chart_library_edge_mining/README.md
+++ b/examples/chart_library_edge_mining/README.md
@@ -1,0 +1,65 @@
+# LangGraph + Chart Library — Edge-Mining Agent
+
+Explicit StateGraph implementation of Chart Library's edge-mining loop
+(cohort → explain → refine → report). Deterministic, checkpointable,
+one LLM call per run (final write-up only; retrieval and analysis are
+pure tool calls).
+
+## Why LangGraph for this
+
+The edge-mining loop is not a free-form tool-calling task. It's a
+specific workflow:
+
+1. Retrieve an initial cohort
+2. Ask which filter moves the distribution most
+3. Refine with that filter
+4. Write up the comparison
+
+A single-LLM-with-tools pattern works but wastes tokens on orchestration
+the workflow already prescribes. LangGraph encodes the order explicitly,
+so the model only handles the synthesis step, and every retrieval is
+checkpointable via LangGraph's saver interface.
+
+## Run
+
+```bash
+pip install langgraph langchain langchain-anthropic requests
+export ANTHROPIC_API_KEY=sk-ant-...
+export CHART_LIBRARY_KEY=cl_...     # free at chartlibrary.io/developers
+python cohort_edge_mining_graph.py NVDA 2024-06-18
+```
+
+## Sample output
+
+```
+[initial cohort] cohort_id=coh_...  n=491/500  5d_p50=+0.48%  elapsed=1891ms
+[explain] same_vix_bucket    n_after= 180  shift=-0.64pp
+[explain] same_trend         n_after= 347  shift=+1.88pp <-- picked
+[explain] recent_5y          n_after= 291  shift=+0.99pp
+[refine] filter=same_trend  n=345/347  5d_p50=+0.62%  elapsed=12ms
+
+─── REPORT ───
+NVDA 2024-06-18 — baseline cohort of 491 historical analogs (54
+delisted included) showed 54.0% above-entry at 5 days with p50
+return +0.48%. Refining by same_trend narrowed to 345 analogs with
+55.8% above-entry and p50 +0.62% (+1.88pp shift). The trend regime
+is the most informative conditional for this setup...
+```
+
+## Extend
+
+- Swap `node_report`'s synthesis LLM for any Anthropic/OpenAI/local model.
+- Add branching: run `node_refine` twice with different winning filters
+  and compare in the report.
+- Plug in a LangGraph saver (memory / redis / postgres) for
+  checkpointable runs.
+- Add a `node_decide` that uses the distribution to set position size
+  inside a live trading agent.
+
+## Submit upstream
+
+LangGraph examples live at `github.com/langchain-ai/langgraph` under
+`examples/`. If you want to propose this as an upstream example, fork,
+drop it in `examples/chart_library_edge_mining/`, and open a PR with
+a short rationale pointing to the Chart Library docs + a live API key
+demo in the notebook.

--- a/examples/chart_library_edge_mining/cohort_edge_mining_graph.py
+++ b/examples/chart_library_edge_mining/cohort_edge_mining_graph.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""
+LangGraph agent that runs Chart Library's edge-mining loop as an explicit
+StateGraph. Each phase (cohort → explain → refine → report) is a node; the
+graph can branch, fork, and persist state across invocations.
+
+Compared to the "single LLM with tools" pattern, this gives you:
+    * Deterministic ordering of tool calls (retrieval THEN analysis)
+    * Easy fork-and-compare of multiple refined cohorts
+    * Checkpointable state (memory saver / redis saver plug in directly)
+    * No model cost for the retrieval/analysis steps — only the final write-up
+
+Run:
+    pip install langgraph langchain langchain-anthropic requests
+    export ANTHROPIC_API_KEY=...
+    export CHART_LIBRARY_KEY=cl_...   # chartlibrary.io/developers
+    python cohort_edge_mining_graph.py NVDA 2024-06-18
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Optional, TypedDict
+
+import requests
+
+try:
+    from langgraph.graph import StateGraph, END
+    from langchain_anthropic import ChatAnthropic
+    from langchain_core.messages import SystemMessage, HumanMessage
+except ImportError:  # pragma: no cover
+    raise SystemExit("pip install langgraph langchain langchain-anthropic requests")
+
+CHART_BASE = "https://chartlibrary.io"
+CHART_KEY = os.environ["CHART_LIBRARY_KEY"]
+H = {"Authorization": f"Bearer {CHART_KEY}", "Content-Type": "application/json"}
+
+
+# ── Tool wrappers ──────────────────────────────────────────
+
+def cohort(symbol: str, date: str, **kw) -> dict:
+    body = {
+        "anchor": {"symbol": symbol, "date": date},
+        "filters": kw.get("filters", {}),
+        "horizons": kw.get("horizons", [5, 10]),
+        "top_k": kw.get("top_k", 500),
+        "include_path_stats": True,
+    }
+    r = requests.post(f"{CHART_BASE}/api/v1/cohort", headers=H, json=body, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def explain(cohort_id: str, horizon: int = 5) -> dict:
+    r = requests.get(
+        f"{CHART_BASE}/api/v1/cohort/{cohort_id}/explain",
+        headers=H, params={"horizon": horizon}, timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def refine(cohort_id: str, filter_name: str) -> dict:
+    extra = {"regime": {filter_name: True}} if filter_name.startswith("same_") else {}
+    r = requests.post(
+        f"{CHART_BASE}/api/v1/cohort/{cohort_id}/filter",
+        headers=H,
+        json={"extra_filters": extra, "include_path_stats": True},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+# ── Graph state ────────────────────────────────────────────
+
+class CohortState(TypedDict, total=False):
+    symbol: str
+    date: str
+    initial: dict
+    explain: dict
+    winning_filter: Optional[str]
+    refined: Optional[dict]
+    report: str
+
+
+# ── Nodes ──────────────────────────────────────────────────
+
+def node_initial_cohort(state: CohortState) -> dict:
+    res = cohort(state["symbol"], state["date"])
+    print(f"[initial cohort] cohort_id={res['cohort_id']}  n={res['n_effective']}/{res['n_raw']}"
+          f"  5d_p50={res['distributions']['5']['return_pct']['p50']:+.2f}%"
+          f"  elapsed={res['elapsed_ms']}ms")
+    return {"initial": res}
+
+
+def node_explain(state: CohortState) -> dict:
+    res = explain(state["initial"]["cohort_id"], horizon=5)
+    # Pick the candidate filter with the largest |above_entry_shift|.
+    winners = sorted(
+        (r for r in res["rankings"] if not r.get("skipped") and r["n_after"] >= 50),
+        key=lambda r: -abs(r.get("above_entry_shift_pp") or 0),
+    )
+    best = winners[0]["filter"] if winners else None
+    for row in res["rankings"]:
+        if row.get("skipped"):
+            continue
+        shift = row.get("above_entry_shift_pp", 0) or 0
+        marker = " <-- picked" if row["filter"] == best else ""
+        print(f"[explain] {row['filter']:<18s}  n_after={row['n_after']:4d}  shift={shift:+.2f}pp{marker}")
+    return {"explain": res, "winning_filter": best}
+
+
+def node_refine(state: CohortState) -> dict:
+    if not state.get("winning_filter"):
+        print("[refine] no winning filter, skipping")
+        return {"refined": None}
+    res = refine(state["initial"]["cohort_id"], state["winning_filter"])
+    print(f"[refine] filter={state['winning_filter']}  n={res['n_effective']}/{res['n_raw']}"
+          f"  5d_p50={res['distributions']['5']['return_pct']['p50']:+.2f}%"
+          f"  elapsed={res['elapsed_ms']}ms")
+    return {"refined": res}
+
+
+def node_report(state: CohortState) -> dict:
+    llm = ChatAnthropic(model="claude-sonnet-4-5", max_tokens=800)
+    initial = state["initial"]
+    refined = state.get("refined")
+
+    context = {
+        "symbol": state["symbol"],
+        "date": state["date"],
+        "baseline": {
+            "n": initial["n_effective"],
+            "survivorship": initial["survivorship"],
+            "5d": initial["distributions"]["5"],
+            "10d": initial["distributions"]["10"],
+        },
+        "winning_filter": state.get("winning_filter"),
+        "refined": {
+            "n": refined["n_effective"],
+            "5d": refined["distributions"]["5"],
+            "10d": refined["distributions"]["10"],
+        } if refined else None,
+        "explain_rankings": state["explain"]["rankings"],
+    }
+
+    messages = [
+        SystemMessage(content=(
+            "You are a stock-research analyst. Produce a 150-word briefing "
+            "using ONLY the numbers in the provided context. Quote sample "
+            "size, disclose survivorship, and note if the refined cohort "
+            "materially changes the picture vs the baseline. Never invent "
+            "numbers. End with a 1-sentence sizing/risk implication."
+        )),
+        HumanMessage(content=f"Data:\n{json.dumps(context, default=str, indent=2)}"),
+    ]
+    result = llm.invoke(messages)
+    return {"report": result.content}
+
+
+# ── Graph construction ────────────────────────────────────
+
+def build_graph():
+    g = StateGraph(CohortState)
+    g.add_node("initial_cohort", node_initial_cohort)
+    g.add_node("explain", node_explain)
+    g.add_node("refine", node_refine)
+    g.add_node("report", node_report)
+
+    g.set_entry_point("initial_cohort")
+    g.add_edge("initial_cohort", "explain")
+    g.add_edge("explain", "refine")
+    g.add_edge("refine", "report")
+    g.add_edge("report", END)
+    return g.compile()
+
+
+if __name__ == "__main__":
+    symbol = sys.argv[1] if len(sys.argv) > 1 else "NVDA"
+    date = sys.argv[2] if len(sys.argv) > 2 else "2024-06-18"
+    graph = build_graph()
+    final = graph.invoke({"symbol": symbol, "date": date})
+    print("\n─── REPORT ───")
+    print(final["report"])


### PR DESCRIPTION
Adds an example showing how to encode a deterministic retrieval loop as a LangGraph StateGraph: `cohort → explain → refine → report`.

## Why this example
Many real retrieval workflows are **prescribed** (not free-form). Encoding the order as a graph instead of a single tool-using LLM:
- Deterministic tool ordering (retrieval before analysis before synthesis)
- One LLM call (final synthesis only) — tools don't need model cost
- Checkpointable state (plugs into any LangGraph saver)
- Easy branching / fork-compare of refined cohorts

## What it does
Chart Library's [Conditional Distribution API](https://chartlibrary.io/developers) exposes historical chart-pattern cohorts. The example:
1. Builds an initial cohort for `(symbol, date)` via HTTP POST
2. Asks the `/explain` endpoint which filter would shift the distribution most
3. Refines with the winning filter (sub-second, no kNN re-run)
4. Runs a single Claude call to narrate the baseline-vs-refined comparison

## Running
```bash
pip install langgraph langchain langchain-anthropic requests
export ANTHROPIC_API_KEY=sk-ant-...
export CHART_LIBRARY_KEY=cl_...     # free at chartlibrary.io/developers
python cohort_edge_mining_graph.py NVDA 2024-06-18
```

## About Chart Library
Open API serving 24M historical chart-pattern embeddings with conditional distribution retrieval. Free tier (200 calls/day). MCP server at `pip install chartlibrary-mcp`. Docs: chartlibrary.io/api/docs.

Pinging as **draft** so maintainers can review the example shape before merge; happy to adjust directory location, naming, or style to match current LangGraph example conventions.