### PR TITLE
fix(cli): add missing typing_extensions dependency for Python <3.11

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
+    "typing_extensions>=4.0 ; python_version < '3.11'",
 ]
 [tool.hatch.version]
 path = "langgraph_cli/__init__.py"


### PR DESCRIPTION
## Summary

`langgraph-cli` crashes on import with `ModuleNotFoundError: No module named 'typing_extensions'` when installed in a clean Python 3.10 environment.

## Root Cause

`langgraph_cli/schemas.py` imports `Required` from `typing_extensions`, but `typing_extensions` is not listed in the package's dependencies. `Required` was only added to the standard `typing` module in Python 3.11, so Python 3.10 environments require the backport.

## Fix

Add `typing_extensions>=4.0` as a conditional dependency for `python_version < '3.11'` in `pyproject.toml`, matching the existing conditional pattern used for `tomli`.

```toml
"typing_extensions>=4.0 ; python_version < '3.11'",
```

Fixes #7462


Made with [Cursor](https://cursor.com)