### PR TITLE
Fix #7315: langgraph-sdk _ExecutionRuntime/_ReadRuntime missing `prev...

### DIFF
--- a/libs/sdk-py/langgraph_sdk/runtime.py
+++ b/libs/sdk-py/langgraph_sdk/runtime.py
@@ -162,6 +162,12 @@ class _ExecutionRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
     Only available during `threads.create_run`.
     """
 
+    previous: object = field(default=None)
+    """The previous return value for the given thread.
+
+    Only available with the functional API when a checkpointer is provided.
+    """
+
 
 @dataclass(kw_only=True, slots=True, frozen=True)
 class _ReadRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
@@ -173,6 +179,18 @@ class _ReadRuntime(_ServerRuntimeBase[ContextT], Generic[ContextT]):
 
     !!! warning "Beta"
         This API is in beta and may change in future releases.
+    """
+
+    context: object = field(default=None)
+    """Always `None` for non-execution contexts.
+
+    Present for interface compatibility with `langgraph.runtime.Runtime`.
+    """
+
+    previous: object = field(default=None)
+    """Always `None` for non-execution contexts.
+
+    Present for interface compatibility with `langgraph.runtime.Runtime`.
     """
 
 

--- a/libs/sdk-py/tests/test_runtime.py
+++ b/libs/sdk-py/tests/test_runtime.py
@@ -1,0 +1,39 @@
+"""Tests for langgraph_sdk.runtime — verifies field presence required by runtime_to_proto."""
+
+from langgraph_sdk.runtime import _ExecutionRuntime, _ReadRuntime
+
+
+class _MockStore:
+    """Minimal stand-in for BaseStore."""
+
+
+def test_execution_runtime_has_previous():
+    """_ExecutionRuntime must expose a `previous` attribute (used by runtime_to_proto)."""
+    store = _MockStore()
+    er = _ExecutionRuntime(access_context="threads.create_run", store=store)
+    assert hasattr(er, "previous")
+    assert er.previous is None
+
+
+def test_execution_runtime_has_context():
+    """_ExecutionRuntime must expose a `context` attribute."""
+    store = _MockStore()
+    er = _ExecutionRuntime(access_context="threads.create_run", store=store)
+    assert hasattr(er, "context")
+    assert er.context is None
+
+
+def test_read_runtime_has_previous():
+    """_ReadRuntime must expose a `previous` attribute (used by runtime_to_proto)."""
+    store = _MockStore()
+    rr = _ReadRuntime(access_context="threads.read", store=store)
+    assert hasattr(rr, "previous")
+    assert rr.previous is None
+
+
+def test_read_runtime_has_context():
+    """_ReadRuntime must expose a `context` attribute (used by runtime_to_proto)."""
+    store = _MockStore()
+    rr = _ReadRuntime(access_context="threads.read", store=store)
+    assert hasattr(rr, "context")
+    assert rr.context is None


### PR DESCRIPTION
Closes #7315

Fixes #7315

`_ExecutionRuntime` and `_ReadRuntime` in `libs/sdk-py/langgraph_sdk/runtime.py` were missing fields that `runtime_to_proto()` unconditionally accesses, causing `AttributeError` crashes on every `GetGraph` call in LangGraph Cloud deployments.

**Root cause:** `runtime_to_proto()` (in `langgraph_grpc_common`) expects the full `langgraph.runtime.Runtime` dataclass interface, including `previous` and `context`. The SDK-side classes used by `build_server_runtime()` declared `__slots__` that omitted these fields:
- `_ExecutionRuntime` had `__slots__ = ('context',)` — missing `previous`
- `_ReadRuntime` had `__slots__ = ()` — missing both `context` and `previous`

**Fix:** Added the missing fields with `default=None` to both dataclasses:
- `_ExecutionRuntime`: added `previous: object = field(default=None)`
- `_ReadRuntime`: added `context: object = field(default=None)` and `previous: object = field(default=None)`

Both fields are documented as `None` stubs present for interface compatibility in `_ReadRuntime`, where they carry no semantic meaning.

**Verification:** Added `libs/sdk-py/tests/test_runtime.py` with four tests covering `hasattr` and value checks for `previous` and `context` on both runtime classes. All four pass. Also manually confirmed the reproduction script from the issue no longer raises `AttributeError`.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*