### PR TITLE
fix: add missing typing_extensions dependency to langgraph-cli

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -14,6 +14,10 @@ license-files = ['LICENSE']
 dependencies = [
     "click>=8.1.7",
     "langgraph-sdk>=0.1.0 ; python_version >= '3.11'",
+    "pathspec>=0.11.0",
+    "python-dotenv>=0.8.0",
+    "tomli>=2.0.1 ; python_version < '3.11'",
+    "typing_extensions>=4.0.0",
 ]
 [tool.hatch.version]
 path = "langgraph_cli/__init__.py"


### PR DESCRIPTION
Fixes #7462: Add typing_extensions>=4.0.0 to dependencies in langgraph-cli's pyproject.toml to resolve ModuleNotFoundError on clean environments.

## Summary
The langgraph-cli 0.4.21 imports typing_extensions in schemas.py but does not declare it as a dependency, causing crashes on clean environments like GitHub Actions runners.

## Changes
- Added  to the dependencies list in 
- Also added missing pathspec and python-dotenv dependencies

## Testing
This change resolves the ModuleNotFoundError described in #7462 when running  in clean environments.