### PR TITLE
fix(cli): add missing typing_extensions dependency

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
+    "typing_extensions>=4.0.0",
 ]
 [tool.hatch.version]
 path = "langgraph_cli/__init__.py"


### PR DESCRIPTION
Problem
  `langgraph-cli` 0.4.21 added `UvSource` in `schemas.py` which imports
  `Required` from `typing_extensions`, but `typing_extensions` was never
  declared as a package dependency.

  This causes a `ModuleNotFoundError` on clean environments (fresh CI
  runners, minimal Docker images) where `typing_extensions` is not
  pre-installed.

  Fixes #7462

Fix
  Add `typing_extensions>=4.0.0` to the `[project]` dependencies in
  `libs/cli/pyproject.toml`.

