### PR TITLE
test(checkpoint): add regression coverage for StrEnum serialization (#6598)

### DIFF
--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1,4 +1,5 @@
 import dataclasses
+import enum
 import json
 import logging
 import pathlib
@@ -8,7 +9,7 @@ import uuid
 from collections import deque
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, IntEnum
 from ipaddress import IPv4Address
 from zoneinfo import ZoneInfo
 
@@ -39,6 +40,10 @@ from langgraph.checkpoint.serde.jsonplus import (
     _warned_unregistered_types,
 )
 from langgraph.store.base import Item
+
+# StrEnum is only available on Python 3.11+. Resolve it at import time so
+# this module stays collectable on 3.10 (the checkpoint package's min version).
+StrEnum: type[Enum] | None = getattr(enum, "StrEnum", None)
 
 
 class InnerPydantic(BaseModel):
@@ -91,6 +96,23 @@ class MyDataclassWSlots:
 
 
 class MyEnum(Enum):
+    FOO = "foo"
+    BAR = "bar"
+
+
+if StrEnum is not None:
+
+    class MyStrEnum(StrEnum):  # type: ignore[misc,valid-type]
+        FOO = "foo"
+        BAR = "bar"
+
+
+class MyIntEnum(IntEnum):
+    ONE = 1
+    TWO = 2
+
+
+class MyLegacyStrEnum(str, Enum):
     FOO = "foo"
     BAR = "bar"
 
@@ -997,3 +1019,53 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+@pytest.mark.skipif(StrEnum is None, reason="StrEnum requires Python 3.11+")
+def test_strenum_round_trip() -> None:
+    """Regression for #6598 — StrEnum must preserve its concrete type."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=[MyStrEnum])
+
+    loaded = serde.loads_typed(serde.dumps_typed(MyStrEnum.FOO))
+
+    assert type(loaded) is MyStrEnum
+    assert loaded is MyStrEnum.FOO
+
+
+def test_intenum_round_trip() -> None:
+    serde = JsonPlusSerializer(allowed_msgpack_modules=[MyIntEnum])
+
+    loaded = serde.loads_typed(serde.dumps_typed(MyIntEnum.ONE))
+
+    assert type(loaded) is MyIntEnum
+    assert loaded is MyIntEnum.ONE
+
+
+def test_legacy_str_enum_round_trip() -> None:
+    serde = JsonPlusSerializer(allowed_msgpack_modules=[MyLegacyStrEnum])
+
+    loaded = serde.loads_typed(serde.dumps_typed(MyLegacyStrEnum.FOO))
+
+    assert type(loaded) is MyLegacyStrEnum
+    assert loaded is MyLegacyStrEnum.FOO
+
+
+@pytest.mark.skipif(StrEnum is None, reason="StrEnum requires Python 3.11+")
+def test_typed_enums_inside_container() -> None:
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[MyStrEnum, MyIntEnum, MyLegacyStrEnum]
+    )
+
+    payload = {
+        "str": MyStrEnum.FOO,
+        "int": MyIntEnum.TWO,
+        "legacy": MyLegacyStrEnum.BAR,
+        "list": [MyStrEnum.BAR, MyIntEnum.ONE],
+    }
+    loaded = serde.loads_typed(serde.dumps_typed(payload))
+
+    assert type(loaded["str"]) is MyStrEnum
+    assert type(loaded["int"]) is MyIntEnum
+    assert type(loaded["legacy"]) is MyLegacyStrEnum
+    assert type(loaded["list"][0]) is MyStrEnum
+    assert type(loaded["list"][1]) is MyIntEnum

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -155,6 +155,49 @@ def test_graph_validation_with_command() -> None:
     assert graph.invoke({"foo": ""}) == {"foo": "bar", "bar": "baz"}
 
 
+# StrEnum is 3.11+; resolve once at module scope so the class below is
+# module-addressable (the serde reconstructs by importing the module and
+# looking up the class by __name__ — a function-local class would be unreachable).
+_StrEnum = getattr(enum, "StrEnum", None)
+
+if _StrEnum is not None:
+
+    class _StrEnumStatus(_StrEnum):  # type: ignore[misc,valid-type]
+        PENDING = "pending"
+        COMPLETED = "completed"
+
+
+@pytest.mark.skipif(_StrEnum is None, reason="StrEnum requires Python 3.11+")
+def test_strenum_state_round_trip_through_checkpointer() -> None:
+    """End-to-end regression for langchain-ai/langgraph#6598.
+
+    A ``StrEnum`` (3.11+) field in graph state must survive the
+    checkpoint serialize/deserialize round trip with its concrete
+    enum type intact.
+    """
+
+    class State(TypedDict):
+        status: _StrEnumStatus
+
+    def advance(state: State) -> State:
+        return {"status": _StrEnumStatus.COMPLETED}
+
+    graph = (
+        StateGraph(State)
+        .add_node("advance", advance)
+        .add_edge(START, "advance")
+        .add_edge("advance", END)
+        .compile(checkpointer=InMemorySaver())
+    )
+
+    config: RunnableConfig = {"configurable": {"thread_id": "t"}}
+    graph.invoke({"status": _StrEnumStatus.PENDING}, config=config)
+
+    loaded = graph.get_state(config=config).values["status"]
+    assert type(loaded) is _StrEnumStatus
+    assert loaded is _StrEnumStatus.COMPLETED
+
+
 def test_checkpoint_errors() -> None:
     class FaultyGetCheckpointer(InMemorySaver):
         def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:


### PR DESCRIPTION
## Summary

Adds unit and end-to-end regression tests for `StrEnum` / `IntEnum` / legacy `str + Enum` serialization through the checkpoint round trip. Guards against a re-introduction of the bug reported in #6598.

## Context

Issue #6598 reports that a `StrEnum` field in graph state is silently converted to a plain `str` on checkpoint load, losing its concrete type. That bug is **already fixed on current `main`** by the `ormsgpack >= 1.12` floor bump in `libs/checkpoint/pyproject.toml` - I verified empirically that under the current dep constraint, `StrEnum` round-trips cleanly via the existing `OPT_PASSTHROUGH_ENUM` option plus the `isinstance(obj, Enum)` branch in `_msgpack_default`.

This PR is therefore **test-only** - no production serializer code changes. It exists to:
- lock in the current working behavior so a future dep bump, option-bitmask change, or refactor of `_msgpack_default` cannot silently regress it,
- and demonstrate at the `StateGraph` + `InMemorySaver` level (the exact surface the reporter was using) that the fix holds end-to-end.

If maintainers want additional production changes (e.g., warnings on silent coercion of non-Enum `str`/`int` subclasses, which `#6598` also touches on), that is a separate scope and not what this PR is proposing.

## Changes

- `libs/checkpoint/tests/test_jsonplus.py` - four direct-serializer tests:
  - `test_strenum_round_trip` - concrete `StrEnum` preserved.
  - `test_intenum_round_trip` - concrete `IntEnum` preserved.
  - `test_legacy_str_enum_round_trip` - `class X(str, Enum)` preserved.
  - `test_typed_enums_inside_container` - all three preserved inside dict/list.
- `libs/langgraph/tests/test_pregel.py` - end-to-end `test_strenum_state_round_trip_through_checkpointer` exercising `StateGraph` + `InMemorySaver` + `StrEnum` state field (the exact shape from the issue reporter).
- `StrEnum` resolved via `getattr(enum, "StrEnum", None)` at module scope so the suite stays collectable on Python 3.10 (current `requires-python = ">=3.10"`). StrEnum-dependent tests are gated with `pytest.mark.skipif`.
- `_StrEnumStatus` in the E2E test is defined at module scope (not inside the test function) because the checkpoint serde reconstructs enum values by importing the module and looking up the class by `__name__` - a function-local class would be unreachable (`__qualname__` contains `<locals>`).

## Test plan

- [x] `uv run pytest libs/checkpoint/tests/test_jsonplus.py` - 95 passed.
- [x] `uv run pytest libs/checkpoint/tests/ --ignore=tests/test_redis_cache.py` - 144 passed.
- [x] Standalone run of the E2E test body against `InMemorySaver` - confirms concrete type preservation.
- [x] `ruff format` / `ruff check` clean on both files.
- [x] `mypy libs/checkpoint/tests/test_jsonplus.py` - no new errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)