### PR TITLE
fix(cli): declare typing_extensions dependency

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "langgraph-sdk>=0.1.0 ; python_version >= '3.11'",
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
+    "typing_extensions>=4.0.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
 ]
 [tool.hatch.version]


### PR DESCRIPTION
## Summary
- add typing_extensions to langgraph-cli runtime dependencies
- align package metadata with the Required import used in langgraph_cli.schemas
- prevent ModuleNotFoundError in clean environments that install the CLI package alone

Closes #7462

## Verification
- not run locally because this change is limited to package metadata in libs/cli/pyproject.toml