### PR TITLE
fix(cli): add typing-extensions dependency for supported Python versions

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "langgraph-sdk>=0.1.0 ; python_version >= '3.11'",
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
+    "typing_extensions>=4.0.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
 ]
 [tool.hatch.version]


### PR DESCRIPTION
## Summary
- add an explicit typing_extensions dependency to the CLI package metadata
- keep the dependency available across the supported Python range where the code imports it directly

## Testing
- packaging metadata change only