### PR TITLE
fix(channels): unwrap Required before origin stripping

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -21,10 +21,10 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
 
     return t
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,10 +1,12 @@
 import operator
 from collections.abc import Sequence
+from typing import Annotated
 
 import pytest
+from typing_extensions import Required
 
 from langgraph._internal._typing import MISSING
-from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.channels.binop import BinaryOperatorAggregate, _strip_extras
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
@@ -88,6 +90,10 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_strip_extras_unwraps_required_annotated() -> None:
+    assert _strip_extras(Required[Annotated[int, "meta"]]) is int
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary
- handle Required and NotRequired wrappers before the generic __origin__ fallback in _strip_extras
- preserve the intended unwrapping behavior for nested forms like Required[Annotated[int, ...]]
- add a regression test covering Required[Annotated[int, "meta"]]

Closes #7496

## Verification
- not run locally because the current environment does not have the project test runner/dependencies configured