### PR TITLE
fix(channels): correct _strip_extras to properly unwrap Required/NotR…

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -22,10 +22,9 @@ __all__ = ("BinaryOperatorAggregate",)
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
     if hasattr(t, "__origin__"):
+        if t.__origin__ in (Required, NotRequired):
+            return _strip_extras(t.__args__[0])
         return _strip_extras(t.__origin__)
-    if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
-        return _strip_extras(t.__args__[0])
-
     return t
 
 


### PR DESCRIPTION
fix(channels): correct _strip_extras to properly unwrap Required/NotRequired

The second if-block in _strip_extras was unreachable dead code. It could
never execute because the first if-block always returned via recursion
when __origin__ was present.

This also meant Required[T] and NotRequired[T] type annotations were
never actually unwrapped. _strip_extras returned the raw typing wrapper
instead of the inner type T, causing BinaryOperatorAggregate to fail to
determine the correct initial value for annotated state fields.

Fix: check for Required/NotRequired inside the first if-block before the
generic __origin__ recursion, so the inner argument type is resolved.
