### PR TITLE
fix(channels): correct _strip_extras to properly unwrap Required/NotR…

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -22,10 +22,9 @@ __all__ = ("BinaryOperatorAggregate",)
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
     if hasattr(t, "__origin__"):
+        if t.__origin__ in (Required, NotRequired):
+            return _strip_extras(t.__args__[0])
         return _strip_extras(t.__origin__)
-    if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
-        return _strip_extras(t.__args__[0])
-
     return t
 
 


### PR DESCRIPTION
## Description
This PR fixes a bug in `BinaryOperatorAggregate` channels where `Required[T]` and `NotRequired[T]` state fields with reducers fail to initialize correctly. 

### Why
The `_strip_extras()` function in `langgraph.channels.binop` had an unreachable dead code block. The second `if hasattr(t, "__origin__")` block was never reached because the first `if hasattr(t, "__origin__")` block always returned via recursion first. 

Because of this, `Required[T]` and `NotRequired[T]` type wrappers were never actually unwrapped. `_strip_extras` returned the generic `Required` wrapper itself instead of the inner type `T`.

### The Fix
Moved the check for `Required`/`NotRequired` explicitly inside the first `if` block, ensuring it acts as an early return before the generic `__origin__` recursion. This allows the inner argument type to be successfully parsed.

**Fixes #7578 **
