### PR TITLE
fix(channels): explicitly reject regular updates after Overwrite in B…

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -118,8 +118,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            if seen_overwrite:
+                msg = create_error_message(
+                    message=f"At key '{self.key}': Cannot apply operator after an Overwrite in the same super-step. Move regular updates before the Overwrite, or use separate super-steps.",
+                    error_code=ErrorCode.INVALID_CONCURRENT_GRAPH_UPDATE,
+                )
+                raise InvalidUpdateError(msg)
+            self.value = self.operator(self.value, value)
         return True
 
     def get(self) -> Value:


### PR DESCRIPTION
## Description
This PR fixes a bug in `BinaryOperatorAggregate` where regular state updates are silently discarded without error if they appear in the sequence after an `Overwrite` value during the same super-step.

### Why
If multiple nodes execute in parallel and write to the same `Annotated[T, reducer]` field, their outputs are collected in a list. If that list contains `[regular_val_1, Overwrite(x), regular_val_2]`, the loop in `BinaryOperatorAggregate.update` applies `regular_val_1`, processes the `Overwrite`, and then skips `regular_val_2` entirely because `seen_overwrite` is set to `True`.

This results in silent, non-deterministic data loss. Wiping out the state while concurrently trying to apply reduce-operations to it in the same atomic execution step is a logic error and should be explicitly rejected.

### Fix
Changed the `update` loop logic: if `seen_overwrite` is True and the channel encounters a regular value, it now raises an `InvalidUpdateError` with a clear message explaining the constraint.

Fixes #7580 
