### PR TITLE
fix(prebuilt): reject invalid tool wrapper return values

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1040,7 +1040,8 @@ class ToolNode(RunnableCallable):
 
         # Call wrapper with request and execute callable
         try:
-            return self._wrap_tool_call(tool_request, execute)
+            response = self._wrap_tool_call(tool_request, execute)
+            return self._validate_wrapper_response(call, response)
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1198,10 +1199,12 @@ class ToolNode(RunnableCallable):
         # Call wrapper with request and execute callable
         try:
             if self._awrap_tool_call is not None:
-                return await self._awrap_tool_call(tool_request, execute)
+                response = await self._awrap_tool_call(tool_request, execute)
+                return self._validate_wrapper_response(call, response)
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            response = self._wrap_tool_call(tool_request, _sync_execute)
+            return self._validate_wrapper_response(call, response)
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1214,6 +1217,24 @@ class ToolNode(RunnableCallable):
                 tool_call_id=tool_request.tool_call["id"],
                 status="error",
             )
+
+    def _validate_wrapper_response(
+        self,
+        call: ToolCall,
+        response: ToolMessage | Command | object,
+    ) -> ToolMessage | Command:
+        """Validate wrap_tool_call / awrap_tool_call return values."""
+        if isinstance(response, Command):
+            return response
+        if isinstance(response, ToolMessage):
+            response.content = cast("str | list", msg_content_output(response.content))
+            return response
+
+        msg = (
+            f"wrap_tool_call for tool {call['name']} returned unexpected type: "
+            f"{type(response)}"
+        )
+        raise TypeError(msg)
 
     def _parse_input(
         self,

--- a/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
+++ b/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
@@ -466,6 +466,80 @@ async def test_async_interceptor_exception_with_unregistered_tool() -> None:
         )
 
 
+def test_wrap_tool_call_bad_return_type_raises_type_error() -> None:
+    """Test that invalid sync wrapper return values fail explicitly."""
+
+    def invalid_interceptor(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        del request, execute
+        return None  # type: ignore[return-value]
+
+    node = ToolNode(
+        [registered_tool], wrap_tool_call=invalid_interceptor, handle_tool_errors=False
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="wrap_tool_call for tool registered_tool returned unexpected type",
+    ):
+        node.invoke(
+            [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "registered_tool",
+                            "args": {"x": 42},
+                            "id": "1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ],
+            config=_create_config_with_runtime(),
+        )
+
+
+async def test_awrap_tool_call_bad_return_type_raises_type_error() -> None:
+    """Test that invalid async wrapper return values fail explicitly."""
+
+    async def invalid_async_interceptor(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        del request, execute
+        return None  # type: ignore[return-value]
+
+    node = ToolNode(
+        [registered_tool],
+        awrap_tool_call=invalid_async_interceptor,
+        handle_tool_errors=False,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="wrap_tool_call for tool registered_tool returned unexpected type",
+    ):
+        await node.ainvoke(
+            [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "registered_tool",
+                            "args": {"x": 42},
+                            "id": "1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ],
+            config=_create_config_with_runtime(),
+        )
+
+
 def test_interceptor_with_dict_input_format() -> None:
     """Test that interceptor works with dict input format."""
 


### PR DESCRIPTION
## Summary
- reject invalid return values from `wrap_tool_call` and `awrap_tool_call` explicitly
- keep valid `ToolMessage` and `Command` wrapper responses working as before
- add focused sync/async regression tests for wrappers that return `None`

## Why
`ToolNode` already validates normal tool execution responses, but wrapper return values were not validated at the wrapper boundary. If a wrapper returned `None` or another unexpected type, that value could leak into the output flow instead of failing with a clear error.

This change makes the wrapper contract explicit and raises a targeted `TypeError` for invalid wrapper return values.

## Testing
- `uv run pytest tests/test_tool_node_interceptor_unregistered.py -k 'bad_return_type or exception_with_unregistered_tool'`
