### PR TITLE
fix: sync cache guard, BinaryOperatorAggregate data loss, ToolNode async blocking

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -118,8 +118,7 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            self.value = self.operator(self.value, value)
         return True
 
     def get(self) -> Value:

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1208,6 +1208,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks
+            return
         self.submit(
             self.cache.set,
             {

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1201,7 +1201,11 @@ class ToolNode(RunnableCallable):
                 return await self._awrap_tool_call(tool_request, execute)
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            # Run sync wrapper in executor to avoid blocking the event loop
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None, self._wrap_tool_call, tool_request, _sync_execute
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:


### PR DESCRIPTION
Fixes #7589, fixes #7590, fixes #7591

Three independent fixes for bugs found during an audit of the Pregel engine, channel system, and ToolNode. Each is a separate commit.

## 1. `SyncPregelLoop.put_writes` caches failed tasks

`AsyncPregelLoop.put_writes` guards against caching `INTERRUPT`/`ERROR` writes. The sync counterpart is missing this guard, so failed or interrupted task writes get persisted to cache and replayed as valid results on subsequent invocations.

```diff
 task = self.tasks.get(task_id)
 if task is None or task.cache_key is None:
     return
+if writes[0][0] in (INTERRUPT, ERROR):
+    # only cache successful tasks
+    return
 self.submit(
     self.cache.set,
```

## 2. `BinaryOperatorAggregate.update()` silently drops values after `Overwrite`

The `if not seen_overwrite:` guard skips operator application for every non-overwrite value that arrives after an `Overwrite` in the same batch. No error, no warning — values are silently discarded. In concurrent supersteps where task ordering is determined by path sorting, this is a data loss path that is invisible to users.

```diff
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            self.value = self.operator(self.value, value)
```

## 3. `ToolNode._arun_one` blocks event loop with sync wrapper fallback

When only a sync `wrap_tool_call` is provided, `_arun_one` calls it directly on the event loop thread. Since `_afunc` dispatches tool calls via `asyncio.gather`, one blocking call serializes everything.

```diff
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                None, self._wrap_tool_call, tool_request, _sync_execute
+            )
```