### PR TITLE
feat(prebuilt): allow ToolNode tools to return list[Command | ToolMessage]

### DIFF
--- a/libs/langgraph/tests/test_time_travel.py
+++ b/libs/langgraph/tests/test_time_travel.py
@@ -1161,9 +1161,7 @@ def test_subgraph_interrupt_resume_with_explicit_head_checkpoint_id(
     assert called == ["step_a", "ask_human"]
 
     # Resume with explicit head checkpoint_id in config
-    head_checkpoint_id = graph.get_state(config).config["configurable"][
-        "checkpoint_id"
-    ]
+    head_checkpoint_id = graph.get_state(config).config["configurable"]["checkpoint_id"]
     called.clear()
     resume_config = {
         "configurable": {

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1349,7 +1349,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#c0dedacbbd1ea981b0259278ad37ed36e6119fae" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -1359,10 +1359,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]
@@ -1751,14 +1747,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "." },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -1778,7 +1774,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "." },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1348,8 +1348,8 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
-source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#c0dedacbbd1ea981b0259278ad37ed36e6119fae" }
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -1359,6 +1359,10 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/fe/abeae8d0d2899e191d67c6c7f065f7e52a953f30b21ef327fa49084e4af9/langchain_core-1.3.1.tar.gz", hash = "sha256:41b384055799f93f34520df6bf7b80e2e5e23153cdfd46874251c6c9916ea030", size = 862403, upload-time = "2026-04-23T18:54:01.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/c2/8493be505921857988db068b7c027f28a9b1587b4425c6a32b1221c9c9fe/langchain_core-1.3.1-py3-none-any.whl", hash = "sha256:8b13d19d3bed3f4768df12c7f6932d2ada715f3ac9fd020c63d28c693968269e", size = 515879, upload-time = "2026-04-23T18:53:59.94Z" },
 ]
 
 [[package]]
@@ -1747,14 +1751,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core", specifier = ">=1.3.1" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "." },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -1774,7 +1778,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "." },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -378,6 +378,22 @@ class ToolInvocationError(ToolException):
         super().__init__(self.message)
 
 
+class _MissingToolMessageError(ValueError):
+    """No ToolMessage matching the outer tool_call_id was found.
+
+    Raised by both `_validate_tool_command` (single-Command return) and
+    `_validate_tool_command_list` (list return with wrong terminator count).
+
+    When raised from `_validate_tool_command`, carries the already-normalized
+    command so that `_validate_tool_command_list` can recover it without
+    repeating the deepcopy/convert_to_messages/name-assignment work.
+    """
+
+    def __init__(self, message: str, command: Command | None = None) -> None:
+        super().__init__(message)
+        self.command = command
+
+
 def _default_handle_tool_errors(e: Exception) -> str:
     """Default error handler for tool errors.
 
@@ -859,9 +875,18 @@ class ToolNode(RunnableCallable):
 
     def _combine_tool_outputs(
         self,
-        outputs: list[ToolMessage | Command],
+        outputs: list[ToolMessage | Command | list[ToolMessage | Command]],
         input_type: Literal["list", "dict", "tool_calls"],
     ) -> list[Command | list[ToolMessage] | dict[str, list[ToolMessage]]]:
+        # Flatten list entries from tools that returned multiple items
+        flat: list[ToolMessage | Command] = []
+        for output in outputs:
+            if isinstance(output, list):
+                flat.extend(output)
+            else:
+                flat.append(output)
+        outputs = flat
+
         # preserve existing behavior for non-command tool outputs for backwards
         # compatibility
         if not any(isinstance(output, Command) for output in outputs):
@@ -906,7 +931,7 @@ class ToolNode(RunnableCallable):
         request: ToolCallRequest,
         input_type: Literal["list", "dict", "tool_calls"],
         config: RunnableConfig,
-    ) -> ToolMessage | Command:
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
         """Execute tool call with configured error handling.
 
         Args:
@@ -915,7 +940,7 @@ class ToolNode(RunnableCallable):
             config: Runnable configuration.
 
         Returns:
-            ToolMessage or Command.
+            ToolMessage, Command, or list of Command/ToolMessage.
 
         Raises:
             Exception: If tool fails and handle_tool_errors is False.
@@ -946,6 +971,28 @@ class ToolNode(RunnableCallable):
                 raise ToolInvocationError(
                     call["name"], exc, call["args"], filtered_errors
                 ) from exc
+
+            # Process successful response (inside try so validation errors
+            # from list/Command paths go through _handle_tool_errors)
+            if isinstance(response, Command):
+                return self._validate_tool_command(
+                    response, request.tool_call, input_type
+                )
+            if isinstance(response, ToolMessage):
+                response.content = cast(
+                    "str | list", msg_content_output(response.content)
+                )
+                return response
+            if isinstance(response, list):
+                if all(isinstance(r, (Command, ToolMessage)) for r in response):
+                    return self._validate_tool_command_list(
+                        response, request.tool_call, input_type
+                    )
+                msg = f"Tool {call['name']} returned a list with invalid element types: expected all Command or ToolMessage"
+                raise TypeError(msg)
+
+            msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
+            raise TypeError(msg)
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,
@@ -988,23 +1035,12 @@ class ToolNode(RunnableCallable):
                 status="error",
             )
 
-        # Process successful response
-        if isinstance(response, Command):
-            # Validate Command before returning to handler
-            return self._validate_tool_command(response, request.tool_call, input_type)
-        if isinstance(response, ToolMessage):
-            response.content = cast("str | list", msg_content_output(response.content))
-            return response
-
-        msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
-        raise TypeError(msg)
-
     def _run_one(
         self,
         call: ToolCall,
         input_type: Literal["list", "dict", "tool_calls"],
         tool_runtime: ToolRuntime,
-    ) -> ToolMessage | Command:
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
         """Execute single tool call with wrap_tool_call wrapper if configured.
 
         Args:
@@ -1059,7 +1095,7 @@ class ToolNode(RunnableCallable):
         request: ToolCallRequest,
         input_type: Literal["list", "dict", "tool_calls"],
         config: RunnableConfig,
-    ) -> ToolMessage | Command:
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
         """Execute tool call asynchronously with configured error handling.
 
         Args:
@@ -1068,7 +1104,7 @@ class ToolNode(RunnableCallable):
             config: Runnable configuration.
 
         Returns:
-            ToolMessage or Command.
+            ToolMessage, Command, or list of Command/ToolMessage.
 
         Raises:
             Exception: If tool fails and handle_tool_errors is False.
@@ -1099,6 +1135,28 @@ class ToolNode(RunnableCallable):
                 raise ToolInvocationError(
                     call["name"], exc, call["args"], filtered_errors
                 ) from exc
+
+            # Process successful response (inside try so validation errors
+            # from list/Command paths go through _handle_tool_errors)
+            if isinstance(response, Command):
+                return self._validate_tool_command(
+                    response, request.tool_call, input_type
+                )
+            if isinstance(response, ToolMessage):
+                response.content = cast(
+                    "str | list", msg_content_output(response.content)
+                )
+                return response
+            if isinstance(response, list):
+                if all(isinstance(r, (Command, ToolMessage)) for r in response):
+                    return self._validate_tool_command_list(
+                        response, request.tool_call, input_type
+                    )
+                msg = f"Tool {call['name']} returned a list with invalid element types: expected all Command or ToolMessage"
+                raise TypeError(msg)
+
+            msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
+            raise TypeError(msg)
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,
@@ -1141,23 +1199,12 @@ class ToolNode(RunnableCallable):
                 status="error",
             )
 
-        # Process successful response
-        if isinstance(response, Command):
-            # Validate Command before returning to handler
-            return self._validate_tool_command(response, request.tool_call, input_type)
-        if isinstance(response, ToolMessage):
-            response.content = cast("str | list", msg_content_output(response.content))
-            return response
-
-        msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
-        raise TypeError(msg)
-
     async def _arun_one(
         self,
         call: ToolCall,
         input_type: Literal["list", "dict", "tool_calls"],
         tool_runtime: ToolRuntime,
-    ) -> ToolMessage | Command:
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
         """Execute single tool call asynchronously with awrap_tool_call wrapper if configured.
 
         Args:
@@ -1404,6 +1451,77 @@ class ToolNode(RunnableCallable):
         tool_call_copy["args"] = {**stripped_args, **injected_args}
         return tool_call_copy
 
+    def _validate_tool_command_list(
+        self,
+        response: list[Command | ToolMessage],
+        tool_call: ToolCall,
+        input_type: Literal["list", "dict", "tool_calls"],
+    ) -> list[Command | ToolMessage]:
+        """Validate a list of Command/ToolMessage returned by a single tool call.
+
+        Ensures exactly one terminating ToolMessage (with tool_call_id matching the
+        outer tool call) exists in the list — either as a top-level element or nested
+        inside a Command.update["messages"].
+
+        Args:
+            response: The list returned by the tool.
+            tool_call: The original tool call dict.
+            input_type: Input format.
+
+        Returns:
+            Validated list with content-normalized ToolMessages.
+
+        Raises:
+            _MissingToolMessageError: If terminator count is not exactly 1.
+        """
+        expected_id = tool_call["id"]
+
+        terminator_count = 0
+        for item in response:
+            if isinstance(item, ToolMessage):
+                if item.tool_call_id == expected_id:
+                    terminator_count += 1
+            elif isinstance(item, Command):
+                update = item.update
+                if isinstance(update, dict):
+                    for msg in update.get(self._messages_key, []) or []:
+                        if (
+                            isinstance(msg, ToolMessage)
+                            and msg.tool_call_id == expected_id
+                        ):
+                            terminator_count += 1
+
+        if terminator_count != 1:
+            msg = (
+                f"Tool {tool_call['name']} returned a list with "
+                f"{terminator_count} messages bound to tool_call_id "
+                f"{expected_id!r}; expected exactly one terminating ToolMessage."
+            )
+            raise _MissingToolMessageError(msg)
+
+        validated: list[Command | ToolMessage] = []
+        for item in response:
+            if isinstance(item, Command):
+                # Reuse _validate_tool_command for input-type checks and
+                # message normalization. If this particular Command lacks
+                # the terminator, _validate_tool_command raises
+                # _MissingToolMessageError — that's fine because the
+                # list-level check above already guarantees exactly one
+                # terminator across the whole list. Any other ValueError
+                # (e.g. input-type mismatch) propagates normally.
+                try:
+                    validated.append(
+                        self._validate_tool_command(item, tool_call, input_type)
+                    )
+                except _MissingToolMessageError as exc:
+                    # _validate_tool_command always sets .command
+                    assert exc.command is not None  # noqa: S101
+                    validated.append(exc.command)
+            else:
+                item.content = cast("str | list", msg_content_output(item.content))
+                validated.append(item)
+        return validated
+
     def _validate_tool_command(
         self,
         command: Command,
@@ -1473,7 +1591,7 @@ class ToolNode(RunnableCallable):
                 "in the message history MUST have a corresponding ToolMessage. "
                 f"You can fix it by modifying the tool to return {example_update}."
             )
-            raise ValueError(msg)
+            raise _MissingToolMessageError(msg, updated_command)
         return updated_command
 
 

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -378,22 +378,6 @@ class ToolInvocationError(ToolException):
         super().__init__(self.message)
 
 
-class _MissingToolMessageError(ValueError):
-    """No ToolMessage matching the outer tool_call_id was found.
-
-    Raised by both `_validate_tool_command` (single-Command return) and
-    `_validate_tool_command_list` (list return with wrong terminator count).
-
-    When raised from `_validate_tool_command`, carries the already-normalized
-    command so that `_validate_tool_command_list` can recover it without
-    repeating the deepcopy/convert_to_messages/name-assignment work.
-    """
-
-    def __init__(self, message: str, command: Command | None = None) -> None:
-        super().__init__(message)
-        self.command = command
-
-
 def _default_handle_tool_errors(e: Exception) -> str:
     """Default error handler for tool errors.
 
@@ -879,19 +863,26 @@ class ToolNode(RunnableCallable):
         input_type: Literal["list", "dict", "tool_calls"],
     ) -> list[Command | list[ToolMessage] | dict[str, list[ToolMessage]]]:
         # Flatten list entries from tools that returned multiple items
-        flat: list[ToolMessage | Command] = []
-        for output in outputs:
-            if isinstance(output, list):
-                flat.extend(output)
-            else:
-                flat.append(output)
-        outputs = flat
+        flat_outputs: list[ToolMessage | Command]
+        if any(isinstance(output, list) for output in outputs):
+            flat_outputs = []
+            for output in outputs:
+                if isinstance(output, list):
+                    flat_outputs.extend(output)
+                else:
+                    flat_outputs.append(output)
+        else:
+            flat_outputs = cast("list[ToolMessage | Command]", outputs)
 
         # preserve existing behavior for non-command tool outputs for backwards
         # compatibility
-        if not any(isinstance(output, Command) for output in outputs):
+        if not any(isinstance(output, Command) for output in flat_outputs):
             # TypedDict, pydantic, dataclass, etc. should all be able to load from dict
-            return outputs if input_type == "list" else {self._messages_key: outputs}
+            return (
+                flat_outputs
+                if input_type == "list"
+                else {self._messages_key: flat_outputs}
+            )
 
         # LangGraph will automatically handle list of Command and non-command node
         # updates
@@ -901,7 +892,7 @@ class ToolNode(RunnableCallable):
 
         # combine all parent commands with goto into a single parent command
         parent_command: Command | None = None
-        for output in outputs:
+        for output in flat_outputs:
             if isinstance(output, Command):
                 if (
                     output.graph is Command.PARENT
@@ -972,27 +963,10 @@ class ToolNode(RunnableCallable):
                     call["name"], exc, call["args"], filtered_errors
                 ) from exc
 
-            # Process successful response (inside try so validation errors
-            # from list/Command paths go through _handle_tool_errors)
-            if isinstance(response, Command):
-                return self._validate_tool_command(
-                    response, request.tool_call, input_type
-                )
-            if isinstance(response, ToolMessage):
-                response.content = cast(
-                    "str | list", msg_content_output(response.content)
-                )
-                return response
-            if isinstance(response, list):
-                if all(isinstance(r, (Command, ToolMessage)) for r in response):
-                    return self._validate_tool_command_list(
-                        response, request.tool_call, input_type
-                    )
-                msg = f"Tool {call['name']} returned a list with invalid element types: expected all Command or ToolMessage"
-                raise TypeError(msg)
-
-            msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
-            raise TypeError(msg)
+            # Inside try so validation errors route through _handle_tool_errors
+            return self._normalize_tool_response(
+                response, request.tool_call, input_type
+            )
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,
@@ -1136,27 +1110,10 @@ class ToolNode(RunnableCallable):
                     call["name"], exc, call["args"], filtered_errors
                 ) from exc
 
-            # Process successful response (inside try so validation errors
-            # from list/Command paths go through _handle_tool_errors)
-            if isinstance(response, Command):
-                return self._validate_tool_command(
-                    response, request.tool_call, input_type
-                )
-            if isinstance(response, ToolMessage):
-                response.content = cast(
-                    "str | list", msg_content_output(response.content)
-                )
-                return response
-            if isinstance(response, list):
-                if all(isinstance(r, (Command, ToolMessage)) for r in response):
-                    return self._validate_tool_command_list(
-                        response, request.tool_call, input_type
-                    )
-                msg = f"Tool {call['name']} returned a list with invalid element types: expected all Command or ToolMessage"
-                raise TypeError(msg)
-
-            msg = f"Tool {call['name']} returned unexpected type: {type(response)}"
-            raise TypeError(msg)
+            # Inside try so validation errors route through _handle_tool_errors
+            return self._normalize_tool_response(
+                response, request.tool_call, input_type
+            )
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,
@@ -1451,6 +1408,29 @@ class ToolNode(RunnableCallable):
         tool_call_copy["args"] = {**stripped_args, **injected_args}
         return tool_call_copy
 
+    def _normalize_tool_response(
+        self,
+        response: Any,
+        tool_call: ToolCall,
+        input_type: Literal["list", "dict", "tool_calls"],
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
+        """Validate and normalize a tool's raw return value."""
+        if isinstance(response, Command):
+            return self._validate_tool_command(response, tool_call, input_type)
+        if isinstance(response, ToolMessage):
+            response.content = cast("str | list", msg_content_output(response.content))
+            return response
+        if isinstance(response, list):
+            if all(isinstance(r, (Command, ToolMessage)) for r in response):
+                return self._validate_tool_command_list(response, tool_call, input_type)
+            msg = (
+                f"Tool {tool_call['name']} returned a list with invalid element "
+                "types: expected all Command or ToolMessage"
+            )
+            raise TypeError(msg)
+        msg = f"Tool {tool_call['name']} returned unexpected type: {type(response)}"
+        raise TypeError(msg)
+
     def _validate_tool_command_list(
         self,
         response: list[Command | ToolMessage],
@@ -1459,20 +1439,9 @@ class ToolNode(RunnableCallable):
     ) -> list[Command | ToolMessage]:
         """Validate a list of Command/ToolMessage returned by a single tool call.
 
-        Ensures exactly one terminating ToolMessage (with tool_call_id matching the
-        outer tool call) exists in the list — either as a top-level element or nested
-        inside a Command.update["messages"].
-
-        Args:
-            response: The list returned by the tool.
-            tool_call: The original tool call dict.
-            input_type: Input format.
-
-        Returns:
-            Validated list with content-normalized ToolMessages.
-
-        Raises:
-            _MissingToolMessageError: If terminator count is not exactly 1.
+        Requires exactly one terminating ToolMessage (matching the outer tool_call_id)
+        across the list — either as a top-level element or nested in a
+        Command.update["messages"].
         """
         expected_id = tool_call["id"]
 
@@ -1481,15 +1450,10 @@ class ToolNode(RunnableCallable):
             if isinstance(item, ToolMessage):
                 if item.tool_call_id == expected_id:
                     terminator_count += 1
-            elif isinstance(item, Command):
-                update = item.update
-                if isinstance(update, dict):
-                    for msg in update.get(self._messages_key, []) or []:
-                        if (
-                            isinstance(msg, ToolMessage)
-                            and msg.tool_call_id == expected_id
-                        ):
-                            terminator_count += 1
+            elif isinstance(item, Command) and isinstance(item.update, dict):
+                for msg in item.update.get(self._messages_key, []):
+                    if isinstance(msg, ToolMessage) and msg.tool_call_id == expected_id:
+                        terminator_count += 1
 
         if terminator_count != 1:
             msg = (
@@ -1497,26 +1461,19 @@ class ToolNode(RunnableCallable):
                 f"{terminator_count} messages bound to tool_call_id "
                 f"{expected_id!r}; expected exactly one terminating ToolMessage."
             )
-            raise _MissingToolMessageError(msg)
+            raise ValueError(msg)
 
+        # Per-Command normalization still runs, but the list-level count above
+        # already guarantees exactly one terminator, so individual Commands may
+        # lack one.
         validated: list[Command | ToolMessage] = []
         for item in response:
             if isinstance(item, Command):
-                # Reuse _validate_tool_command for input-type checks and
-                # message normalization. If this particular Command lacks
-                # the terminator, _validate_tool_command raises
-                # _MissingToolMessageError — that's fine because the
-                # list-level check above already guarantees exactly one
-                # terminator across the whole list. Any other ValueError
-                # (e.g. input-type mismatch) propagates normally.
-                try:
-                    validated.append(
-                        self._validate_tool_command(item, tool_call, input_type)
+                validated.append(
+                    self._validate_tool_command(
+                        item, tool_call, input_type, require_terminator=False
                     )
-                except _MissingToolMessageError as exc:
-                    # _validate_tool_command always sets .command
-                    assert exc.command is not None  # noqa: S101
-                    validated.append(exc.command)
+                )
             else:
                 item.content = cast("str | list", msg_content_output(item.content))
                 validated.append(item)
@@ -1527,6 +1484,8 @@ class ToolNode(RunnableCallable):
         command: Command,
         call: ToolCall,
         input_type: Literal["list", "dict", "tool_calls"],
+        *,
+        require_terminator: bool = True,
     ) -> Command:
         if isinstance(command.update, dict):
             # input type is dict when ToolNode is invoked with a dict input
@@ -1576,7 +1535,11 @@ class ToolNode(RunnableCallable):
 
         # validate that we always have a ToolMessage matching the tool call in
         # Command.update if command is sent to the CURRENT graph
-        if updated_command.graph is None and not has_matching_tool_message:
+        if (
+            require_terminator
+            and updated_command.graph is None
+            and not has_matching_tool_message
+        ):
             example_update = (
                 '`Command(update={"messages": '
                 '[ToolMessage("Success", tool_call_id=tool_call_id), ...]}, ...)`'
@@ -1591,7 +1554,7 @@ class ToolNode(RunnableCallable):
                 "in the message history MUST have a corresponding ToolMessage. "
                 f"You can fix it by modifying the tool to return {example_update}."
             )
-            raise _MissingToolMessageError(msg, updated_command)
+            raise ValueError(msg)
         return updated_command
 
 

--- a/libs/prebuilt/pyproject.toml
+++ b/libs/prebuilt/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "langgraph-checkpoint>=2.1.0,<5.0.0",
-    "langchain-core>=1.0.0",
+    "langchain-core>=1.3.1",
 ]
 
 [project.urls]
@@ -62,7 +62,6 @@ dev = [
 default-groups = ['dev']
 
 [tool.uv.sources]
-langchain-core = { git = "https://github.com/langchain-ai/langchain.git", branch = "hunter/multi-mixin-basetool", subdirectory = "libs/core" }
 langgraph = { path = "../langgraph", editable = true }
 langgraph-checkpoint = { path = "../checkpoint", editable = true }
 langgraph-checkpoint-sqlite = { path = "../checkpoint-sqlite", editable = true }

--- a/libs/prebuilt/pyproject.toml
+++ b/libs/prebuilt/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
 default-groups = ['dev']
 
 [tool.uv.sources]
+langchain-core = { git = "https://github.com/langchain-ai/langchain.git", branch = "hunter/multi-mixin-basetool", subdirectory = "libs/core" }
 langgraph = { path = "../langgraph", editable = true }
 langgraph-checkpoint = { path = "../checkpoint", editable = true }
 langgraph-checkpoint-sqlite = { path = "../checkpoint-sqlite", editable = true }

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -23,7 +23,6 @@ from langchain_core.messages import (
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool, InjectedToolArg, ToolException
 from langchain_core.tools import tool as dec_tool
-from langchain_core.tools.base import InjectedToolCallId
 from langgraph.config import get_stream_writer
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
 from langgraph.graph import START, MessagesState, StateGraph
@@ -2227,54 +2226,52 @@ def test_tool_node_injected_state_overwrites_llm_value() -> None:
 
 
 class _ReturningTool(BaseTool):
-    """A tool whose _run/_arun returns an arbitrary value."""
+    """A tool that returns a configured value verbatim."""
 
     name: str = "list_tool"
-    description: str = "Returns a list"
+    description: str = "Returns a configured value"
     return_value: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        if callable(self.return_value):
-            return self.return_value(**kwargs)
         return self.return_value
 
     async def _arun(self, **kwargs: Any) -> Any:
-        if callable(self.return_value):
-            return self.return_value(**kwargs)
         return self.return_value
 
 
-def _make_tool(return_value: Any, name: str = "list_tool") -> _ReturningTool:
-    return _ReturningTool(name=name, return_value=return_value)
+def _list_tool_call(outer_id: str = "call-1") -> dict[str, Any]:
+    return {"name": "list_tool", "args": {}, "id": outer_id, "type": "tool_call"}
+
+
+def _invoke_returning(
+    return_value: Any,
+    *,
+    outer_id: str = "call-1",
+    handle_tool_errors: bool = True,
+) -> Any:
+    node = ToolNode(
+        [_ReturningTool(return_value=return_value)],
+        handle_tool_errors=handle_tool_errors,
+    )
+    return node.invoke(
+        {"messages": [AIMessage("", tool_calls=[_list_tool_call(outer_id)])]},
+        config=_create_config_with_runtime(),
+    )
 
 
 def test_tool_node_list_return_command_and_tool_message() -> None:
     """Valid: tool returns [Command(update={...}), ToolMessage(...)]."""
     outer_id = "call-1"
-    tool = _make_tool(
+    result = _invoke_returning(
         [
             Command(update={"foo": "bar"}),
             ToolMessage(content="done", tool_call_id=outer_id),
         ]
     )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    # Should produce combined outputs: the Command and the ToolMessage
     assert isinstance(result, list)
-    # The Command with update should be present
     commands = [r for r in result if isinstance(r, Command)]
     assert len(commands) == 1
     assert commands[0].update == {"foo": "bar"}
-    # The ToolMessage should be wrapped in dict form
     non_commands = [r for r in result if not isinstance(r, Command)]
     assert len(non_commands) == 1
     assert isinstance(non_commands[0], dict)
@@ -2288,34 +2285,19 @@ def test_tool_node_list_return_command_and_tool_message() -> None:
 def test_tool_node_list_return_nested_terminator() -> None:
     """Valid: terminator nested inside Command.update['messages']."""
     outer_id = "call-1"
-    tool = _make_tool(
+    result = _invoke_returning(
         [
             Command(update={"foo": "bar"}),
             Command(
                 update={
-                    "messages": [
-                        ToolMessage(content="done", tool_call_id=outer_id),
-                    ]
+                    "messages": [ToolMessage(content="done", tool_call_id=outer_id)]
                 }
             ),
         ]
     )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
     assert isinstance(result, list)
     commands = [r for r in result if isinstance(r, Command)]
-    # Both commands should be present
     assert len(commands) == 2
-    # One has foo update, the other has messages update
     updates = [c.update for c in commands]
     assert {"foo": "bar"} in updates
     msgs_update = next(u for u in updates if "messages" in (u or {}))
@@ -2328,317 +2310,80 @@ def test_tool_node_list_return_nested_terminator() -> None:
 def test_tool_node_list_return_parent_goto_with_terminator() -> None:
     """Valid: [Command(graph=PARENT, goto=[Send(...)]), ToolMessage(...)]."""
     outer_id = "call-1"
-    tool = _make_tool(
+    result = _invoke_returning(
         [
             Command(graph=Command.PARENT, goto=[Send("child", {})]),
             ToolMessage(content="ok", tool_call_id=outer_id),
         ]
     )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
     assert isinstance(result, list)
-    # Should have a parent command with Send and a wrapped ToolMessage
     parent_cmds = [
         r for r in result if isinstance(r, Command) and r.graph is Command.PARENT
     ]
     assert len(parent_cmds) == 1
     assert isinstance(parent_cmds[0].goto, list)
     assert any(isinstance(s, Send) for s in parent_cmds[0].goto)
-    # ToolMessage should be present
     non_commands = [r for r in result if not isinstance(r, Command)]
     assert len(non_commands) == 1
 
 
-def test_tool_node_list_return_regression_single_command() -> None:
-    """Single Command return is unchanged."""
-
-    @dec_tool
-    def cmd_tool(tool_call_id: Annotated[str, InjectedToolCallId]):
-        """A tool returning a single Command."""
-        return Command(
-            update={"messages": [ToolMessage(content="hi", tool_call_id=tool_call_id)]},
-            goto="next",
-            graph=Command.PARENT,
-        )
-
-    tool_call = {
-        "name": "cmd_tool",
-        "args": {},
-        "id": "call-1",
-        "type": "tool_call",
-    }
-    node = ToolNode([cmd_tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, list)
-    assert len(result) == 1
-    assert isinstance(result[0], Command)
-    assert result[0].goto == "next"
-
-
-def test_tool_node_list_return_regression_single_tool_message() -> None:
-    """Single ToolMessage return is unchanged."""
-
-    def simple_tool(x: int) -> str:
-        """A simple tool."""
-        return f"result: {x}"
-
-    tool_call = {
-        "name": "simple_tool",
-        "args": {"x": 42},
-        "id": "call-1",
-        "type": "tool_call",
-    }
-    node = ToolNode([simple_tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, dict)
-    assert "messages" in result
-    assert len(result["messages"]) == 1
-    assert isinstance(result["messages"][0], ToolMessage)
-    assert result["messages"][0].content == "result: 42"
-
-
 def test_tool_node_list_return_no_terminator_raises() -> None:
     """Invalid: list with no terminating ToolMessage."""
-    outer_id = "call-1"
-    tool = _make_tool([Command(update={"foo": "bar"})])
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool], handle_tool_errors=False)
     with pytest.raises(ValueError, match="0 messages bound to tool_call_id"):
-        node.invoke(
-            {"messages": [AIMessage("", tool_calls=[tool_call])]},
-            config=_create_config_with_runtime(),
-        )
+        _invoke_returning([Command(update={"foo": "bar"})], handle_tool_errors=False)
 
 
 def test_tool_node_list_return_multiple_terminators_raises() -> None:
     """Invalid: list with two terminating ToolMessages."""
     outer_id = "call-1"
-    tool = _make_tool(
-        [
-            ToolMessage(content="a", tool_call_id=outer_id),
-            ToolMessage(content="b", tool_call_id=outer_id),
-        ]
-    )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool], handle_tool_errors=False)
     with pytest.raises(ValueError, match="2 messages bound to tool_call_id"):
-        node.invoke(
-            {"messages": [AIMessage("", tool_calls=[tool_call])]},
-            config=_create_config_with_runtime(),
+        _invoke_returning(
+            [
+                ToolMessage(content="a", tool_call_id=outer_id),
+                ToolMessage(content="b", tool_call_id=outer_id),
+            ],
+            handle_tool_errors=False,
         )
 
 
-def test_tool_node_list_return_empty_list_becomes_tool_message() -> None:
-    """An empty list is stringified by langchain_core's _format_output into a
-    ToolMessage before reaching ToolNode, so it does not hit the list path.
-    """
-    outer_id = "call-1"
-    tool = _make_tool([])
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    # langchain_core wraps [] into a ToolMessage, ToolNode returns it normally
+def test_tool_node_list_return_validation_error_handled() -> None:
+    """handle_tool_errors=True converts validation errors to an error ToolMessage."""
+    result = _invoke_returning([Command(update={"foo": "bar"})])
     assert isinstance(result, dict)
-    assert isinstance(result["messages"][0], ToolMessage)
+    msg = result["messages"][0]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "0 messages bound to tool_call_id" in msg.content
 
 
-def test_tool_node_list_return_non_mixin_elements_become_tool_message() -> None:
-    """Lists whose elements are not all ToolOutputMixin are stringified by
-    langchain_core's _format_output before reaching ToolNode.
-
-    [1,2,3] and [Command(...), "oops"] never arrive
-    as lists at ToolNode — they become ToolMessage(content="...").
-    """
+async def test_tool_node_list_return_async_smoke() -> None:
+    """Async path parallels sync for the happy case."""
     outer_id = "call-1"
-    for bad_list in [[1, 2, 3], [Command(update={"foo": "bar"}), "oops"]]:
-        tool = _make_tool(bad_list)
-        tool_call = {
-            "name": "list_tool",
-            "args": {},
-            "id": outer_id,
-            "type": "tool_call",
-        }
-        node = ToolNode([tool])
-        result = node.invoke(
-            {"messages": [AIMessage("", tool_calls=[tool_call])]},
-            config=_create_config_with_runtime(),
-        )
-        # langchain_core stringifies these into a ToolMessage
-        assert isinstance(result, dict)
-        assert isinstance(result["messages"][0], ToolMessage)
-
-
-def test_tool_node_non_command_non_toolmessage_becomes_tool_message() -> None:
-    """A non-Command/non-ToolMessage scalar return is stringified by
-    langchain_core's _format_output into a ToolMessage before reaching ToolNode.
-
-    The TypeError path in ToolNode is a safety net for custom BaseTool.invoke
-    overrides; the standard _format_output flow never triggers it because it
-    wraps arbitrary values into ToolMessage.
-    """
-    outer_id = "call-1"
-    tool = _make_tool(12345)
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, dict)
-    assert isinstance(result["messages"][0], ToolMessage)
-    assert result["messages"][0].content == "12345"
-
-
-async def test_tool_node_list_return_async_command_and_tool_message() -> None:
-    """Async: tool returns [Command(...), ToolMessage(...)]."""
-    outer_id = "call-1"
-    tool = _make_tool(
+    node = ToolNode(
         [
-            Command(update={"foo": "bar"}),
-            ToolMessage(content="done", tool_call_id=outer_id),
+            _ReturningTool(
+                return_value=[
+                    Command(update={"foo": "bar"}),
+                    ToolMessage(content="done", tool_call_id=outer_id),
+                ]
+            )
         ]
     )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
     result = await node.ainvoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        {"messages": [AIMessage("", tool_calls=[_list_tool_call(outer_id)])]},
         config=_create_config_with_runtime(),
     )
     assert isinstance(result, list)
     commands = [r for r in result if isinstance(r, Command)]
-    assert len(commands) == 1
-    assert commands[0].update == {"foo": "bar"}
-    non_commands = [r for r in result if not isinstance(r, Command)]
-    assert len(non_commands) == 1
-    assert isinstance(non_commands[0], dict)
-    msgs = non_commands[0]["messages"]
-    assert len(msgs) == 1
-    assert isinstance(msgs[0], ToolMessage)
-    assert msgs[0].content == "done"
-
-
-async def test_tool_node_list_return_async_nested_terminator() -> None:
-    """Async: terminator nested inside Command.update."""
-    outer_id = "call-1"
-    tool = _make_tool(
-        [
-            Command(update={"foo": "bar"}),
-            Command(
-                update={
-                    "messages": [
-                        ToolMessage(content="done", tool_call_id=outer_id),
-                    ]
-                }
-            ),
-        ]
-    )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = await node.ainvoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, list)
-    commands = [r for r in result if isinstance(r, Command)]
-    assert len(commands) == 2
-
-
-async def test_tool_node_list_return_async_no_terminator_raises() -> None:
-    """Async: no terminator raises ValueError."""
-    outer_id = "call-1"
-    tool = _make_tool([Command(update={"foo": "bar"})])
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool], handle_tool_errors=False)
-    with pytest.raises(ValueError, match="0 messages bound to tool_call_id"):
-        await node.ainvoke(
-            {"messages": [AIMessage("", tool_calls=[tool_call])]},
-            config=_create_config_with_runtime(),
-        )
-
-
-async def test_tool_node_list_return_async_empty_list_becomes_tool_message() -> None:
-    """Async: empty list is converted to ToolMessage by langchain_core."""
-    outer_id = "call-1"
-    tool = _make_tool([])
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool])
-    result = await node.ainvoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, dict)
-    assert isinstance(result["messages"][0], ToolMessage)
+    assert len(commands) == 1 and commands[0].update == {"foo": "bar"}
 
 
 def test_tool_node_list_return_mixed_with_regular_tool() -> None:
-    """AIMessage with two tool calls — one list-returning, one regular.
-
-    Verifies all entries end up correctly combined and a non-list tool's terminator
-    is unaffected by the list validation path.
-    """
+    """List-returning tool and a regular tool dispatched from the same AIMessage."""
     list_tool_id = "call-list"
     regular_tool_id = "call-regular"
-
-    list_tool = _make_tool(
-        [
+    list_tool = _ReturningTool(
+        return_value=[
             Command(update={"foo": "bar"}),
             ToolMessage(content="list done", tool_call_id=list_tool_id),
         ]
@@ -2649,12 +2394,7 @@ def test_tool_node_list_return_mixed_with_regular_tool() -> None:
         return f"regular: {x}"
 
     tool_calls = [
-        {
-            "name": "list_tool",
-            "args": {},
-            "id": list_tool_id,
-            "type": "tool_call",
-        },
+        {"name": "list_tool", "args": {}, "id": list_tool_id, "type": "tool_call"},
         {
             "name": "regular_tool",
             "args": {"x": 7},
@@ -2667,74 +2407,11 @@ def test_tool_node_list_return_mixed_with_regular_tool() -> None:
         {"messages": [AIMessage("", tool_calls=tool_calls)]},
         config=_create_config_with_runtime(),
     )
-    # result should be a list with:
-    # - dict wrapping the regular ToolMessage
-    # - Command with foo update
-    # - dict wrapping the list's ToolMessage
-    # (order may vary due to executor)
     assert isinstance(result, list)
     commands = [r for r in result if isinstance(r, Command)]
     assert len(commands) == 1
     assert commands[0].update == {"foo": "bar"}
-    dicts = [r for r in result if isinstance(r, dict)]
-    all_msgs = []
-    for d in dicts:
-        all_msgs.extend(d["messages"])
+    all_msgs = [m for r in result if isinstance(r, dict) for m in r["messages"]]
     tool_call_ids = {m.tool_call_id for m in all_msgs}
     assert list_tool_id in tool_call_ids
     assert regular_tool_id in tool_call_ids
-
-
-def test_tool_node_list_return_validation_error_handled() -> None:
-    """When handle_tool_errors=True, validation errors from list path are handled."""
-    outer_id = "call-1"
-    # Return a list with no terminator — this will raise ValueError
-    tool = _make_tool([Command(update={"foo": "bar"})])
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool], handle_tool_errors=True)
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    # With handle_tool_errors=True, the error should be caught and returned
-    # as an error ToolMessage
-    assert isinstance(result, dict)
-    assert "messages" in result
-    assert len(result["messages"]) == 1
-    msg = result["messages"][0]
-    assert isinstance(msg, ToolMessage)
-    assert msg.status == "error"
-    assert "0 messages bound to tool_call_id" in msg.content
-
-
-def test_tool_node_list_return_multiple_terminators_handled() -> None:
-    """When handle_tool_errors=True, multiple-terminator ValueError is handled."""
-    outer_id = "call-1"
-    tool = _make_tool(
-        [
-            ToolMessage(content="a", tool_call_id=outer_id),
-            ToolMessage(content="b", tool_call_id=outer_id),
-        ]
-    )
-    tool_call = {
-        "name": "list_tool",
-        "args": {},
-        "id": outer_id,
-        "type": "tool_call",
-    }
-    node = ToolNode([tool], handle_tool_errors=True)
-    result = node.invoke(
-        {"messages": [AIMessage("", tool_calls=[tool_call])]},
-        config=_create_config_with_runtime(),
-    )
-    assert isinstance(result, dict)
-    assert "messages" in result
-    msg = result["messages"][0]
-    assert isinstance(msg, ToolMessage)
-    assert msg.status == "error"
-    assert "2 messages bound to tool_call_id" in msg.content

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -23,6 +23,7 @@ from langchain_core.messages import (
 from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool, InjectedToolArg, ToolException
 from langchain_core.tools import tool as dec_tool
+from langchain_core.tools.base import InjectedToolCallId
 from langgraph.config import get_stream_writer
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
 from langgraph.graph import START, MessagesState, StateGraph
@@ -2223,3 +2224,517 @@ def test_tool_node_injected_state_overwrites_llm_value() -> None:
     )
     tool_message = result["messages"][-1]
     assert tool_message.content == "PUBLIC_DATA"
+
+
+class _ReturningTool(BaseTool):
+    """A tool whose _run/_arun returns an arbitrary value."""
+
+    name: str = "list_tool"
+    description: str = "Returns a list"
+    return_value: Any = None
+
+    def _run(self, **kwargs: Any) -> Any:
+        if callable(self.return_value):
+            return self.return_value(**kwargs)
+        return self.return_value
+
+    async def _arun(self, **kwargs: Any) -> Any:
+        if callable(self.return_value):
+            return self.return_value(**kwargs)
+        return self.return_value
+
+
+def _make_tool(return_value: Any, name: str = "list_tool") -> _ReturningTool:
+    return _ReturningTool(name=name, return_value=return_value)
+
+
+def test_tool_node_list_return_command_and_tool_message() -> None:
+    """Valid: tool returns [Command(update={...}), ToolMessage(...)]."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            Command(update={"foo": "bar"}),
+            ToolMessage(content="done", tool_call_id=outer_id),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    # Should produce combined outputs: the Command and the ToolMessage
+    assert isinstance(result, list)
+    # The Command with update should be present
+    commands = [r for r in result if isinstance(r, Command)]
+    assert len(commands) == 1
+    assert commands[0].update == {"foo": "bar"}
+    # The ToolMessage should be wrapped in dict form
+    non_commands = [r for r in result if not isinstance(r, Command)]
+    assert len(non_commands) == 1
+    assert isinstance(non_commands[0], dict)
+    msgs = non_commands[0]["messages"]
+    assert len(msgs) == 1
+    assert isinstance(msgs[0], ToolMessage)
+    assert msgs[0].content == "done"
+    assert msgs[0].tool_call_id == outer_id
+
+
+def test_tool_node_list_return_nested_terminator() -> None:
+    """Valid: terminator nested inside Command.update['messages']."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            Command(update={"foo": "bar"}),
+            Command(
+                update={
+                    "messages": [
+                        ToolMessage(content="done", tool_call_id=outer_id),
+                    ]
+                }
+            ),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, list)
+    commands = [r for r in result if isinstance(r, Command)]
+    # Both commands should be present
+    assert len(commands) == 2
+    # One has foo update, the other has messages update
+    updates = [c.update for c in commands]
+    assert {"foo": "bar"} in updates
+    msgs_update = next(u for u in updates if "messages" in (u or {}))
+    assert any(
+        isinstance(m, ToolMessage) and m.tool_call_id == outer_id
+        for m in msgs_update["messages"]
+    )
+
+
+def test_tool_node_list_return_parent_goto_with_terminator() -> None:
+    """Valid: [Command(graph=PARENT, goto=[Send(...)]), ToolMessage(...)]."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            Command(graph=Command.PARENT, goto=[Send("child", {})]),
+            ToolMessage(content="ok", tool_call_id=outer_id),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, list)
+    # Should have a parent command with Send and a wrapped ToolMessage
+    parent_cmds = [
+        r for r in result if isinstance(r, Command) and r.graph is Command.PARENT
+    ]
+    assert len(parent_cmds) == 1
+    assert isinstance(parent_cmds[0].goto, list)
+    assert any(isinstance(s, Send) for s in parent_cmds[0].goto)
+    # ToolMessage should be present
+    non_commands = [r for r in result if not isinstance(r, Command)]
+    assert len(non_commands) == 1
+
+
+def test_tool_node_list_return_regression_single_command() -> None:
+    """Single Command return is unchanged."""
+
+    @dec_tool
+    def cmd_tool(tool_call_id: Annotated[str, InjectedToolCallId]):
+        """A tool returning a single Command."""
+        return Command(
+            update={"messages": [ToolMessage(content="hi", tool_call_id=tool_call_id)]},
+            goto="next",
+            graph=Command.PARENT,
+        )
+
+    tool_call = {
+        "name": "cmd_tool",
+        "args": {},
+        "id": "call-1",
+        "type": "tool_call",
+    }
+    node = ToolNode([cmd_tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], Command)
+    assert result[0].goto == "next"
+
+
+def test_tool_node_list_return_regression_single_tool_message() -> None:
+    """Single ToolMessage return is unchanged."""
+
+    def simple_tool(x: int) -> str:
+        """A simple tool."""
+        return f"result: {x}"
+
+    tool_call = {
+        "name": "simple_tool",
+        "args": {"x": 42},
+        "id": "call-1",
+        "type": "tool_call",
+    }
+    node = ToolNode([simple_tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, dict)
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].content == "result: 42"
+
+
+def test_tool_node_list_return_no_terminator_raises() -> None:
+    """Invalid: list with no terminating ToolMessage."""
+    outer_id = "call-1"
+    tool = _make_tool([Command(update={"foo": "bar"})])
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool], handle_tool_errors=False)
+    with pytest.raises(ValueError, match="0 messages bound to tool_call_id"):
+        node.invoke(
+            {"messages": [AIMessage("", tool_calls=[tool_call])]},
+            config=_create_config_with_runtime(),
+        )
+
+
+def test_tool_node_list_return_multiple_terminators_raises() -> None:
+    """Invalid: list with two terminating ToolMessages."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            ToolMessage(content="a", tool_call_id=outer_id),
+            ToolMessage(content="b", tool_call_id=outer_id),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool], handle_tool_errors=False)
+    with pytest.raises(ValueError, match="2 messages bound to tool_call_id"):
+        node.invoke(
+            {"messages": [AIMessage("", tool_calls=[tool_call])]},
+            config=_create_config_with_runtime(),
+        )
+
+
+def test_tool_node_list_return_empty_list_becomes_tool_message() -> None:
+    """An empty list is stringified by langchain_core's _format_output into a
+    ToolMessage before reaching ToolNode, so it does not hit the list path.
+    """
+    outer_id = "call-1"
+    tool = _make_tool([])
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    # langchain_core wraps [] into a ToolMessage, ToolNode returns it normally
+    assert isinstance(result, dict)
+    assert isinstance(result["messages"][0], ToolMessage)
+
+
+def test_tool_node_list_return_non_mixin_elements_become_tool_message() -> None:
+    """Lists whose elements are not all ToolOutputMixin are stringified by
+    langchain_core's _format_output before reaching ToolNode.
+
+    [1,2,3] and [Command(...), "oops"] never arrive
+    as lists at ToolNode — they become ToolMessage(content="...").
+    """
+    outer_id = "call-1"
+    for bad_list in [[1, 2, 3], [Command(update={"foo": "bar"}), "oops"]]:
+        tool = _make_tool(bad_list)
+        tool_call = {
+            "name": "list_tool",
+            "args": {},
+            "id": outer_id,
+            "type": "tool_call",
+        }
+        node = ToolNode([tool])
+        result = node.invoke(
+            {"messages": [AIMessage("", tool_calls=[tool_call])]},
+            config=_create_config_with_runtime(),
+        )
+        # langchain_core stringifies these into a ToolMessage
+        assert isinstance(result, dict)
+        assert isinstance(result["messages"][0], ToolMessage)
+
+
+def test_tool_node_non_command_non_toolmessage_becomes_tool_message() -> None:
+    """A non-Command/non-ToolMessage scalar return is stringified by
+    langchain_core's _format_output into a ToolMessage before reaching ToolNode.
+
+    The TypeError path in ToolNode is a safety net for custom BaseTool.invoke
+    overrides; the standard _format_output flow never triggers it because it
+    wraps arbitrary values into ToolMessage.
+    """
+    outer_id = "call-1"
+    tool = _make_tool(12345)
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, dict)
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].content == "12345"
+
+
+async def test_tool_node_list_return_async_command_and_tool_message() -> None:
+    """Async: tool returns [Command(...), ToolMessage(...)]."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            Command(update={"foo": "bar"}),
+            ToolMessage(content="done", tool_call_id=outer_id),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = await node.ainvoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, list)
+    commands = [r for r in result if isinstance(r, Command)]
+    assert len(commands) == 1
+    assert commands[0].update == {"foo": "bar"}
+    non_commands = [r for r in result if not isinstance(r, Command)]
+    assert len(non_commands) == 1
+    assert isinstance(non_commands[0], dict)
+    msgs = non_commands[0]["messages"]
+    assert len(msgs) == 1
+    assert isinstance(msgs[0], ToolMessage)
+    assert msgs[0].content == "done"
+
+
+async def test_tool_node_list_return_async_nested_terminator() -> None:
+    """Async: terminator nested inside Command.update."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            Command(update={"foo": "bar"}),
+            Command(
+                update={
+                    "messages": [
+                        ToolMessage(content="done", tool_call_id=outer_id),
+                    ]
+                }
+            ),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = await node.ainvoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, list)
+    commands = [r for r in result if isinstance(r, Command)]
+    assert len(commands) == 2
+
+
+async def test_tool_node_list_return_async_no_terminator_raises() -> None:
+    """Async: no terminator raises ValueError."""
+    outer_id = "call-1"
+    tool = _make_tool([Command(update={"foo": "bar"})])
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool], handle_tool_errors=False)
+    with pytest.raises(ValueError, match="0 messages bound to tool_call_id"):
+        await node.ainvoke(
+            {"messages": [AIMessage("", tool_calls=[tool_call])]},
+            config=_create_config_with_runtime(),
+        )
+
+
+async def test_tool_node_list_return_async_empty_list_becomes_tool_message() -> None:
+    """Async: empty list is converted to ToolMessage by langchain_core."""
+    outer_id = "call-1"
+    tool = _make_tool([])
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool])
+    result = await node.ainvoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, dict)
+    assert isinstance(result["messages"][0], ToolMessage)
+
+
+def test_tool_node_list_return_mixed_with_regular_tool() -> None:
+    """AIMessage with two tool calls — one list-returning, one regular.
+
+    Verifies all entries end up correctly combined and a non-list tool's terminator
+    is unaffected by the list validation path.
+    """
+    list_tool_id = "call-list"
+    regular_tool_id = "call-regular"
+
+    list_tool = _make_tool(
+        [
+            Command(update={"foo": "bar"}),
+            ToolMessage(content="list done", tool_call_id=list_tool_id),
+        ]
+    )
+
+    def regular_tool(x: int) -> str:
+        """A normal tool."""
+        return f"regular: {x}"
+
+    tool_calls = [
+        {
+            "name": "list_tool",
+            "args": {},
+            "id": list_tool_id,
+            "type": "tool_call",
+        },
+        {
+            "name": "regular_tool",
+            "args": {"x": 7},
+            "id": regular_tool_id,
+            "type": "tool_call",
+        },
+    ]
+    node = ToolNode([list_tool, regular_tool])
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=tool_calls)]},
+        config=_create_config_with_runtime(),
+    )
+    # result should be a list with:
+    # - dict wrapping the regular ToolMessage
+    # - Command with foo update
+    # - dict wrapping the list's ToolMessage
+    # (order may vary due to executor)
+    assert isinstance(result, list)
+    commands = [r for r in result if isinstance(r, Command)]
+    assert len(commands) == 1
+    assert commands[0].update == {"foo": "bar"}
+    dicts = [r for r in result if isinstance(r, dict)]
+    all_msgs = []
+    for d in dicts:
+        all_msgs.extend(d["messages"])
+    tool_call_ids = {m.tool_call_id for m in all_msgs}
+    assert list_tool_id in tool_call_ids
+    assert regular_tool_id in tool_call_ids
+
+
+def test_tool_node_list_return_validation_error_handled() -> None:
+    """When handle_tool_errors=True, validation errors from list path are handled."""
+    outer_id = "call-1"
+    # Return a list with no terminator — this will raise ValueError
+    tool = _make_tool([Command(update={"foo": "bar"})])
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool], handle_tool_errors=True)
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    # With handle_tool_errors=True, the error should be caught and returned
+    # as an error ToolMessage
+    assert isinstance(result, dict)
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "0 messages bound to tool_call_id" in msg.content
+
+
+def test_tool_node_list_return_multiple_terminators_handled() -> None:
+    """When handle_tool_errors=True, multiple-terminator ValueError is handled."""
+    outer_id = "call-1"
+    tool = _make_tool(
+        [
+            ToolMessage(content="a", tool_call_id=outer_id),
+            ToolMessage(content="b", tool_call_id=outer_id),
+        ]
+    )
+    tool_call = {
+        "name": "list_tool",
+        "args": {},
+        "id": outer_id,
+        "type": "tool_call",
+    }
+    node = ToolNode([tool], handle_tool_errors=True)
+    result = node.invoke(
+        {"messages": [AIMessage("", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msg = result["messages"][0]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "2 messages bound to tool_call_id" in msg.content

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -249,8 +249,8 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
-source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#dad867ffd2278dd1904c5736a2d5c3b85d3d8d99" }
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -260,6 +260,10 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/fe/abeae8d0d2899e191d67c6c7f065f7e52a953f30b21ef327fa49084e4af9/langchain_core-1.3.1.tar.gz", hash = "sha256:41b384055799f93f34520df6bf7b80e2e5e23153cdfd46874251c6c9916ea030", size = 862403, upload-time = "2026-04-23T18:54:01.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/c2/8493be505921857988db068b7c027f28a9b1587b4425c6a32b1221c9c9fe/langchain_core-1.3.1-py3-none-any.whl", hash = "sha256:8b13d19d3bed3f4768df12c7f6932d2ada715f3ac9fd020c63d28c693968269e", size = 515879, upload-time = "2026-04-23T18:53:59.94Z" },
 ]
 
 [[package]]
@@ -531,14 +535,14 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core", specifier = ">=1.3.1" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -558,7 +562,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#dad867ffd2278dd1904c5736a2d5c3b85d3d8d99" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -260,10 +260,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]
@@ -535,14 +531,14 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -562,7 +558,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -262,8 +262,8 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0"
-source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#c0dedacbbd1ea981b0259278ad37ed36e6119fae" }
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -273,6 +273,10 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/fe/abeae8d0d2899e191d67c6c7f065f7e52a953f30b21ef327fa49084e4af9/langchain_core-1.3.1.tar.gz", hash = "sha256:41b384055799f93f34520df6bf7b80e2e5e23153cdfd46874251c6c9916ea030", size = 862403, upload-time = "2026-04-23T18:54:01.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/c2/8493be505921857988db068b7c027f28a9b1587b4425c6a32b1221c9c9fe/langchain_core-1.3.1-py3-none-any.whl", hash = "sha256:8b13d19d3bed3f4768df12c7f6932d2ada715f3ac9fd020c63d28c693968269e", size = 515879, upload-time = "2026-04-23T18:53:59.94Z" },
 ]
 
 [[package]]
@@ -418,14 +422,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core", specifier = ">=1.3.1" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -445,7 +449,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
+    { name = "langchain-core" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -263,7 +263,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool#c0dedacbbd1ea981b0259278ad37ed36e6119fae" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langsmith" },
@@ -273,10 +273,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/fe/20190232d9b513242899dbb0c2bb77e31b4d61e343743adbe90ebc2603d2/langchain_core-1.3.0.tar.gz", hash = "sha256:14a39f528bf459aa3aa40d0a7f7f1bae7520d435ef991ae14a4ceb74d8c49046", size = 860755, upload-time = "2026-04-17T14:51:38.298Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/e2/dbfa347aa072a6dc4cd38d6f9ebfc730b4c14c258c47f480f4c5c546f177/langchain_core-1.3.0-py3-none-any.whl", hash = "sha256:baf16ee028475df177b9ab8869a751c79406d64a6f12125b93802991b566cced", size = 515140, upload-time = "2026-04-17T14:51:36.274Z" },
 ]
 
 [[package]]
@@ -422,14 +418,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
@@ -449,7 +445,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "langchain-core" },
+    { name = "langchain-core", git = "https://github.com/langchain-ai/langchain.git?subdirectory=libs%2Fcore&branch=hunter%2Fmulti-mixin-basetool" },
     { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },


### PR DESCRIPTION
## Summary

Extends `ToolNode` so that a single tool invocation can return `list[Command | ToolMessage]` instead of only a single `Command` or `ToolMessage`. This brings `ToolNode`'s per-tool-call contract in line with the rest of LangGraph, where nodes can already return multiple Commands.

Depends on langchain-ai/langchain#36963 which allows `list[ToolOutputMixin]` to pass through `BaseTool._format_output` unchanged.

## Changes

### `libs/prebuilt/langgraph/prebuilt/tool_node.py`

**New list-return gate in `_execute_tool_sync` / `_execute_tool_async`** — After the existing `Command` and `ToolMessage` checks, a new branch accepts `list[Command | ToolMessage]` and routes it through `_validate_tool_command_list`. Lists with non-`Command`/`ToolMessage` elements raise `TypeError`. Both sync and async paths are updated symmetrically.

**`_validate_tool_command_list`** — Enforces the terminating-ToolMessage rule: exactly one `ToolMessage` in the list must carry `tool_call_id == <outer_id>` (top-level or nested inside a `Command.update["messages"]`). Zero or multiple terminators raise `_MissingToolMessageError`. Individual Commands in the list are validated via the existing `_validate_tool_command`; when a Command lacks the terminator (which is allowed since the list-level check handles it), the `_MissingToolMessageError` is caught and the already-normalized command from the exception is used.

**`_MissingToolMessageError`** — A `ValueError` subclass raised by `_validate_tool_command` (and `_validate_tool_command_list`) when no matching `ToolMessage` is found. Carries the already-normalized command so callers can recover without re-doing deepcopy/message-conversion work. Using a typed exception avoids brittle string-matching on error messages.

**`_combine_tool_outputs`** — Flattens list entries at the top of the method so downstream combiner logic (parent-`goto` accumulation, ToolMessage wrapping) is unchanged.

**Response processing moved inside try/except** — In both sync and async execute methods, the response validation (Command/ToolMessage/list checks) now runs inside the existing error-handling try block, so validation errors from the list path go through `_handle_tool_errors` like other tool errors.

**Return type signatures** widened on `_execute_tool_sync`, `_execute_tool_async`, `_run_one`, `_arun_one` to include `list[Command | ToolMessage]`.

### `libs/prebuilt/tests/test_tool_node.py`

New tests covering: valid list returns (top-level terminator, nested terminator, parent-goto + terminator), regression tests for single Command/ToolMessage returns, invalid cases (no terminator, multiple terminators), async parity, integration with mixed list/non-list tool calls, and `_handle_tool_errors` interaction.
