### PR TITLE
fix(checkpoint): add namespace validation to store delete methods

### DIFF
--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -933,6 +933,7 @@ class BaseStore(ABC):
             namespace: Hierarchical path for the item.
             key: Unique identifier within the namespace.
         """
+        self._validate_namespace(namespace)
         self.batch([PutOp(namespace, str(key), None, ttl=None)])
 
     def list_namespaces(
@@ -1194,6 +1195,7 @@ class BaseStore(ABC):
             namespace: Hierarchical path for the item.
             key: Unique identifier within the namespace.
         """
+        await self._validate_namespace(namespace)
         await self.abatch([PutOp(namespace, str(key), None)])
 
     async def alist_namespaces(


### PR DESCRIPTION
## Summary
- Adds `_validate_namespace()` call to `delete()` and `adelete()` methods
- This matches the validation already present in `put()` and `aput()`
- Prevents invalid namespaces (reserved 'langgraph', periods in labels, empty) from being accepted

## Changes
- `delete()`: Added `self._validate_namespace(namespace)` before `self.batch()`
- `adelete()`: Added `await self._validate_namespace(namespace)` before `await self.abatch()`

Closes #7575