### PR TITLE
chore: node-level timeouts

### DIFF
--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -56,10 +56,8 @@ CONFIG_KEY_CHECKPOINT_NS = sys.intern("checkpoint_ns")
 # holds the current checkpoint_ns, "" for root graph
 CONFIG_KEY_NODE_FINISHED = sys.intern("__pregel_node_finished")
 # holds a callback to be called when a node is finished
-CONFIG_KEY_TASK_TIMEOUT_STARTED = sys.intern("__pregel_task_timeout_started")
-# holds a callback to be called when a timed node attempt starts
-CONFIG_KEY_TASK_TIMEOUT_FINISHED = sys.intern("__pregel_task_timeout_finished")
-# holds a callback to be called when a timed node attempt finishes
+CONFIG_KEY_TIMED_ATTEMPT_OBSERVER = sys.intern("__pregel_timed_attempt_observer")
+# holds a callback to be called when a timed node attempt starts or finishes
 CONFIG_KEY_SCRATCHPAD = sys.intern("__pregel_scratchpad")
 # holds a mutable dict for temporary storage scoped to the current task
 CONFIG_KEY_RUNNER_SUBMIT = sys.intern("__pregel_runner_submit")
@@ -110,8 +108,7 @@ RESERVED = {
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_NS,
-    CONFIG_KEY_TASK_TIMEOUT_STARTED,
-    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
+    CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
     CONFIG_KEY_RESUME_MAP,
     # other constants
     PUSH,

--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -56,6 +56,10 @@ CONFIG_KEY_CHECKPOINT_NS = sys.intern("checkpoint_ns")
 # holds the current checkpoint_ns, "" for root graph
 CONFIG_KEY_NODE_FINISHED = sys.intern("__pregel_node_finished")
 # holds a callback to be called when a node is finished
+CONFIG_KEY_TASK_TIMEOUT_STARTED = sys.intern("__pregel_task_timeout_started")
+# holds a callback to be called when a timed node attempt starts
+CONFIG_KEY_TASK_TIMEOUT_FINISHED = sys.intern("__pregel_task_timeout_finished")
+# holds a callback to be called when a timed node attempt finishes
 CONFIG_KEY_SCRATCHPAD = sys.intern("__pregel_scratchpad")
 # holds a mutable dict for temporary storage scoped to the current task
 CONFIG_KEY_RUNNER_SUBMIT = sys.intern("__pregel_runner_submit")
@@ -106,6 +110,8 @@ RESERVED = {
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_TASK_TIMEOUT_STARTED,
+    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
     CONFIG_KEY_RESUME_MAP,
     # other constants
     PUSH,

--- a/libs/langgraph/langgraph/_internal/_runnable.py
+++ b/libs/langgraph/langgraph/_internal/_runnable.py
@@ -706,7 +706,12 @@ class RunnableSeq(Runnable):
                                 step.ainvoke(input, config, **kwargs), context=context
                             )
                     else:
-                        input = await step.ainvoke(input, config, **kwargs)
+                        with set_config_context(config) as context:
+                            input = await context.run(
+                                lambda: asyncio.create_task(
+                                    step.ainvoke(input, config, **kwargs)
+                                )
+                            )
                 else:
                     input = await step.ainvoke(input, config)
         # finish the root run

--- a/libs/langgraph/langgraph/_internal/_timeout.py
+++ b/libs/langgraph/langgraph/_internal/_timeout.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+SYNC_TIMEOUT_UNSUPPORTED = (
+    "Node timeouts are only supported for async nodes because sync Python "
+    "execution cannot be safely cancelled in-process."
+)
+
 
 def validate_timeout(value: float | timedelta | None) -> float | timedelta | None:
     if value is None:

--- a/libs/langgraph/langgraph/_internal/_timeout.py
+++ b/libs/langgraph/langgraph/_internal/_timeout.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 from datetime import timedelta
 
 
-def _coerce_timeout_seconds(value: float | timedelta | None) -> float | None:
+def validate_timeout(value: float | timedelta | None) -> float | timedelta | None:
     if value is None:
         return None
-    return value.total_seconds() if isinstance(value, timedelta) else float(value)
-
-
-def validate_timeout(value: float | timedelta | None) -> float | timedelta | None:
-    timeout = _coerce_timeout_seconds(value)
-    if timeout is not None and timeout <= 0:
+    seconds = value.total_seconds() if isinstance(value, timedelta) else float(value)
+    if seconds <= 0:
         raise ValueError("timeout must be greater than 0")
     return value
 
 
 def timeout_seconds(value: float | timedelta | None) -> float | None:
-    validate_timeout(value)
-    return _coerce_timeout_seconds(value)
+    if value is None:
+        return None
+    seconds = value.total_seconds() if isinstance(value, timedelta) else float(value)
+    if seconds <= 0:
+        raise ValueError("timeout must be greater than 0")
+    return seconds

--- a/libs/langgraph/langgraph/_internal/_timeout.py
+++ b/libs/langgraph/langgraph/_internal/_timeout.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Literal
 
-SYNC_TIMEOUT_UNSUPPORTED = (
+_SYNC_TIMEOUT_PREFIX = (
     "Node timeouts are only supported for async nodes because sync Python "
     "execution cannot be safely cancelled in-process."
 )
 
 
-def validate_timeout(value: float | timedelta | None) -> float | timedelta | None:
-    if value is None:
-        return None
-    seconds = value.total_seconds() if isinstance(value, timedelta) else float(value)
-    if seconds <= 0:
-        raise ValueError("timeout must be greater than 0")
-    return value
-
-
-def timeout_seconds(value: float | timedelta | None) -> float | None:
+def coerce_timeout(value: float | timedelta | None) -> float | None:
+    """Normalize a timeout to positive seconds, or None if unset."""
     if value is None:
         return None
     seconds = value.total_seconds() if isinstance(value, timedelta) else float(value)
     if seconds <= 0:
         raise ValueError("timeout must be greater than 0")
     return seconds
+
+
+def sync_timeout_unsupported(
+    name: str, *, kind: Literal["Node", "Task"] = "Node"
+) -> ValueError:
+    """Build the canonical error for using `timeout` with a sync target."""
+    return ValueError(f"{_SYNC_TIMEOUT_PREFIX} {kind} {name!r} is sync.")

--- a/libs/langgraph/langgraph/_internal/_timeout.py
+++ b/libs/langgraph/langgraph/_internal/_timeout.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+
+def _coerce_timeout_seconds(value: float | timedelta | None) -> float | None:
+    if value is None:
+        return None
+    return value.total_seconds() if isinstance(value, timedelta) else float(value)
+
+
+def validate_timeout(value: float | timedelta | None) -> float | timedelta | None:
+    timeout = _coerce_timeout_seconds(value)
+    if timeout is not None and timeout <= 0:
+        raise ValueError("timeout must be greater than 0")
+    return value
+
+
+def timeout_seconds(value: float | timedelta | None) -> float | None:
+    validate_timeout(value)
+    return _coerce_timeout_seconds(value)

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -20,6 +20,7 @@ __all__ = (
     "GraphBubbleUp",
     "GraphInterrupt",
     "NodeInterrupt",
+    "NodeTimeoutError",
     "ParentCommand",
     "EmptyInputError",
     "TaskNotFound",
@@ -125,3 +126,23 @@ class TaskNotFound(Exception):
     """Raised when the executor is unable to find a task (for distributed mode)."""
 
     pass
+
+
+class NodeTimeoutError(TimeoutError):
+    """Raised when a node invocation exceeds its configured `timeout`.
+
+    Subclasses the built-in `TimeoutError`, so existing `except TimeoutError`
+    handlers keep working. If the node has a `retry_policy` whose `retry_on`
+    permits `TimeoutError`, the attempt will be retried.
+    """
+
+    node: str
+    elapsed: float
+
+    def __init__(self, node: str, timeout: float, elapsed: float) -> None:
+        super().__init__(
+            f"Node '{node}' exceeded its timeout of {timeout:.3f}s "
+            f"(elapsed: {elapsed:.3f}s)."
+        )
+        self.node = node
+        self.elapsed = elapsed

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -137,6 +137,7 @@ class NodeTimeoutError(TimeoutError):
     """
 
     node: str
+    timeout: float
     elapsed: float
 
     def __init__(self, node: str, timeout: float, elapsed: float) -> None:
@@ -145,4 +146,5 @@ class NodeTimeoutError(TimeoutError):
             f"(elapsed: {elapsed:.3f}s)."
         )
         self.node = node
+        self.timeout = timeout
         self.elapsed = elapsed

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -5,6 +5,7 @@ import inspect
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import (
     Any,
     Generic,
@@ -51,6 +52,7 @@ class _TaskFunction(Generic[P, T]):
         *,
         retry_policy: Sequence[RetryPolicy],
         cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
+        timeout: float | timedelta | None = None,
         name: str | None = None,
     ) -> None:
         if name is not None:
@@ -67,6 +69,7 @@ class _TaskFunction(Generic[P, T]):
         self.func = func
         self.retry_policy = retry_policy
         self.cache_policy = cache_policy
+        self.timeout = timeout
         functools.update_wrapper(self, func)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> SyncAsyncFuture[T]:
@@ -74,6 +77,7 @@ class _TaskFunction(Generic[P, T]):
             self.func,
             retry_policy=self.retry_policy,
             cache_policy=self.cache_policy,
+            timeout=self.timeout,
             *args,
             **kwargs,
         )
@@ -98,6 +102,7 @@ def task(
     name: str | None = None,
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
+    timeout: float | timedelta | None = None,
     **kwargs: Unpack[DeprecatedKwargs],
 ) -> Callable[
     [Callable[P, Awaitable[T]] | Callable[P, T]],
@@ -119,6 +124,7 @@ def task(
     name: str | None = None,
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
+    timeout: float | timedelta | None = None,
     **kwargs: Unpack[DeprecatedKwargs],
 ) -> (
     Callable[[Callable[P, Awaitable[T]] | Callable[P, T]], _TaskFunction[P, T]]
@@ -142,6 +148,8 @@ def task(
         name: An optional name for the task. If not provided, the function name will be used.
         retry_policy: An optional retry policy (or list of policies) to use for the task in case of a failure.
         cache_policy: An optional cache policy to use for the task. This allows caching of the task results.
+        timeout: Maximum wall-clock duration for a single task attempt, in seconds
+            (or as a `timedelta`). If exceeded, `NodeTimeoutError` is raised.
 
     Returns:
         A callable function when used as a decorator.
@@ -209,7 +217,11 @@ def task(
         func: Callable[P, Awaitable[T]] | Callable[P, T],
     ) -> Callable[P, SyncAsyncFuture[T]]:
         return _TaskFunction(
-            func, retry_policy=retry_policies, cache_policy=cache_policy, name=name
+            func,
+            retry_policy=retry_policies,
+            cache_policy=cache_policy,
+            timeout=timeout,
+            name=name,
         )
 
     if __func_or_none__ is not None:
@@ -400,6 +412,7 @@ class entrypoint(Generic[ContextT]):
         context_schema: type[ContextT] | None = None,
         cache_policy: CachePolicy | None = None,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         """Initialize the entrypoint decorator."""
@@ -426,6 +439,7 @@ class entrypoint(Generic[ContextT]):
         self.cache = cache
         self.cache_policy = cache_policy
         self.retry_policy = retry_policy
+        self.timeout = timeout
         self.context_schema = context_schema
 
     @dataclass(**_DC_KWARGS)
@@ -535,6 +549,7 @@ class entrypoint(Generic[ContextT]):
                     bound=bound,
                     triggers=[START],
                     channels=START,
+                    timeout=self.timeout,
                     writers=[
                         ChannelWrite(
                             [

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -23,6 +23,7 @@ from typing_extensions import Unpack
 
 from langgraph._internal import _serde
 from langgraph._internal._constants import CACHE_NS_WRITES, PREVIOUS
+from langgraph._internal._timeout import validate_timeout
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
@@ -204,6 +205,7 @@ def task(
         )
         if retry_policy is None:
             retry_policy = retry  # type: ignore[assignment]
+    validate_timeout(timeout)
 
     retry_policies: Sequence[RetryPolicy] = (
         ()
@@ -439,7 +441,7 @@ class entrypoint(Generic[ContextT]):
         self.cache = cache
         self.cache_policy = cache_policy
         self.retry_policy = retry_policy
-        self.timeout = timeout
+        self.timeout = validate_timeout(timeout)
         self.context_schema = context_schema
 
     @dataclass(**_DC_KWARGS)

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -23,7 +23,8 @@ from typing_extensions import Unpack
 
 from langgraph._internal import _serde
 from langgraph._internal._constants import CACHE_NS_WRITES, PREVIOUS
-from langgraph._internal._timeout import validate_timeout
+from langgraph._internal._runnable import is_async_callable
+from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, validate_timeout
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
@@ -151,6 +152,7 @@ def task(
         cache_policy: An optional cache policy to use for the task. This allows caching of the task results.
         timeout: Maximum wall-clock duration for a single task attempt, in seconds
             (or as a `timedelta`). If exceeded, `NodeTimeoutError` is raised.
+            Supported only for async tasks.
 
     Returns:
         A callable function when used as a decorator.
@@ -218,6 +220,9 @@ def task(
     def decorator(
         func: Callable[P, Awaitable[T]] | Callable[P, T],
     ) -> Callable[P, SyncAsyncFuture[T]]:
+        if timeout is not None and not is_async_callable(func):
+            name_ = name or getattr(func, "__name__", func.__class__.__name__)
+            raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Task {name_!r} is sync.")
         return _TaskFunction(
             func,
             retry_policy=retry_policies,

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -24,7 +24,7 @@ from typing_extensions import Unpack
 from langgraph._internal import _serde
 from langgraph._internal._constants import CACHE_NS_WRITES, PREVIOUS
 from langgraph._internal._runnable import is_async_callable
-from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, validate_timeout
+from langgraph._internal._timeout import coerce_timeout, sync_timeout_unsupported
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
@@ -54,7 +54,7 @@ class _TaskFunction(Generic[P, T]):
         *,
         retry_policy: Sequence[RetryPolicy],
         cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
-        timeout: float | timedelta | None = None,
+        timeout: float | None = None,
         name: str | None = None,
     ) -> None:
         if name is not None:
@@ -207,7 +207,7 @@ def task(
         )
         if retry_policy is None:
             retry_policy = retry  # type: ignore[assignment]
-    validate_timeout(timeout)
+    timeout_s = coerce_timeout(timeout)
 
     retry_policies: Sequence[RetryPolicy] = (
         ()
@@ -220,14 +220,14 @@ def task(
     def decorator(
         func: Callable[P, Awaitable[T]] | Callable[P, T],
     ) -> Callable[P, SyncAsyncFuture[T]]:
-        if timeout is not None and not is_async_callable(func):
+        if timeout_s is not None and not is_async_callable(func):
             name_ = name or getattr(func, "__name__", func.__class__.__name__)
-            raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Task {name_!r} is sync.")
+            raise sync_timeout_unsupported(str(name_), kind="Task")
         return _TaskFunction(
             func,
             retry_policy=retry_policies,
             cache_policy=cache_policy,
-            timeout=timeout,
+            timeout=timeout_s,
             name=name,
         )
 
@@ -446,7 +446,7 @@ class entrypoint(Generic[ContextT]):
         self.cache = cache
         self.cache_policy = cache_policy
         self.retry_policy = retry_policy
-        self.timeout = validate_timeout(timeout)
+        self.timeout = coerce_timeout(timeout)
         self.context_schema = context_schema
 
     @dataclass(**_DC_KWARGS)

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import Any, Generic, Protocol, TypeAlias
 
 from langchain_core.runnables import Runnable, RunnableConfig
@@ -91,4 +90,4 @@ class StateNodeSpec(Generic[NodeInputT, ContextT]):
     cache_policy: CachePolicy | None
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
-    timeout: float | timedelta | None = None
+    timeout: float | None = None

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any, Generic, Protocol, TypeAlias
 
 from langchain_core.runnables import Runnable, RunnableConfig
@@ -90,3 +91,4 @@ class StateNodeSpec(Generic[NodeInputT, ContextT]):
     cache_policy: CachePolicy | None
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
+    timeout: float | timedelta | None = None

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -619,10 +619,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             timeout: Maximum wall-clock duration for a single invocation of this
                 node, in seconds (or as a `timedelta`). When exceeded, a
                 [`NodeTimeoutError`][langgraph.errors.NodeTimeoutError] is raised
-                and the retry policy (if any) decides whether to retry. For
-                synchronous nodes, timing out does not preempt arbitrary user
-                code, so external side effects may continue in a background
-                thread until that code returns.
+                and the retry policy (if any) decides whether to retry. Timeouts
+                are supported only for async nodes; sync nodes cannot be safely
+                cancelled in-process.
 
         Example:
             ```python

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -618,7 +618,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             timeout: Maximum wall-clock duration for a single invocation of this
                 node, in seconds (or as a `timedelta`). When exceeded, a
                 [`NodeTimeoutError`][langgraph.errors.NodeTimeoutError] is raised
-                and the retry policy (if any) decides whether to retry.
+                and the retry policy (if any) decides whether to retry. For
+                synchronous nodes, timing out does not preempt arbitrary user
+                code, so external side effects may continue in a background
+                thread until that code returns.
 
         Example:
             ```python

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -46,7 +46,7 @@ from langgraph._internal._fields import (
 )
 from langgraph._internal._pydantic import create_model
 from langgraph._internal._runnable import coerce_to_runnable
-from langgraph._internal._timeout import validate_timeout
+from langgraph._internal._timeout import coerce_timeout
 from langgraph._internal._typing import EMPTY_SEQ, MISSING, DeprecatedKwargs
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -675,7 +675,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)
-        validate_timeout(timeout)
+        timeout = coerce_timeout(timeout)
 
         if not isinstance(node, str):
             action = node

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -7,6 +7,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Hashable, Sequence
 from dataclasses import is_dataclass
+from datetime import timedelta
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
 from types import FunctionType
@@ -300,6 +301,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema.
@@ -367,6 +369,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph` where input schema is specified.
@@ -439,6 +442,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema.
@@ -506,6 +510,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is specified.
@@ -580,6 +585,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
+        timeout: float | timedelta | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`.
@@ -609,6 +615,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 !!! warning
 
                     This is only used for graph rendering and doesn't have any effect on the graph execution.
+            timeout: Maximum wall-clock duration for a single invocation of this
+                node, in seconds (or as a `timedelta`). When exceeded, a
+                [`NodeTimeoutError`][langgraph.errors.NodeTimeoutError] is raised
+                and the retry policy (if any) decides whether to retry.
 
         Example:
             ```python
@@ -757,6 +767,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=cache_policy,
                 ends=ends,
                 defer=defer,
+                timeout=timeout,
             )
         elif inferred_input_schema is not None:
             self.nodes[node] = StateNodeSpec(
@@ -767,6 +778,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=cache_policy,
                 ends=ends,
                 defer=defer,
+                timeout=timeout,
             )
         else:
             self.nodes[node] = StateNodeSpec[StateT, ContextT](
@@ -777,6 +789,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=cache_policy,
                 ends=ends,
                 defer=defer,
+                timeout=timeout,
             )
 
         input_schema = input_schema or inferred_input_schema
@@ -1332,6 +1345,7 @@ class CompiledStateGraph(
                 retry_policy=node.retry_policy,
                 cache_policy=node.cache_policy,
                 bound=node.runnable,  # type: ignore[arg-type]
+                timeout=node.timeout,
             )
         else:
             raise RuntimeError

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -46,6 +46,7 @@ from langgraph._internal._fields import (
 )
 from langgraph._internal._pydantic import create_model
 from langgraph._internal._runnable import coerce_to_runnable
+from langgraph._internal._timeout import validate_timeout
 from langgraph._internal._typing import EMPTY_SEQ, MISSING, DeprecatedKwargs
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -675,6 +676,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)
+        validate_timeout(timeout)
 
         if not isinstance(node, str):
             action = node

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -62,6 +62,7 @@ from langgraph._internal._constants import (
     TASKS,
 )
 from langgraph._internal._scratchpad import PregelScratchpad
+from langgraph._internal._timeout import validate_timeout
 from langgraph._internal._typing import EMPTY_SEQ, MISSING
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
@@ -146,7 +147,7 @@ class Call:
         self.retry_policy = retry_policy
         self.cache_policy = cache_policy
         self.callbacks = callbacks
-        self.timeout = timeout
+        self.timeout = validate_timeout(timeout)
 
 
 def should_interrupt(

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -7,6 +7,7 @@ import threading
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import copy
+from datetime import timedelta
 from functools import partial
 from hashlib import sha1
 from typing import (
@@ -114,13 +115,21 @@ class PregelTaskWrites(NamedTuple):
 
 
 class Call:
-    __slots__ = ("func", "input", "retry_policy", "cache_policy", "callbacks")
+    __slots__ = (
+        "func",
+        "input",
+        "retry_policy",
+        "cache_policy",
+        "callbacks",
+        "timeout",
+    )
 
     func: Callable
     input: tuple[tuple[Any, ...], dict[str, Any]]
     retry_policy: Sequence[RetryPolicy] | None
     cache_policy: CachePolicy | None
     callbacks: Callbacks
+    timeout: float | timedelta | None
 
     def __init__(
         self,
@@ -130,12 +139,14 @@ class Call:
         retry_policy: Sequence[RetryPolicy] | None,
         cache_policy: CachePolicy | None,
         callbacks: Callbacks,
+        timeout: float | timedelta | None = None,
     ) -> None:
         self.func = func
         self.input = input
         self.retry_policy = retry_policy
         self.cache_policy = cache_policy
         self.callbacks = callbacks
+        self.timeout = timeout
 
 
 def should_interrupt(
@@ -733,6 +744,7 @@ def prepare_single_task(
                         task_path[:3],
                         writers=proc.flat_writers,
                         subgraphs=proc.subgraphs,
+                        timeout=proc.timeout,
                     )
             else:
                 return PregelTask(task_id, name, task_path[:3])
@@ -870,6 +882,7 @@ def prepare_push_task_functional(
             cache_key,
             task_id,
             in_progress_task_path,
+            timeout=call.timeout,
         )
     else:
         return PregelTask(task_id, name, in_progress_task_path)
@@ -1041,6 +1054,7 @@ def prepare_push_task_send(
             translated_task_path,
             writers=proc.flat_writers,
             subgraphs=proc.subgraphs,
+            timeout=proc.timeout,
         )
     else:
         return PregelTask(task_id, packet.node, translated_task_path)

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -62,7 +62,7 @@ from langgraph._internal._constants import (
     TASKS,
 )
 from langgraph._internal._scratchpad import PregelScratchpad
-from langgraph._internal._timeout import validate_timeout
+from langgraph._internal._timeout import coerce_timeout
 from langgraph._internal._typing import EMPTY_SEQ, MISSING
 from langgraph.channels.base import BaseChannel
 from langgraph.channels.topic import Topic
@@ -130,7 +130,7 @@ class Call:
     retry_policy: Sequence[RetryPolicy] | None
     cache_policy: CachePolicy | None
     callbacks: Callbacks
-    timeout: float | timedelta | None
+    timeout: float | None
 
     def __init__(
         self,
@@ -147,7 +147,7 @@ class Call:
         self.retry_policy = retry_policy
         self.cache_policy = cache_policy
         self.callbacks = callbacks
-        self.timeout = validate_timeout(timeout)
+        self.timeout = coerce_timeout(timeout)
 
 
 def should_interrupt(

--- a/libs/langgraph/langgraph/pregel/_call.py
+++ b/libs/langgraph/langgraph/pregel/_call.py
@@ -21,7 +21,7 @@ from langgraph._internal._runnable import (
     is_async_callable,
     run_in_executor,
 )
-from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, validate_timeout
+from langgraph._internal._timeout import coerce_timeout, sync_timeout_unsupported
 from langgraph.config import get_config
 from langgraph.pregel._write import ChannelWrite, ChannelWriteEntry
 from langgraph.types import CachePolicy, RetryPolicy
@@ -260,10 +260,10 @@ def call(
     timeout: float | timedelta | None = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
-    validate_timeout(timeout)
-    if timeout is not None and not is_async_callable(func):
+    timeout_s = coerce_timeout(timeout)
+    if timeout_s is not None and not is_async_callable(func):
         name = getattr(func, "__name__", func.__class__.__name__)
-        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Task {name!r} is sync.")
+        raise sync_timeout_unsupported(name, kind="Task")
     config = get_config()
     impl = config[CONF][CONFIG_KEY_CALL]
     fut = impl(
@@ -272,6 +272,6 @@ def call(
         retry_policy=retry_policy,
         cache_policy=cache_policy,
         callbacks=config["callbacks"],
-        timeout=timeout,
+        timeout=timeout_s,
     )
     return fut

--- a/libs/langgraph/langgraph/pregel/_call.py
+++ b/libs/langgraph/langgraph/pregel/_call.py
@@ -8,6 +8,7 @@ import inspect
 import sys
 import types
 from collections.abc import Awaitable, Callable, Generator, Sequence
+from datetime import timedelta
 from typing import Any, Generic, TypeVar, cast
 
 from langchain_core.runnables import Runnable
@@ -255,6 +256,7 @@ def call(
     *args: Any,
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
+    timeout: float | timedelta | None = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
     config = get_config()
@@ -265,5 +267,6 @@ def call(
         retry_policy=retry_policy,
         cache_policy=cache_policy,
         callbacks=config["callbacks"],
+        timeout=timeout,
     )
     return fut

--- a/libs/langgraph/langgraph/pregel/_call.py
+++ b/libs/langgraph/langgraph/pregel/_call.py
@@ -21,6 +21,7 @@ from langgraph._internal._runnable import (
     is_async_callable,
     run_in_executor,
 )
+from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, validate_timeout
 from langgraph.config import get_config
 from langgraph.pregel._write import ChannelWrite, ChannelWriteEntry
 from langgraph.types import CachePolicy, RetryPolicy
@@ -259,6 +260,10 @@ def call(
     timeout: float | timedelta | None = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
+    validate_timeout(timeout)
+    if timeout is not None and not is_async_callable(func):
+        name = getattr(func, "__name__", func.__class__.__name__)
+        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Task {name!r} is sync.")
     config = get_config()
     impl = config[CONF][CONFIG_KEY_CALL]
     fut = impl(

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -128,7 +128,7 @@ class PregelNode:
     timeout: float | timedelta | None
     """Maximum time in seconds (or a timedelta) allowed for a single invocation
     of this node. If exceeded, `NodeTimeoutError` is raised and the retry policy
-    (if any) decides whether to retry."""
+    (if any) decides whether to retry. Supported only for async nodes."""
 
     tags: Sequence[str] | None
     """Tags to attach to the node for tracing."""

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from datetime import timedelta
 from functools import cached_property
 from typing import (
     Any,
@@ -123,6 +124,11 @@ class PregelNode:
     cache_policy: CachePolicy | None
     """The cache policy to use when invoking the node."""
 
+    timeout: float | timedelta | None
+    """Maximum time in seconds (or a timedelta) allowed for a single invocation
+    of this node. If exceeded, `NodeTimeoutError` is raised and the retry policy
+    (if any) decides whether to retry."""
+
     tags: Sequence[str] | None
     """Tags to attach to the node for tracing."""
 
@@ -145,6 +151,7 @@ class PregelNode:
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
         cache_policy: CachePolicy | None = None,
         subgraphs: Sequence[PregelProtocol] | None = None,
+        timeout: float | timedelta | None = None,
     ) -> None:
         self.channels = channels
         self.triggers = list(triggers)
@@ -156,6 +163,7 @@ class PregelNode:
             self.retry_policy = (retry_policy,)
         else:
             self.retry_policy = retry_policy
+        self.timeout = timeout
         self.tags = tags
         self.metadata = metadata
         if subgraphs is not None:

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -12,7 +12,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph._internal._config import merge_configs
 from langgraph._internal._constants import CONF, CONFIG_KEY_READ
 from langgraph._internal._runnable import RunnableCallable, RunnableSeq
-from langgraph._internal._timeout import validate_timeout
+from langgraph._internal._timeout import coerce_timeout
 from langgraph.pregel._utils import find_subgraph_pregel
 from langgraph.pregel._write import ChannelWrite
 from langgraph.pregel.protocol import PregelProtocol
@@ -125,10 +125,10 @@ class PregelNode:
     cache_policy: CachePolicy | None
     """The cache policy to use when invoking the node."""
 
-    timeout: float | timedelta | None
-    """Maximum time in seconds (or a timedelta) allowed for a single invocation
-    of this node. If exceeded, `NodeTimeoutError` is raised and the retry policy
-    (if any) decides whether to retry. Supported only for async nodes."""
+    timeout: float | None
+    """Maximum time in seconds allowed for a single invocation of this node.
+    If exceeded, `NodeTimeoutError` is raised and the retry policy (if any)
+    decides whether to retry. Supported only for async nodes."""
 
     tags: Sequence[str] | None
     """Tags to attach to the node for tracing."""
@@ -164,7 +164,7 @@ class PregelNode:
             self.retry_policy = (retry_policy,)
         else:
             self.retry_policy = retry_policy
-        self.timeout = validate_timeout(timeout)
+        self.timeout = coerce_timeout(timeout)
         self.tags = tags
         self.metadata = metadata
         if subgraphs is not None:

--- a/libs/langgraph/langgraph/pregel/_read.py
+++ b/libs/langgraph/langgraph/pregel/_read.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph._internal._config import merge_configs
 from langgraph._internal._constants import CONF, CONFIG_KEY_READ
 from langgraph._internal._runnable import RunnableCallable, RunnableSeq
+from langgraph._internal._timeout import validate_timeout
 from langgraph.pregel._utils import find_subgraph_pregel
 from langgraph.pregel._write import ChannelWrite
 from langgraph.pregel.protocol import PregelProtocol
@@ -163,7 +164,7 @@ class PregelNode:
             self.retry_policy = (retry_policy,)
         else:
             self.retry_policy = retry_policy
-        self.timeout = timeout
+        self.timeout = validate_timeout(timeout)
         self.tags = tags
         self.metadata = metadata
         if subgraphs is not None:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -6,7 +6,7 @@ import random
 import sys
 import threading
 import time
-from collections.abc import Awaitable, Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -28,7 +28,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
     NS_SEP,
 )
-from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, timeout_seconds
+from langgraph._internal._timeout import sync_timeout_unsupported
 from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
 from langgraph.runtime import ExecutionInfo, Runtime
 from langgraph.types import Command, PregelExecutableTask, RetryPolicy
@@ -56,10 +56,10 @@ class _TimedAttemptPayload(TypedDict):
 
 
 class _TimedAttemptScope:
-    """Guarded-config window: dispatch under a lock, atomically disable on close().
+    """Guarded-config window for timed attempts.
 
-    `close()` and the guarded send are serialized so a late write cannot slip
-    past the timeout boundary.
+    `close()` and the guarded send are serialized so writes from a cancelled
+    background task cannot slip past the timeout boundary.
     """
 
     __slots__ = ("_active", "_lock")
@@ -89,17 +89,19 @@ class _TimedAttemptScope:
         return guarded_send
 
 
-def _suppress_background_task_exception(task: asyncio.Task[Any]) -> None:
-    """Drain detached task exceptions so cancelled background work stays silent."""
-
+def _drain_cancelled(task: asyncio.Task[Any]) -> None:
+    # Mark the abandoned task's exception as retrieved so asyncio doesn't log it.
     with suppress(asyncio.CancelledError):
         task.exception()
 
 
-def _task_timeout_payload(
+def _start_timed_attempt(
     task: PregelExecutableTask, config: RunnableConfig, timeout_s: float
-) -> _TimedAttemptPayload:
+) -> _TimedAttemptPayload | None:
     configurable = config.get(CONF, {})
+    callback = configurable.get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER)
+    if callback is None:
+        return None
     runtime = configurable.get(CONFIG_KEY_RUNTIME)
     execution_info = runtime.execution_info if isinstance(runtime, Runtime) else None
     attempt = execution_info.node_attempt if execution_info is not None else 1
@@ -115,7 +117,7 @@ def _task_timeout_payload(
         else configurable.get(CONFIG_KEY_CHECKPOINT_NS)
     )
     started_at = datetime.now(timezone.utc)
-    return {
+    payload: _TimedAttemptPayload = {
         "execution_id": f"run:{run_id or '-'}|task:{task.id}|attempt:{attempt}",
         "task_id": task.id,
         "task_name": task.name,
@@ -128,26 +130,21 @@ def _task_timeout_payload(
         "timeout_secs": timeout_s,
         "event": "start",
     }
+    _dispatch_observer(callback, payload)
+    return payload
 
 
-def _notify_timed_attempt(
-    config: RunnableConfig, payload: _TimedAttemptPayload
+def _finish_timed_attempt(
+    config: RunnableConfig,
+    payload: _TimedAttemptPayload | None,
+    error: BaseException | None = None,
 ) -> None:
+    if payload is None:
+        return
     callback = config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER)
     if callback is None:
         return
-    try:
-        callback(payload)
-    except Exception:
-        logger.warning("Timed attempt observer failed", exc_info=True)
-
-
-def _timed_attempt_finish_payload(
-    payload: _TimedAttemptPayload,
-    *,
-    error: BaseException | None,
-) -> _TimedAttemptPayload:
-    return {
+    finish: _TimedAttemptPayload = {
         **payload,
         "event": "finish",
         "finished_at": datetime.now(timezone.utc),
@@ -155,105 +152,54 @@ def _timed_attempt_finish_payload(
         "error_type": type(error).__name__ if error is not None else None,
         "error_message": str(error) if error is not None else None,
     }
+    _dispatch_observer(callback, finish)
 
 
-class _TimedAttempt:
-    __slots__ = ("_config", "_payload")
-
-    def __init__(
-        self, config: RunnableConfig, payload: _TimedAttemptPayload | None
-    ) -> None:
-        self._config = config
-        self._payload = payload
-
-    @classmethod
-    def start(
-        cls,
-        task: PregelExecutableTask,
-        config: RunnableConfig,
-        timeout_s: float | None,
-    ) -> _TimedAttempt | None:
-        if (
-            timeout_s is None
-            or config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None
-        ):
-            return None
-        payload = _task_timeout_payload(task, config, timeout_s)
-        _notify_timed_attempt(config, payload)
-        return cls(config, payload)
-
-    def finish(self, error: BaseException | None = None) -> None:
-        if self._payload is None:
-            return
-        _notify_timed_attempt(
-            self._config,
-            _timed_attempt_finish_payload(self._payload, error=error),
-        )
-        self._payload = None
-
-
-def _finish_timed_attempt(
-    attempt: _TimedAttempt | None, error: BaseException | None = None
+def _dispatch_observer(
+    callback: Callable[[_TimedAttemptPayload], None], payload: _TimedAttemptPayload
 ) -> None:
-    if attempt is not None:
-        attempt.finish(error)
+    try:
+        callback(payload)
+    except Exception:
+        logger.warning("Timed attempt observer failed", exc_info=True)
 
 
 async def _arun_with_timeout(
     task: PregelExecutableTask,
     config: RunnableConfig,
-    timeout_s: float | None,
-    run: Callable[[RunnableConfig], Coroutine[Any, Any, Any]],
-) -> Any:
-    if timeout_s is None:
-        return await run(config)
-    scoped_attempt = _TimedAttemptScope()
-    scoped_config = scoped_attempt.wrap_config(config)
-    start = time.monotonic()
-    background_task: asyncio.Task[Any] = asyncio.create_task(run(scoped_config))
-    try:
-        return await asyncio.wait_for(
-            asyncio.shield(background_task), timeout=timeout_s
-        )
-    except asyncio.TimeoutError as exc:
-        elapsed = time.monotonic() - start
-        scoped_attempt.close()
-        task.writes.clear()
-        background_task.cancel()
-        background_task.add_done_callback(_suppress_background_task_exception)
-        raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
-    except asyncio.CancelledError:
-        scoped_attempt.close()
-        background_task.cancel()
-        background_task.add_done_callback(_suppress_background_task_exception)
-        raise
-    finally:
-        scoped_attempt.close()
-
-
-async def _arun_task_with_timeout(
-    task: PregelExecutableTask,
-    config: RunnableConfig,
-    timeout_s: float | None,
+    timeout_s: float,
     *,
     stream: bool,
 ) -> Any:
-    run: Callable[[RunnableConfig], Coroutine[Any, Any, Any]]
+    scope = _TimedAttemptScope()
+    scoped_config = scope.wrap_config(config)
+    start = time.monotonic()
     if stream:
 
-        async def drain_stream(run_config: RunnableConfig) -> None:
-            async for _ in task.proc.astream(task.input, run_config):
+        async def run() -> Any:
+            async for _ in task.proc.astream(task.input, scoped_config):
                 pass
 
-        run = drain_stream
     else:
 
-        async def invoke(run_config: RunnableConfig) -> Any:
-            return await task.proc.ainvoke(task.input, run_config)
+        async def run() -> Any:
+            return await task.proc.ainvoke(task.input, scoped_config)
 
-        run = invoke
-
-    return await _arun_with_timeout(task, config, timeout_s, run)
+    bg: asyncio.Task[Any] = asyncio.create_task(run())
+    try:
+        return await asyncio.wait_for(asyncio.shield(bg), timeout=timeout_s)
+    except asyncio.TimeoutError as exc:
+        elapsed = time.monotonic() - start
+        task.writes.clear()
+        bg.cancel()
+        bg.add_done_callback(_drain_cancelled)
+        raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
+    except asyncio.CancelledError:
+        bg.cancel()
+        bg.add_done_callback(_drain_cancelled)
+        raise
+    finally:
+        scope.close()
 
 
 def _ensure_execution_info(
@@ -316,9 +262,11 @@ def run_with_retry(
 ) -> None:
     """Run a task with retries."""
     retry_policy = task.retry_policy or retry_policy
-    timeout_s = timeout_seconds(task.timeout)
-    if timeout_s is not None:
-        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
+    if task.timeout is not None:
+        # `validate_timeout_supported` catches sync nodes at compile time;
+        # this is a runtime safety net for paths (e.g. distributed runtime)
+        # that may bypass that validation.
+        raise sync_timeout_unsupported(task.name)
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -424,7 +372,7 @@ async def arun_with_retry(
 ) -> None:
     """Run a task asynchronously with retries."""
     retry_policy = task.retry_policy or retry_policy
-    timeout_s = timeout_seconds(task.timeout)
+    timeout_s = task.timeout
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -459,24 +407,22 @@ async def arun_with_retry(
                     )
                 },
             )
-        timed_attempt: _TimedAttempt | None = None
+        attempt_payload = (
+            _start_timed_attempt(task, config, timeout_s)
+            if timeout_s is not None
+            else None
+        )
         try:
-            # clear any writes from previous attempts
             task.writes.clear()
-            timed_attempt = _TimedAttempt.start(task, config, timeout_s)
-            # run the task
-            try:
-                result = await _arun_task_with_timeout(
-                    task, config, timeout_s, stream=stream
-                )
-            except GraphBubbleUp:
-                raise
-            except BaseException as exc:
-                _finish_timed_attempt(timed_attempt, exc)
-                raise
-            _finish_timed_attempt(timed_attempt)
+            if timeout_s is None:
+                if stream:
+                    async for _ in task.proc.astream(task.input, config):
+                        pass
+                    break
+                return await task.proc.ainvoke(task.input, config)
+            result = await _arun_with_timeout(task, config, timeout_s, stream=stream)
+            _finish_timed_attempt(config, attempt_payload)
             if stream:
-                # if successful, end
                 break
             return result
         except ParentCommand as exc:
@@ -484,27 +430,24 @@ async def arun_with_retry(
             cmd = exc.args[0]
             # strip task_ids from namespace for comparison (ns format: "node1|node2:task_id")
             if cmd.graph in (ns, recast_checkpoint_ns(ns), task.name):
-                # this command is for the current graph, handle it
                 try:
                     for w in task.writers:
                         w.invoke(cmd, config)
                 except Exception as writer_exc:
-                    _finish_timed_attempt(timed_attempt, writer_exc)
+                    _finish_timed_attempt(config, attempt_payload, writer_exc)
                     raise
-                _finish_timed_attempt(timed_attempt)
+                _finish_timed_attempt(config, attempt_payload)
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            _finish_timed_attempt(timed_attempt)
-            # bubble up
+            _finish_timed_attempt(config, attempt_payload)
             raise
         except GraphBubbleUp:
-            _finish_timed_attempt(timed_attempt)
-            # if interrupted, end
+            _finish_timed_attempt(config, attempt_payload)
             raise
         except Exception as exc:
-            _finish_timed_attempt(timed_attempt, exc)
+            _finish_timed_attempt(config, attempt_payload, exc)
             if SUPPORTS_EXC_NOTES:
                 exc.add_note(f"During task with name '{task.name}' and id '{task.id}'")
             if not retry_policy:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -39,18 +39,17 @@ logger = logging.getLogger(__name__)
 SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
 
 
-def _timeout_seconds(value: float | timedelta | None) -> float | None:
-    return timeout_seconds(value)
-
-
 class _TimedAttemptScope:
-    """Atomically disable writes and child scheduling after an attempt times out."""
+    """Guarded-config window: dispatch under a lock, atomically disable on close().
 
-    __slots__ = ("_active", "_lock", "node_name", "timeout_s")
+    `close()` and the guarded send/call are serialized so a late write cannot
+    slip past the timeout boundary.
+    """
 
-    def __init__(self, node_name: str, timeout_s: float) -> None:
+    __slots__ = ("_active", "_lock", "node_name")
+
+    def __init__(self, node_name: str) -> None:
         self.node_name = node_name
-        self.timeout_s = timeout_s
         self._active = True
         self._lock = threading.Lock()
 
@@ -74,8 +73,6 @@ class _TimedAttemptScope:
     ) -> Callable[[Sequence[tuple[str, Any]]], None]:
         def guarded_send(writes: Sequence[tuple[str, Any]]) -> None:
             with self._lock:
-                # Hold the lock through dispatch so close() cannot race a late write
-                # into the attempt after the timeout boundary has been crossed.
                 if self._active:
                     send(writes)
 
@@ -84,8 +81,6 @@ class _TimedAttemptScope:
     def _guard_call(self, call: Callable[..., Any]) -> Callable[..., Any]:
         def guarded_call(*args: Any, **kwargs: Any) -> Any:
             with self._lock:
-                # Same as guarded_send(): scheduling a child task must remain atomic
-                # with respect to close(), or a timed-out attempt can still leak work.
                 if self._active:
                     return call(*args, **kwargs)
                 future: Future[Any] = Future()
@@ -109,10 +104,21 @@ def _suppress_background_task_exception(task: asyncio.Task[Any]) -> None:
 def _task_timeout_payload(
     task: PregelExecutableTask, config: RunnableConfig, timeout_s: float
 ) -> dict[str, Any]:
-    runtime = config.get(CONF, {}).get(CONFIG_KEY_RUNTIME)
+    configurable = config.get(CONF, {})
+    runtime = configurable.get(CONFIG_KEY_RUNTIME)
     execution_info = runtime.execution_info if isinstance(runtime, Runtime) else None
     attempt = execution_info.node_attempt if execution_info is not None else 1
     run_id = execution_info.run_id if execution_info is not None else None
+    thread_id = (
+        execution_info.thread_id
+        if execution_info is not None
+        else configurable.get(CONFIG_KEY_THREAD_ID)
+    )
+    checkpoint_ns = (
+        execution_info.checkpoint_ns
+        if execution_info is not None
+        else configurable.get(CONFIG_KEY_CHECKPOINT_NS)
+    )
     started_at = datetime.now(timezone.utc)
     return {
         "execution_id": f"run:{run_id or '-'}|task:{task.id}|attempt:{attempt}",
@@ -120,16 +126,8 @@ def _task_timeout_payload(
         "task_name": task.name,
         "attempt": attempt,
         "run_id": run_id,
-        "thread_id": (
-            execution_info.thread_id
-            if execution_info is not None
-            else config.get(CONF, {}).get(CONFIG_KEY_THREAD_ID)
-        ),
-        "checkpoint_ns": (
-            execution_info.checkpoint_ns
-            if execution_info is not None
-            else config.get(CONF, {}).get(CONFIG_KEY_CHECKPOINT_NS)
-        ),
+        "thread_id": thread_id,
+        "checkpoint_ns": checkpoint_ns,
         "started_at": started_at.isoformat(),
         "deadline_at": (started_at + timedelta(seconds=timeout_s)).isoformat(),
         "timeout_secs": timeout_s,
@@ -148,6 +146,19 @@ def _notify_timed_attempt(
         callback(payload)
     except Exception:
         logger.warning("Timed attempt observer failed", exc_info=True)
+
+
+def _build_start_payload(
+    task: PregelExecutableTask,
+    config: RunnableConfig,
+    timeout_s: float | None,
+) -> dict[str, Any] | None:
+    """Return a start payload iff a timeout is set AND an observer is registered."""
+    if timeout_s is None:
+        return None
+    if config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None:
+        return None
+    return {**_task_timeout_payload(task, config, timeout_s), "event": "start"}
 
 
 def _timed_attempt_finish_payload(
@@ -180,7 +191,7 @@ def _invoke_with_timeout(
     """
     if timeout_s is None:
         return task.proc.invoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_attempt = _TimedAttemptScope(task.name)
     scoped_config = scoped_attempt.wrap_config(config)
     result: list[Any] = []
     exc: list[BaseException] = []
@@ -204,8 +215,6 @@ def _invoke_with_timeout(
     if not done.wait(timeout_s):
         elapsed = time.monotonic() - start
         scoped_attempt.close()
-        # Discard any writes emitted before the deadline — a timed-out attempt
-        # is a failure, so partial writes must not leak into the commit.
         task.writes.clear()
         raise NodeTimeoutError(task.name, timeout_s, elapsed)
     if exc:
@@ -218,7 +227,7 @@ async def _ainvoke_with_timeout(
 ) -> Any:
     if timeout_s is None:
         return await task.proc.ainvoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_attempt = _TimedAttemptScope(task.name)
     scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
     invoke_task = asyncio.create_task(task.proc.ainvoke(task.input, scoped_config))
@@ -247,7 +256,7 @@ async def _astream_with_timeout(
         async for _ in task.proc.astream(task.input, config):
             pass
         return
-    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_attempt = _TimedAttemptScope(task.name)
     scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
 
@@ -334,7 +343,7 @@ def run_with_retry(
 ) -> None:
     """Run a task with retries."""
     retry_policy = task.retry_policy or retry_policy
-    timeout_s = _timeout_seconds(task.timeout)
+    timeout_s = timeout_seconds(task.timeout)
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -368,14 +377,7 @@ def run_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timed_attempt_payload = (
-                {
-                    **_task_timeout_payload(task, config, timeout_s),
-                    "event": "start",
-                }
-                if timeout_s is not None
-                else None
-            )
+            timed_attempt_payload = _build_start_payload(task, config, timeout_s)
             _notify_timed_attempt(config, timed_attempt_payload)
             try:
                 result = _invoke_with_timeout(task, config, timeout_s)
@@ -478,7 +480,7 @@ async def arun_with_retry(
 ) -> None:
     """Run a task asynchronously with retries."""
     retry_policy = task.retry_policy or retry_policy
-    timeout_s = _timeout_seconds(task.timeout)
+    timeout_s = timeout_seconds(task.timeout)
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -517,14 +519,7 @@ async def arun_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timed_attempt_payload = (
-                {
-                    **_task_timeout_payload(task, config, timeout_s),
-                    "event": "start",
-                }
-                if timeout_s is not None
-                else None
-            )
+            timed_attempt_payload = _build_start_payload(task, config, timeout_s)
             _notify_timed_attempt(config, timed_attempt_payload)
             if stream:
                 try:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -6,7 +6,7 @@ import random
 import sys
 import threading
 import time
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -30,10 +30,6 @@ from langgraph._internal._constants import (
 )
 from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, timeout_seconds
 from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
-from langgraph.pregel._utils import (
-    runnable_primary_has_native_astream,
-    runnable_primary_has_native_async,
-)
 from langgraph.runtime import ExecutionInfo, Runtime
 from langgraph.types import Command, PregelExecutableTask, RetryPolicy
 
@@ -146,28 +142,6 @@ def _notify_timed_attempt(
         logger.warning("Timed attempt observer failed", exc_info=True)
 
 
-def _build_start_payload(
-    task: PregelExecutableTask,
-    config: RunnableConfig,
-    timeout_s: float,
-) -> _TimedAttemptPayload | None:
-    """Return a start payload iff an observer is registered."""
-    if config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None:
-        return None
-    return _task_timeout_payload(task, config, timeout_s)
-
-
-def _start_timed_attempt(
-    task: PregelExecutableTask,
-    config: RunnableConfig,
-    timeout_s: float,
-) -> _TimedAttemptPayload | None:
-    payload = _build_start_payload(task, config, timeout_s)
-    if payload is not None:
-        _notify_timed_attempt(config, payload)
-    return payload
-
-
 def _timed_attempt_finish_payload(
     payload: _TimedAttemptPayload,
     *,
@@ -183,85 +157,103 @@ def _timed_attempt_finish_payload(
     }
 
 
-def _finish_timed_attempt(
-    config: RunnableConfig,
-    payload: _TimedAttemptPayload | None,
-    error: BaseException | None = None,
-) -> None:
-    if payload is not None:
+class _TimedAttempt:
+    __slots__ = ("_config", "_payload")
+
+    def __init__(
+        self, config: RunnableConfig, payload: _TimedAttemptPayload | None
+    ) -> None:
+        self._config = config
+        self._payload = payload
+
+    @classmethod
+    def start(
+        cls,
+        task: PregelExecutableTask,
+        config: RunnableConfig,
+        timeout_s: float | None,
+    ) -> _TimedAttempt | None:
+        if (
+            timeout_s is None
+            or config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None
+        ):
+            return None
+        payload = _task_timeout_payload(task, config, timeout_s)
+        _notify_timed_attempt(config, payload)
+        return cls(config, payload)
+
+    def finish(self, error: BaseException | None = None) -> None:
+        if self._payload is None:
+            return
         _notify_timed_attempt(
-            config,
-            _timed_attempt_finish_payload(payload, error=error),
+            self._config,
+            _timed_attempt_finish_payload(self._payload, error=error),
         )
+        self._payload = None
 
 
-def _invoke_with_timeout(
-    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
-) -> Any:
-    if timeout_s is None:
-        return task.proc.invoke(task.input, config)
-    raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
-
-
-async def _ainvoke_with_timeout(
-    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
-) -> Any:
-    if timeout_s is None:
-        return await task.proc.ainvoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope()
-    scoped_config = scoped_attempt.wrap_config(config)
-    start = time.monotonic()
-    invoke_task = asyncio.create_task(task.proc.ainvoke(task.input, scoped_config))
-    try:
-        return await asyncio.wait_for(asyncio.shield(invoke_task), timeout=timeout_s)
-    except asyncio.TimeoutError as exc:
-        elapsed = time.monotonic() - start
-        scoped_attempt.close()
-        task.writes.clear()
-        invoke_task.cancel()
-        invoke_task.add_done_callback(_suppress_background_task_exception)
-        raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
-    except asyncio.CancelledError:
-        scoped_attempt.close()
-        invoke_task.cancel()
-        invoke_task.add_done_callback(_suppress_background_task_exception)
-        raise
-    finally:
-        scoped_attempt.close()
-
-
-async def _astream_with_timeout(
-    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
+def _finish_timed_attempt(
+    attempt: _TimedAttempt | None, error: BaseException | None = None
 ) -> None:
+    if attempt is not None:
+        attempt.finish(error)
+
+
+async def _arun_with_timeout(
+    task: PregelExecutableTask,
+    config: RunnableConfig,
+    timeout_s: float | None,
+    run: Callable[[RunnableConfig], Coroutine[Any, Any, Any]],
+) -> Any:
     if timeout_s is None:
-        async for _ in task.proc.astream(task.input, config):
-            pass
-        return
+        return await run(config)
     scoped_attempt = _TimedAttemptScope()
     scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
-
-    async def _drain() -> None:
-        async for _ in task.proc.astream(task.input, scoped_config):
-            pass
-
-    stream_task = asyncio.create_task(_drain())
+    background_task: asyncio.Task[Any] = asyncio.create_task(run(scoped_config))
     try:
-        await asyncio.wait_for(asyncio.shield(stream_task), timeout=timeout_s)
+        return await asyncio.wait_for(
+            asyncio.shield(background_task), timeout=timeout_s
+        )
     except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
         scoped_attempt.close()
         task.writes.clear()
-        stream_task.cancel()
-        stream_task.add_done_callback(_suppress_background_task_exception)
+        background_task.cancel()
+        background_task.add_done_callback(_suppress_background_task_exception)
         raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
     except asyncio.CancelledError:
         scoped_attempt.close()
-        stream_task.cancel()
-        stream_task.add_done_callback(_suppress_background_task_exception)
+        background_task.cancel()
+        background_task.add_done_callback(_suppress_background_task_exception)
         raise
     finally:
         scoped_attempt.close()
+
+
+async def _arun_task_with_timeout(
+    task: PregelExecutableTask,
+    config: RunnableConfig,
+    timeout_s: float | None,
+    *,
+    stream: bool,
+) -> Any:
+    run: Callable[[RunnableConfig], Coroutine[Any, Any, Any]]
+    if stream:
+
+        async def drain_stream(run_config: RunnableConfig) -> None:
+            async for _ in task.proc.astream(task.input, run_config):
+                pass
+
+        run = drain_stream
+    else:
+
+        async def invoke(run_config: RunnableConfig) -> Any:
+            return await task.proc.ainvoke(task.input, run_config)
+
+        run = invoke
+
+    return await _arun_with_timeout(task, config, timeout_s, run)
 
 
 def _ensure_execution_info(
@@ -360,42 +352,22 @@ def run_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timed_attempt_payload = (
-                _start_timed_attempt(task, config, timeout_s)
-                if timeout_s is not None
-                else None
-            )
-            try:
-                result = _invoke_with_timeout(task, config, timeout_s)
-            except (ParentCommand, GraphBubbleUp):
-                raise
-            except BaseException as exc:
-                _finish_timed_attempt(config, timed_attempt_payload, exc)
-                raise
-            _finish_timed_attempt(config, timed_attempt_payload)
-            return result
+            return task.proc.invoke(task.input, config)
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
             cmd = exc.args[0]
             # strip task_ids from namespace for comparison (ns format: "node1|node2:task_id")
             if cmd.graph in (ns, recast_checkpoint_ns(ns), task.name):
                 # this command is for the current graph, handle it
-                try:
-                    for w in task.writers:
-                        w.invoke(cmd, config)
-                except Exception as writer_exc:
-                    _finish_timed_attempt(config, timed_attempt_payload, writer_exc)
-                    raise
-                _finish_timed_attempt(config, timed_attempt_payload)
+                for w in task.writers:
+                    w.invoke(cmd, config)
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            _finish_timed_attempt(config, timed_attempt_payload)
             # bubble up
             raise
         except GraphBubbleUp:
-            _finish_timed_attempt(config, timed_attempt_payload)
             # if interrupted, end
             raise
         except Exception as exc:
@@ -453,14 +425,6 @@ async def arun_with_retry(
     """Run a task asynchronously with retries."""
     retry_policy = task.retry_policy or retry_policy
     timeout_s = timeout_seconds(task.timeout)
-    if timeout_s is not None:
-        supports_timeout = (
-            runnable_primary_has_native_astream(task.proc)
-            if stream
-            else runnable_primary_has_native_async(task.proc)
-        )
-        if not supports_timeout:
-            raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -495,37 +459,26 @@ async def arun_with_retry(
                     )
                 },
             )
+        timed_attempt: _TimedAttempt | None = None
         try:
             # clear any writes from previous attempts
             task.writes.clear()
+            timed_attempt = _TimedAttempt.start(task, config, timeout_s)
             # run the task
-            timed_attempt_payload = (
-                _start_timed_attempt(task, config, timeout_s)
-                if timeout_s is not None
-                else None
-            )
+            try:
+                result = await _arun_task_with_timeout(
+                    task, config, timeout_s, stream=stream
+                )
+            except GraphBubbleUp:
+                raise
+            except BaseException as exc:
+                _finish_timed_attempt(timed_attempt, exc)
+                raise
+            _finish_timed_attempt(timed_attempt)
             if stream:
-                try:
-                    await _astream_with_timeout(task, config, timeout_s)
-                except (ParentCommand, GraphBubbleUp):
-                    raise
-                except BaseException as exc:
-                    _finish_timed_attempt(config, timed_attempt_payload, exc)
-                    raise
-                else:
-                    _finish_timed_attempt(config, timed_attempt_payload)
-                    # if successful, end
-                    break
-            else:
-                try:
-                    result = await _ainvoke_with_timeout(task, config, timeout_s)
-                except (ParentCommand, GraphBubbleUp):
-                    raise
-                except BaseException as exc:
-                    _finish_timed_attempt(config, timed_attempt_payload, exc)
-                    raise
-                _finish_timed_attempt(config, timed_attempt_payload)
-                return result
+                # if successful, end
+                break
+            return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
             cmd = exc.args[0]
@@ -536,21 +489,22 @@ async def arun_with_retry(
                     for w in task.writers:
                         w.invoke(cmd, config)
                 except Exception as writer_exc:
-                    _finish_timed_attempt(config, timed_attempt_payload, writer_exc)
+                    _finish_timed_attempt(timed_attempt, writer_exc)
                     raise
-                _finish_timed_attempt(config, timed_attempt_payload)
+                _finish_timed_attempt(timed_attempt)
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            _finish_timed_attempt(config, timed_attempt_payload)
+            _finish_timed_attempt(timed_attempt)
             # bubble up
             raise
         except GraphBubbleUp:
-            _finish_timed_attempt(config, timed_attempt_payload)
+            _finish_timed_attempt(timed_attempt)
             # if interrupted, end
             raise
         except Exception as exc:
+            _finish_timed_attempt(timed_attempt, exc)
             if SUPPORTS_EXC_NOTES:
                 exc.add_note(f"During task with name '{task.name}' and id '{task.id}'")
             if not retry_policy:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -9,7 +9,8 @@ import threading
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import Future
-from dataclasses import dataclass, replace
+from contextlib import suppress
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -29,6 +30,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
     NS_SEP,
 )
+from langgraph._internal._timeout import timeout_seconds
 from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
 from langgraph.runtime import ExecutionInfo, Runtime
 from langgraph.types import Command, PregelExecutableTask, RetryPolicy
@@ -38,25 +40,19 @@ SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
 
 
 def _timeout_seconds(value: float | timedelta | None) -> float | None:
-    if value is None:
-        return None
-    timeout = value.total_seconds() if isinstance(value, timedelta) else float(value)
-    if timeout <= 0:
-        raise ValueError("timeout must be greater than 0")
-    return timeout
+    return timeout_seconds(value)
 
 
-@dataclass(slots=True)
 class _TimedAttemptScope:
-    node_name: str
-    timeout_s: float
-    _active: threading.Event
+    """Atomically disable writes and child scheduling after an attempt times out."""
+
+    __slots__ = ("_active", "_lock", "node_name", "timeout_s")
 
     def __init__(self, node_name: str, timeout_s: float) -> None:
         self.node_name = node_name
         self.timeout_s = timeout_s
-        self._active = threading.Event()
-        self._active.set()
+        self._active = True
+        self._lock = threading.Lock()
 
     def wrap_config(self, config: RunnableConfig) -> RunnableConfig:
         configurable = config.get(CONF, {})
@@ -70,30 +66,44 @@ class _TimedAttemptScope:
         return patch_configurable(config, updates)
 
     def close(self) -> None:
-        self._active.clear()
+        with self._lock:
+            self._active = False
 
     def _guard_send(
         self, send: Callable[[Sequence[tuple[str, Any]]], None]
     ) -> Callable[[Sequence[tuple[str, Any]]], None]:
         def guarded_send(writes: Sequence[tuple[str, Any]]) -> None:
-            if self._active.is_set():
-                send(writes)
+            with self._lock:
+                # Hold the lock through dispatch so close() cannot race a late write
+                # into the attempt after the timeout boundary has been crossed.
+                if self._active:
+                    send(writes)
 
         return guarded_send
 
     def _guard_call(self, call: Callable[..., Any]) -> Callable[..., Any]:
         def guarded_call(*args: Any, **kwargs: Any) -> Any:
-            if self._active.is_set():
-                return call(*args, **kwargs)
-            future: Future[Any] = Future()
-            future.set_exception(
-                RuntimeError(
-                    f"Timed-out attempt for node '{self.node_name}' cannot schedule child tasks."
+            with self._lock:
+                # Same as guarded_send(): scheduling a child task must remain atomic
+                # with respect to close(), or a timed-out attempt can still leak work.
+                if self._active:
+                    return call(*args, **kwargs)
+                future: Future[Any] = Future()
+                future.set_exception(
+                    RuntimeError(
+                        f"Timed-out attempt for node '{self.node_name}' cannot schedule child tasks."
+                    )
                 )
-            )
             return future
 
         return guarded_call
+
+
+def _suppress_background_task_exception(task: asyncio.Task[Any]) -> None:
+    """Drain detached task exceptions so cancelled background work stays silent."""
+
+    with suppress(asyncio.CancelledError):
+        task.exception()
 
 
 def _task_timeout_payload(
@@ -194,6 +204,9 @@ def _invoke_with_timeout(
     if not done.wait(timeout_s):
         elapsed = time.monotonic() - start
         scoped_attempt.close()
+        # Discard any writes emitted before the deadline — a timed-out attempt
+        # is a failure, so partial writes must not leak into the commit.
+        task.writes.clear()
         raise NodeTimeoutError(task.name, timeout_s, elapsed)
     if exc:
         raise exc[0]
@@ -205,14 +218,26 @@ async def _ainvoke_with_timeout(
 ) -> Any:
     if timeout_s is None:
         return await task.proc.ainvoke(task.input, config)
+    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
+    invoke_task = asyncio.create_task(task.proc.ainvoke(task.input, scoped_config))
     try:
-        return await asyncio.wait_for(
-            task.proc.ainvoke(task.input, config), timeout=timeout_s
-        )
+        return await asyncio.wait_for(asyncio.shield(invoke_task), timeout=timeout_s)
     except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
+        scoped_attempt.close()
+        task.writes.clear()
+        invoke_task.cancel()
+        invoke_task.add_done_callback(_suppress_background_task_exception)
         raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
+    except asyncio.CancelledError:
+        scoped_attempt.close()
+        invoke_task.cancel()
+        invoke_task.add_done_callback(_suppress_background_task_exception)
+        raise
+    finally:
+        scoped_attempt.close()
 
 
 async def _astream_with_timeout(
@@ -222,17 +247,31 @@ async def _astream_with_timeout(
         async for _ in task.proc.astream(task.input, config):
             pass
         return
+    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
 
     async def _drain() -> None:
-        async for _ in task.proc.astream(task.input, config):
+        async for _ in task.proc.astream(task.input, scoped_config):
             pass
 
+    stream_task = asyncio.create_task(_drain())
     try:
-        await asyncio.wait_for(_drain(), timeout=timeout_s)
+        await asyncio.wait_for(asyncio.shield(stream_task), timeout=timeout_s)
     except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
+        scoped_attempt.close()
+        task.writes.clear()
+        stream_task.cancel()
+        stream_task.add_done_callback(_suppress_background_task_exception)
         raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
+    except asyncio.CancelledError:
+        scoped_attempt.close()
+        stream_task.cancel()
+        stream_task.add_done_callback(_suppress_background_task_exception)
+        raise
+    finally:
+        scoped_attempt.close()
 
 
 def _ensure_execution_info(
@@ -340,6 +379,8 @@ def run_with_retry(
             _notify_timed_attempt(config, timed_attempt_payload)
             try:
                 result = _invoke_with_timeout(task, config, timeout_s)
+            except (ParentCommand, GraphBubbleUp):
+                raise
             except BaseException as exc:
                 _notify_timed_attempt(
                     config,
@@ -362,13 +403,25 @@ def run_with_retry(
                 # this command is for the current graph, handle it
                 for w in task.writers:
                     w.invoke(cmd, config)
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+                )
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
+            _notify_timed_attempt(
+                config,
+                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+            )
             # bubble up
             raise
         except GraphBubbleUp:
+            _notify_timed_attempt(
+                config,
+                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+            )
             # if interrupted, end
             raise
         except Exception as exc:
@@ -476,6 +529,8 @@ async def arun_with_retry(
             if stream:
                 try:
                     await _astream_with_timeout(task, config, timeout_s)
+                except (ParentCommand, GraphBubbleUp):
+                    raise
                 except BaseException as exc:
                     _notify_timed_attempt(
                         config,
@@ -498,6 +553,8 @@ async def arun_with_retry(
             else:
                 try:
                     result = await _ainvoke_with_timeout(task, config, timeout_s)
+                except (ParentCommand, GraphBubbleUp):
+                    raise
                 except BaseException as exc:
                     _notify_timed_attempt(
                         config,
@@ -523,13 +580,25 @@ async def arun_with_retry(
                 # this command is for the current graph, handle it
                 for w in task.writers:
                     w.invoke(cmd, config)
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+                )
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
+            _notify_timed_attempt(
+                config,
+                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+            )
             # bubble up
             raise
         except GraphBubbleUp:
+            _notify_timed_attempt(
+                config,
+                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+            )
             # if interrupted, end
             raise
         except Exception as exc:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import random
 import sys
 import threading
 import time
 from collections.abc import Awaitable, Callable, Sequence
-from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from concurrent.futures import Future
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from langchain_core.runnables import RunnableConfig
@@ -16,14 +18,15 @@ from langchain_core.runnables import RunnableConfig
 from langgraph._internal._config import patch_configurable, recast_checkpoint_ns
 from langgraph._internal._constants import (
     CONF,
+    CONFIG_KEY_CALL,
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_RESUMING,
     CONFIG_KEY_RUNTIME,
+    CONFIG_KEY_SEND,
     CONFIG_KEY_TASK_ID,
-    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
-    CONFIG_KEY_TASK_TIMEOUT_STARTED,
     CONFIG_KEY_THREAD_ID,
+    CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
     NS_SEP,
 )
 from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
@@ -37,9 +40,60 @@ SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
 def _timeout_seconds(value: float | timedelta | None) -> float | None:
     if value is None:
         return None
-    if isinstance(value, timedelta):
-        return value.total_seconds()
-    return float(value)
+    timeout = value.total_seconds() if isinstance(value, timedelta) else float(value)
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than 0")
+    return timeout
+
+
+@dataclass(slots=True)
+class _TimedAttemptScope:
+    node_name: str
+    timeout_s: float
+    _active: threading.Event
+
+    def __init__(self, node_name: str, timeout_s: float) -> None:
+        self.node_name = node_name
+        self.timeout_s = timeout_s
+        self._active = threading.Event()
+        self._active.set()
+
+    def wrap_config(self, config: RunnableConfig) -> RunnableConfig:
+        configurable = config.get(CONF, {})
+        updates: dict[str, Any] = {}
+        if (send := configurable.get(CONFIG_KEY_SEND)) is not None:
+            updates[CONFIG_KEY_SEND] = self._guard_send(send)
+        if (call := configurable.get(CONFIG_KEY_CALL)) is not None:
+            updates[CONFIG_KEY_CALL] = self._guard_call(call)
+        if not updates:
+            return config
+        return patch_configurable(config, updates)
+
+    def close(self) -> None:
+        self._active.clear()
+
+    def _guard_send(
+        self, send: Callable[[Sequence[tuple[str, Any]]], None]
+    ) -> Callable[[Sequence[tuple[str, Any]]], None]:
+        def guarded_send(writes: Sequence[tuple[str, Any]]) -> None:
+            if self._active.is_set():
+                send(writes)
+
+        return guarded_send
+
+    def _guard_call(self, call: Callable[..., Any]) -> Callable[..., Any]:
+        def guarded_call(*args: Any, **kwargs: Any) -> Any:
+            if self._active.is_set():
+                return call(*args, **kwargs)
+            future: Future[Any] = Future()
+            future.set_exception(
+                RuntimeError(
+                    f"Timed-out attempt for node '{self.node_name}' cannot schedule child tasks."
+                )
+            )
+            return future
+
+        return guarded_call
 
 
 def _task_timeout_payload(
@@ -47,21 +101,15 @@ def _task_timeout_payload(
 ) -> dict[str, Any]:
     runtime = config.get(CONF, {}).get(CONFIG_KEY_RUNTIME)
     execution_info = runtime.execution_info if isinstance(runtime, Runtime) else None
-    started_at = datetime.now(UTC)
+    attempt = execution_info.node_attempt if execution_info is not None else 1
+    run_id = execution_info.run_id if execution_info is not None else None
+    started_at = datetime.now(timezone.utc)
     return {
-        "execution_id": ":".join(
-            part
-            for part in (
-                execution_info.run_id if execution_info is not None else None,
-                task.id,
-                str(execution_info.node_attempt if execution_info is not None else 1),
-            )
-            if part is not None
-        ),
+        "execution_id": f"run:{run_id or '-'}|task:{task.id}|attempt:{attempt}",
         "task_id": task.id,
         "task_name": task.name,
-        "attempt": execution_info.node_attempt if execution_info is not None else 1,
-        "run_id": execution_info.run_id if execution_info is not None else None,
+        "attempt": attempt,
+        "run_id": run_id,
         "thread_id": (
             execution_info.thread_id
             if execution_info is not None
@@ -78,43 +126,35 @@ def _task_timeout_payload(
     }
 
 
-def _notify_task_timeout_started(
+def _notify_timed_attempt(
     config: RunnableConfig, payload: dict[str, Any] | None
 ) -> None:
     if payload is None:
         return
-    callback = config.get(CONF, {}).get(CONFIG_KEY_TASK_TIMEOUT_STARTED)
+    callback = config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER)
     if callback is None:
         return
     try:
         callback(payload)
     except Exception:
-        logger.warning("Timed task start callback failed", exc_info=True)
+        logger.warning("Timed attempt observer failed", exc_info=True)
 
 
-def _notify_task_timeout_finished(
-    config: RunnableConfig,
+def _timed_attempt_finish_payload(
     payload: dict[str, Any] | None,
     *,
     error: BaseException | None,
-) -> None:
+) -> dict[str, Any] | None:
     if payload is None:
-        return
-    callback = config.get(CONF, {}).get(CONFIG_KEY_TASK_TIMEOUT_FINISHED)
-    if callback is None:
-        return
-    try:
-        callback(
-            {
-                **payload,
-                "finished_at": datetime.now(UTC).isoformat(),
-                "status": "error" if error is not None else "success",
-                "error_type": type(error).__name__ if error is not None else None,
-                "error_message": str(error) if error is not None else None,
-            }
-        )
-    except Exception:
-        logger.warning("Timed task finish callback failed", exc_info=True)
+        return None
+    return {
+        **payload,
+        "event": "finish",
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "status": "error" if error is not None else "success",
+        "error_type": type(error).__name__ if error is not None else None,
+        "error_message": str(error) if error is not None else None,
+    }
 
 
 def _invoke_with_timeout(
@@ -124,20 +164,26 @@ def _invoke_with_timeout(
 
     Python cannot safely cancel a running thread, so if the worker exceeds
     `timeout_s` we raise `NodeTimeoutError` and leave the thread to finish
-    on its own (daemonized, so it will not block process exit).
+    on its own. Writes and child task scheduling from a timed-out attempt are
+    discarded, but any other side effects in user code may still continue in
+    the daemon worker thread until it returns.
     """
     if timeout_s is None:
         return task.proc.invoke(task.input, config)
+    scoped_attempt = _TimedAttemptScope(task.name, timeout_s)
+    scoped_config = scoped_attempt.wrap_config(config)
     result: list[Any] = []
     exc: list[BaseException] = []
     done = threading.Event()
+    ctx = contextvars.copy_context()
 
     def target() -> None:
         try:
-            result.append(task.proc.invoke(task.input, config))
+            result.append(ctx.run(task.proc.invoke, task.input, scoped_config))
         except BaseException as e:
             exc.append(e)
         finally:
+            scoped_attempt.close()
             done.set()
 
     start = time.monotonic()
@@ -147,6 +193,7 @@ def _invoke_with_timeout(
     worker.start()
     if not done.wait(timeout_s):
         elapsed = time.monotonic() - start
+        scoped_attempt.close()
         raise NodeTimeoutError(task.name, timeout_s, elapsed)
     if exc:
         raise exc[0]
@@ -163,9 +210,9 @@ async def _ainvoke_with_timeout(
         return await asyncio.wait_for(
             task.proc.ainvoke(task.input, config), timeout=timeout_s
         )
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
-        raise NodeTimeoutError(task.name, timeout_s, elapsed) from None
+        raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
 
 
 async def _astream_with_timeout(
@@ -183,9 +230,9 @@ async def _astream_with_timeout(
 
     try:
         await asyncio.wait_for(_drain(), timeout=timeout_s)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
-        raise NodeTimeoutError(task.name, timeout_s, elapsed) from None
+        raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
 
 
 def _ensure_execution_info(
@@ -282,18 +329,30 @@ def run_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timeout_payload = (
-                _task_timeout_payload(task, config, timeout_s)
+            timed_attempt_payload = (
+                {
+                    **_task_timeout_payload(task, config, timeout_s),
+                    "event": "start",
+                }
                 if timeout_s is not None
                 else None
             )
-            _notify_task_timeout_started(config, timeout_payload)
+            _notify_timed_attempt(config, timed_attempt_payload)
             try:
                 result = _invoke_with_timeout(task, config, timeout_s)
             except BaseException as exc:
-                _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(
+                        timed_attempt_payload,
+                        error=exc,
+                    ),
+                )
                 raise
-            _notify_task_timeout_finished(config, timeout_payload, error=None)
+            _notify_timed_attempt(
+                config,
+                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
+            )
             return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
@@ -405,29 +464,56 @@ async def arun_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timeout_payload = (
-                _task_timeout_payload(task, config, timeout_s)
+            timed_attempt_payload = (
+                {
+                    **_task_timeout_payload(task, config, timeout_s),
+                    "event": "start",
+                }
                 if timeout_s is not None
                 else None
             )
-            _notify_task_timeout_started(config, timeout_payload)
+            _notify_timed_attempt(config, timed_attempt_payload)
             if stream:
                 try:
                     await _astream_with_timeout(task, config, timeout_s)
                 except BaseException as exc:
-                    _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                    _notify_timed_attempt(
+                        config,
+                        _timed_attempt_finish_payload(
+                            timed_attempt_payload,
+                            error=exc,
+                        ),
+                    )
                     raise
                 else:
-                    _notify_task_timeout_finished(config, timeout_payload, error=None)
+                    _notify_timed_attempt(
+                        config,
+                        _timed_attempt_finish_payload(
+                            timed_attempt_payload,
+                            error=None,
+                        ),
+                    )
                     # if successful, end
                     break
             else:
                 try:
                     result = await _ainvoke_with_timeout(task, config, timeout_s)
                 except BaseException as exc:
-                    _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                    _notify_timed_attempt(
+                        config,
+                        _timed_attempt_finish_payload(
+                            timed_attempt_payload,
+                            error=exc,
+                        ),
+                    )
                     raise
-                _notify_task_timeout_finished(config, timeout_payload, error=None)
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(
+                        timed_attempt_payload,
+                        error=None,
+                    ),
+                )
                 return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -46,11 +46,11 @@ class _TimedAttemptPayload(TypedDict):
     run_id: str | None
     thread_id: str | None
     checkpoint_ns: str | None
-    started_at: str
-    deadline_at: str
+    started_at: datetime
+    deadline_at: datetime
     timeout_secs: float
     event: Literal["start", "finish"]
-    finished_at: NotRequired[str]
+    finished_at: NotRequired[datetime]
     status: NotRequired[Literal["success", "error"]]
     error_type: NotRequired[str | None]
     error_message: NotRequired[str | None]
@@ -124,8 +124,8 @@ def _task_timeout_payload(
         "run_id": run_id,
         "thread_id": thread_id,
         "checkpoint_ns": checkpoint_ns,
-        "started_at": started_at.isoformat(),
-        "deadline_at": (started_at + timedelta(seconds=timeout_s)).isoformat(),
+        "started_at": started_at,
+        "deadline_at": started_at + timedelta(seconds=timeout_s),
         "timeout_secs": timeout_s,
         "event": "start",
     }
@@ -168,7 +168,7 @@ def _timed_attempt_finish_payload(
     return {
         **payload,
         "event": "finish",
-        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": datetime.now(timezone.utc),
         "status": "error" if error is not None else "success",
         "error_type": type(error).__name__ if error is not None else None,
         "error_message": str(error) if error is not None else None,

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import logging
 import random
 import sys
@@ -29,8 +28,12 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
     NS_SEP,
 )
-from langgraph._internal._timeout import timeout_seconds
+from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED, timeout_seconds
 from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
+from langgraph.pregel._utils import (
+    runnable_primary_has_native_astream,
+    runnable_primary_has_native_async,
+)
 from langgraph.runtime import ExecutionInfo, Runtime
 from langgraph.types import Command, PregelExecutableTask, RetryPolicy
 
@@ -132,10 +135,8 @@ def _task_timeout_payload(
 
 
 def _notify_timed_attempt(
-    config: RunnableConfig, payload: _TimedAttemptPayload | None
+    config: RunnableConfig, payload: _TimedAttemptPayload
 ) -> None:
-    if payload is None:
-        return
     callback = config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER)
     if callback is None:
         return
@@ -148,23 +149,30 @@ def _notify_timed_attempt(
 def _build_start_payload(
     task: PregelExecutableTask,
     config: RunnableConfig,
-    timeout_s: float | None,
+    timeout_s: float,
 ) -> _TimedAttemptPayload | None:
-    """Return a start payload iff a timeout is set AND an observer is registered."""
-    if timeout_s is None:
-        return None
+    """Return a start payload iff an observer is registered."""
     if config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None:
         return None
     return _task_timeout_payload(task, config, timeout_s)
 
 
+def _start_timed_attempt(
+    task: PregelExecutableTask,
+    config: RunnableConfig,
+    timeout_s: float,
+) -> _TimedAttemptPayload | None:
+    payload = _build_start_payload(task, config, timeout_s)
+    if payload is not None:
+        _notify_timed_attempt(config, payload)
+    return payload
+
+
 def _timed_attempt_finish_payload(
-    payload: _TimedAttemptPayload | None,
+    payload: _TimedAttemptPayload,
     *,
     error: BaseException | None,
-) -> _TimedAttemptPayload | None:
-    if payload is None:
-        return None
+) -> _TimedAttemptPayload:
     return {
         **payload,
         "event": "finish",
@@ -175,48 +183,24 @@ def _timed_attempt_finish_payload(
     }
 
 
+def _finish_timed_attempt(
+    config: RunnableConfig,
+    payload: _TimedAttemptPayload | None,
+    error: BaseException | None = None,
+) -> None:
+    if payload is not None:
+        _notify_timed_attempt(
+            config,
+            _timed_attempt_finish_payload(payload, error=error),
+        )
+
+
 def _invoke_with_timeout(
     task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
 ) -> Any:
-    """Run the sync invocation under a wall-clock timeout.
-
-    Python cannot safely cancel a running thread, so if the worker exceeds
-    `timeout_s` we raise `NodeTimeoutError` and leave the thread to finish
-    on its own. Writes from a timed-out attempt are discarded, but any other
-    side effects in user code may still continue in the daemon worker thread
-    until it returns.
-    """
     if timeout_s is None:
         return task.proc.invoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope()
-    scoped_config = scoped_attempt.wrap_config(config)
-    result: list[Any] = []
-    exc: list[BaseException] = []
-    done = threading.Event()
-    ctx = contextvars.copy_context()
-
-    def target() -> None:
-        try:
-            result.append(ctx.run(task.proc.invoke, task.input, scoped_config))
-        except BaseException as e:
-            exc.append(e)
-        finally:
-            scoped_attempt.close()
-            done.set()
-
-    start = time.monotonic()
-    worker = threading.Thread(
-        target=target, name=f"node:{task.name}:{task.id}", daemon=True
-    )
-    worker.start()
-    if not done.wait(timeout_s):
-        elapsed = time.monotonic() - start
-        scoped_attempt.close()
-        task.writes.clear()
-        raise NodeTimeoutError(task.name, timeout_s, elapsed)
-    if exc:
-        raise exc[0]
-    return result[0]
+    raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
 
 
 async def _ainvoke_with_timeout(
@@ -341,6 +325,8 @@ def run_with_retry(
     """Run a task with retries."""
     retry_policy = task.retry_policy or retry_policy
     timeout_s = timeout_seconds(task.timeout)
+    if timeout_s is not None:
+        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -374,23 +360,19 @@ def run_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timed_attempt_payload = _build_start_payload(task, config, timeout_s)
-            _notify_timed_attempt(config, timed_attempt_payload)
-
-            def finish_timed_attempt(error: BaseException | None = None) -> None:
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(timed_attempt_payload, error=error),
-                )
-
+            timed_attempt_payload = (
+                _start_timed_attempt(task, config, timeout_s)
+                if timeout_s is not None
+                else None
+            )
             try:
                 result = _invoke_with_timeout(task, config, timeout_s)
             except (ParentCommand, GraphBubbleUp):
                 raise
             except BaseException as exc:
-                finish_timed_attempt(exc)
+                _finish_timed_attempt(config, timed_attempt_payload, exc)
                 raise
-            finish_timed_attempt()
+            _finish_timed_attempt(config, timed_attempt_payload)
             return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
@@ -402,18 +384,18 @@ def run_with_retry(
                     for w in task.writers:
                         w.invoke(cmd, config)
                 except Exception as writer_exc:
-                    finish_timed_attempt(writer_exc)
+                    _finish_timed_attempt(config, timed_attempt_payload, writer_exc)
                     raise
-                finish_timed_attempt()
+                _finish_timed_attempt(config, timed_attempt_payload)
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            finish_timed_attempt()
+            _finish_timed_attempt(config, timed_attempt_payload)
             # bubble up
             raise
         except GraphBubbleUp:
-            finish_timed_attempt()
+            _finish_timed_attempt(config, timed_attempt_payload)
             # if interrupted, end
             raise
         except Exception as exc:
@@ -471,6 +453,14 @@ async def arun_with_retry(
     """Run a task asynchronously with retries."""
     retry_policy = task.retry_policy or retry_policy
     timeout_s = timeout_seconds(task.timeout)
+    if timeout_s is not None:
+        supports_timeout = (
+            runnable_primary_has_native_astream(task.proc)
+            if stream
+            else runnable_primary_has_native_async(task.proc)
+        )
+        if not supports_timeout:
+            raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {task.name!r} is sync.")
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -509,25 +499,21 @@ async def arun_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            timed_attempt_payload = _build_start_payload(task, config, timeout_s)
-            _notify_timed_attempt(config, timed_attempt_payload)
-
-            def finish_timed_attempt(error: BaseException | None = None) -> None:
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(timed_attempt_payload, error=error),
-                )
-
+            timed_attempt_payload = (
+                _start_timed_attempt(task, config, timeout_s)
+                if timeout_s is not None
+                else None
+            )
             if stream:
                 try:
                     await _astream_with_timeout(task, config, timeout_s)
                 except (ParentCommand, GraphBubbleUp):
                     raise
                 except BaseException as exc:
-                    finish_timed_attempt(exc)
+                    _finish_timed_attempt(config, timed_attempt_payload, exc)
                     raise
                 else:
-                    finish_timed_attempt()
+                    _finish_timed_attempt(config, timed_attempt_payload)
                     # if successful, end
                     break
             else:
@@ -536,9 +522,9 @@ async def arun_with_retry(
                 except (ParentCommand, GraphBubbleUp):
                     raise
                 except BaseException as exc:
-                    finish_timed_attempt(exc)
+                    _finish_timed_attempt(config, timed_attempt_payload, exc)
                     raise
-                finish_timed_attempt()
+                _finish_timed_attempt(config, timed_attempt_payload)
                 return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
@@ -550,18 +536,18 @@ async def arun_with_retry(
                     for w in task.writers:
                         w.invoke(cmd, config)
                 except Exception as writer_exc:
-                    finish_timed_attempt(writer_exc)
+                    _finish_timed_attempt(config, timed_attempt_payload, writer_exc)
                     raise
-                finish_timed_attempt()
+                _finish_timed_attempt(config, timed_attempt_payload)
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            finish_timed_attempt()
+            _finish_timed_attempt(config, timed_attempt_payload)
             # bubble up
             raise
         except GraphBubbleUp:
-            finish_timed_attempt()
+            _finish_timed_attempt(config, timed_attempt_payload)
             # if interrupted, end
             raise
         except Exception as exc:

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -6,7 +6,7 @@ import random
 import sys
 import threading
 import time
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -93,6 +93,15 @@ def _drain_cancelled(task: asyncio.Task[Any]) -> None:
     # Mark the abandoned task's exception as retrieved so asyncio doesn't log it.
     with suppress(asyncio.CancelledError):
         task.exception()
+
+
+def _create_task_with_config_context(
+    run: Callable[[], Coroutine[Any, Any, Any]], config: RunnableConfig
+) -> asyncio.Task[Any]:
+    from langgraph._internal._runnable import set_config_context
+
+    with set_config_context(config) as context:
+        return context.run(lambda: asyncio.create_task(run()))
 
 
 def _start_timed_attempt(
@@ -185,16 +194,18 @@ async def _arun_with_timeout(
         async def run() -> Any:
             return await task.proc.ainvoke(task.input, scoped_config)
 
-    bg: asyncio.Task[Any] = asyncio.create_task(run())
+    bg = _create_task_with_config_context(run, scoped_config)
     try:
         return await asyncio.wait_for(asyncio.shield(bg), timeout=timeout_s)
     except asyncio.TimeoutError as exc:
         elapsed = time.monotonic() - start
+        scope.close()
         task.writes.clear()
         bg.cancel()
         bg.add_done_callback(_drain_cancelled)
         raise NodeTimeoutError(task.name, timeout_s, elapsed) from exc
     except asyncio.CancelledError:
+        scope.close()
         bg.cancel()
         bg.add_done_callback(_drain_cancelled)
         raise

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -4,9 +4,11 @@ import asyncio
 import logging
 import random
 import sys
+import threading
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from langchain_core.runnables import RunnableConfig
@@ -19,15 +21,171 @@ from langgraph._internal._constants import (
     CONFIG_KEY_RESUMING,
     CONFIG_KEY_RUNTIME,
     CONFIG_KEY_TASK_ID,
+    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
+    CONFIG_KEY_TASK_TIMEOUT_STARTED,
     CONFIG_KEY_THREAD_ID,
     NS_SEP,
 )
-from langgraph.errors import GraphBubbleUp, ParentCommand
+from langgraph.errors import GraphBubbleUp, NodeTimeoutError, ParentCommand
 from langgraph.runtime import ExecutionInfo, Runtime
 from langgraph.types import Command, PregelExecutableTask, RetryPolicy
 
 logger = logging.getLogger(__name__)
 SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
+
+
+def _timeout_seconds(value: float | timedelta | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    return float(value)
+
+
+def _task_timeout_payload(
+    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float
+) -> dict[str, Any]:
+    runtime = config.get(CONF, {}).get(CONFIG_KEY_RUNTIME)
+    execution_info = runtime.execution_info if isinstance(runtime, Runtime) else None
+    started_at = datetime.now(UTC)
+    return {
+        "execution_id": ":".join(
+            part
+            for part in (
+                execution_info.run_id if execution_info is not None else None,
+                task.id,
+                str(execution_info.node_attempt if execution_info is not None else 1),
+            )
+            if part is not None
+        ),
+        "task_id": task.id,
+        "task_name": task.name,
+        "attempt": execution_info.node_attempt if execution_info is not None else 1,
+        "run_id": execution_info.run_id if execution_info is not None else None,
+        "thread_id": (
+            execution_info.thread_id
+            if execution_info is not None
+            else config.get(CONF, {}).get(CONFIG_KEY_THREAD_ID)
+        ),
+        "checkpoint_ns": (
+            execution_info.checkpoint_ns
+            if execution_info is not None
+            else config.get(CONF, {}).get(CONFIG_KEY_CHECKPOINT_NS)
+        ),
+        "started_at": started_at.isoformat(),
+        "deadline_at": (started_at + timedelta(seconds=timeout_s)).isoformat(),
+        "timeout_secs": timeout_s,
+    }
+
+
+def _notify_task_timeout_started(
+    config: RunnableConfig, payload: dict[str, Any] | None
+) -> None:
+    if payload is None:
+        return
+    callback = config.get(CONF, {}).get(CONFIG_KEY_TASK_TIMEOUT_STARTED)
+    if callback is None:
+        return
+    try:
+        callback(payload)
+    except Exception:
+        logger.warning("Timed task start callback failed", exc_info=True)
+
+
+def _notify_task_timeout_finished(
+    config: RunnableConfig,
+    payload: dict[str, Any] | None,
+    *,
+    error: BaseException | None,
+) -> None:
+    if payload is None:
+        return
+    callback = config.get(CONF, {}).get(CONFIG_KEY_TASK_TIMEOUT_FINISHED)
+    if callback is None:
+        return
+    try:
+        callback(
+            {
+                **payload,
+                "finished_at": datetime.now(UTC).isoformat(),
+                "status": "error" if error is not None else "success",
+                "error_type": type(error).__name__ if error is not None else None,
+                "error_message": str(error) if error is not None else None,
+            }
+        )
+    except Exception:
+        logger.warning("Timed task finish callback failed", exc_info=True)
+
+
+def _invoke_with_timeout(
+    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
+) -> Any:
+    """Run the sync invocation under a wall-clock timeout.
+
+    Python cannot safely cancel a running thread, so if the worker exceeds
+    `timeout_s` we raise `NodeTimeoutError` and leave the thread to finish
+    on its own (daemonized, so it will not block process exit).
+    """
+    if timeout_s is None:
+        return task.proc.invoke(task.input, config)
+    result: list[Any] = []
+    exc: list[BaseException] = []
+    done = threading.Event()
+
+    def target() -> None:
+        try:
+            result.append(task.proc.invoke(task.input, config))
+        except BaseException as e:
+            exc.append(e)
+        finally:
+            done.set()
+
+    start = time.monotonic()
+    worker = threading.Thread(
+        target=target, name=f"node:{task.name}:{task.id}", daemon=True
+    )
+    worker.start()
+    if not done.wait(timeout_s):
+        elapsed = time.monotonic() - start
+        raise NodeTimeoutError(task.name, timeout_s, elapsed)
+    if exc:
+        raise exc[0]
+    return result[0]
+
+
+async def _ainvoke_with_timeout(
+    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
+) -> Any:
+    if timeout_s is None:
+        return await task.proc.ainvoke(task.input, config)
+    start = time.monotonic()
+    try:
+        return await asyncio.wait_for(
+            task.proc.ainvoke(task.input, config), timeout=timeout_s
+        )
+    except asyncio.TimeoutError:
+        elapsed = time.monotonic() - start
+        raise NodeTimeoutError(task.name, timeout_s, elapsed) from None
+
+
+async def _astream_with_timeout(
+    task: PregelExecutableTask, config: RunnableConfig, timeout_s: float | None
+) -> None:
+    if timeout_s is None:
+        async for _ in task.proc.astream(task.input, config):
+            pass
+        return
+    start = time.monotonic()
+
+    async def _drain() -> None:
+        async for _ in task.proc.astream(task.input, config):
+            pass
+
+    try:
+        await asyncio.wait_for(_drain(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        elapsed = time.monotonic() - start
+        raise NodeTimeoutError(task.name, timeout_s, elapsed) from None
 
 
 def _ensure_execution_info(
@@ -90,6 +248,7 @@ def run_with_retry(
 ) -> None:
     """Run a task with retries."""
     retry_policy = task.retry_policy or retry_policy
+    timeout_s = _timeout_seconds(task.timeout)
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -123,7 +282,19 @@ def run_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
-            return task.proc.invoke(task.input, config)
+            timeout_payload = (
+                _task_timeout_payload(task, config, timeout_s)
+                if timeout_s is not None
+                else None
+            )
+            _notify_task_timeout_started(config, timeout_payload)
+            try:
+                result = _invoke_with_timeout(task, config, timeout_s)
+            except BaseException as exc:
+                _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                raise
+            _notify_task_timeout_finished(config, timeout_payload, error=None)
+            return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
             cmd = exc.args[0]
@@ -195,6 +366,7 @@ async def arun_with_retry(
 ) -> None:
     """Run a task asynchronously with retries."""
     retry_policy = task.retry_policy or retry_policy
+    timeout_s = _timeout_seconds(task.timeout)
     attempts = 0
     node_first_attempt_time = time.time()
     config = task.config
@@ -233,13 +405,30 @@ async def arun_with_retry(
             # clear any writes from previous attempts
             task.writes.clear()
             # run the task
+            timeout_payload = (
+                _task_timeout_payload(task, config, timeout_s)
+                if timeout_s is not None
+                else None
+            )
+            _notify_task_timeout_started(config, timeout_payload)
             if stream:
-                async for _ in task.proc.astream(task.input, config):
-                    pass
-                # if successful, end
-                break
+                try:
+                    await _astream_with_timeout(task, config, timeout_s)
+                except BaseException as exc:
+                    _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                    raise
+                else:
+                    _notify_task_timeout_finished(config, timeout_payload, error=None)
+                    # if successful, end
+                    break
             else:
-                return await task.proc.ainvoke(task.input, config)
+                try:
+                    result = await _ainvoke_with_timeout(task, config, timeout_s)
+                except BaseException as exc:
+                    _notify_task_timeout_finished(config, timeout_payload, error=exc)
+                    raise
+                _notify_task_timeout_finished(config, timeout_payload, error=None)
+                return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
             cmd = exc.args[0]

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -8,18 +8,17 @@ import sys
 import threading
 import time
 from collections.abc import Awaitable, Callable, Sequence
-from concurrent.futures import Future
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Literal
 
 from langchain_core.runnables import RunnableConfig
+from typing_extensions import NotRequired, TypedDict
 
 from langgraph._internal._config import patch_configurable, recast_checkpoint_ns
 from langgraph._internal._constants import (
     CONF,
-    CONFIG_KEY_CALL,
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_RESUMING,
@@ -39,30 +38,42 @@ logger = logging.getLogger(__name__)
 SUPPORTS_EXC_NOTES = sys.version_info >= (3, 11)
 
 
+class _TimedAttemptPayload(TypedDict):
+    execution_id: str
+    task_id: str
+    task_name: str
+    attempt: int
+    run_id: str | None
+    thread_id: str | None
+    checkpoint_ns: str | None
+    started_at: str
+    deadline_at: str
+    timeout_secs: float
+    event: Literal["start", "finish"]
+    finished_at: NotRequired[str]
+    status: NotRequired[Literal["success", "error"]]
+    error_type: NotRequired[str | None]
+    error_message: NotRequired[str | None]
+
+
 class _TimedAttemptScope:
     """Guarded-config window: dispatch under a lock, atomically disable on close().
 
-    `close()` and the guarded send/call are serialized so a late write cannot
-    slip past the timeout boundary.
+    `close()` and the guarded send are serialized so a late write cannot slip
+    past the timeout boundary.
     """
 
-    __slots__ = ("_active", "_lock", "node_name")
+    __slots__ = ("_active", "_lock")
 
-    def __init__(self, node_name: str) -> None:
-        self.node_name = node_name
+    def __init__(self) -> None:
         self._active = True
         self._lock = threading.Lock()
 
     def wrap_config(self, config: RunnableConfig) -> RunnableConfig:
         configurable = config.get(CONF, {})
-        updates: dict[str, Any] = {}
         if (send := configurable.get(CONFIG_KEY_SEND)) is not None:
-            updates[CONFIG_KEY_SEND] = self._guard_send(send)
-        if (call := configurable.get(CONFIG_KEY_CALL)) is not None:
-            updates[CONFIG_KEY_CALL] = self._guard_call(call)
-        if not updates:
-            return config
-        return patch_configurable(config, updates)
+            return patch_configurable(config, {CONFIG_KEY_SEND: self._guard_send(send)})
+        return config
 
     def close(self) -> None:
         with self._lock:
@@ -78,21 +89,6 @@ class _TimedAttemptScope:
 
         return guarded_send
 
-    def _guard_call(self, call: Callable[..., Any]) -> Callable[..., Any]:
-        def guarded_call(*args: Any, **kwargs: Any) -> Any:
-            with self._lock:
-                if self._active:
-                    return call(*args, **kwargs)
-                future: Future[Any] = Future()
-                future.set_exception(
-                    RuntimeError(
-                        f"Timed-out attempt for node '{self.node_name}' cannot schedule child tasks."
-                    )
-                )
-            return future
-
-        return guarded_call
-
 
 def _suppress_background_task_exception(task: asyncio.Task[Any]) -> None:
     """Drain detached task exceptions so cancelled background work stays silent."""
@@ -103,7 +99,7 @@ def _suppress_background_task_exception(task: asyncio.Task[Any]) -> None:
 
 def _task_timeout_payload(
     task: PregelExecutableTask, config: RunnableConfig, timeout_s: float
-) -> dict[str, Any]:
+) -> _TimedAttemptPayload:
     configurable = config.get(CONF, {})
     runtime = configurable.get(CONFIG_KEY_RUNTIME)
     execution_info = runtime.execution_info if isinstance(runtime, Runtime) else None
@@ -131,11 +127,12 @@ def _task_timeout_payload(
         "started_at": started_at.isoformat(),
         "deadline_at": (started_at + timedelta(seconds=timeout_s)).isoformat(),
         "timeout_secs": timeout_s,
+        "event": "start",
     }
 
 
 def _notify_timed_attempt(
-    config: RunnableConfig, payload: dict[str, Any] | None
+    config: RunnableConfig, payload: _TimedAttemptPayload | None
 ) -> None:
     if payload is None:
         return
@@ -152,20 +149,20 @@ def _build_start_payload(
     task: PregelExecutableTask,
     config: RunnableConfig,
     timeout_s: float | None,
-) -> dict[str, Any] | None:
+) -> _TimedAttemptPayload | None:
     """Return a start payload iff a timeout is set AND an observer is registered."""
     if timeout_s is None:
         return None
     if config.get(CONF, {}).get(CONFIG_KEY_TIMED_ATTEMPT_OBSERVER) is None:
         return None
-    return {**_task_timeout_payload(task, config, timeout_s), "event": "start"}
+    return _task_timeout_payload(task, config, timeout_s)
 
 
 def _timed_attempt_finish_payload(
-    payload: dict[str, Any] | None,
+    payload: _TimedAttemptPayload | None,
     *,
     error: BaseException | None,
-) -> dict[str, Any] | None:
+) -> _TimedAttemptPayload | None:
     if payload is None:
         return None
     return {
@@ -185,13 +182,13 @@ def _invoke_with_timeout(
 
     Python cannot safely cancel a running thread, so if the worker exceeds
     `timeout_s` we raise `NodeTimeoutError` and leave the thread to finish
-    on its own. Writes and child task scheduling from a timed-out attempt are
-    discarded, but any other side effects in user code may still continue in
-    the daemon worker thread until it returns.
+    on its own. Writes from a timed-out attempt are discarded, but any other
+    side effects in user code may still continue in the daemon worker thread
+    until it returns.
     """
     if timeout_s is None:
         return task.proc.invoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope(task.name)
+    scoped_attempt = _TimedAttemptScope()
     scoped_config = scoped_attempt.wrap_config(config)
     result: list[Any] = []
     exc: list[BaseException] = []
@@ -227,7 +224,7 @@ async def _ainvoke_with_timeout(
 ) -> Any:
     if timeout_s is None:
         return await task.proc.ainvoke(task.input, config)
-    scoped_attempt = _TimedAttemptScope(task.name)
+    scoped_attempt = _TimedAttemptScope()
     scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
     invoke_task = asyncio.create_task(task.proc.ainvoke(task.input, scoped_config))
@@ -256,7 +253,7 @@ async def _astream_with_timeout(
         async for _ in task.proc.astream(task.input, config):
             pass
         return
-    scoped_attempt = _TimedAttemptScope(task.name)
+    scoped_attempt = _TimedAttemptScope()
     scoped_config = scoped_attempt.wrap_config(config)
     start = time.monotonic()
 
@@ -379,23 +376,21 @@ def run_with_retry(
             # run the task
             timed_attempt_payload = _build_start_payload(task, config, timeout_s)
             _notify_timed_attempt(config, timed_attempt_payload)
+
+            def finish_timed_attempt(error: BaseException | None = None) -> None:
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(timed_attempt_payload, error=error),
+                )
+
             try:
                 result = _invoke_with_timeout(task, config, timeout_s)
             except (ParentCommand, GraphBubbleUp):
                 raise
             except BaseException as exc:
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(
-                        timed_attempt_payload,
-                        error=exc,
-                    ),
-                )
+                finish_timed_attempt(exc)
                 raise
-            _notify_timed_attempt(
-                config,
-                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-            )
+            finish_timed_attempt()
             return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
@@ -403,27 +398,22 @@ def run_with_retry(
             # strip task_ids from namespace for comparison (ns format: "node1|node2:task_id")
             if cmd.graph in (ns, recast_checkpoint_ns(ns), task.name):
                 # this command is for the current graph, handle it
-                for w in task.writers:
-                    w.invoke(cmd, config)
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-                )
+                try:
+                    for w in task.writers:
+                        w.invoke(cmd, config)
+                except Exception as writer_exc:
+                    finish_timed_attempt(writer_exc)
+                    raise
+                finish_timed_attempt()
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            _notify_timed_attempt(
-                config,
-                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-            )
+            finish_timed_attempt()
             # bubble up
             raise
         except GraphBubbleUp:
-            _notify_timed_attempt(
-                config,
-                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-            )
+            finish_timed_attempt()
             # if interrupted, end
             raise
         except Exception as exc:
@@ -521,28 +511,23 @@ async def arun_with_retry(
             # run the task
             timed_attempt_payload = _build_start_payload(task, config, timeout_s)
             _notify_timed_attempt(config, timed_attempt_payload)
+
+            def finish_timed_attempt(error: BaseException | None = None) -> None:
+                _notify_timed_attempt(
+                    config,
+                    _timed_attempt_finish_payload(timed_attempt_payload, error=error),
+                )
+
             if stream:
                 try:
                     await _astream_with_timeout(task, config, timeout_s)
                 except (ParentCommand, GraphBubbleUp):
                     raise
                 except BaseException as exc:
-                    _notify_timed_attempt(
-                        config,
-                        _timed_attempt_finish_payload(
-                            timed_attempt_payload,
-                            error=exc,
-                        ),
-                    )
+                    finish_timed_attempt(exc)
                     raise
                 else:
-                    _notify_timed_attempt(
-                        config,
-                        _timed_attempt_finish_payload(
-                            timed_attempt_payload,
-                            error=None,
-                        ),
-                    )
+                    finish_timed_attempt()
                     # if successful, end
                     break
             else:
@@ -551,21 +536,9 @@ async def arun_with_retry(
                 except (ParentCommand, GraphBubbleUp):
                     raise
                 except BaseException as exc:
-                    _notify_timed_attempt(
-                        config,
-                        _timed_attempt_finish_payload(
-                            timed_attempt_payload,
-                            error=exc,
-                        ),
-                    )
+                    finish_timed_attempt(exc)
                     raise
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(
-                        timed_attempt_payload,
-                        error=None,
-                    ),
-                )
+                finish_timed_attempt()
                 return result
         except ParentCommand as exc:
             ns: str = config[CONF][CONFIG_KEY_CHECKPOINT_NS]
@@ -573,27 +546,22 @@ async def arun_with_retry(
             # strip task_ids from namespace for comparison (ns format: "node1|node2:task_id")
             if cmd.graph in (ns, recast_checkpoint_ns(ns), task.name):
                 # this command is for the current graph, handle it
-                for w in task.writers:
-                    w.invoke(cmd, config)
-                _notify_timed_attempt(
-                    config,
-                    _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-                )
+                try:
+                    for w in task.writers:
+                        w.invoke(cmd, config)
+                except Exception as writer_exc:
+                    finish_timed_attempt(writer_exc)
+                    raise
+                finish_timed_attempt()
                 break
             elif cmd.graph == Command.PARENT:
                 # this command is for the parent graph, assign it to the parent.
                 exc.args = (replace(cmd, graph=_checkpoint_ns_for_parent_command(ns)),)
-            _notify_timed_attempt(
-                config,
-                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-            )
+            finish_timed_attempt()
             # bubble up
             raise
         except GraphBubbleUp:
-            _notify_timed_attempt(
-                config,
-                _timed_attempt_finish_payload(timed_attempt_payload, error=None),
-            )
+            finish_timed_attempt()
             # if interrupted, end
             raise
         except Exception as exc:

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -14,6 +14,7 @@ from collections.abc import (
     Iterator,
     Sequence,
 )
+from datetime import timedelta
 from functools import partial
 from typing import (
     Any,
@@ -537,6 +538,7 @@ def _call(
     *,
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
+    timeout: float | timedelta | None = None,
     callbacks: Callbacks = None,
     futures: weakref.ref[FuturesDict],
     schedule_task: Callable[
@@ -560,6 +562,7 @@ def _call(
             retry_policy=retry_policy,
             cache_policy=cache_policy,
             callbacks=callbacks,
+            timeout=timeout,
         ),
     ):
         if fut := next(
@@ -624,6 +627,7 @@ def _acall(
     *,
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
+    timeout: float | timedelta | None = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict],
@@ -657,6 +661,7 @@ def _acall(
             input,
             retry_policy=retry_policy,
             cache_policy=cache_policy,
+            timeout=timeout,
             callbacks=callbacks,
             futures=futures,
             schedule_task=schedule_task,
@@ -678,6 +683,7 @@ async def _acall_impl(
     *,
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
+    timeout: float | timedelta | None = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict[asyncio.Future, asyncio.Event]],
@@ -703,6 +709,7 @@ async def _acall_impl(
                 retry_policy=retry_policy,
                 cache_policy=cache_policy,
                 callbacks=callbacks,
+                timeout=timeout,
             ),
         ):
             if fut := next(

--- a/libs/langgraph/langgraph/pregel/_utils.py
+++ b/libs/langgraph/langgraph/pregel/_utils.py
@@ -4,7 +4,7 @@ import ast
 import inspect
 import re
 import textwrap
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from langchain_core.runnables import Runnable, RunnableLambda, RunnableSequence
@@ -12,7 +12,13 @@ from langgraph.checkpoint.base import ChannelVersions
 from typing_extensions import override
 
 from langgraph._internal._runnable import RunnableCallable, RunnableSeq
+from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED
 from langgraph.pregel.protocol import PregelProtocol
+
+_SEQUENCE_TYPES = (RunnableSeq, RunnableSequence)
+_CALLABLE_TYPES = (RunnableCallable, RunnableLambda)
+_BASE_AINVOKE = Runnable.ainvoke
+_BASE_ASTREAM = Runnable.astream
 
 
 def get_new_channel_versions(
@@ -62,6 +68,80 @@ def find_subgraph_pregel(candidate: Runnable) -> PregelProtocol | None:
                 )
 
     return None
+
+
+def _sequence_steps(runnable: Runnable) -> Sequence[Runnable] | None:
+    if isinstance(runnable, _SEQUENCE_TYPES):
+        return runnable.steps
+    return None
+
+
+def _is_async_runnable_lambda(runnable: RunnableLambda) -> bool:
+    return not hasattr(runnable, "func") and hasattr(runnable, "afunc")
+
+
+def _overrides_ainvoke(runnable: Runnable) -> bool:
+    method = getattr(type(runnable), "ainvoke", None)
+    return method is not None and method is not _BASE_AINVOKE
+
+
+def _overrides_astream(runnable: Runnable) -> bool:
+    method = getattr(type(runnable), "astream", None)
+    return method is not None and method is not _BASE_ASTREAM
+
+
+def _has_native_async(runnable: Runnable) -> bool:
+    if isinstance(runnable, RunnableCallable):
+        return runnable.func is None and runnable.afunc is not None
+    if isinstance(runnable, RunnableLambda):
+        return _is_async_runnable_lambda(runnable)
+    return _overrides_ainvoke(runnable)
+
+
+def _has_native_astream(runnable: Runnable) -> bool:
+    if _has_native_async(runnable):
+        return True
+    if isinstance(runnable, _CALLABLE_TYPES):
+        return False
+    return _overrides_astream(runnable)
+
+
+def _primary_step(runnable: Runnable) -> Runnable | None:
+    while (steps := _sequence_steps(runnable)) is not None:
+        if not steps:
+            return None
+        runnable = steps[0]
+    return runnable
+
+
+def runnable_has_native_async(runnable: Runnable) -> bool:
+    """Return whether a runnable can be timed without running sync code."""
+
+    if (steps := _sequence_steps(runnable)) is not None:
+        for step in steps:
+            if not runnable_has_native_async(step):
+                return False
+        return True
+    return _has_native_async(runnable)
+
+
+def runnable_primary_has_native_async(runnable: Runnable) -> bool:
+    """Check only the user step of an assembled Pregel task runnable."""
+
+    return (primary := _primary_step(runnable)) is not None and _has_native_async(
+        primary
+    )
+
+
+def runnable_primary_has_native_astream(runnable: Runnable) -> bool:
+    return (primary := _primary_step(runnable)) is not None and _has_native_astream(
+        primary
+    )
+
+
+def validate_timeout_supported(runnable: Runnable, *, name: str) -> None:
+    if not runnable_has_native_async(runnable):
+        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {name!r} is sync.")
 
 
 def get_function_nonlocals(func: Callable) -> list[Any]:

--- a/libs/langgraph/langgraph/pregel/_utils.py
+++ b/libs/langgraph/langgraph/pregel/_utils.py
@@ -14,7 +14,7 @@ from langgraph.checkpoint.base import ChannelVersions
 from typing_extensions import override
 
 from langgraph._internal._runnable import RunnableCallable, RunnableSeq
-from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED
+from langgraph._internal._timeout import sync_timeout_unsupported
 from langgraph.pregel.protocol import PregelProtocol
 
 _SEQUENCE_TYPES = (RunnableSeq, RunnableSequence)
@@ -107,7 +107,7 @@ def _runnable_has_native_async(runnable: Runnable) -> bool:
 
 def validate_timeout_supported(runnable: Runnable, *, name: str) -> None:
     if not _runnable_has_native_async(runnable):
-        raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {name!r} is sync.")
+        raise sync_timeout_unsupported(name)
 
 
 def get_function_nonlocals(func: Callable) -> list[Any]:

--- a/libs/langgraph/langgraph/pregel/_utils.py
+++ b/libs/langgraph/langgraph/pregel/_utils.py
@@ -5,9 +5,11 @@ import inspect
 import re
 import textwrap
 from collections.abc import Callable, Sequence
+from functools import partial
 from typing import Any
 
 from langchain_core.runnables import Runnable, RunnableLambda, RunnableSequence
+from langchain_core.runnables.config import run_in_executor
 from langgraph.checkpoint.base import ChannelVersions
 from typing_extensions import override
 
@@ -16,9 +18,6 @@ from langgraph._internal._timeout import SYNC_TIMEOUT_UNSUPPORTED
 from langgraph.pregel.protocol import PregelProtocol
 
 _SEQUENCE_TYPES = (RunnableSeq, RunnableSequence)
-_CALLABLE_TYPES = (RunnableCallable, RunnableLambda)
-_BASE_AINVOKE = Runnable.ainvoke
-_BASE_ASTREAM = Runnable.astream
 
 
 def get_new_channel_versions(
@@ -76,71 +75,38 @@ def _sequence_steps(runnable: Runnable) -> Sequence[Runnable] | None:
     return None
 
 
-def _is_async_runnable_lambda(runnable: RunnableLambda) -> bool:
-    return not hasattr(runnable, "func") and hasattr(runnable, "afunc")
+def _has_method_override(runnable: Runnable, method_name: str) -> bool:
+    method = getattr(type(runnable), method_name, None)
+    return method is not None and method is not getattr(Runnable, method_name)
 
 
-def _overrides_ainvoke(runnable: Runnable) -> bool:
-    method = getattr(type(runnable), "ainvoke", None)
-    return method is not None and method is not _BASE_AINVOKE
-
-
-def _overrides_astream(runnable: Runnable) -> bool:
-    method = getattr(type(runnable), "astream", None)
-    return method is not None and method is not _BASE_ASTREAM
+def _is_executor_backed_afunc(afunc: Callable[..., Any] | None) -> bool:
+    return isinstance(afunc, partial) and afunc.func is run_in_executor
 
 
 def _has_native_async(runnable: Runnable) -> bool:
     if isinstance(runnable, RunnableCallable):
-        return runnable.func is None and runnable.afunc is not None
+        return runnable.afunc is not None and not _is_executor_backed_afunc(
+            runnable.afunc
+        )
     if isinstance(runnable, RunnableLambda):
-        return _is_async_runnable_lambda(runnable)
-    return _overrides_ainvoke(runnable)
+        return bool(getattr(runnable, "afunc", False))
+    return _has_method_override(runnable, "ainvoke")
 
 
-def _has_native_astream(runnable: Runnable) -> bool:
-    if _has_native_async(runnable):
-        return True
-    if isinstance(runnable, _CALLABLE_TYPES):
-        return False
-    return _overrides_astream(runnable)
-
-
-def _primary_step(runnable: Runnable) -> Runnable | None:
-    while (steps := _sequence_steps(runnable)) is not None:
-        if not steps:
-            return None
-        runnable = steps[0]
-    return runnable
-
-
-def runnable_has_native_async(runnable: Runnable) -> bool:
+def _runnable_has_native_async(runnable: Runnable) -> bool:
     """Return whether a runnable can be timed without running sync code."""
 
     if (steps := _sequence_steps(runnable)) is not None:
         for step in steps:
-            if not runnable_has_native_async(step):
+            if not _runnable_has_native_async(step):
                 return False
         return True
     return _has_native_async(runnable)
 
 
-def runnable_primary_has_native_async(runnable: Runnable) -> bool:
-    """Check only the user step of an assembled Pregel task runnable."""
-
-    return (primary := _primary_step(runnable)) is not None and _has_native_async(
-        primary
-    )
-
-
-def runnable_primary_has_native_astream(runnable: Runnable) -> bool:
-    return (primary := _primary_step(runnable)) is not None and _has_native_astream(
-        primary
-    )
-
-
 def validate_timeout_supported(runnable: Runnable, *, name: str) -> None:
-    if not runnable_has_native_async(runnable):
+    if not _runnable_has_native_async(runnable):
         raise ValueError(f"{SYNC_TIMEOUT_UNSUPPORTED} Node {name!r} is sync.")
 
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -139,7 +139,7 @@ from langgraph.pregel._messages import StreamMessagesHandler
 from langgraph.pregel._read import DEFAULT_BOUND, PregelNode
 from langgraph.pregel._retry import RetryPolicy
 from langgraph.pregel._runner import PregelRunner
-from langgraph.pregel._utils import get_new_channel_versions
+from langgraph.pregel._utils import get_new_channel_versions, validate_timeout_supported
 from langgraph.pregel._validate import validate_graph, validate_keys
 from langgraph.pregel._write import ChannelWrite, ChannelWriteEntry
 from langgraph.pregel.debug import get_bolded_text, get_colored_text, tasks_w_writes
@@ -828,6 +828,9 @@ class Pregel(
         )
 
     def validate(self) -> Self:
+        for name, node in self.nodes.items():
+            if node.timeout is not None:
+                validate_timeout_supported(node.bound, name=name)
         validate_graph(
             self.nodes,
             {k: v for k, v in self.channels.items() if isinstance(v, BaseChannel)},

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -17,6 +17,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import is_dataclass, replace
+from datetime import timedelta
 from functools import partial
 from inspect import isclass
 from typing import (
@@ -186,6 +187,7 @@ class NodeBuilder:
         "_bound",
         "_retry_policy",
         "_cache_policy",
+        "_timeout",
     )
 
     _channels: str | list[str]
@@ -196,6 +198,7 @@ class NodeBuilder:
     _bound: Runnable
     _retry_policy: list[RetryPolicy]
     _cache_policy: CachePolicy | None
+    _timeout: float | timedelta | None
 
     def __init__(
         self,
@@ -208,6 +211,7 @@ class NodeBuilder:
         self._bound = DEFAULT_BOUND
         self._retry_policy = []
         self._cache_policy = None
+        self._timeout = None
 
     def subscribe_only(
         self,
@@ -326,6 +330,11 @@ class NodeBuilder:
         self._cache_policy = policy
         return self
 
+    def set_timeout(self, timeout: float | timedelta | None) -> Self:
+        """Set the per-attempt timeout for this node."""
+        self._timeout = timeout
+        return self
+
     def build(self) -> PregelNode:
         """Builds the node."""
         return PregelNode(
@@ -337,6 +346,7 @@ class NodeBuilder:
             bound=self._bound,
             retry_policy=self._retry_policy,
             cache_policy=self._cache_policy,
+            timeout=self._timeout,
         )
 
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -96,7 +96,7 @@ from langgraph._internal._runnable import (
     RunnableSeq,
     coerce_to_runnable,
 )
-from langgraph._internal._timeout import validate_timeout
+from langgraph._internal._timeout import coerce_timeout
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.callbacks import (
     GraphInterruptEvent,
@@ -199,7 +199,7 @@ class NodeBuilder:
     _bound: Runnable
     _retry_policy: list[RetryPolicy]
     _cache_policy: CachePolicy | None
-    _timeout: float | timedelta | None
+    _timeout: float | None
 
     def __init__(
         self,
@@ -333,7 +333,7 @@ class NodeBuilder:
 
     def set_timeout(self, timeout: float | timedelta | None) -> Self:
         """Set the per-attempt timeout for this node."""
-        self._timeout = validate_timeout(timeout)
+        self._timeout = coerce_timeout(timeout)
         return self
 
     def build(self) -> PregelNode:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -96,6 +96,7 @@ from langgraph._internal._runnable import (
     RunnableSeq,
     coerce_to_runnable,
 )
+from langgraph._internal._timeout import validate_timeout
 from langgraph._internal._typing import MISSING, DeprecatedKwargs
 from langgraph.callbacks import (
     GraphInterruptEvent,
@@ -332,7 +333,7 @@ class NodeBuilder:
 
     def set_timeout(self, timeout: float | timedelta | None) -> Self:
         """Set the per-attempt timeout for this node."""
-        self._timeout = timeout
+        self._timeout = validate_timeout(timeout)
         return self
 
     def build(self) -> PregelNode:

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -4,6 +4,7 @@ import sys
 from collections import deque
 from collections.abc import Callable, Hashable, Sequence
 from dataclasses import asdict, dataclass
+from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -548,6 +549,7 @@ class PregelExecutableTask:
     path: tuple[str | int | tuple, ...]
     writers: Sequence[Runnable] = ()
     subgraphs: Sequence[PregelProtocol] = ()
+    timeout: float | timedelta | None = None
 
 
 class StateSnapshot(NamedTuple):

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -4,7 +4,6 @@ import sys
 from collections import deque
 from collections.abc import Callable, Hashable, Sequence
 from dataclasses import asdict, dataclass
-from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -549,7 +548,7 @@ class PregelExecutableTask:
     path: tuple[str | int | tuple, ...]
     writers: Sequence[Runnable] = ()
     subgraphs: Sequence[PregelProtocol] = ()
-    timeout: float | timedelta | None = None
+    timeout: float | None = None
 
 
 class StateSnapshot(NamedTuple):

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2,7 +2,7 @@ import asyncio
 import threading
 import time
 from collections import deque
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1053,6 +1053,10 @@ def test_run_with_retry_timeout_observer_tracks_attempts():
     assert starts[0]["execution_id"] != starts[1]["execution_id"]
     assert starts[0]["timeout_secs"] == 0.05
     assert starts[0]["task_name"] == "flaky"
+    assert isinstance(starts[0]["started_at"], datetime)
+    assert isinstance(starts[0]["deadline_at"], datetime)
+    assert isinstance(finishes[0]["finished_at"], datetime)
+    assert starts[0]["deadline_at"] > starts[0]["started_at"]
 
 
 def test_run_with_retry_timeout_observer_treats_parent_command_as_non_error():

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -21,10 +21,11 @@ from langgraph._internal._constants import (
 )
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
-from langgraph.errors import NodeTimeoutError
+from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
 from langgraph.pregel import NodeBuilder, Pregel
+from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
     _ensure_execution_info,
@@ -34,7 +35,7 @@ from langgraph.pregel._retry import (
     run_with_retry,
 )
 from langgraph.runtime import DEFAULT_RUNTIME, ExecutionInfo, Runtime
-from langgraph.types import PregelExecutableTask, RetryPolicy
+from langgraph.types import Command, PregelExecutableTask, RetryPolicy
 
 
 def test_should_retry_on_single_exception():
@@ -716,6 +717,21 @@ def test_run_with_retry_timeout_discards_stale_sync_writes():
     assert task.writes == deque([("value", "fresh")])
 
 
+def test_run_with_retry_timeout_discards_pre_timeout_sync_writes():
+    class SlowWriterProc:
+        def invoke(self, input, config):
+            config[CONF][CONFIG_KEY_SEND]([("value", "stale-before-timeout")])
+            time.sleep(0.2)
+            return "late"
+
+    task = _make_task(SlowWriterProc(), timeout=0.05)
+
+    with pytest.raises(NodeTimeoutError):
+        run_with_retry(task, retry_policy=None)
+
+    assert task.writes == deque()
+
+
 def test_run_with_retry_timeout_accepts_timedelta():
     class SlowProc:
         def invoke(self, input, config):
@@ -743,8 +759,146 @@ def test_arun_with_retry_timeout_fires_async():
     asyncio.run(_run())
 
 
+def test_arun_with_retry_timeout_discards_stale_executor_writes():
+    release_first_attempt = threading.Event()
+
+    class FlakyAsyncProc:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def ainvoke(self, input, config):
+            self.calls += 1
+            if self.calls == 1:
+
+                def late_write() -> str:
+                    release_first_attempt.wait(timeout=1.0)
+                    config[CONF][CONFIG_KEY_SEND]([("value", "stale")])
+                    return "late"
+
+                return await asyncio.to_thread(late_write)
+            release_first_attempt.set()
+            config[CONF][CONFIG_KEY_SEND]([("value", "fresh")])
+            return "ok"
+
+    policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.0,
+        jitter=False,
+        retry_on=NodeTimeoutError,
+    )
+    task = _make_task(FlakyAsyncProc(), timeout=0.05, retry_policy=(policy,))
+
+    async def _run() -> None:
+        assert await arun_with_retry(task, retry_policy=None) == "ok"
+        await asyncio.sleep(0.05)
+        assert task.writes == deque([("value", "fresh")])
+
+    asyncio.run(_run())
+
+
+def test_arun_with_retry_timeout_discards_pre_timeout_writes():
+    class SlowAsyncWriterProc:
+        async def ainvoke(self, input, config):
+            config[CONF][CONFIG_KEY_SEND]([("value", "stale-before-timeout")])
+            await asyncio.sleep(0.2)
+            return "late"
+
+    task = _make_task(SlowAsyncWriterProc(), timeout=0.05, name="aslow-writer")
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await arun_with_retry(task, retry_policy=None)
+        assert task.writes == deque()
+
+    asyncio.run(_run())
+
+
+def test_astream_with_retry_timeout_discards_pre_timeout_writes():
+    class SlowStreamWriterProc:
+        async def astream(self, input, config):
+            config[CONF][CONFIG_KEY_SEND]([("value", "stale-before-timeout")])
+            await asyncio.sleep(0.2)
+            if False:
+                yield None
+
+    task = _make_task(SlowStreamWriterProc(), timeout=0.05, name="astream-writer")
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await arun_with_retry(task, retry_policy=None, stream=True)
+        assert task.writes == deque()
+
+    asyncio.run(_run())
+
+
+def test_arun_with_retry_timeout_cannot_be_swallowed():
+    class StubbornProc:
+        async def ainvoke(self, input, config):
+            try:
+                await asyncio.sleep(1.0)
+            except asyncio.CancelledError:
+                config[CONF][CONFIG_KEY_SEND]([("value", "stale")])
+                await asyncio.sleep(0)
+                return "late"
+            return "ok"
+
+    task = _make_task(StubbornProc(), timeout=0.05, name="stubborn")
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError) as excinfo:
+            await arun_with_retry(task, retry_policy=None)
+        assert excinfo.value.node == "stubborn"
+        await asyncio.sleep(0.05)
+        assert task.writes == deque()
+
+    asyncio.run(_run())
+
+
+def test_astream_with_retry_timeout_cannot_be_swallowed():
+    class StubbornStreamProc:
+        async def astream(self, input, config):
+            try:
+                await asyncio.sleep(1.0)
+            except asyncio.CancelledError:
+                config[CONF][CONFIG_KEY_SEND]([("value", "stale")])
+                await asyncio.sleep(0)
+                if False:
+                    yield None
+                return
+            yield "ok"
+
+    task = _make_task(StubbornStreamProc(), timeout=0.05, name="stubborn-stream")
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError) as excinfo:
+            await arun_with_retry(task, retry_policy=None, stream=True)
+        assert excinfo.value.node == "stubborn-stream"
+        await asyncio.sleep(0.05)
+        assert task.writes == deque()
+
+    asyncio.run(_run())
+
+
 class _TimeoutState(TypedDict):
     x: int
+
+
+def test_timeout_validation_is_eager_across_apis():
+    with pytest.raises(ValueError, match="greater than 0"):
+        task(timeout=0)
+
+    with pytest.raises(ValueError, match="greater than 0"):
+        entrypoint(timeout=0)
+
+    with pytest.raises(ValueError, match="greater than 0"):
+        NodeBuilder().set_timeout(0)
+
+    with pytest.raises(ValueError, match="greater than 0"):
+        PregelNode(channels="x", triggers=["x"], timeout=0)
+
+    builder = StateGraph(_TimeoutState)
+    with pytest.raises(ValueError, match="greater than 0"):
+        builder.add_node("slow", lambda state: state, timeout=0)
 
 
 def test_state_graph_add_node_timeout_e2e():
@@ -876,3 +1030,44 @@ def test_run_with_retry_timeout_observer_tracks_attempts():
     assert starts[0]["execution_id"] != starts[1]["execution_id"]
     assert starts[0]["timeout_secs"] == 0.05
     assert starts[0]["task_name"] == "flaky"
+
+
+def test_run_with_retry_timeout_observer_treats_parent_command_as_non_error():
+    events: list[dict] = []
+
+    class ParentProc:
+        def invoke(self, input, config):
+            raise ParentCommand(Command(graph=Command.PARENT))
+
+    task = _make_task(ParentProc(), timeout=0.05, name="parent")
+    task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
+
+    with pytest.raises(ParentCommand):
+        run_with_retry(task, retry_policy=None)
+
+    finish = next(payload for payload in events if payload["event"] == "finish")
+    assert finish["status"] == "success"
+    assert finish["error_type"] is None
+    assert finish["error_message"] is None
+
+
+def test_arun_with_retry_timeout_observer_treats_bubble_up_as_non_error():
+    events: list[dict] = []
+
+    class BubbleProc:
+        async def ainvoke(self, input, config):
+            raise GraphInterrupt(())
+
+    task = _make_task(BubbleProc(), timeout=0.05, name="bubble")
+    task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
+
+    async def _run() -> None:
+        with pytest.raises(GraphInterrupt):
+            await arun_with_retry(task, retry_policy=None)
+
+    asyncio.run(_run())
+
+    finish = next(payload for payload in events if payload["event"] == "finish")
+    assert finish["status"] == "success"
+    assert finish["error_type"] is None
+    assert finish["error_message"] is None

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 import time
 from collections import deque
 from datetime import timedelta
@@ -13,13 +14,17 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_RUNTIME,
+    CONFIG_KEY_SEND,
     CONFIG_KEY_TASK_ID,
-    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
-    CONFIG_KEY_TASK_TIMEOUT_STARTED,
     CONFIG_KEY_THREAD_ID,
+    CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
 )
+from langgraph.channels.ephemeral_value import EphemeralValue
+from langgraph.channels.last_value import LastValue
 from langgraph.errors import NodeTimeoutError
+from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
+from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
     _ensure_execution_info,
@@ -579,12 +584,14 @@ def test_run_with_retry_creates_execution_info_when_missing():
 
 def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="tid"):
     runtime = DEFAULT_RUNTIME.override(execution_info=None)
+    writes = deque()
     config = {
         "run_id": "run-x",
         CONF: {
             CONFIG_KEY_RUNTIME: runtime,
             CONFIG_KEY_CHECKPOINT_ID: "cp",
             CONFIG_KEY_CHECKPOINT_NS: f"{name}:{task_id}",
+            CONFIG_KEY_SEND: writes.extend,
             CONFIG_KEY_TASK_ID: task_id,
             CONFIG_KEY_THREAD_ID: "thr",
         },
@@ -593,7 +600,7 @@ def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="ti
         name=name,
         input=None,
         proc=proc,
-        writes=deque(),
+        writes=writes,
         config=config,
         triggers=[name],
         retry_policy=retry_policy,
@@ -609,6 +616,10 @@ def test_timeout_seconds_coercion():
     assert _timeout_seconds(1.5) == 1.5
     assert _timeout_seconds(2) == 2.0
     assert _timeout_seconds(timedelta(milliseconds=250)) == 0.25
+    with pytest.raises(ValueError, match="greater than 0"):
+        _timeout_seconds(0)
+    with pytest.raises(ValueError, match="greater than 0"):
+        _timeout_seconds(timedelta())
 
 
 def test_run_with_retry_timeout_fires_sync():
@@ -637,6 +648,20 @@ def test_run_with_retry_timeout_ok_when_fast():
     assert run_with_retry(task, retry_policy=None) == "ok"
 
 
+def test_run_with_retry_timeout_preserves_contextvars():
+    import contextvars
+
+    request_id = contextvars.ContextVar("request_id", default="missing")
+    request_id.set("req-123")
+
+    class Proc:
+        def invoke(self, input, config):
+            return request_id.get()
+
+    task = _make_task(Proc(), timeout=1.0)
+    assert run_with_retry(task, retry_policy=None) == "req-123"
+
+
 def test_run_with_retry_timeout_retries_when_retry_on_timeout():
     """With retry_policy.retry_on=NodeTimeoutError, a timed-out attempt is retried."""
     calls: list[float] = []
@@ -658,6 +683,37 @@ def test_run_with_retry_timeout_retries_when_retry_on_timeout():
     task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,))
     assert run_with_retry(task, retry_policy=None) == "ok"
     assert len(calls) == 2
+
+
+def test_run_with_retry_timeout_discards_stale_sync_writes():
+    release_first_attempt = threading.Event()
+
+    class FlakyProc:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def invoke(self, input, config):
+            self.calls += 1
+            if self.calls == 1:
+                release_first_attempt.wait(timeout=1.0)
+                config[CONF][CONFIG_KEY_SEND]([("value", "stale")])
+                return "late"
+            release_first_attempt.set()
+            config[CONF][CONFIG_KEY_SEND]([("value", "fresh")])
+            return "ok"
+
+    policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.0,
+        jitter=False,
+        retry_on=NodeTimeoutError,
+    )
+    task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,))
+
+    assert run_with_retry(task, retry_policy=None) == "ok"
+    time.sleep(0.05)
+
+    assert task.writes == deque([("value", "fresh")])
 
 
 def test_run_with_retry_timeout_accepts_timedelta():
@@ -740,9 +796,59 @@ def test_state_graph_add_node_timeout_composes_with_retry():
     assert len(attempts) == 2
 
 
-def test_run_with_retry_timeout_callbacks_track_attempts():
-    starts: list[dict] = []
-    finishes: list[dict] = []
+def test_task_decorator_timeout_e2e():
+    @task(timeout=0.05)
+    def slow_task(x: int) -> int:
+        time.sleep(0.2)
+        return x + 1
+
+    @entrypoint()
+    def workflow(x: int) -> int:
+        return slow_task(x).result()
+
+    with pytest.raises(NodeTimeoutError):
+        workflow.invoke(1)
+
+
+def test_entrypoint_timeout_e2e():
+    @entrypoint(timeout=0.05)
+    def slow_workflow(x: int) -> int:
+        time.sleep(0.2)
+        return x
+
+    with pytest.raises(NodeTimeoutError):
+        slow_workflow.invoke(1)
+
+
+def test_node_builder_timeout_e2e():
+    def slow(value: int) -> int:
+        time.sleep(0.2)
+        return value + 1
+
+    graph = Pregel(
+        nodes={
+            "slow": (
+                NodeBuilder()
+                .subscribe_only("input")
+                .do(slow)
+                .set_timeout(0.05)
+                .write_to("output")
+            )
+        },
+        channels={
+            "input": EphemeralValue(int),
+            "output": LastValue(int),
+        },
+        input_channels="input",
+        output_channels="output",
+    )
+
+    with pytest.raises(NodeTimeoutError):
+        graph.invoke(1)
+
+
+def test_run_with_retry_timeout_observer_tracks_attempts():
+    events: list[dict] = []
 
     class FlakyProc:
         def invoke(self, input, config):
@@ -758,11 +864,12 @@ def test_run_with_retry_timeout_callbacks_track_attempts():
         retry_on=NodeTimeoutError,
     )
     task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,), name="flaky")
-    task.config[CONF][CONFIG_KEY_TASK_TIMEOUT_STARTED] = starts.append
-    task.config[CONF][CONFIG_KEY_TASK_TIMEOUT_FINISHED] = finishes.append
+    task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
 
     assert run_with_retry(task, retry_policy=None) == "ok"
 
+    starts = [payload for payload in events if payload["event"] == "start"]
+    finishes = [payload for payload in events if payload["event"] == "finish"]
     assert [payload["attempt"] for payload in starts] == [1, 2]
     assert [payload["attempt"] for payload in finishes] == [1, 2]
     assert [payload["status"] for payload in finishes] == ["error", "success"]

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -21,7 +21,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
 )
 from langgraph._internal._runnable import RunnableCallable
-from langgraph._internal._timeout import timeout_seconds
+from langgraph._internal._timeout import coerce_timeout
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
 from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
@@ -613,19 +613,19 @@ def _make_task(
         id=task_id,
         path=("__pregel_pull", name),
         writers=writers,
-        timeout=timeout,
+        timeout=coerce_timeout(timeout),
     )
 
 
-def test_timeout_seconds_coercion():
-    assert timeout_seconds(None) is None
-    assert timeout_seconds(1.5) == 1.5
-    assert timeout_seconds(2) == 2.0
-    assert timeout_seconds(timedelta(milliseconds=250)) == 0.25
+def test_coerce_timeout():
+    assert coerce_timeout(None) is None
+    assert coerce_timeout(1.5) == 1.5
+    assert coerce_timeout(2) == 2.0
+    assert coerce_timeout(timedelta(milliseconds=250)) == 0.25
     with pytest.raises(ValueError, match="greater than 0"):
-        timeout_seconds(0)
+        coerce_timeout(0)
     with pytest.raises(ValueError, match="greater than 0"):
-        timeout_seconds(timedelta())
+        coerce_timeout(timedelta())
 
 
 def test_run_with_retry_rejects_sync_timeout_without_starting_proc():
@@ -741,6 +741,7 @@ def test_arun_with_retry_timeout_fires_async():
         with pytest.raises(NodeTimeoutError) as excinfo:
             await arun_with_retry(task, retry_policy=None)
         assert excinfo.value.node == "aslow"
+        assert excinfo.value.timeout == 0.05
 
     asyncio.run(_run())
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -19,6 +19,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_THREAD_ID,
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
 )
+from langgraph._internal._timeout import timeout_seconds
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
 from langgraph.errors import GraphInterrupt, NodeTimeoutError, ParentCommand
@@ -30,7 +31,6 @@ from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
     _ensure_execution_info,
     _should_retry_on,
-    _timeout_seconds,
     arun_with_retry,
     run_with_retry,
 )
@@ -613,14 +613,14 @@ def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="ti
 
 
 def test_timeout_seconds_coercion():
-    assert _timeout_seconds(None) is None
-    assert _timeout_seconds(1.5) == 1.5
-    assert _timeout_seconds(2) == 2.0
-    assert _timeout_seconds(timedelta(milliseconds=250)) == 0.25
+    assert timeout_seconds(None) is None
+    assert timeout_seconds(1.5) == 1.5
+    assert timeout_seconds(2) == 2.0
+    assert timeout_seconds(timedelta(milliseconds=250)) == 0.25
     with pytest.raises(ValueError, match="greater than 0"):
-        _timeout_seconds(0)
+        timeout_seconds(0)
     with pytest.raises(ValueError, match="greater than 0"):
-        _timeout_seconds(timedelta())
+        timeout_seconds(timedelta())
 
 
 def test_run_with_retry_timeout_fires_sync():

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1,4 +1,7 @@
+import asyncio
+import time
 from collections import deque
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -11,13 +14,18 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_RUNTIME,
     CONFIG_KEY_TASK_ID,
+    CONFIG_KEY_TASK_TIMEOUT_FINISHED,
+    CONFIG_KEY_TASK_TIMEOUT_STARTED,
     CONFIG_KEY_THREAD_ID,
 )
-from langgraph.graph import START, StateGraph
+from langgraph.errors import NodeTimeoutError
+from langgraph.graph import END, START, StateGraph
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
     _ensure_execution_info,
     _should_retry_on,
+    _timeout_seconds,
+    arun_with_retry,
     run_with_retry,
 )
 from langgraph.runtime import DEFAULT_RUNTIME, ExecutionInfo, Runtime
@@ -567,3 +575,197 @@ def test_run_with_retry_creates_execution_info_when_missing():
     assert info.run_id == "run-abc"
     assert info.node_attempt == 1
     assert info.node_first_attempt_time is not None
+
+
+def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="tid"):
+    runtime = DEFAULT_RUNTIME.override(execution_info=None)
+    config = {
+        "run_id": "run-x",
+        CONF: {
+            CONFIG_KEY_RUNTIME: runtime,
+            CONFIG_KEY_CHECKPOINT_ID: "cp",
+            CONFIG_KEY_CHECKPOINT_NS: f"{name}:{task_id}",
+            CONFIG_KEY_TASK_ID: task_id,
+            CONFIG_KEY_THREAD_ID: "thr",
+        },
+    }
+    return PregelExecutableTask(
+        name=name,
+        input=None,
+        proc=proc,
+        writes=deque(),
+        config=config,
+        triggers=[name],
+        retry_policy=retry_policy,
+        cache_key=None,
+        id=task_id,
+        path=("__pregel_pull", name),
+        timeout=timeout,
+    )
+
+
+def test_timeout_seconds_coercion():
+    assert _timeout_seconds(None) is None
+    assert _timeout_seconds(1.5) == 1.5
+    assert _timeout_seconds(2) == 2.0
+    assert _timeout_seconds(timedelta(milliseconds=250)) == 0.25
+
+
+def test_run_with_retry_timeout_fires_sync():
+    """Sync node that runs too long raises NodeTimeoutError with node name."""
+
+    class SlowProc:
+        def invoke(self, input, config):
+            time.sleep(1.0)
+            return input
+
+    task = _make_task(SlowProc(), timeout=0.05, name="slow")
+    with pytest.raises(NodeTimeoutError) as excinfo:
+        run_with_retry(task, retry_policy=None)
+    assert excinfo.value.node == "slow"
+    assert excinfo.value.elapsed >= 0.05
+
+
+def test_run_with_retry_timeout_ok_when_fast():
+    """Node that finishes under the timeout succeeds normally."""
+
+    class FastProc:
+        def invoke(self, input, config):
+            return "ok"
+
+    task = _make_task(FastProc(), timeout=1.0)
+    assert run_with_retry(task, retry_policy=None) == "ok"
+
+
+def test_run_with_retry_timeout_retries_when_retry_on_timeout():
+    """With retry_policy.retry_on=NodeTimeoutError, a timed-out attempt is retried."""
+    calls: list[float] = []
+
+    class FlakyProc:
+        def invoke(self, input, config):
+            calls.append(time.monotonic())
+            if len(calls) < 2:
+                time.sleep(0.5)
+                return "late"
+            return "ok"
+
+    policy = RetryPolicy(
+        max_attempts=3,
+        initial_interval=0.0,
+        jitter=False,
+        retry_on=NodeTimeoutError,
+    )
+    task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,))
+    assert run_with_retry(task, retry_policy=None) == "ok"
+    assert len(calls) == 2
+
+
+def test_run_with_retry_timeout_accepts_timedelta():
+    class SlowProc:
+        def invoke(self, input, config):
+            time.sleep(0.5)
+            return input
+
+    task = _make_task(SlowProc(), timeout=timedelta(milliseconds=50))
+    with pytest.raises(NodeTimeoutError):
+        run_with_retry(task, retry_policy=None)
+
+
+def test_arun_with_retry_timeout_fires_async():
+    class SlowProc:
+        async def ainvoke(self, input, config):
+            await asyncio.sleep(1.0)
+            return input
+
+    task = _make_task(SlowProc(), timeout=0.05, name="aslow")
+
+    async def _run():
+        with pytest.raises(NodeTimeoutError) as excinfo:
+            await arun_with_retry(task, retry_policy=None)
+        assert excinfo.value.node == "aslow"
+
+    asyncio.run(_run())
+
+
+class _TimeoutState(TypedDict):
+    x: int
+
+
+def test_state_graph_add_node_timeout_e2e():
+    """End-to-end: add_node(..., timeout=...) raises NodeTimeoutError on invoke."""
+
+    def slow(state: _TimeoutState) -> _TimeoutState:
+        time.sleep(1.0)
+        return {"x": state["x"] + 1}
+
+    builder = StateGraph(_TimeoutState)
+    builder.add_node("slow", slow, timeout=0.05)
+    builder.add_edge(START, "slow")
+    builder.add_edge("slow", END)
+    graph = builder.compile()
+
+    with pytest.raises(NodeTimeoutError):
+        graph.invoke({"x": 1})
+
+
+def test_state_graph_add_node_timeout_composes_with_retry():
+    """add_node(..., timeout=...) + retry_policy retries then succeeds."""
+
+    attempts: list[int] = []
+
+    def flaky(state: _TimeoutState) -> _TimeoutState:
+        attempts.append(len(attempts))
+        if len(attempts) < 2:
+            time.sleep(0.5)
+        return {"x": state["x"] + 1}
+
+    builder = StateGraph(_TimeoutState)
+    builder.add_node(
+        "flaky",
+        flaky,
+        timeout=0.1,
+        retry_policy=RetryPolicy(
+            max_attempts=3,
+            initial_interval=0.0,
+            jitter=False,
+            retry_on=NodeTimeoutError,
+        ),
+    )
+    builder.add_edge(START, "flaky")
+    builder.add_edge("flaky", END)
+    graph = builder.compile()
+
+    result = graph.invoke({"x": 0})
+    assert result == {"x": 1}
+    assert len(attempts) == 2
+
+
+def test_run_with_retry_timeout_callbacks_track_attempts():
+    starts: list[dict] = []
+    finishes: list[dict] = []
+
+    class FlakyProc:
+        def invoke(self, input, config):
+            runtime = config[CONF][CONFIG_KEY_RUNTIME]
+            if runtime.execution_info.node_attempt == 1:
+                time.sleep(0.2)
+            return "ok"
+
+    policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.0,
+        jitter=False,
+        retry_on=NodeTimeoutError,
+    )
+    task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,), name="flaky")
+    task.config[CONF][CONFIG_KEY_TASK_TIMEOUT_STARTED] = starts.append
+    task.config[CONF][CONFIG_KEY_TASK_TIMEOUT_FINISHED] = finishes.append
+
+    assert run_with_retry(task, retry_policy=None) == "ok"
+
+    assert [payload["attempt"] for payload in starts] == [1, 2]
+    assert [payload["attempt"] for payload in finishes] == [1, 2]
+    assert [payload["status"] for payload in finishes] == ["error", "success"]
+    assert starts[0]["execution_id"] != starts[1]["execution_id"]
+    assert starts[0]["timeout_secs"] == 0.05
+    assert starts[0]["task_name"] == "flaky"

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+from langchain_core.runnables import RunnableLambda
 from langgraph.checkpoint.memory import MemorySaver
 from typing_extensions import TypedDict
 
@@ -626,55 +627,89 @@ def test_timeout_seconds_coercion():
         timeout_seconds(timedelta())
 
 
-def test_run_with_retry_timeout_fires_sync():
-    """Sync node that runs too long raises NodeTimeoutError with node name."""
+def test_run_with_retry_rejects_sync_timeout_without_starting_proc():
+    started = False
 
-    class SlowProc:
+    class Proc:
         def invoke(self, input, config):
-            time.sleep(1.0)
+            nonlocal started
+            started = True
             return input
 
-    task = _make_task(SlowProc(), timeout=0.05, name="slow")
-    with pytest.raises(NodeTimeoutError) as excinfo:
+    task = _make_task(Proc(), timeout=0.05, name="sync")
+
+    with pytest.raises(ValueError, match="only supported for async nodes"):
         run_with_retry(task, retry_policy=None)
-    assert excinfo.value.node == "slow"
-    assert excinfo.value.elapsed >= 0.05
+    assert not started
 
 
-def test_run_with_retry_timeout_ok_when_fast():
-    """Node that finishes under the timeout succeeds normally."""
+def test_arun_with_retry_rejects_sync_timeout_without_starting_proc():
+    started = False
 
+    class Proc:
+        def invoke(self, input, config):
+            nonlocal started
+            started = True
+            return input
+
+    task = _make_task(Proc(), timeout=0.05, name="sync")
+
+    async def _run() -> None:
+        with pytest.raises(ValueError, match="only supported for async nodes"):
+            await arun_with_retry(task, retry_policy=None)
+
+    asyncio.run(_run())
+    assert not started
+
+
+def test_arun_with_retry_stream_rejects_sync_runnable_lambda_timeout():
+    started = False
+
+    def proc(input):
+        nonlocal started
+        started = True
+        return input
+
+    task = _make_task(RunnableLambda(proc), timeout=0.05, name="sync-lambda")
+
+    async def _run() -> None:
+        with pytest.raises(ValueError, match="only supported for async nodes"):
+            await arun_with_retry(task, retry_policy=None, stream=True)
+
+    asyncio.run(_run())
+    assert not started
+
+
+def test_run_with_retry_without_timeout_runs_sync_directly():
     class FastProc:
         def invoke(self, input, config):
             return "ok"
 
-    task = _make_task(FastProc(), timeout=1.0)
+    task = _make_task(FastProc(), timeout=None)
     assert run_with_retry(task, retry_policy=None) == "ok"
 
 
-def test_run_with_retry_timeout_preserves_contextvars():
-    import contextvars
+def test_arun_with_retry_timeout_ok_when_fast():
+    class FastProc:
+        async def ainvoke(self, input, config):
+            return "ok"
 
-    request_id = contextvars.ContextVar("request_id", default="missing")
-    request_id.set("req-123")
+    task = _make_task(FastProc(), timeout=1.0)
 
-    class Proc:
-        def invoke(self, input, config):
-            return request_id.get()
+    async def _run() -> None:
+        assert await arun_with_retry(task, retry_policy=None) == "ok"
 
-    task = _make_task(Proc(), timeout=1.0)
-    assert run_with_retry(task, retry_policy=None) == "req-123"
+    asyncio.run(_run())
 
 
-def test_run_with_retry_timeout_retries_when_retry_on_timeout():
-    """With retry_policy.retry_on=NodeTimeoutError, a timed-out attempt is retried."""
+def test_arun_with_retry_timeout_retries_when_retry_on_timeout():
     calls: list[float] = []
 
     class FlakyProc:
-        def invoke(self, input, config):
+        async def ainvoke(self, input, config):
             calls.append(time.monotonic())
             if len(calls) < 2:
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
                 return "late"
             return "ok"
 
@@ -685,54 +720,12 @@ def test_run_with_retry_timeout_retries_when_retry_on_timeout():
         retry_on=NodeTimeoutError,
     )
     task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,))
-    assert run_with_retry(task, retry_policy=None) == "ok"
-    assert len(calls) == 2
 
+    async def _run() -> None:
+        assert await arun_with_retry(task, retry_policy=None) == "ok"
+        assert len(calls) == 2
 
-def test_run_with_retry_timeout_discards_stale_sync_writes():
-    release_first_attempt = threading.Event()
-
-    class FlakyProc:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        def invoke(self, input, config):
-            self.calls += 1
-            if self.calls == 1:
-                release_first_attempt.wait(timeout=1.0)
-                config[CONF][CONFIG_KEY_SEND]([("value", "stale")])
-                return "late"
-            release_first_attempt.set()
-            config[CONF][CONFIG_KEY_SEND]([("value", "fresh")])
-            return "ok"
-
-    policy = RetryPolicy(
-        max_attempts=2,
-        initial_interval=0.0,
-        jitter=False,
-        retry_on=NodeTimeoutError,
-    )
-    task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,))
-
-    assert run_with_retry(task, retry_policy=None) == "ok"
-    time.sleep(0.05)
-
-    assert task.writes == deque([("value", "fresh")])
-
-
-def test_run_with_retry_timeout_discards_pre_timeout_sync_writes():
-    class SlowWriterProc:
-        def invoke(self, input, config):
-            config[CONF][CONFIG_KEY_SEND]([("value", "stale-before-timeout")])
-            time.sleep(0.2)
-            return "late"
-
-    task = _make_task(SlowWriterProc(), timeout=0.05)
-
-    with pytest.raises(NodeTimeoutError):
-        run_with_retry(task, retry_policy=None)
-
-    assert task.writes == deque()
+    asyncio.run(_run())
 
 
 def test_entrypoint_timeout_allows_pre_timeout_child_task_to_run():
@@ -744,26 +737,32 @@ def test_entrypoint_timeout_allows_pre_timeout_child_task_to_run():
         return value + 1
 
     @entrypoint(timeout=0.05)
-    def parent(value: int) -> int:
+    async def parent(value: int) -> int:
         child(value)
-        time.sleep(0.2)
+        await asyncio.sleep(0.2)
         return value
 
-    with pytest.raises(NodeTimeoutError):
-        parent.invoke(1)
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await parent.ainvoke(1)
 
+    asyncio.run(_run())
     assert child_started.wait(timeout=1.0)
 
 
-def test_run_with_retry_timeout_accepts_timedelta():
+def test_arun_with_retry_timeout_accepts_timedelta():
     class SlowProc:
-        def invoke(self, input, config):
-            time.sleep(0.5)
+        async def ainvoke(self, input, config):
+            await asyncio.sleep(0.5)
             return input
 
     task = _make_task(SlowProc(), timeout=timedelta(milliseconds=50))
-    with pytest.raises(NodeTimeoutError):
-        run_with_retry(task, retry_policy=None)
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await arun_with_retry(task, retry_policy=None)
+
+    asyncio.run(_run())
 
 
 def test_arun_with_retry_timeout_fires_async():
@@ -924,11 +923,90 @@ def test_timeout_validation_is_eager_across_apis():
         builder.add_node("slow", lambda state: state, timeout=0)
 
 
-def test_state_graph_add_node_timeout_e2e():
-    """End-to-end: add_node(..., timeout=...) raises NodeTimeoutError on invoke."""
+def test_timeout_rejects_sync_functional_apis_at_declaration_time():
+    with pytest.raises(ValueError, match="only supported for async nodes"):
 
+        @task(timeout=0.05)
+        def sync_task(value: int) -> int:
+            return value
+
+    with pytest.raises(ValueError, match="only supported for async nodes"):
+
+        @entrypoint(timeout=0.05)
+        def sync_entrypoint(value: int) -> int:
+            return value
+
+
+def test_state_graph_compile_rejects_sync_node_timeout():
     def slow(state: _TimeoutState) -> _TimeoutState:
-        time.sleep(1.0)
+        return {"x": state["x"] + 1}
+
+    builder = StateGraph(_TimeoutState)
+    builder.add_node("slow", slow, timeout=0.05)
+    builder.add_edge(START, "slow")
+    builder.add_edge("slow", END)
+
+    with pytest.raises(ValueError, match="only supported for async nodes"):
+        builder.compile()
+
+
+def test_pregel_validate_rejects_sync_node_timeout():
+    def slow(value: int) -> int:
+        return value + 1
+
+    with pytest.raises(ValueError, match="only supported for async nodes"):
+        Pregel(
+            nodes={
+                "slow": (
+                    NodeBuilder()
+                    .subscribe_only("input")
+                    .do(slow)
+                    .set_timeout(0.05)
+                    .write_to("output")
+                )
+            },
+            channels={
+                "input": EphemeralValue(int),
+                "output": LastValue(int),
+            },
+            input_channels="input",
+            output_channels="output",
+        )
+
+
+def test_pregel_validate_accepts_async_runnable_lambda_timeout():
+    async def slow(value: int) -> int:
+        await asyncio.sleep(0.2)
+        return value + 1
+
+    graph = Pregel(
+        nodes={
+            "slow": (
+                NodeBuilder()
+                .subscribe_only("input")
+                .do(RunnableLambda(slow))
+                .set_timeout(0.05)
+                .write_to("output")
+            )
+        },
+        channels={
+            "input": EphemeralValue(int),
+            "output": LastValue(int),
+        },
+        input_channels="input",
+        output_channels="output",
+    )
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await graph.ainvoke(1)
+
+    asyncio.run(_run())
+
+
+def test_state_graph_add_node_timeout_e2e():
+    async def slow(state: _TimeoutState) -> _TimeoutState:
+        await asyncio.sleep(1.0)
         return {"x": state["x"] + 1}
 
     builder = StateGraph(_TimeoutState)
@@ -937,8 +1015,11 @@ def test_state_graph_add_node_timeout_e2e():
     builder.add_edge("slow", END)
     graph = builder.compile()
 
-    with pytest.raises(NodeTimeoutError):
-        graph.invoke({"x": 1})
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await graph.ainvoke({"x": 1})
+
+    asyncio.run(_run())
 
 
 def test_state_graph_add_node_timeout_composes_with_retry():
@@ -946,10 +1027,10 @@ def test_state_graph_add_node_timeout_composes_with_retry():
 
     attempts: list[int] = []
 
-    def flaky(state: _TimeoutState) -> _TimeoutState:
+    async def flaky(state: _TimeoutState) -> _TimeoutState:
         attempts.append(len(attempts))
         if len(attempts) < 2:
-            time.sleep(0.5)
+            await asyncio.sleep(0.5)
         return {"x": state["x"] + 1}
 
     builder = StateGraph(_TimeoutState)
@@ -968,38 +1049,47 @@ def test_state_graph_add_node_timeout_composes_with_retry():
     builder.add_edge("flaky", END)
     graph = builder.compile()
 
-    result = graph.invoke({"x": 0})
-    assert result == {"x": 1}
-    assert len(attempts) == 2
+    async def _run() -> None:
+        result = await graph.ainvoke({"x": 0})
+        assert result == {"x": 1}
+        assert len(attempts) == 2
+
+    asyncio.run(_run())
 
 
 def test_task_decorator_timeout_e2e():
     @task(timeout=0.05)
-    def slow_task(x: int) -> int:
-        time.sleep(0.2)
+    async def slow_task(x: int) -> int:
+        await asyncio.sleep(0.2)
         return x + 1
 
     @entrypoint()
-    def workflow(x: int) -> int:
-        return slow_task(x).result()
+    async def workflow(x: int) -> int:
+        return await slow_task(x)
 
-    with pytest.raises(NodeTimeoutError):
-        workflow.invoke(1)
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await workflow.ainvoke(1)
+
+    asyncio.run(_run())
 
 
 def test_entrypoint_timeout_e2e():
     @entrypoint(timeout=0.05)
-    def slow_workflow(x: int) -> int:
-        time.sleep(0.2)
+    async def slow_workflow(x: int) -> int:
+        await asyncio.sleep(0.2)
         return x
 
-    with pytest.raises(NodeTimeoutError):
-        slow_workflow.invoke(1)
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await slow_workflow.ainvoke(1)
+
+    asyncio.run(_run())
 
 
 def test_node_builder_timeout_e2e():
-    def slow(value: int) -> int:
-        time.sleep(0.2)
+    async def slow(value: int) -> int:
+        await asyncio.sleep(0.2)
         return value + 1
 
     graph = Pregel(
@@ -1020,18 +1110,21 @@ def test_node_builder_timeout_e2e():
         output_channels="output",
     )
 
-    with pytest.raises(NodeTimeoutError):
-        graph.invoke(1)
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await graph.ainvoke(1)
+
+    asyncio.run(_run())
 
 
-def test_run_with_retry_timeout_observer_tracks_attempts():
+def test_arun_with_retry_timeout_observer_tracks_attempts():
     events: list[dict] = []
 
     class FlakyProc:
-        def invoke(self, input, config):
+        async def ainvoke(self, input, config):
             runtime = config[CONF][CONFIG_KEY_RUNTIME]
             if runtime.execution_info.node_attempt == 1:
-                time.sleep(0.2)
+                await asyncio.sleep(0.2)
             return "ok"
 
     policy = RetryPolicy(
@@ -1043,7 +1136,10 @@ def test_run_with_retry_timeout_observer_tracks_attempts():
     task = _make_task(FlakyProc(), timeout=0.05, retry_policy=(policy,), name="flaky")
     task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
 
-    assert run_with_retry(task, retry_policy=None) == "ok"
+    async def _run() -> None:
+        assert await arun_with_retry(task, retry_policy=None) == "ok"
+
+    asyncio.run(_run())
 
     starts = [payload for payload in events if payload["event"] == "start"]
     finishes = [payload for payload in events if payload["event"] == "finish"]
@@ -1059,18 +1155,21 @@ def test_run_with_retry_timeout_observer_tracks_attempts():
     assert starts[0]["deadline_at"] > starts[0]["started_at"]
 
 
-def test_run_with_retry_timeout_observer_treats_parent_command_as_non_error():
+def test_arun_with_retry_timeout_observer_treats_parent_command_as_non_error():
     events: list[dict] = []
 
     class ParentProc:
-        def invoke(self, input, config):
+        async def ainvoke(self, input, config):
             raise ParentCommand(Command(graph=Command.PARENT))
 
     task = _make_task(ParentProc(), timeout=0.05, name="parent")
     task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
 
-    with pytest.raises(ParentCommand):
-        run_with_retry(task, retry_policy=None)
+    async def _run() -> None:
+        with pytest.raises(ParentCommand):
+            await arun_with_retry(task, retry_policy=None)
+
+    asyncio.run(_run())
 
     finish = next(payload for payload in events if payload["event"] == "finish")
     assert finish["status"] == "success"
@@ -1078,11 +1177,11 @@ def test_run_with_retry_timeout_observer_treats_parent_command_as_non_error():
     assert finish["error_message"] is None
 
 
-def test_run_with_retry_timeout_observer_finishes_when_parent_writer_errors():
+def test_arun_with_retry_timeout_observer_finishes_when_parent_writer_errors():
     events: list[dict] = []
 
     class ParentProc:
-        def invoke(self, input, config):
+        async def ainvoke(self, input, config):
             raise ParentCommand(Command(graph="parent", update={"value": "updated"}))
 
     class FailingWriter:
@@ -1094,8 +1193,11 @@ def test_run_with_retry_timeout_observer_finishes_when_parent_writer_errors():
     )
     task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
 
-    with pytest.raises(ValueError, match="writer failed"):
-        run_with_retry(task, retry_policy=None)
+    async def _run() -> None:
+        with pytest.raises(ValueError, match="writer failed"):
+            await arun_with_retry(task, retry_policy=None)
+
+    asyncio.run(_run())
 
     finish = next(payload for payload in events if payload["event"] == "finish")
     assert finish["status"] == "error"

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -583,7 +583,9 @@ def test_run_with_retry_creates_execution_info_when_missing():
     assert info.node_first_attempt_time is not None
 
 
-def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="tid"):
+def _make_task(
+    proc, *, timeout=None, retry_policy=(), name="timed", task_id="tid", writers=()
+):
     runtime = DEFAULT_RUNTIME.override(execution_info=None)
     writes = deque()
     config = {
@@ -608,6 +610,7 @@ def _make_task(proc, *, timeout=None, retry_policy=(), name="timed", task_id="ti
         cache_key=None,
         id=task_id,
         path=("__pregel_pull", name),
+        writers=writers,
         timeout=timeout,
     )
 
@@ -730,6 +733,26 @@ def test_run_with_retry_timeout_discards_pre_timeout_sync_writes():
         run_with_retry(task, retry_policy=None)
 
     assert task.writes == deque()
+
+
+def test_entrypoint_timeout_allows_pre_timeout_child_task_to_run():
+    child_started = threading.Event()
+
+    @task()
+    def child(value: int) -> int:
+        child_started.set()
+        return value + 1
+
+    @entrypoint(timeout=0.05)
+    def parent(value: int) -> int:
+        child(value)
+        time.sleep(0.2)
+        return value
+
+    with pytest.raises(NodeTimeoutError):
+        parent.invoke(1)
+
+    assert child_started.wait(timeout=1.0)
 
 
 def test_run_with_retry_timeout_accepts_timedelta():
@@ -1049,6 +1072,31 @@ def test_run_with_retry_timeout_observer_treats_parent_command_as_non_error():
     assert finish["status"] == "success"
     assert finish["error_type"] is None
     assert finish["error_message"] is None
+
+
+def test_run_with_retry_timeout_observer_finishes_when_parent_writer_errors():
+    events: list[dict] = []
+
+    class ParentProc:
+        def invoke(self, input, config):
+            raise ParentCommand(Command(graph="parent", update={"value": "updated"}))
+
+    class FailingWriter:
+        def invoke(self, input, config):
+            raise ValueError("writer failed")
+
+    task = _make_task(
+        ParentProc(), timeout=0.05, name="parent", writers=(FailingWriter(),)
+    )
+    task.config[CONF][CONFIG_KEY_TIMED_ATTEMPT_OBSERVER] = events.append
+
+    with pytest.raises(ValueError, match="writer failed"):
+        run_with_retry(task, retry_policy=None)
+
+    finish = next(payload for payload in events if payload["event"] == "finish")
+    assert finish["status"] == "error"
+    assert finish["error_type"] == "ValueError"
+    assert finish["error_message"] == "writer failed"
 
 
 def test_arun_with_retry_timeout_observer_treats_bubble_up_as_non_error():

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -20,6 +20,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_THREAD_ID,
     CONFIG_KEY_TIMED_ATTEMPT_OBSERVER,
 )
+from langgraph._internal._runnable import RunnableCallable
 from langgraph._internal._timeout import timeout_seconds
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
@@ -643,43 +644,6 @@ def test_run_with_retry_rejects_sync_timeout_without_starting_proc():
     assert not started
 
 
-def test_arun_with_retry_rejects_sync_timeout_without_starting_proc():
-    started = False
-
-    class Proc:
-        def invoke(self, input, config):
-            nonlocal started
-            started = True
-            return input
-
-    task = _make_task(Proc(), timeout=0.05, name="sync")
-
-    async def _run() -> None:
-        with pytest.raises(ValueError, match="only supported for async nodes"):
-            await arun_with_retry(task, retry_policy=None)
-
-    asyncio.run(_run())
-    assert not started
-
-
-def test_arun_with_retry_stream_rejects_sync_runnable_lambda_timeout():
-    started = False
-
-    def proc(input):
-        nonlocal started
-        started = True
-        return input
-
-    task = _make_task(RunnableLambda(proc), timeout=0.05, name="sync-lambda")
-
-    async def _run() -> None:
-        with pytest.raises(ValueError, match="only supported for async nodes"):
-            await arun_with_retry(task, retry_policy=None, stream=True)
-
-    asyncio.run(_run())
-    assert not started
-
-
 def test_run_with_retry_without_timeout_runs_sync_directly():
     class FastProc:
         def invoke(self, input, config):
@@ -985,6 +949,39 @@ def test_pregel_validate_accepts_async_runnable_lambda_timeout():
                 NodeBuilder()
                 .subscribe_only("input")
                 .do(RunnableLambda(slow))
+                .set_timeout(0.05)
+                .write_to("output")
+            )
+        },
+        channels={
+            "input": EphemeralValue(int),
+            "output": LastValue(int),
+        },
+        input_channels="input",
+        output_channels="output",
+    )
+
+    async def _run() -> None:
+        with pytest.raises(NodeTimeoutError):
+            await graph.ainvoke(1)
+
+    asyncio.run(_run())
+
+
+def test_pregel_validate_accepts_runnable_callable_with_sync_and_async_timeout():
+    def sync(value: int) -> int:
+        return value + 1
+
+    async def async_(value: int) -> int:
+        await asyncio.sleep(0.2)
+        return value + 1
+
+    graph = Pregel(
+        nodes={
+            "slow": (
+                NodeBuilder()
+                .subscribe_only("input")
+                .do(RunnableCallable(sync, async_))
                 .set_timeout(0.05)
                 .write_to("output")
             )

--- a/libs/langgraph/tests/test_time_travel.py
+++ b/libs/langgraph/tests/test_time_travel.py
@@ -1161,9 +1161,7 @@ def test_subgraph_interrupt_resume_with_explicit_head_checkpoint_id(
     assert called == ["step_a", "ask_human"]
 
     # Resume with explicit head checkpoint_id in config
-    head_checkpoint_id = graph.get_state(config).config["configurable"][
-        "checkpoint_id"
-    ]
+    head_checkpoint_id = graph.get_state(config).config["configurable"]["checkpoint_id"]
     called.clear()
     resume_config = {
         "configurable": {


### PR DESCRIPTION
This PR adds task/node-level timeouts.

## Why async-only

Python sync code can't be safely cancelled in-process, so timeouts only apply to async nodes/tasks. Configuring a timeout on a sync node raises at compile time (and again as a runtime safety net in `run_with_retry`).

## Public API

A single `timeout=` kwarg on `add_node`, `@task`, `@entrypoint`, and `NodeBuilder.set_timeout`. Pass a number/`timedelta` for the simple case (treated as a hard wall-clock cap), or a `TimeoutPolicy` (in `langgraph.types`) for finer control:

```python
from langgraph.types import TimeoutPolicy

# simple: a hard wall-clock cap on each attempt
builder.add_node("agent", agent_fn, timeout=60)

# full control
builder.add_node(
    "agent",
    agent_fn,
    timeout=TimeoutPolicy(
        run_timeout=60,                # hard wall-clock cap, never refreshed
        idle_timeout=10,               # cap on time without observable progress
        refresh_on="auto",             # "auto" | "heartbeat"
    ),
)
```

- `run_timeout`: hard wall-clock cap on a single attempt.
- `idle_timeout`: progress-resetting cap. Refreshed by writes, stream events, child-task scheduling, runtime stream-writer calls, and any LangChain callback event from descendants of this node's run; `runtime.heartbeat()` is a manual signal for work that doesn't naturally emit any of these.
- `refresh_on="heartbeat"` narrows the refresh source to explicit `runtime.heartbeat()` only — useful when you want a strict idle definition that isn't reset by chatty subordinates.

Either timeout firing raises `NodeTimeoutError(kind="run"|"idle")` (subclass of `TimeoutError`), which carries `node`, `timeout`, `run_timeout`, `idle_timeout`, `elapsed`, and `kind`. If the node's `retry_policy` permits `TimeoutError` it'll retry; the timer resets per attempt.

## What gets cancelled and what doesn't

When a watchdog fires:

1. The `_IdleTimedAttemptScope` is closed under a lock so any in-flight `CONFIG_KEY_SEND` / stream / child-task scheduling that races with the timeout is dropped atomically.
2. Buffered `task.writes` are cleared (so pre-timeout writes from the failed attempt don't leak into the checkpoint).
3. The background `asyncio.Task` is cancelled; its eventual exception is drained via a done-callback so asyncio doesn't log it.

Child tasks that were *already scheduled* before the timeout fired still complete — they aren't part of the cancelled task's structured cancellation surface. This is intentional and tested.

## External-watchdog hook

`CONFIG_KEY_TIMED_ATTEMPT_OBSERVER` is a per-config callback that receives lifecycle events for each timed attempt:

- `start` — fired before the proc runs, with `task_id`, `task_name`, `attempt`, `run_id`, `thread_id`, `checkpoint_ns`, `started_at`, and the configured `run_timeout_secs` / `idle_timeout_secs` / `refresh_on`.
- `progress` — fired on `scope.touch()` (i.e. each progress signal that resets the idle clock), rate-limited to ~4 events per `idle_timeout` window so token-rate callbacks don't flood the observer. Carries the same context plus `progress_at`.
- `finish` — fired with `finished_at`, `status` (`"success"`/`"error"`), `error_type`, `error_message`. `ParentCommand` and `GraphBubbleUp` are treated as control flow, not errors.

This lets an orchestrating process listen to `start` + rolling `progress` to compute its own kill deadline (`progress_at + idle_timeout_secs`), so it can hard-kill a worker process if the in-process cancellation deadlocks. Observer callbacks run in whatever thread fires them and any exception they raise is logged and swallowed.
