### PR TITLE
fix: collect serde allowlist types from abstract containers

### DIFF
--- a/libs/langgraph/langgraph/_internal/_serde.py
+++ b/libs/langgraph/langgraph/_internal/_serde.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import sys
 import types
-from collections import deque
+from collections import abc, deque
 from enum import Enum
 from typing import (
     Annotated,
@@ -157,7 +157,22 @@ def _collect_from_type(
     if origin is Literal:
         return
 
-    if origin in (list, set, tuple, dict, deque, frozenset):
+    if origin in (
+        list,
+        set,
+        tuple,
+        dict,
+        deque,
+        frozenset,
+        abc.Collection,
+        abc.Iterable,
+        abc.Mapping,
+        abc.MutableMapping,
+        abc.MutableSequence,
+        abc.MutableSet,
+        abc.Sequence,
+        abc.Set,
+    ):
         for arg in get_args(typ):
             _collect_from_type(arg, allowlist, seen, seen_ids)
         return
@@ -228,13 +243,19 @@ def _safe_get_type_hints(typ: Any) -> dict[str, Any]:
 def _is_pydantic_model(typ: Any) -> bool:
     if not isinstance(typ, type):
         return False
-    if issubclass(typ, BaseModel):
-        return True
+    try:
+        if issubclass(typ, BaseModel):
+            return True
+    except TypeError:
+        return False
     try:
         from pydantic.v1 import BaseModel as BaseModelV1
     except Exception:
         return False
-    return issubclass(typ, BaseModelV1)
+    try:
+        return issubclass(typ, BaseModelV1)
+    except TypeError:
+        return False
 
 
 def _pydantic_field_types(typ: type[Any]) -> list[Any]:

--- a/libs/langgraph/tests/test_serde_allowlist.py
+++ b/libs/langgraph/tests/test_serde_allowlist.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NewType, Optional, Union
@@ -57,6 +58,9 @@ class NestedDataclass:
     inner: InnerDataclass
     items: list[InnerModel]
     mapping: dict[str, InnerDataclass]
+    abstract_items: Sequence[InnerDataclass]
+    abstract_mapping: Mapping[str, InnerModel]
+    iterable: Iterable[InnerDataclass]
     optional: InnerModel | None
     union: InnerDataclass | InnerModel
     queue: deque[InnerDataclass]


### PR DESCRIPTION
## Summary

- collect serde allowlist entries from abstract container annotations such as `Sequence[T]`, `Mapping[K, V]`, and `Iterable[T]`
- guard pydantic model detection against typing aliases that can raise from `issubclass()` on Python 3.10
- extend the serde allowlist regression test to cover abstract containers

## Root Cause

`collect_allowlist_from_schemas()` only recursed into built-in containers like `list`, `dict`, and `deque`. Abstract containers from `collections.abc` were not handled, so nested custom types could be missed. On Python 3.10, some parameterized abstract containers also pass `isinstance(..., type)` but still raise `TypeError` when passed to `issubclass()`.

## Test Plan

- `NO_DOCKER=true /tmp/langgraph-repro-venv/bin/python -m pytest -q -o addopts='' tests/test_serde_allowlist.py`
