### PR TITLE
docs: fix checkpoint README article

### DIFF
--- a/libs/checkpoint/README.md
+++ b/libs/checkpoint/README.md
@@ -24,7 +24,7 @@ You must pass these when invoking the graph as part of the configurable part of 
 
 ### Serde
 
-`langgraph_checkpoint` also defines protocol for serialization/deserialization (serde) and provides an default implementation (`langgraph.checkpoint.serde.jsonplus.JsonPlusSerializer`) that handles a wide variety of types, including LangChain and LangGraph primitives, datetimes, enums and more.
+`langgraph_checkpoint` also defines protocol for serialization/deserialization (serde) and provides a default implementation (`langgraph.checkpoint.serde.jsonplus.JsonPlusSerializer`) that handles a wide variety of types, including LangChain and LangGraph primitives, datetimes, enums and more.
 
 > [!IMPORTANT]
 > **Checkpoint deserialization security:** By default the serializer allows any Python type found in checkpoint data. New applications should set the environment variable `LANGGRAPH_STRICT_MSGPACK=true` or pass an explicit `allowed_msgpack_modules` list to `JsonPlusSerializer` to restrict deserialization to known-safe types.


### PR DESCRIPTION
Fixes a small grammar issue in the checkpoint README: `an default implementation` -> `a default implementation`.