### PR TITLE
fix(channels): BinaryOperatorAggregate applies values after Overwrite

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -118,8 +118,10 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            # Values arriving after Overwrite should still be aggregated on top
+            # of the new base; otherwise concurrent writes that happen to sort
+            # after the Overwrite are silently discarded.
+            self.value = self.operator(self.value, value)
         return True
 
     def get(self) -> Value:


### PR DESCRIPTION
Fixes #7590.

## Bug

\`BinaryOperatorAggregate.update()\` in \`libs/langgraph/langgraph/channels/binop.py\` guarded the accumulate branch with \`if not seen_overwrite:\`. Any regular value arriving after an \`Overwrite\` in the same batch was silently dropped — no error, no warning.

In concurrent supersteps the order of writes inside \`apply_writes\` is decided by path sort, not user intent. So if task A emits \`Overwrite(base)\` and task B emits a regular value, and A sorts first, B's contribution disappears.

Minimal repro from the issue:

\`\`\`python
from langgraph.channels.binop import BinaryOperatorAggregate
import operator

ch = BinaryOperatorAggregate(int, operator.add)
ch.update([1])                   # value = 1
ch.update([Overwrite(10), 5])    # expected 15, actual 10 (5 dropped)
\`\`\`

## Fix

Drop the \`if not seen_overwrite:\` guard so regular values are always applied. \`Overwrite\` resets the base; subsequent values accumulate on top of that new base, which is the same behavior that happens when the writes arrive in the opposite order or across separate batches. The existing "only one Overwrite per super-step" error still catches the truly ambiguous case.

## Test plan

- Repro above now produces \`ch.value == 15\` as expected.
- \`make test\` on \`libs/langgraph\` — channel tests still pass; no test was pinning the previous silent-drop behavior (grepped the suite for \`seen_overwrite\` / \`Overwrite.*drop\`).