### PR TITLE
fix(_serde): recurse into collections.abc generic containers

### DIFF
--- a/libs/langgraph/langgraph/_internal/_serde.py
+++ b/libs/langgraph/langgraph/_internal/_serde.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc
 import dataclasses
 import logging
 import sys
@@ -157,7 +158,17 @@ def _collect_from_type(
     if origin is Literal:
         return
 
-    if origin in (list, set, tuple, dict, deque, frozenset):
+    if origin in (list, set, tuple, dict, deque, frozenset) or origin in (
+        collections.abc.Sequence,
+        collections.abc.MutableSequence,
+        collections.abc.Set,
+        collections.abc.MutableSet,
+        collections.abc.Mapping,
+        collections.abc.MutableMapping,
+        collections.abc.Iterable,
+        collections.abc.Iterator,
+        collections.abc.Collection,
+    ):
         for arg in get_args(typ):
             _collect_from_type(arg, allowlist, seen, seen_ids)
         return


### PR DESCRIPTION
Fixes #7601.

## Bug

\`collect_allowlist_from_schemas()\` raises on a dataclass field typed with \`collections.abc.Sequence[Item]\` (and friends):

\`\`\`python
from dataclasses import dataclass
from collections.abc import Sequence
from langgraph._internal._serde import collect_allowlist_from_schemas

@dataclass
class Item: x: int

@dataclass
class State: items: Sequence[Item]

collect_allowlist_from_schemas(schemas=[State])
# TypeError: issubclass() arg 1 must be a class
\`\`\`

## Root cause

\`_collect_from_type\` special-cases the concrete container origins — \`list\`, \`set\`, \`tuple\`, \`dict\`, \`deque\`, \`frozenset\` — and recurses into their \`get_args()\`. The \`collections.abc\` equivalents (\`Sequence\`, \`MutableSequence\`, \`Set\`, \`MutableSet\`, \`Mapping\`, \`MutableMapping\`, \`Iterable\`, \`Iterator\`, \`Collection\`) are not in that set, so a subscripted abc falls through to the pydantic-model branch. On Python 3.10 the generic alias slips past the \`isinstance(typ, type)\` guard in \`_is_pydantic_model\` and lands on \`issubclass(typ, BaseModelV1)\`, which raises.

## Fix

Extend the origin allowlist to cover the nine \`collections.abc\` variants users can reasonably hit in a schema. The recursion shape is identical — \`get_args(typ)\` still returns the element types — so subscripted abcs now behave the same as their concrete siblings.

## Test plan

- Repro above now succeeds; \`allowlist\` contains \`("__main__", "Item")\`.
- \`make test\` on \`libs/langgraph\` passes locally.