### PR TITLE
fix(pregel): don't cache INTERRUPT/ERROR writes in SyncPregelLoop

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1208,6 +1208,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks (mirrors AsyncPregelLoop.put_writes)
+            return
         self.submit(
             self.cache.set,
             {


### PR DESCRIPTION
Fixes #7589.

\`AsyncPregelLoop.put_writes\` (\`_loop.py:1407-1409\`) already skips the \`cache.set\` when the first write is \`INTERRUPT\` or \`ERROR\`, with the comment "only cache successful tasks". The sibling sync path at \`:1203-1218\` was missing the same guard, so with \`CachePolicy\` enabled on a node:

1. Node raises or is interrupted → failure writes are persisted.
2. Next \`graph.invoke()\` with the same inputs → the cache replays the error writes as a valid result.
3. Retry never happens, and the failure is silently masked.

Mirror the async guard so only successful tasks reach the cache in the sync path.