### PR TITLE
fix(prebuilt): offload sync wrap_tool_call to a worker thread in ToolNode._arun_one

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1203,9 +1203,13 @@ class ToolNode(RunnableCallable):
         try:
             if self._awrap_tool_call is not None:
                 return await self._awrap_tool_call(tool_request, execute)
-            # None check was performed above already
+            # None check was performed above already. Run the sync wrapper in
+            # a worker thread so it doesn't serialize concurrent tool calls on
+            # the event loop (every ainvoke batch previously blocked here).
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            return await asyncio.to_thread(
+                self._wrap_tool_call, tool_request, _sync_execute
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:


### PR DESCRIPTION
Fixes #7591.

\`ToolNode._arun_one\` falls back to calling a sync \`wrap_tool_call\` directly on the event-loop thread when no async variant is registered:

\`\`\`python
return self._wrap_tool_call(tool_request, _sync_execute)
\`\`\`

Because \`_afunc\` dispatches all tool calls via \`asyncio.gather\`, a single blocking sync wrapper serializes every concurrent tool execution and stalls the loop — the whole batch's latency collapses to the sum of its tool times instead of the max.

Hand the sync call to \`asyncio.to_thread\` so each concurrent \`ainvoke\` tool call hops to its own worker thread. Users who register an async \`awrap_tool_call\` continue through the existing \`await\` path unchanged.