### PR TITLE
fix(pregel): clamp retry sleep to max_interval after jitter

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -170,10 +170,15 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
-            sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
-            )
+            # Apply jitter if configured, but keep the final sleep within
+            # max_interval so the documented cap isn't silently blown through.
+            if matching_policy.jitter:
+                sleep_time = min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+            else:
+                sleep_time = interval
             time.sleep(sleep_time)
 
             # log the retry
@@ -287,10 +292,15 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
-            sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
-            )
+            # Apply jitter if configured, but keep the final sleep within
+            # max_interval so the documented cap isn't silently blown through.
+            if matching_policy.jitter:
+                sleep_time = min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+            else:
+                sleep_time = interval
             await asyncio.sleep(sleep_time)
 
             # log the retry


### PR DESCRIPTION
Fixes #7554.

The retry loop in \`pregel/_retry.py\` (both sync and async variants) clamps the base interval to \`matching_policy.max_interval\` via \`min(...)\`, but adds up to 1 s of jitter **after** the cap:

\`\`\`python
sleep_time = interval + random.uniform(0, 1) if matching_policy.jitter else interval
\`\`\`

So \`RetryPolicy(initial_interval=0.5, max_interval=0.5, jitter=True)\` can actually sleep up to ~1.5 s per retry, silently violating the documented "Maximum amount of time that may elapse between retries".

Re-apply the \`max_interval\` cap after jittering. When the jittered value fits below the cap nothing changes; when it would exceed, clamp. Keeps the jitter spread when \`interval\` has headroom but never blows past the declared upper bound.