### PR TITLE
fix(channels): _strip_extras unwraps Required/NotRequired correctly

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -21,11 +21,13 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
+    # Handle Required/NotRequired first: their __origin__ is the wrapper class
+    # itself, not the inner type, so the generic __origin__ branch below would
+    # return the bare Required/NotRequired and lose the T inside.
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
-
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
     return t
 
 


### PR DESCRIPTION
Fixes #7578.

\`_strip_extras\` in \`channels/binop.py\` has two if-blocks, the first of which always short-circuits because \`hasattr(t, "__origin__")\` is true for both \`Annotated\` and \`Required\`/\`NotRequired\`. That makes the Required/NotRequired branch unreachable — dead code — and means a field annotated \`Required[Annotated[int, operator.add]]\` in a TypedDict state never gets its inner \`int\` surfaced.

Concretely: for \`Required[X]\`, \`t.__origin__\` is the \`Required\` class itself, not \`X\`. The generic "has \`__origin__\`" branch recurses into \`Required\` and the inner type is lost, so \`BinaryOperatorAggregate\` ends up treating the field's type as \`Required\` and cannot compute a valid initial value.

## Fix

Check \`Required\` / \`NotRequired\` **first** and recurse into \`args[0]\` before falling through to the generic \`__origin__\` unwrap. \`Annotated\` keeps working as before (its \`__origin__\` is the underlying type itself, so the generic branch is correct).

## Test plan

\`\`\`python
import operator
from typing import Annotated
from typing_extensions import Required
from langgraph.channels.binop import _strip_extras

assert _strip_extras(Annotated[int, operator.add]) is int
assert _strip_extras(Required[Annotated[int, operator.add]]) is int  # was Required before
\`\`\`

\`make test\` on \`libs/langgraph\` passes locally.