### PR TITLE
fix(channels): unwrap Required and NotRequired in BinaryOperatorAggregate

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -21,10 +21,10 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
 
     return t
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,7 +1,9 @@
 import operator
 from collections.abc import Sequence
+from typing import Annotated
 
 import pytest
+from typing_extensions import NotRequired, Required
 
 from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -88,6 +90,17 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+@pytest.mark.parametrize("wrapper", [Required, NotRequired])
+def test_binop_strips_required_notrequired_wrappers(wrapper) -> None:
+    channel = BinaryOperatorAggregate(
+        wrapper[Annotated[int, operator.add]], operator.add
+    ).from_checkpoint(MISSING)
+
+    assert channel.get() == 0
+    assert channel.update([1, 2])
+    assert channel.get() == 3
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary

Fixes #7578.

`_strip_extras()` documented that it strips `Annotated`, `Required`, and `NotRequired`, but the generic `__origin__` branch ran before the `Required` / `NotRequired` branch. As a result, `Required[Annotated[int, operator.add]]` and `NotRequired[Annotated[int, operator.add]]` were reduced to the wrapper object instead of `int`, so `BinaryOperatorAggregate` could not initialize the channel value.

This moves the `Required` / `NotRequired` handling before the generic origin recursion and adds regression coverage for both wrappers.

## Tests

- `uv run --no-sync python -m pytest tests/test_channels.py::test_binop_strips_required_notrequired_wrappers -q`
- `uv run --no-sync python -m pytest tests/test_channels.py -q`
- `uv run --no-sync ruff check langgraph/channels/binop.py tests/test_channels.py`
- `uv run --no-sync ruff format --check langgraph/channels/binop.py tests/test_channels.py`

Note: on this Windows machine, `uv run --group test` / `uv run --group lint` tries to build `uvloop`, which is unsupported on Windows, so I ran the same pytest/ruff checks in the prepared local environment with `--no-sync`.