### PR TITLE
fix: cap RetryPolicy jitter at max_interval

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -170,9 +170,14 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured without exceeding max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -287,9 +292,14 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured without exceeding max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import deque
 from unittest.mock import Mock, patch
 
@@ -305,6 +306,88 @@ def test_graph_with_jitter_retry_policy():
     # Verify jitter was applied
     mock_random.assert_called_with(0, 1)  # Jitter should use random.uniform(0, 1)
     mock_sleep.assert_called_with(0.01 + 0.05)  # Sleep should include jitter
+
+
+def test_graph_with_jitter_retry_policy_respects_max_interval():
+    """Test that jitter never increases the sync sleep past max_interval."""
+
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    def failing_node(state):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count < 2:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=3,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=0.75),
+        patch("time.sleep") as mock_sleep,
+    ):
+        result = graph.invoke({"foo": ""})
+
+    assert attempt_count == 2
+    assert result["foo"] == "success"
+    mock_sleep.assert_called_once_with(0.5)
+
+
+def test_async_graph_with_jitter_retry_policy_respects_max_interval():
+    """Test that jitter never increases the async sleep past max_interval."""
+
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    async def failing_node(state):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count < 2:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=3,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=0.75),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        result = asyncio.run(graph.ainvoke({"foo": ""}))
+
+    assert attempt_count == 2
+    assert result["foo"] == "success"
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def test_graph_with_multiple_retry_policies():


### PR DESCRIPTION
`run_with_retry` and `arun_with_retry` were capping the backoff interval before adding jitter, so `random.uniform(0, 1)` could push the actual sleep past `max_interval`. This keeps the jittered sleep capped in both paths and adds regression tests covering the sync and async cases with a tight `max_interval`. Fixes #7554.

## Testing
- `NO_DOCKER=true pytest -o addopts='' tests/test_retry.py -k 'respects_max_interval or test_graph_with_jitter_retry_policy'`
- `NO_DOCKER=true pytest -o addopts='' tests/test_retry.py`
- `ruff check langgraph/pregel/_retry.py tests/test_retry.py`
