### PR TITLE
fix(prebuilt): avoid blocking event loop in sync tool wrappers

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -72,6 +72,7 @@ from langchain_core.runnables.config import (
     RunnableConfig,
     get_config_list,
     get_executor_for_config,
+    run_in_executor,
 )
 from langchain_core.tools import BaseTool, InjectedToolArg
 from langchain_core.tools import tool as create_tool
@@ -1205,7 +1206,9 @@ class ToolNode(RunnableCallable):
                 return await self._awrap_tool_call(tool_request, execute)
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            return await run_in_executor(
+                config, self._wrap_tool_call, tool_request, _sync_execute
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:

--- a/libs/prebuilt/tests/test_on_tool_call.py
+++ b/libs/prebuilt/tests/test_on_tool_call.py
@@ -1,5 +1,7 @@
 """Unit tests for tool call interceptor in ToolNode."""
 
+import asyncio
+import time
 from collections.abc import Callable
 from unittest.mock import Mock
 
@@ -120,6 +122,49 @@ async def test_passthrough_handler_async() -> None:
     assert isinstance(tool_message, ToolMessage)
     assert tool_message.content == "5"
     assert tool_message.tool_call_id == "call_2"
+
+
+async def test_async_sync_handler_does_not_block_event_loop() -> None:
+    """Test sync handlers run off the event loop during async execution."""
+
+    def blocking_handler(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        time.sleep(0.1)
+        return execute(request)
+
+    tool_node = ToolNode([add], wrap_tool_call=blocking_handler)
+    started = time.perf_counter()
+    tick_elapsed = 0.0
+
+    async def tick() -> None:
+        nonlocal tick_elapsed
+        await asyncio.sleep(0.01)
+        tick_elapsed = time.perf_counter() - started
+
+    await asyncio.gather(
+        tool_node.ainvoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "adding",
+                        tool_calls=[
+                            {
+                                "name": "add",
+                                "args": {"a": 2, "b": 3},
+                                "id": "call_2",
+                            }
+                        ],
+                    )
+                ]
+            },
+            config=_create_config_with_runtime(),
+        ),
+        tick(),
+    )
+
+    assert tick_elapsed < 0.08
 
 
 def test_modify_arguments() -> None:


### PR DESCRIPTION
## Summary
- run sync `wrap_tool_call` handlers through the executor when `ToolNode` is invoked asynchronously
- add a regression test that verifies the event loop can keep ticking while a sync wrapper blocks

Fixes #7591

## Tests
- `uv run pytest tests/test_on_tool_call.py tests/test_tool_node.py::test_tool_node_inject_runtime_dynamic_tool_via_wrap_tool_call_async -q`
- `uv run ruff check langgraph/prebuilt/tool_node.py tests/test_on_tool_call.py`
- `uv run ruff format --check langgraph/prebuilt/tool_node.py tests/test_on_tool_call.py`
- `uv run mypy langgraph/prebuilt/tool_node.py`
