### PR TITLE
fix(langgraph): unwrap Required and NotRequired in _strip_extras

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -21,10 +21,10 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
 
     return t
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,10 +1,12 @@
 import operator
 from collections.abc import Sequence
+from typing import Annotated
 
 import pytest
+from typing_extensions import NotRequired, Required
 
 from langgraph._internal._typing import MISSING
-from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.channels.binop import BinaryOperatorAggregate, _strip_extras
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
@@ -88,6 +90,13 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_strip_extras_unwraps_required_and_notrequired() -> None:
+    assert _strip_extras(Required[int]) is int
+    assert _strip_extras(NotRequired[int]) is int
+    assert _strip_extras(Required[Annotated[int, operator.add]]) is int
+    assert _strip_extras(NotRequired[Annotated[int, operator.add]]) is int
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary
- fix `_strip_extras` so it unwraps `Required[...]` and `NotRequired[...]` before falling back to `__origin__`
- preserve the existing `Annotated[...]` unwrapping behavior
- add regression coverage for both plain and annotated `Required` / `NotRequired`

## Testing
- `make format`
- `make lint`
- `TEST=tests/test_channels.py make test`

Closes #7578
