### PR TITLE
fix(langgraph): unwrap Required and NotRequired in _strip_extras

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -21,10 +21,10 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
 
     return t
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,10 +1,12 @@
 import operator
 from collections.abc import Sequence
+from typing import Annotated
 
 import pytest
+from typing_extensions import NotRequired, Required
 
 from langgraph._internal._typing import MISSING
-from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.channels.binop import BinaryOperatorAggregate, _strip_extras
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
@@ -88,6 +90,13 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_strip_extras_unwraps_required_and_notrequired() -> None:
+    assert _strip_extras(Required[int]) is int
+    assert _strip_extras(NotRequired[int]) is int
+    assert _strip_extras(Required[Annotated[int, operator.add]]) is int
+    assert _strip_extras(NotRequired[Annotated[int, operator.add]]) is int
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary
- fix  so it unwraps  and  before falling back to 
- preserve the existing  unwrapping behavior
- add regression coverage for both plain and annotated  / 

## Testing
- Running format in libs/checkpoint
uv run ruff format .
24 files left unchanged
uv run ruff check --fix .
All checks passed!
Running format in libs/checkpoint-conformance
uv run ruff format .
16 files left unchanged
uv run ruff check --fix .
All checks passed!
Running format in libs/checkpoint-postgres
uv run ruff format .
16 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
Running format in libs/checkpoint-sqlite
uv run ruff format .
13 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
Running format in libs/cli
uv run ruff format .
64 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
Running format in libs/langgraph
uv run ruff format .
120 files left unchanged
uv run ruff check --fix .
All checks passed!
Running format in libs/prebuilt
uv run ruff format .
22 files left unchanged
uv run ruff check --fix .
All checks passed!
Running format in libs/sdk-py
uv run ruff check --select I --fix .
All checks passed!
uv run ruff format .
43 files left unchanged
- Running lint in libs/checkpoint
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
Success: no issues found in 24 source files
Running lint in libs/checkpoint-conformance
uv run ruff check .
All checks passed!
uv run ty check
All checks passed!
Running lint in libs/checkpoint-postgres
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
Success: no issues found in 16 source files
Running lint in libs/checkpoint-sqlite
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
Success: no issues found in 13 source files
Running lint in libs/cli
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache || uv run mypy . --cache-dir .mypy_cache
Running lint in libs/langgraph
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy langgraph --cache-dir .mypy_cache
Success: no issues found in 68 source files
Running lint in libs/prebuilt
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy langgraph --cache-dir .mypy_cache
Success: no issues found in 5 source files
Running lint in libs/sdk-py
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
uv run ty check .
All checks passed!
- Running test in libs/checkpoint
uv run pytest tests/test_channels.py
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/nithi/oss-work/langgraph/libs/checkpoint/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nithi/oss-work/langgraph/libs/checkpoint
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, asyncio-1.3.0, langsmith-0.7.31
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.00s =============================
Running test in libs/checkpoint-conformance
uv run pytest tests/test_channels.py
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/nithi/oss-work/langgraph/libs/checkpoint-conformance/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nithi/oss-work/langgraph/libs/checkpoint-conformance
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, langsmith-0.7.31
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.00s =============================
Running test in libs/checkpoint-postgres
Testing PostgreSQL 15
POSTGRES_VERSION= docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
		echo "Failed to start PostgreSQL, printing logs..."; \
		docker compose -f tests/compose-postgres.yml logs; \
		exit 1 \
	)
Failed to start PostgreSQL, printing logs...
Test failed for PostgreSQL 15
Running test in libs/checkpoint-sqlite
uv run pytest tests/test_channels.py
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/nithi/oss-work/langgraph/libs/checkpoint-sqlite/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nithi/oss-work/langgraph/libs/checkpoint-sqlite
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, retry-1.7.0, asyncio-1.3.0, langsmith-0.7.31
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.00s =============================
Running test in libs/cli
uv run pytest tests/test_channels.py
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/nithi/oss-work/langgraph/libs/cli/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nithi/oss-work/langgraph/libs/cli
configfile: pyproject.toml
plugins: mock-3.15.1, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.00s =============================
Running test in libs/langgraph
if [ "" = "false" ]; then \
		make start-services &&\
		make start-dev-server &&\
		uv run pytest tests/test_channels.py; \
		EXIT_CODE=$?; \
		make stop-services; \
		make stop-dev-server; \
		exit $EXIT_CODE; \
	else \
		NO_DOCKER=true uv run pytest tests/test_channels.py ; \
		EXIT_CODE=$?; \
		exit $EXIT_CODE; \
	fi
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/nithi/oss-work/langgraph/libs/langgraph
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, repeat-0.9.4, cov-7.1.0, syrupy-5.1.0, xdist-3.8.0, dotenv-0.5.2, langsmith-0.7.31
collected 6 items

tests/test_channels.py ......                                            [100%]

============================= slowest 5 durations ==============================

(5 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 6 passed in 0.02s ===============================
Running test in libs/prebuilt
make start-services && LANGGRAPH_TEST_FAST=0 uv run --active pytest tests/test_channels.py; \
	EXIT_CODE=$?; \
	make stop-services; \
	exit $EXIT_CODE
docker compose -f tests/compose-postgres.yml -f tests/compose-redis.yml up -V --force-recreate --wait --remove-orphans
docker compose -f tests/compose-postgres.yml -f tests/compose-redis.yml down -v
Running test in libs/sdk-py
uv run pytest tests
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.3, pluggy-1.6.0 -- /Users/nithi/oss-work/langgraph/libs/sdk-py/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/nithi/oss-work/langgraph/libs/sdk-py
configfile: pyproject.toml
plugins: anyio-4.12.1, mock-3.15.1, asyncio-1.3.0, langsmith-0.7.31
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 86 items

tests/test_api_parity.py::test_sync_api_matches_async[AssistantsClient-SyncAssistantsClient] PASSED [  1%]
tests/test_api_parity.py::test_sync_api_matches_async[ThreadsClient-SyncThreadsClient] PASSED [  2%]
tests/test_api_parity.py::test_sync_api_matches_async[RunsClient-SyncRunsClient] PASSED [  3%]
tests/test_api_parity.py::test_sync_api_matches_async[CronClient-SyncCronClient] PASSED [  4%]
tests/test_api_parity.py::test_sync_api_matches_async[StoreClient-SyncStoreClient] PASSED [  5%]
tests/test_assistants_client.py::test_assistants_search_returns_list_by_default PASSED [  6%]
tests/test_assistants_client.py::test_assistants_search_can_return_object_with_pagination_metadata PASSED [  8%]
tests/test_assistants_client.py::test_sync_assistants_search_can_return_object_with_pagination_metadata PASSED [  9%]
tests/test_cache.py::test_swr_proxies_to_server_impl PASSED              [ 10%]
tests/test_cache.py::test_swr_requires_server_runtime PASSED             [ 11%]
tests/test_cache.py::test_swr_defaults PASSED                            [ 12%]
tests/test_client_exports.py::test_client_exports PASSED                 [ 13%]
tests/test_client_exports.py::test_public_api_exports PASSED             [ 15%]
tests/test_client_exports.py::test_client_instantiation PASSED           [ 16%]
tests/test_client_stream.py::test_stream_sse PASSED                      [ 17%]
tests/test_client_stream.py::test_http_client_stream_flushes_trailing_event PASSED [ 18%]
tests/test_client_stream.py::test_sync_http_client_stream_flushes_trailing_event PASSED [ 19%]
tests/test_client_stream.py::test_sync_http_client_stream_recovers_after_disconnect PASSED [ 20%]
tests/test_client_stream.py::test_http_client_stream_recovers_after_disconnect PASSED [ 22%]
tests/test_client_stream.py::test_sse_to_v2_dict_basic PASSED            [ 23%]
tests/test_client_stream.py::test_sse_to_v2_dict_with_namespace PASSED   [ 24%]
tests/test_client_stream.py::test_sse_to_v2_dict_with_multiple_ns PASSED [ 25%]
tests/test_client_stream.py::test_sse_to_v2_dict_end_event PASSED        [ 26%]
tests/test_client_stream.py::test_sse_to_v2_dict_metadata_event PASSED   [ 27%]
tests/test_client_stream.py::test_sse_to_v2_dict_messages_partial PASSED [ 29%]
tests/test_client_stream.py::test_sse_to_v2_dict_values_with_interrupts PASSED [ 30%]
tests/test_client_stream.py::test_async_stream_v2_client_side_conversion PASSED [ 31%]
tests/test_client_stream.py::test_sync_stream_v2_client_side_conversion PASSED [ 32%]
tests/test_crons_client.py::test_async_create_for_thread PASSED          [ 33%]
tests/test_crons_client.py::test_async_create_for_thread_with_end_time PASSED [ 34%]
tests/test_crons_client.py::test_async_create PASSED                     [ 36%]
tests/test_crons_client.py::test_async_create_with_end_time PASSED       [ 37%]
tests/test_crons_client.py::test_sync_create_for_thread PASSED           [ 38%]
tests/test_crons_client.py::test_sync_create_for_thread_with_end_time PASSED [ 39%]
tests/test_crons_client.py::test_sync_create PASSED                      [ 40%]
tests/test_crons_client.py::test_sync_create_with_end_time PASSED        [ 41%]
tests/test_crons_client.py::test_sync_create_with_enabled_parameter[enabled] PASSED [ 43%]
tests/test_crons_client.py::test_sync_create_with_enabled_parameter[disabled] PASSED [ 44%]
tests/test_crons_client.py::test_async_update PASSED                     [ 45%]
tests/test_crons_client.py::test_async_update_with_end_time PASSED       [ 46%]
tests/test_crons_client.py::test_sync_update PASSED                      [ 47%]
tests/test_crons_client.py::test_sync_update_with_end_time PASSED        [ 48%]
tests/test_crons_client.py::test_sync_update_with_enabled_parameter[enabled] PASSED [ 50%]
tests/test_crons_client.py::test_sync_update_with_enabled_parameter[disabled] PASSED [ 51%]
tests/test_encryption.py::TestHandlerValidation::test_duplicate_handlers_raise_error PASSED [ 52%]
tests/test_encryption.py::TestHandlerValidation::test_handlers_must_be_async PASSED [ 53%]
tests/test_encryption.py::TestHandlerValidation::test_handlers_must_have_two_params PASSED [ 54%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[400-BadRequestError] PASSED [ 55%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[401-AuthenticationError] PASSED [ 56%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[403-PermissionDeniedError] PASSED [ 58%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[404-NotFoundError] PASSED [ 59%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[409-ConflictError] PASSED [ 60%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[422-UnprocessableEntityError] PASSED [ 61%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[429-RateLimitError] PASSED [ 62%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[500-InternalServerError] PASSED [ 63%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[503-InternalServerError] PASSED [ 65%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[418-APIStatusError] PASSED [ 66%]
tests/test_errors.py::test_request_id_is_extracted_when_present PASSED   [ 67%]
tests/test_errors.py::test_non_json_body_does_not_break_mapping PASSED   [ 68%]
tests/test_errors.py::test_field_extraction_from_json_body PASSED        [ 69%]
tests/test_errors.py::test_error_message_in_str_and_args PASSED          [ 70%]
tests/test_errors.py::test_all_error_types_display_message[400-BadRequestError] PASSED [ 72%]
tests/test_errors.py::test_all_error_types_display_message[401-AuthenticationError] PASSED [ 73%]
tests/test_errors.py::test_all_error_types_display_message[403-PermissionDeniedError] PASSED [ 74%]
tests/test_errors.py::test_all_error_types_display_message[404-NotFoundError] PASSED [ 75%]
tests/test_errors.py::test_all_error_types_display_message[409-ConflictError] PASSED [ 76%]
tests/test_errors.py::test_all_error_types_display_message[422-UnprocessableEntityError] PASSED [ 77%]
tests/test_errors.py::test_all_error_types_display_message[429-RateLimitError] PASSED [ 79%]
tests/test_errors.py::test_all_error_types_display_message[500-InternalServerError] PASSED [ 80%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_async_create_includes_langsmith_tracer PASSED [ 81%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_sync_create_includes_langsmith_tracer PASSED [ 82%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_sync_wait_includes_langsmith_tracer PASSED [ 83%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_create_without_langsmith_tracing_excludes_key PASSED [ 84%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_langsmith_tracing_project_name_only PASSED [ 86%]
tests/test_serde.py::test_serde_basic PASSED                             [ 87%]
tests/test_serde.py::test_serde_pydantic PASSED                          [ 88%]
tests/test_serde.py::test_serde_dataclass PASSED                         [ 89%]
tests/test_serde.py::test_serde_pydantic_cls_fails PASSED                [ 90%]
tests/test_serde_schema.py::test_base_model_like PASSED                  [ 91%]
tests/test_serde_schema.py::test_dataclass_like PASSED                   [ 93%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_loads_from_env_by_default PASSED [ 94%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_skips_env_when_sentinel_used PASSED [ 95%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_uses_explicit_key_when_provided PASSED [ 96%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_loads_from_env_by_default PASSED [ 97%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_skips_env_when_sentinel_used PASSED [ 98%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_uses_explicit_key_when_provided PASSED [100%]

=============================== warnings summary ===============================
tests/test_encryption.py::TestHandlerValidation::test_duplicate_handlers_raise_error
  /Users/nithi/oss-work/langgraph/libs/sdk-py/.venv/lib/python3.13/site-packages/_pytest/python.py:166: LangGraphBetaWarning: The Encryption API is in beta and may change in future versions.
    result = testfunction(**testargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations ==============================
0.10s call     tests/test_client_exports.py::test_client_instantiation
0.01s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_loads_from_env_by_default
0.01s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_skips_env_when_sentinel_used
0.01s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_uses_explicit_key_when_provided
0.01s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_skips_env_when_sentinel_used
======================== 86 passed, 1 warning in 0.33s =========================

Closes #7578