### PR TITLE
fix(prebuilt): off-load sync wrap_tool_call to thread pool to keep event loop free

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1205,7 +1205,20 @@ class ToolNode(RunnableCallable):
                 return await self._awrap_tool_call(tool_request, execute)
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+            # Off-load sync wrap_tool_call to a worker thread so it does not
+            # block the event loop. _afunc dispatches every tool call via
+            # asyncio.gather, so a single blocking sync wrapper would otherwise
+            # serialize concurrent tool executions.
+            if inspect.iscoroutinefunction(self._wrap_tool_call):
+                # Defensive: a coroutine function passed as the sync wrapper.
+                # Await it directly instead of off-loading to a thread.
+                return await cast(
+                    "Awaitable[ToolMessage | Command]",
+                    self._wrap_tool_call(tool_request, _sync_execute),
+                )
+            return await asyncio.to_thread(
+                self._wrap_tool_call, tool_request, _sync_execute
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:

--- a/libs/prebuilt/tests/test_on_tool_call.py
+++ b/libs/prebuilt/tests/test_on_tool_call.py
@@ -1,5 +1,7 @@
 """Unit tests for tool call interceptor in ToolNode."""
 
+import asyncio
+import threading
 from collections.abc import Callable
 from unittest.mock import Mock
 
@@ -1379,3 +1381,75 @@ def test_tool_call_request_is_frozen() -> None:
     assert fresh_new_request.tool == add  # Other fields should remain the same
     assert fresh_new_request.state == state
     assert fresh_new_request.runtime is None
+
+
+async def test_sync_wrap_tool_call_does_not_block_event_loop() -> None:
+    """Sync wrap_tool_call must run off the event loop in the async path.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/7591.
+
+    Before the fix, `ToolNode._arun_one` invoked the sync wrapper directly on
+    the event loop thread, so a single blocking sync wrapper stalled the loop
+    and serialized every concurrent `ainvoke` tool call. Here we have the
+    sync wrapper block on a `threading.Event` that is only ever set by a
+    concurrent asyncio task. If the event loop is blocked, the unblock task
+    never gets to run and the wrapper hangs forever (test fails by timeout).
+    """
+
+    started = threading.Event()
+    unblock = threading.Event()
+
+    def blocking_handler(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        # Signal that the wrapper is on the worker thread, then wait for the
+        # asyncio task running on the event loop to release us. If the wrapper
+        # is mistakenly invoked on the event loop, this wait deadlocks.
+        started.set()
+        # Cap the wait so a regression surfaces as a clean failure rather than
+        # hanging the whole test session.
+        if not unblock.wait(timeout=5.0):
+            msg = "event loop appears blocked: unblock signal never arrived"
+            raise AssertionError(msg)
+        return execute(request)
+
+    tool_node = ToolNode([add], wrap_tool_call=blocking_handler)
+
+    async def release_when_started() -> None:
+        # Wait off the wrapper's worker thread for it to enter the blocking
+        # section, then release it from the event loop. If the wrapper were
+        # running on the event loop, this coroutine would never run.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, started.wait)
+        unblock.set()
+
+    releaser = asyncio.create_task(release_when_started())
+
+    result = await asyncio.wait_for(
+        tool_node.ainvoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "adding",
+                        tool_calls=[
+                            {
+                                "name": "add",
+                                "args": {"a": 1, "b": 2},
+                                "id": "call_event_loop",
+                            }
+                        ],
+                    )
+                ]
+            },
+            config=_create_config_with_runtime(),
+        ),
+        timeout=10.0,
+    )
+
+    await releaser
+
+    tool_message = result["messages"][-1]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "3"
+    assert tool_message.status != "error"


### PR DESCRIPTION
Fixes #7591.

## Why

`ToolNode._arun_one` falls back to calling a sync `wrap_tool_call` directly on the event-loop thread when no async `awrap_tool_call` is registered:

```python
return self._wrap_tool_call(tool_request, _sync_execute)
```

`_afunc` dispatches every tool call through `asyncio.gather`, so a single blocking sync wrapper stalls the loop and serializes every concurrent `ainvoke` tool call. The whole batch's latency collapses to the sum of its tool times instead of the max.

## What

In `ToolNode._arun_one`, detect whether `wrap_tool_call` is a coroutine function. If so, await it directly. Otherwise hand it to `asyncio.to_thread` so each concurrent tool call hops to its own worker thread and the event loop stays free to drive the rest of the `asyncio.gather` batch.

The async wrapper path (`_awrap_tool_call`) is unchanged and still awaited directly.

## Tested

Adds `test_sync_wrap_tool_call_does_not_block_event_loop` in `libs/prebuilt/tests/test_on_tool_call.py`. The sync wrapper hangs on a `threading.Event` that is only ever set by a concurrent asyncio task on the event loop. If the wrapper is mistakenly invoked on the loop, the unblock task can never run and the call deadlocks; `asyncio.wait_for` then surfaces it as a clean failure rather than a flaky timing assertion.
