### PR TITLE
fix(channels): apply values after overwrite

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -118,8 +118,7 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            self.value = self.operator(self.value, value)
         return True
 
     def get(self) -> Value:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -9,6 +9,7 @@ from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
+from langgraph.types import Overwrite
 
 pytestmark = pytest.mark.anyio
 
@@ -88,6 +89,15 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_applies_values_after_overwrite() -> None:
+    channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(MISSING)
+
+    channel.update([1])
+    channel.update([Overwrite(10), 5])
+
+    assert channel.get() == 15
 
 
 def test_untracked_value() -> None:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -9320,8 +9320,8 @@ def test_overwrite_parallel(
     graph = builder.compile(checkpointer=sync_checkpointer)
     config = {"configurable": {"thread_id": "1"}}
     result = graph.invoke({"messages": ["START"]}, config)
-    # a, c are overwritten by b, then d is written
-    assert result == {"messages": ["b", "d"]}
+    # a is overwritten by b; c is retained and then d is written
+    assert result == {"messages": ["b", "c", "d"]}
 
 
 @pytest.mark.parametrize("as_json", [False, True])


### PR DESCRIPTION
Fixes #7590

BinaryOperatorAggregate no longer drops regular values that arrive after an Overwrite in the same batch. Added a regression test for the channel behavior and updated the parallel overwrite test to match the new semantics.

Verified with: NO_DOCKER=true uv run pytest tests/test_channels.py -q; NO_DOCKER=true uv run pytest tests/test_pregel.py -q -k 'overwrite_sequential or overwrite_parallel or overwrite_parallel_error'; uv run ruff check langgraph/channels/binop.py tests/test_channels.py tests/test_pregel.py