### PR TITLE
feat(checkpoint-sqlite): implement delete_for_runs / adelete_for_runs

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -493,6 +493,30 @@ class SqliteSaver(BaseCheckpointSaver[str]):
                 (str(thread_id),),
             )
 
+    def delete_for_runs(self, run_ids: Sequence[str]) -> None:
+        """Delete all checkpoints and writes associated with the given run IDs.
+
+        Args:
+            run_ids: The run IDs whose checkpoints should be deleted.
+        """
+        if not run_ids:
+            return
+        placeholders = ",".join("?" * len(run_ids))
+        params = list(run_ids)
+        with self.cursor() as cur:
+            cur.execute(
+                f"""DELETE FROM writes
+                WHERE (thread_id, checkpoint_ns, checkpoint_id) IN (
+                    SELECT thread_id, checkpoint_ns, checkpoint_id FROM checkpoints
+                    WHERE json_extract(CAST(metadata AS TEXT), '$.run_id') IN ({placeholders})
+                )""",
+                params,
+            )
+            cur.execute(
+                f"DELETE FROM checkpoints WHERE json_extract(CAST(metadata AS TEXT), '$.run_id') IN ({placeholders})",
+                params,
+            )
+
     async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database asynchronously.
 

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -589,6 +589,51 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             )
             await self.conn.commit()
 
+    def delete_for_runs(self, run_ids: Sequence[str]) -> None:
+        """Delete all checkpoints and writes associated with the given run IDs.
+
+        Args:
+            run_ids: The run IDs whose checkpoints should be deleted.
+        """
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.adelete_for_runs(...)`."
+                )
+        except RuntimeError:
+            pass
+        return asyncio.run_coroutine_threadsafe(
+            self.adelete_for_runs(run_ids), self.loop
+        ).result()
+
+    async def adelete_for_runs(self, run_ids: Sequence[str]) -> None:
+        """Delete all checkpoints and writes associated with the given run IDs.
+
+        Args:
+            run_ids: The run IDs whose checkpoints should be deleted.
+        """
+        if not run_ids:
+            return
+        await self.setup()
+        placeholders = ",".join("?" * len(run_ids))
+        params = list(run_ids)
+        async with self.lock, self.conn.cursor() as cur:
+            await cur.execute(
+                f"""DELETE FROM writes
+                WHERE (thread_id, checkpoint_ns, checkpoint_id) IN (
+                    SELECT thread_id, checkpoint_ns, checkpoint_id FROM checkpoints
+                    WHERE json_extract(CAST(metadata AS TEXT), '$.run_id') IN ({placeholders})
+                )""",
+                params,
+            )
+            await cur.execute(
+                f"DELETE FROM checkpoints WHERE json_extract(CAST(metadata AS TEXT), '$.run_id') IN ({placeholders})",
+                params,
+            )
+            await self.conn.commit()
+
     def get_next_version(self, current: str | None, channel: None) -> str:
         """Generate the next version ID for a channel.
 

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,107 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_adelete_for_runs_removes_target_run(self) -> None:
+        """adelete_for_runs removes checkpoints for the specified run_id."""
+        from uuid import uuid4
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            run1, run2 = str(uuid4()), str(uuid4())
+            tid = "thread-adfr-1"
+
+            for run_id in (run1, run2):
+                cfg: RunnableConfig = {
+                    "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                    "metadata": {"run_id": run_id},
+                }
+                await saver.aput(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+
+            await saver.adelete_for_runs([run1])
+
+            remaining = [
+                t async for t in saver.alist({"configurable": {"thread_id": tid}})
+            ]
+            run_ids = {t.metadata.get("run_id") for t in remaining}
+            assert run1 not in run_ids
+            assert run2 in run_ids
+
+    @pytest.mark.asyncio
+    async def test_adelete_for_runs_removes_writes(self) -> None:
+        """adelete_for_runs also removes pending writes for deleted checkpoints."""
+        from uuid import uuid4
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            run1 = str(uuid4())
+            tid = "thread-adfr-2"
+
+            cfg: RunnableConfig = {
+                "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                "metadata": {"run_id": run1},
+            }
+            stored = await saver.aput(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+            await saver.aput_writes(stored, [("channel", "value")], str(uuid4()))
+
+            pre = await saver.aget_tuple(stored)
+            assert pre is not None and len(pre.pending_writes) == 1
+
+            await saver.adelete_for_runs([run1])
+
+            post = await saver.aget_tuple(stored)
+            assert post is None
+
+    @pytest.mark.asyncio
+    async def test_adelete_for_runs_empty_noop(self) -> None:
+        """adelete_for_runs with an empty list does nothing."""
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            await saver.adelete_for_runs([])
+
+    @pytest.mark.asyncio
+    async def test_adelete_for_runs_multiple(self) -> None:
+        """adelete_for_runs removes all checkpoints for each run_id in the list."""
+        from uuid import uuid4
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            run1, run2, run3 = str(uuid4()), str(uuid4()), str(uuid4())
+            tid = "thread-adfr-3"
+
+            for run_id in (run1, run2, run3):
+                cfg: RunnableConfig = {
+                    "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                    "metadata": {"run_id": run_id},
+                }
+                await saver.aput(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+
+            await saver.adelete_for_runs([run1, run2])
+
+            remaining = [
+                t async for t in saver.alist({"configurable": {"thread_id": tid}})
+            ]
+            run_ids = {t.metadata.get("run_id") for t in remaining}
+            assert run1 not in run_ids
+            assert run2 not in run_ids
+            assert run3 in run_ids
+
+    @pytest.mark.asyncio
+    async def test_adelete_for_runs_across_namespaces(self) -> None:
+        """adelete_for_runs deletes across all checkpoint namespaces."""
+        from uuid import uuid4
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            run1 = str(uuid4())
+            tid = "thread-adfr-4"
+
+            for ns in ("", "child:1"):
+                cfg: RunnableConfig = {
+                    "configurable": {"thread_id": tid, "checkpoint_ns": ns},
+                    "metadata": {"run_id": run1},
+                }
+                await saver.aput(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+
+            await saver.adelete_for_runs([run1])
+
+            for ns in ("", "child:1"):
+                results = [
+                    t async for t in saver.alist(
+                        {"configurable": {"thread_id": tid, "checkpoint_ns": ns}}
+                    )
+                ]
+                run_ids = {t.metadata.get("run_id") for t in results}
+                assert run1 not in run_ids

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from uuid import uuid4
 
 import pytest
 from langchain_core.runnables import RunnableConfig
@@ -307,3 +308,104 @@ class TestSqliteSaver:
             # Nested digit-starting key via dotted path
             results = list(saver.list(None, filter={"user.123abc": "ok2"}))
             assert len(results) == 1
+
+    def test_delete_for_runs_removes_target_run(self) -> None:
+        """delete_for_runs removes checkpoints for the specified run_id."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            run1, run2 = str(uuid4()), str(uuid4())
+            tid = "thread-dfr-1"
+
+            cfg1: RunnableConfig = {
+                "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                "metadata": {"run_id": run1},
+            }
+            cfg2: RunnableConfig = {
+                "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                "metadata": {"run_id": run2},
+            }
+            cp1 = empty_checkpoint()
+            cp2 = empty_checkpoint()
+            saver.put(cfg1, cp1, {"source": "input", "step": 0}, {})
+            saver.put(cfg2, cp2, {"source": "input", "step": 0}, {})
+
+            saver.delete_for_runs([run1])
+
+            remaining = list(saver.list({"configurable": {"thread_id": tid}}))
+            run_ids = {t.metadata.get("run_id") for t in remaining}
+            assert run1 not in run_ids
+            assert run2 in run_ids
+
+    def test_delete_for_runs_removes_writes(self) -> None:
+        """delete_for_runs also removes pending writes for deleted checkpoints."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            run1 = str(uuid4())
+            tid = "thread-dfr-2"
+
+            cfg: RunnableConfig = {
+                "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                "metadata": {"run_id": run1},
+            }
+            cp = empty_checkpoint()
+            stored = saver.put(cfg, cp, {"source": "input", "step": 0}, {})
+            saver.put_writes(stored, [("channel", "value")], str(uuid4()))
+
+            pre = saver.get_tuple(stored)
+            assert pre is not None and len(pre.pending_writes) == 1
+
+            saver.delete_for_runs([run1])
+
+            post = saver.get_tuple(stored)
+            assert post is None
+
+    def test_delete_for_runs_empty_noop(self) -> None:
+        """delete_for_runs with an empty list does nothing."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            saver.delete_for_runs([])
+
+    def test_delete_for_runs_nonexistent_noop(self) -> None:
+        """delete_for_runs with unknown run_ids does nothing."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            saver.delete_for_runs([str(uuid4())])
+
+    def test_delete_for_runs_multiple(self) -> None:
+        """delete_for_runs removes all checkpoints for each run_id in the list."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            run1, run2, run3 = str(uuid4()), str(uuid4()), str(uuid4())
+            tid = "thread-dfr-3"
+
+            for run_id in (run1, run2, run3):
+                cfg: RunnableConfig = {
+                    "configurable": {"thread_id": tid, "checkpoint_ns": ""},
+                    "metadata": {"run_id": run_id},
+                }
+                saver.put(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+
+            saver.delete_for_runs([run1, run2])
+
+            remaining = list(saver.list({"configurable": {"thread_id": tid}}))
+            run_ids = {t.metadata.get("run_id") for t in remaining}
+            assert run1 not in run_ids
+            assert run2 not in run_ids
+            assert run3 in run_ids
+
+    def test_delete_for_runs_across_namespaces(self) -> None:
+        """delete_for_runs deletes across all checkpoint namespaces."""
+        with SqliteSaver.from_conn_string(":memory:") as saver:
+            run1 = str(uuid4())
+            tid = "thread-dfr-4"
+
+            for ns in ("", "child:1"):
+                cfg: RunnableConfig = {
+                    "configurable": {"thread_id": tid, "checkpoint_ns": ns},
+                    "metadata": {"run_id": run1},
+                }
+                saver.put(cfg, empty_checkpoint(), {"source": "input", "step": 0}, {})
+
+            saver.delete_for_runs([run1])
+
+            for ns in ("", "child:1"):
+                results = list(
+                    saver.list({"configurable": {"thread_id": tid, "checkpoint_ns": ns}})
+                )
+                run_ids = {t.metadata.get("run_id") for t in results}
+                assert run1 not in run_ids


### PR DESCRIPTION
## Summary

Closes #7644.

`BaseCheckpointSaver` already exposes `delete_for_runs` / `adelete_for_runs` as part of the `DELETE_FOR_RUNS` conformance capability, but neither `SqliteSaver` nor `AsyncSqliteSaver` implemented them — both raised `NotImplementedError`.

This PR adds the missing implementations:

- **`SqliteSaver.delete_for_runs`** – synchronous, uses two `DELETE` statements with a subquery to remove writes before checkpoints.
- **`AsyncSqliteSaver.adelete_for_runs`** – async variant using `aiosqlite`.
- **`AsyncSqliteSaver.delete_for_runs`** – thin sync wrapper (same pattern as `delete_thread`).

The metadata column is a JSON BLOB; run IDs are extracted via `json_extract(CAST(metadata AS TEXT), '$.run_id')`, consistent with how `list()` filter predicates already query metadata fields.

## Behaviour

| Case | Result |
|---|---|
| Empty `run_ids` list | No-op (early return) |
| Unknown run IDs | No-op (no rows matched) |
| Single run ID | Checkpoint + writes deleted; other runs untouched |
| Multiple run IDs | All listed checkpoints + writes deleted |
| Multiple namespaces | Deleted across all `checkpoint_ns` values |

## Tests

- `tests/test_sqlite.py` – 6 new tests covering `SqliteSaver.delete_for_runs`
- `tests/test_aiosqlite.py` – 5 new tests covering `AsyncSqliteSaver.adelete_for_runs`

All 23 tests (existing + new) pass locally.

https://claude.ai/code/session_01WTw4FmfZ2VRKcV9Ftne5eg