### PR TITLE
fix(langgraph): avoid caching sync task error writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1286,6 +1286,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks
+            return
         self.submit(
             self.cache.set,
             {

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5830,6 +5830,30 @@ def test_multiple_interrupts_functional_cache(
     assert counter == 6
 
 
+def test_sync_functional_cache_does_not_cache_task_errors(
+    sync_checkpointer: BaseCheckpointSaver, cache: BaseCache
+) -> None:
+    counter = 0
+
+    @task(cache_policy=CachePolicy())
+    def fails(x: int) -> int:
+        nonlocal counter
+        counter += 1
+        raise RuntimeError(f"boom {counter}")
+
+    @entrypoint(checkpointer=sync_checkpointer, cache=cache)
+    def graph(x: int) -> int:
+        return fails(x).result()
+
+    config = {"configurable": {"thread_id": str(uuid.uuid4())}}
+    with pytest.raises(RuntimeError, match="boom 1"):
+        graph.invoke(1, config)
+    with pytest.raises(RuntimeError, match="boom 2"):
+        graph.invoke(1, config)
+
+    assert counter == 2
+
+
 def test_task_before_interrupt_resume(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
Fixes #7589.

## Summary
- skip functional cache writes for sync tasks when the first write is `INTERRUPT` or `ERROR`
- match the existing async `put_writes` behavior
- add a regression test proving failed cached sync tasks re-run instead of replaying cached error writes

## Tests
- `make format_diff`
- `make lint_diff`
- `NO_DOCKER=true make test TEST='tests/test_pregel.py::test_sync_functional_cache_does_not_cache_task_errors tests/test_pregel.py::test_multiple_interrupts_functional_cache -q'`