### PR TITLE
release: alpha bump prebuilt 1.1.0a1, langgraph 1.2.0a4

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.0a3"
+version = "1.2.0a4"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"
@@ -27,7 +27,7 @@ dependencies = [
     "langchain-core>=1.4.0a2,<2",
     "langgraph-checkpoint>=4.1.0a3,<5.0.0",
     "langgraph-sdk>=0.3.0,<0.4.0",
-    "langgraph-prebuilt>=1.0.12,<1.1.0",
+    "langgraph-prebuilt>=1.1.0a1,<1.2.0",
     "xxhash>=3.5.0",
     "pydantic>=2.7.4",
 ]

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a3"
+version = "1.2.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
@@ -1755,7 +1755,7 @@ test = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.12"
+version = "1.1.0a1"
 source = { editable = "../prebuilt" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/pyproject.toml
+++ b/libs/prebuilt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-prebuilt"
-version = "1.0.12"
+version = "1.1.0a1"
 description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
 authors = []
 requires-python = ">=3.10"

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -281,7 +281,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a3"
+version = "1.2.0a4"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },
@@ -503,7 +503,7 @@ test = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.12"
+version = "1.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a3"
+version = "1.2.0a4"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },
@@ -430,7 +430,7 @@ test = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.12"
+version = "1.1.0a1"
 source = { editable = "../prebuilt" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## Summary
- Bumps \`langgraph-prebuilt\` 1.0.12 → 1.1.0a1
- Bumps \`langgraph\` 1.2.0a3 → 1.2.0a4
- Bumps min \`langgraph-prebuilt\` constraint in \`langgraph\` to \`>=1.1.0a1\`
- Refreshes uv locks across the workspace

The prebuilt bump publishes the streaming \`ToolCallTransformer\` (added in #7519, never released).