### PR TITLE
fix(prebuilt): scope `ToolCallTransformer` projection to its own namespace

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/_tool_call_transformer.py
+++ b/libs/prebuilt/langgraph/prebuilt/_tool_call_transformer.py
@@ -77,8 +77,14 @@ class ToolCallTransformer(StreamTransformer):
         return stream
 
     def process(self, event: ProtocolEvent) -> bool:
-        # Namespace filtering is handled by the mux via `scope_exact`.
         if event["method"] != "tools":
+            return True
+
+        # Only project events emitted at this transformer's scope. Subgraph
+        # events still flow through the parent's mux (the parent's main
+        # event log keeps them) but they belong to the child mini-mux's
+        # `tool_calls` projection, not the parent's.
+        if tuple(event["params"]["namespace"]) != self.scope:
             return True
 
         data = event["params"]["data"]

--- a/libs/prebuilt/tests/test_tool_call_transformer.py
+++ b/libs/prebuilt/tests/test_tool_call_transformer.py
@@ -160,6 +160,76 @@ class TestToolCallTransformerUnit:
         kept = [e for e in _unstamped(mux._events._items) if e["method"] == "tools"]
         assert len(kept) == 1
 
+    def test_out_of_scope_event_skipped(self) -> None:
+        """Subgraph-scoped `tools` events must not project into a parent
+        transformer's `tool_calls` log.
+
+        The parent's main event log keeps the event (so wire consumers
+        still see it) but the parent's `ToolCallTransformer` only owns
+        the projection at its own scope. Per-scope `ToolCallTransformer`
+        instances on child mini-muxes are responsible for projecting
+        events at their own depth.
+        """
+        # Root-scope transformer (`scope == ()`).
+        mux, transformer = _mux()
+        _subscribe(mux._events)
+        mux.push(
+            _tool_event(
+                "tool-started",
+                "tc1",
+                tool_name="inner_echo",
+                namespace=["child:abc"],
+            )
+        )
+        # No `ToolCallStream` was projected into the root's log.
+        assert _unstamped(transformer._log._items) == []
+        assert "tc1" not in transformer._active
+        # The event still passes through the main event log so consumers
+        # of the raw `tools` channel see it untouched.
+        kept = [e for e in _unstamped(mux._events._items) if e["method"] == "tools"]
+        assert len(kept) == 1
+
+    def test_in_scope_event_projected_when_scope_set(self) -> None:
+        """A non-root transformer projects only events at its own scope."""
+        scope: tuple[str, ...] = ("child:abc",)
+        transformer = ToolCallTransformer(scope=scope)
+        mux = StreamMux(
+            [ValuesTransformer(), MessagesTransformer(), transformer],
+            scope=scope,
+            is_async=False,
+        )
+        _subscribe(transformer._log)
+        # Event at this scope: projected.
+        mux.push(
+            _tool_event(
+                "tool-started",
+                "tc1",
+                tool_name="echo",
+                namespace=list(scope),
+            )
+        )
+        assert len(_unstamped(transformer._log._items)) == 1
+        # Event at a deeper scope: ignored.
+        mux.push(
+            _tool_event(
+                "tool-started",
+                "tc2",
+                tool_name="grandchild",
+                namespace=[*scope, "grand:xyz"],
+            )
+        )
+        assert len(_unstamped(transformer._log._items)) == 1
+        # Event at root (above this scope): ignored.
+        mux.push(
+            _tool_event(
+                "tool-started",
+                "tc3",
+                tool_name="root_tool",
+                namespace=[],
+            )
+        )
+        assert len(_unstamped(transformer._log._items)) == 1
+
 
 # ---------------------------------------------------------------------------
 # End-to-end tests with a real graph


### PR DESCRIPTION
`ToolCallTransformer.process` was projecting every `tools` event into its own `tool_calls` log without checking the event's namespace. The earlier comment in the file claimed namespace filtering was handled by the mux via `scope_exact`, but the mux routes every event through every registered transformer in order — there is no per-transformer scope filter.

Concretely: when an outer `create_agent` had `transformers=[ToolCallTransformer]` registered at compile time and an inner `create_agent` was invoked through one of its tools, the `ToolCallStream` for the inner agent's tools showed up in **both** the outer run's `run.tool_calls` and the inner subgraph's `handle.tool_calls`. The outer's projection should only own its own scope; per-scope `ToolCallTransformer` instances on child mini-muxes (built via `mux._make_child`) are responsible for projecting events at their own depth.

Wire consumers reading raw `tools` events from the main event log are unaffected — the transformer still returns `True` (pass-through), so the event continues to flow through the parent's log untouched.

This is a behavior fix, not an API change. Anyone who was relying on the leaked tool calls in the parent projection was reading them through a path that contradicted the docstring on `ToolCallTransformer` (which already described per-scope semantics).

Tests added in `test_tool_call_transformer.py`:

- `test_out_of_scope_event_skipped` — root transformer ignores subgraph-namespaced events but the main log still keeps them.
- `test_in_scope_event_projected_when_scope_set` — a non-root transformer projects its own scope and ignores both deeper and shallower scopes.