### PR TITLE
fix: compare Postgres store numeric filters numerically

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -623,14 +623,16 @@ class BasePostgresStore(Generic[C]):
         """Helper to generate filter conditions."""
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
-        elif op == "$gt":
-            return "value->>%s > %s", [key, str(value)]
-        elif op == "$gte":
-            return "value->>%s >= %s", [key, str(value)]
-        elif op == "$lt":
-            return "value->>%s < %s", [key, str(value)]
-        elif op == "$lte":
-            return "value->>%s <= %s", [key, str(value)]
+        elif op in {"$gt", "$gte", "$lt", "$lte"}:
+            sql_op = {"$gt": ">", "$gte": ">=", "$lt": "<", "$lte": "<="}[op]
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return (
+                    "CASE WHEN jsonb_typeof(value->%s) = 'number' "
+                    f"THEN (value->>%s)::double precision {sql_op} %s "
+                    "ELSE false END",
+                    [key, key, float(value)],
+                )
+            return f"value->>%s {sql_op} %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]
         else:

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -217,6 +217,26 @@ def test_batch_search_ops(store: PostgresStore) -> None:
     assert results[2][0].namespace == ("test", "foo")
 
 
+def test_numeric_filter_comparisons_are_numeric(store: PostgresStore) -> None:
+    store.put(("items",), "item2", {"score": 2})
+    store.put(("items",), "item9", {"score": 9})
+    store.put(("items",), "item10", {"score": 10})
+    store.put(("items",), "item11", {"score": 11})
+    store.put(("items",), "item_text", {"score": "11"})
+
+    gte_results = store.search(("items",), filter={"score": {"$gte": 10}})
+    assert {item.key for item in gte_results} == {"item10", "item11"}
+
+    gt_results = store.search(("items",), filter={"score": {"$gt": 10}})
+    assert {item.key for item in gt_results} == {"item11"}
+
+    lt_results = store.search(("items",), filter={"score": {"$lt": 10}})
+    assert {item.key for item in lt_results} == {"item2", "item9"}
+
+    lte_results = store.search(("items",), filter={"score": {"$lte": 10}})
+    assert {item.key for item in lte_results} == {"item2", "item9", "item10"}
+
+
 def test_batch_list_namespaces_ops(store: PostgresStore) -> None:
     # Setup test data with various namespaces
     test_data = [

--- a/libs/checkpoint-postgres/tests/test_store_filter_conditions.py
+++ b/libs/checkpoint-postgres/tests/test_store_filter_conditions.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import pytest
+
+from langgraph.store.postgres.base import BasePostgresStore
+
+
+@pytest.fixture(autouse=True)
+def clear_test_db() -> None:
+    pass
+
+
+def test_numeric_filter_conditions_use_numeric_comparison() -> None:
+    store = object.__new__(BasePostgresStore)
+
+    cases = [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ]
+    for op, sql_op in cases:
+        sql, params = store._get_filter_condition("score", op, 10)
+        assert sql == (
+            "CASE WHEN jsonb_typeof(value->%s) = 'number' "
+            f"THEN (value->>%s)::double precision {sql_op} %s "
+            "ELSE false END"
+        )
+        assert params == ["score", "score", 10.0]
+
+
+@pytest.mark.parametrize("value", ["10", True])
+def test_non_numeric_filter_conditions_keep_text_comparison(value: Any) -> None:
+    store = object.__new__(BasePostgresStore)
+
+    sql, params = store._get_filter_condition("score", "$gte", value)
+
+    assert sql == "value->>%s >= %s"
+    assert params == ["score", str(value)]


### PR DESCRIPTION
## Summary
- compare Postgres store numeric range filters as numbers instead of text
- guard numeric casts with `jsonb_typeof(...) = 'number'` so non-numeric metadata values do not throw during numeric filters
- add regression coverage for generated SQL and Postgres store search behavior

Fixes #7684.

## Tests
- `uv run --directory libs/checkpoint-postgres pytest tests/test_store_filter_conditions.py -q`
- `uv run --directory libs/checkpoint-postgres ruff check langgraph/store/postgres/base.py tests/test_store.py tests/test_store_filter_conditions.py`
- `uv run --directory libs/checkpoint-postgres ruff format --check langgraph/store/postgres/base.py tests/test_store.py tests/test_store_filter_conditions.py`
- `uv run --directory libs/checkpoint-postgres mypy langgraph/store/postgres/base.py tests/test_store_filter_conditions.py --cache-dir .mypy_cache_test`
- `git diff --check`

The focused Postgres integration test was also invoked, but local Docker/Postgres is unavailable in this environment (`docker: command not found`, then fixture connection refused on `localhost:5441`), so it is expected to run in CI with the repo's compose setup.