### PR TITLE
fix(langgraph): correct broken docs URL in multi-pending-interrupts RuntimeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -768,7 +768,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
Fixes #7686

The `RuntimeError` raised in `PregelLoop` when resuming with multiple pending interrupts linked to a docs page that returns HTTP 404. Update the URL to the current section that documents the `{interrupt_id: resume_value}` map pattern.

- Old (404): `https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation`
- New: `https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts`

Verified the new URL resolves to the section that documents the keyed-resume pattern. The change is a string literal in an error message; no behavior changes.