### PR TITLE
Copy copiable config values in ensure_config

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -305,10 +305,9 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
             continue
         for k, v in config.items():
             if _is_not_empty(v) and k in CONFIG_KEYS:
-                if k == CONF:
-                    empty[k] = cast(dict, v).copy()
-                else:
-                    empty[k] = v  # type: ignore[literal-required]
+                empty[k] = (
+                    cast(Any, v).copy() if k in COPIABLE_KEYS else v
+                )  # type: ignore[literal-required]
         for k, v in config.items():
             if _is_not_empty(v) and k not in CONFIG_KEYS:
                 empty[CONF][k] = v

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -344,6 +344,29 @@ def test_configurable_metadata() -> None:
     assert metadata["nooverride"] == 18
 
 
+def test_ensure_config_does_not_mutate_input_metadata() -> None:
+    config: RunnableConfig = {"metadata": {"source": "original"}}
+
+    merged = ensure_config(config, {"configurable": {"thread_id": "thread-1"}})
+
+    assert merged["metadata"] == {
+        "source": "original",
+        "thread_id": "thread-1",
+    }
+    assert config["metadata"] == {"source": "original"}
+
+
+def test_ensure_config_does_not_reuse_metadata_between_calls() -> None:
+    config: RunnableConfig = {"metadata": {"source": "original"}}
+
+    first = ensure_config(config, {"configurable": {"thread_id": "thread-1"}})
+    second = ensure_config(config, {"configurable": {"thread_id": "thread-2"}})
+
+    assert first["metadata"]["thread_id"] == "thread-1"
+    assert second["metadata"]["thread_id"] == "thread-2"
+    assert config["metadata"] == {"source": "original"}
+
+
 def test_callback_manager_copies_whitelisted_configurable_ids_to_metadata() -> None:
     config = {
         "configurable": {


### PR DESCRIPTION
## Summary
- copy all `COPIABLE_KEYS` in `ensure_config()` instead of only copying `configurable`
- prevent caller-provided `metadata` objects from being mutated when `thread_id` and related values are propagated
- add regression tests covering metadata isolation across repeated `ensure_config()` calls

Closes #7441

## Testing
- python -m pytest -q -c NUL D:\codex-work\langgraph-7441\tmp_verify_ensure_config_copy.py
- direct Python assertion script against `langgraph._internal._config.ensure_config`

## Notes
- The repository's full `tests/test_utils.py` collection is currently blocked on this Windows host by unrelated environment/version issues in the local stack (`uvloop` on Windows and a `langchain_core` compatibility mismatch during collection).
- The fix itself was verified with focused isolated tests covering the reported mutation behavior.