### PR TITLE
Fix serde allowlist handling for collections.abc generics

### DIFF
--- a/libs/langgraph/langgraph/_internal/_serde.py
+++ b/libs/langgraph/langgraph/_internal/_serde.py
@@ -4,6 +4,7 @@ import dataclasses
 import logging
 import sys
 import types
+from collections import abc
 from collections import deque
 from enum import Enum
 from typing import (
@@ -158,6 +159,13 @@ def _collect_from_type(
         return
 
     if origin in (list, set, tuple, dict, deque, frozenset):
+        for arg in get_args(typ):
+            _collect_from_type(arg, allowlist, seen, seen_ids)
+        return
+
+    if isinstance(origin, type) and issubclass(
+        origin, (abc.Collection, abc.Mapping)
+    ):
         for arg in get_args(typ):
             _collect_from_type(arg, allowlist, seen, seen_ids)
         return

--- a/libs/langgraph/tests/test_serde_allowlist.py
+++ b/libs/langgraph/tests/test_serde_allowlist.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import abc
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
@@ -155,5 +156,13 @@ def test_collect_allowlist_typing_union_optional() -> None:
     typing_optional = Optional[InnerDataclass]  # noqa: UP045
     typing_union = Union[InnerDataclass, InnerModel]  # noqa: UP007
     allowlist = collect_allowlist_from_schemas(schemas=[typing_optional, typing_union])
+    assert (InnerDataclass.__module__, InnerDataclass.__name__) in allowlist
+    assert (InnerModel.__module__, InnerModel.__name__) in allowlist
+
+
+def test_collect_allowlist_collections_abc_generic_containers() -> None:
+    allowlist = collect_allowlist_from_schemas(
+        schemas=[abc.Sequence[InnerDataclass], abc.Mapping[str, InnerModel]]
+    )
     assert (InnerDataclass.__module__, InnerDataclass.__name__) in allowlist
     assert (InnerModel.__module__, InnerModel.__name__) in allowlist


### PR DESCRIPTION
## Summary
- handle collections.abc generic container aliases while collecting the serde allowlist
- avoid the TypeError triggered by generic containers defined from collections.abc
- add a focused regression test covering a collections.abc generic alias

Closes #7601

## Testing
- uv run pytest libs/langgraph/tests/test_serde_allowlist.py could not run here because pytest is not installed in this environment