### PR TITLE
release: alpha bump langgraph 1.2.0a6

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.0a5"
+version = "1.2.0a6"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a5"
+version = "1.2.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -281,7 +281,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a5"
+version = "1.2.0a6"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a5"
+version = "1.2.0a6"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Stacked on #7696. Bumps `langgraph` to `1.2.0a6` to ship the v3 stream-events kwarg-forwarding fix.

Refreshed `uv.lock` files for `libs/langgraph`, `libs/prebuilt`, and `libs/sdk-py`. Same shape as #7682. `langgraph-prebuilt` is unchanged (no prebuilt-side changes in this cycle).