### PR TITLE
release: alpha bump (a4) for langgraph, checkpoint, checkpoint-postgres

### DIFF
--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0a3"
+version = "3.1.0a4"
 description = "Library with a Postgres implementation of LangGraph checkpoint saver."
 authors = []
 requires-python = ">=3.10"
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ['LICENSE']
 dependencies = [
-  "langgraph-checkpoint>=4.1.0a3,<5.0.0",
+  "langgraph-checkpoint>=4.1.0a4,<5.0.0",
   "orjson>=3.11.5",
   "psycopg>=3.2.0",
   "psycopg-pool>=3.2.0",

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -276,7 +276,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },
@@ -324,7 +324,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0a3"
+version = "3.1.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "langgraph-checkpoint" },

--- a/libs/checkpoint-sqlite/uv.lock
+++ b/libs/checkpoint-sqlite/uv.lock
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 description = "Library with base interfaces for LangGraph checkpoint savers."
 authors = []
 requires-python = ">=3.10"

--- a/libs/checkpoint/uv.lock
+++ b/libs/checkpoint/uv.lock
@@ -286,7 +286,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.0a6"
+version = "1.2.0a7"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "langchain-core>=1.4.0a2,<2",
-    "langgraph-checkpoint>=4.1.0a3,<5.0.0",
+    "langgraph-checkpoint>=4.1.0a4,<5.0.0",
     "langgraph-sdk>=0.3.0,<0.4.0",
     "langgraph-prebuilt>=1.1.0a2,<1.2.0",
     "xxhash>=3.5.0",

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a6"
+version = "1.2.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
@@ -1563,7 +1563,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },
@@ -1611,7 +1611,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0a3"
+version = "3.1.0a4"
 source = { editable = "../checkpoint-postgres" }
 dependencies = [
     { name = "langgraph-checkpoint" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -281,7 +281,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a6"
+version = "1.2.0a7"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },
@@ -365,7 +365,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },
@@ -413,7 +413,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.0a3"
+version = "3.1.0a4"
 source = { editable = "../checkpoint-postgres" }
 dependencies = [
     { name = "langgraph-checkpoint" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a6"
+version = "1.2.0a7"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },
@@ -382,7 +382,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0a3"
+version = "4.1.0a4"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
- Bumps `langgraph` 1.2.0a6 → 1.2.0a7
- Bumps `langgraph-checkpoint` 4.1.0a3 → 4.1.0a4
- Bumps `langgraph-checkpoint-postgres` 3.1.0a3 → 3.1.0a4
- Bumps min `langgraph-checkpoint` constraint in `langgraph` and `checkpoint-postgres` to `>=4.1.0a4`
- Refreshes uv locks across the workspace

