### PR TITLE
feat: add fetch() primitive for automated data dependencies

### DIFF
--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -540,7 +540,7 @@ class Interrupt:
         * `resumable`
         * `interrupt_id`, deprecated in favor of `id`
 
-    !!! version-changed "Changed in version v0.6.x"
+    !!! version-changed "Changed in version v1.2.0a7"
         * `kind` field added to distinguish human-in-the-loop interrupts from
           automated data-fetch requests. Defaults to `"human"` for backwards
           compatibility.

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -79,6 +79,7 @@ __all__ = (
     "Command",
     "Durability",
     "interrupt",
+    "fetch",
     "Overwrite",
     "GraphOutput",
     "ensure_valid_checkpointer",
@@ -538,6 +539,11 @@ class Interrupt:
         * `when`
         * `resumable`
         * `interrupt_id`, deprecated in favor of `id`
+
+    !!! version-changed "Changed in version v0.6.x"
+        * `kind` field added to distinguish human-in-the-loop interrupts from
+          automated data-fetch requests. Defaults to `"human"` for backwards
+          compatibility.
     """
 
     value: Any
@@ -546,13 +552,25 @@ class Interrupt:
     id: str
     """The ID of the interrupt. Can be used to resume the interrupt directly."""
 
+    kind: Literal["human", "fetch"]
+    """Semantic kind of this interrupt.
+
+    - `"human"`: execution is paused waiting for a human decision. Resume is
+      indeterminate — may never happen.
+    - `"fetch"`: execution is paused waiting for an automated data dependency.
+      The serving layer is expected to fulfill the request and always resume,
+      within a bounded SLA.
+    """
+
     def __init__(
         self,
         value: Any,
         id: str = _DEFAULT_INTERRUPT_ID,
+        kind: Literal["human", "fetch"] = "human",
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         self.value = value
+        self.kind = kind
 
         if (
             (ns := deprecated_kwargs.get("ns", MISSING)) is not MISSING
@@ -564,8 +582,13 @@ class Interrupt:
             self.id = id
 
     @classmethod
-    def from_ns(cls, value: Any, ns: str) -> Interrupt:
-        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()))
+    def from_ns(
+        cls,
+        value: Any,
+        ns: str,
+        kind: Literal["human", "fetch"] = "human",
+    ) -> Interrupt:
+        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()), kind=kind)
 
     @property
     @deprecated("`interrupt_id` is deprecated. Use `id` instead.", category=None)
@@ -594,6 +617,15 @@ class PregelTask(NamedTuple):
     interrupts: tuple[Interrupt, ...] = ()
     state: None | RunnableConfig | StateSnapshot = None
     result: Any | None = None
+
+    @property
+    def fetches(self) -> tuple[Interrupt, ...]:
+        """Interrupts with `kind="fetch"` — automated data dependencies.
+
+        Serving layer code can use this to distinguish data-fetch requests
+        from human-in-the-loop interrupts without inspecting interrupt payloads.
+        """
+        return tuple(i for i in self.interrupts if i.kind == "fetch")
 
 
 if sys.version_info > (3, 11):
@@ -798,7 +830,7 @@ class Command(Generic[N], ToolOutputMixin):
     PARENT: ClassVar[Literal["__parent__"]] = "__parent__"
 
 
-def interrupt(value: Any) -> Any:
+def interrupt(value: Any, *, _kind: Literal["human", "fetch"] = "human") -> Any:
     """Interrupt the graph with a resumable exception from within a node.
 
     The `interrupt` function enables human-in-the-loop workflows by pausing graph
@@ -919,9 +951,47 @@ def interrupt(value: Any) -> Any:
             Interrupt.from_ns(
                 value=value,
                 ns=conf[CONFIG_KEY_CHECKPOINT_NS],
+                kind=_kind,
             ),
         )
     )
+
+
+def fetch(value: Any) -> Any:
+    """Declare a data dependency from within a node or tool.
+
+    Semantically distinct from `interrupt()`: a `fetch()` call signals that
+    the graph needs an automated data response — not a human decision. The
+    serving layer is expected to always fulfill the request and resume execution
+    within a bounded SLA.
+
+    Thin wrapper over `interrupt()` that sets `kind="fetch"` on the resulting
+    `Interrupt`, enabling the serving layer to route fetch requests separately
+    from human interrupts without inspecting payloads:
+
+    ```python
+    snapshot = graph.get_state(config)
+    for task in snapshot.tasks:
+        for req in task.fetches:          # kind="fetch" — always automated
+            result = data_layer.get(req.value)
+            graph.invoke(Command(resume={req.id: result}), config)
+        for intr in task.interrupts:
+            if intr.kind == "human":
+                ui.show(intr.value)
+    ```
+
+    Args:
+        value: Describes the data needed. Surfaced to the serving layer as
+            `Interrupt.value` on the suspended task.
+
+    Returns:
+        Any: The value provided by the serving layer when resuming.
+
+    Raises:
+        GraphInterrupt: On the first invocation within the node, checkpoints
+            state and suspends execution.
+    """
+    return interrupt(value, _kind="fetch")
 
 
 @dataclass(slots=True)

--- a/libs/langgraph/tests/test_fetch.py
+++ b/libs/langgraph/tests/test_fetch.py
@@ -1,0 +1,181 @@
+"""Tests for the fetch() primitive and Interrupt.kind field."""
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, Interrupt, fetch, interrupt
+
+pytestmark = pytest.mark.anyio
+
+
+class State(TypedDict):
+    result: str
+
+
+def _graph_with_fetch():
+    def node(state: State):
+        data = fetch({"resource": "transactions", "user_id": "123"})
+        return {"result": data}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+def _graph_with_both():
+    def node(state: State):
+        data = fetch({"resource": "accounts"})
+        answer = interrupt("what do you want to do?")
+        return {"result": f"{data}:{answer}"}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+# ── Interrupt.kind ────────────────────────────────────────────────────────────
+
+
+def test_interrupt_kind_default_is_human():
+    intr = Interrupt(value="please respond", id="abc")
+    assert intr.kind == "human"
+
+
+def test_interrupt_kind_fetch():
+    intr = Interrupt(value={"resource": "transactions"}, id="abc", kind="fetch")
+    assert intr.kind == "fetch"
+
+
+def test_interrupt_from_ns_default_kind():
+    intr = Interrupt.from_ns(value="hi", ns="some-ns")
+    assert intr.kind == "human"
+
+
+def test_interrupt_from_ns_fetch_kind():
+    intr = Interrupt.from_ns(value={"resource": "accounts"}, ns="some-ns", kind="fetch")
+    assert intr.kind == "fetch"
+
+
+# ── PregelTask.fetches ────────────────────────────────────────────────────────
+
+
+def test_pregeltask_fetches_filters_by_kind():
+    from langgraph.types import PregelTask
+
+    human_intr = Interrupt(value="question?", id="h1", kind="human")
+    fetch_intr = Interrupt(value={"resource": "txn"}, id="f1", kind="fetch")
+    task = PregelTask(
+        id="t1", name="node", path=(), interrupts=(human_intr, fetch_intr)
+    )
+    assert task.fetches == (fetch_intr,)
+    assert len(task.interrupts) == 2  # all still visible in interrupts
+
+
+def test_pregeltask_fetches_empty_when_no_fetch():
+    from langgraph.types import PregelTask
+
+    task = PregelTask(
+        id="t1",
+        name="node",
+        path=(),
+        interrupts=(Interrupt(value="hi", id="h1", kind="human"),),
+    )
+    assert task.fetches == ()
+
+
+# ── fetch() function ──────────────────────────────────────────────────────────
+
+
+def test_fetch_suspends_with_kind_fetch():
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t1"}}
+
+    graph.invoke({"result": ""}, config)
+
+    snapshot = graph.get_state(config)
+    assert len(snapshot.tasks) == 1
+    task = snapshot.tasks[0]
+
+    # task.fetches returns only fetch-kind interrupts
+    assert len(task.fetches) == 1
+    req = task.fetches[0]
+    assert req.kind == "fetch"
+    assert req.value == {"resource": "transactions", "user_id": "123"}
+
+    # all interrupts also contains it
+    assert req in task.interrupts
+
+
+def test_fetch_resumes_with_data():
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t2"}}
+
+    graph.invoke({"result": ""}, config)
+    result = graph.invoke(Command(resume="account_data"), config)
+    assert result["result"] == "account_data"
+
+
+def test_fetch_kind_does_not_appear_in_human_interrupts():
+    """Serving layer can filter: task.interrupts where kind == human."""
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t3"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+
+    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
+    assert human_interrupts == []
+
+
+def test_interrupt_still_defaults_to_human_kind():
+    """Existing interrupt() calls are unaffected — kind defaults to human."""
+
+    def node(state: State):
+        answer = interrupt("please confirm")
+        return {"result": answer}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "t4"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+
+    assert len(task.interrupts) == 1
+    assert task.interrupts[0].kind == "human"
+    assert task.fetches == ()
+
+
+def test_fetch_and_interrupt_coexist_in_same_node():
+    """A node can mix fetch() and interrupt() — task.fetches separates them."""
+    graph = _graph_with_both()
+    config = {"configurable": {"thread_id": "t5"}}
+
+    # First invoke — hits fetch(), suspends
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+    assert len(task.fetches) == 1
+    assert task.fetches[0].value == {"resource": "accounts"}
+
+    # Resume fetch — hits interrupt(), suspends
+    graph.invoke(Command(resume="account_data"), config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
+    assert len(human_interrupts) == 1
+    assert human_interrupts[0].value == "what do you want to do?"
+
+    # Resume human interrupt — completes
+    result = graph.invoke(Command(resume="nothing"), config)
+    assert result["result"] == "account_data:nothing"

--- a/libs/langgraph/tests/test_fetch.py
+++ b/libs/langgraph/tests/test_fetch.py
@@ -120,6 +120,35 @@ def test_fetch_resumes_with_data():
     assert result["result"] == "account_data"
 
 
+def test_fetch_checkpoint_persists_across_graph_recompile():
+    saver = InMemorySaver()
+
+    def node(state: State):
+        data = fetch({"resource": "transactions", "user_id": "123"})
+        return {"result": data}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+
+    graph = builder.compile(checkpointer=saver)
+    config = {"configurable": {"thread_id": "t6"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+
+    assert snapshot.tasks[0].fetches[0].value == {
+        "resource": "transactions",
+        "user_id": "123",
+    }
+
+    # Recompile with the same saver and resume using the persisted checkpoint.
+    graph_reloaded = builder.compile(checkpointer=saver)
+    result = graph_reloaded.invoke(Command(resume="account_data"), config)
+    assert result["result"] == "account_data"
+
+
 def test_fetch_kind_does_not_appear_in_human_interrupts():
     """Serving layer can filter: task.interrupts where kind == human."""
     graph = _graph_with_fetch()

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5598,6 +5598,7 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                     {
                         "id": AnyStr(),
                         "value": "test",
+                        "kind": "human",
                     },
                 ],
                 "name": "graph",
@@ -5642,6 +5643,7 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                             {
                                 "id": AnyStr(),
                                 "value": "test",
+                                "kind": "human",
                             },
                         ),
                         "name": "graph",


### PR DESCRIPTION
This PR adds the `fetch()` primitive as a typed variant of `interrupt()` for s2s data dependencies, while preserving existing human interrupt behavior.

Changes:
- Added `kind` field to `Interrupt` (`human` | `fetch`)
- Added `PregelTask.fetches` property to return only fetch-kind interrupts
- Added `fetch()` convenience wrapper over `interrupt()` with `kind='fetch'`
- Added checkpoint/resume coverage for `fetch()` in `tests/test_fetch.py`
- Updated existing debug-stream interrupt expectations to include `kind='human'`

Testing:
- `uv run pytest tests/test_fetch.py -q` -> 12 passed
- service-dependent sync tests for impacted cases are now passing

Closes #7700