### PR TITLE
Add optional Shipgate scan for CLI graph examples

### DIFF
--- a/libs/cli/examples/graphs/README.md
+++ b/libs/cli/examples/graphs/README.md
@@ -1,0 +1,24 @@
+# CLI Graph Examples
+
+This directory contains LangGraph CLI example graphs declared in
+`langgraph.json`.
+
+## Optional release-readiness scan
+
+The included `shipgate.yaml` and `tool-inventory.json` let you run an advisory
+static scan of the example tool surface before adapting these graphs for
+production-like use. The inventory documents the search tool used by the dynamic
+LangChain `tools` binding in `agent.py`.
+
+```bash
+pipx install agents-shipgate
+agents-shipgate scan -c libs/cli/examples/graphs/shipgate.yaml --ci-mode advisory
+```
+
+Agents Shipgate reads local source and manifest files only. It does not execute
+the graph, call an LLM, call tools, connect to MCP servers, make scanner network
+calls, or collect telemetry.
+
+The scan is advisory for these examples. It is intended to show which
+release-review metadata would need attention before wiring similar graphs to
+real external tools or production credentials.

--- a/libs/cli/examples/graphs/shipgate.yaml
+++ b/libs/cli/examples/graphs/shipgate.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ThreeMoonsLab/agents-shipgate/main/docs/manifest-v0.1.json
+# Optional Agents Shipgate manifest for these LangGraph CLI examples.
+version: "0.1"
+
+project:
+  name: langgraph-cli-graphs
+
+agent:
+  name: cli-graph-examples
+  declared_purpose:
+    - demonstrate LangGraph CLI graph entrypoints
+    - route model responses through declared graph nodes and tool nodes
+    - show search-backed graph patterns for local development
+  prohibited_actions: []
+
+environment:
+  target: local
+
+tool_sources:
+  - id: cli_graph_agent
+    type: langchain
+    path: agent.py
+  - id: cli_graph_storm
+    type: langchain
+    path: storm.py
+
+langchain:
+  tool_inventories:
+    - tool-inventory.json
+
+policies:
+  require_approval_for_tools: []
+  require_confirmation_for_tools: []
+  require_idempotency_for_tools: []
+
+permissions:
+  scopes:
+    - tavily:search:read
+  notes: "These examples require user-provided development credentials for external search/model providers."
+
+ci:
+  mode: advisory
+
+output:
+  directory: agents-shipgate-reports
+  formats:
+    - markdown
+    - json

--- a/libs/cli/examples/graphs/tool-inventory.json
+++ b/libs/cli/examples/graphs/tool-inventory.json
@@ -1,0 +1,32 @@
+{
+  "tools": [
+    {
+      "name": "tavily_search_results_json",
+      "description": "Search the web and return a small set of relevant results for the example graph.",
+      "inputSchema": {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query."
+          }
+        }
+      },
+      "outputSchema": {
+        "type": "object"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "idempotentHint": true
+      },
+      "auth": {
+        "type": "api_key",
+        "scopes": [
+          "tavily:search:read"
+        ]
+      },
+      "owner": "langgraph-examples"
+    }
+  ]
+}


### PR DESCRIPTION
This adds an optional static release-readiness example for `libs/cli/examples/graphs`.

Why:
- The CLI graph examples declare LangGraph entrypoints with a dynamic LangChain `tools` binding.
- Agents Shipgate gives users an advisory way to inspect that tool surface before adapting the examples for production-like credentials or external tools.
- The included `tool-inventory.json` documents the Tavily search tool so the dynamic binding is reviewable without executing the graph.

How to try it:

```bash
pipx install agents-shipgate
agents-shipgate scan -c libs/cli/examples/graphs/shipgate.yaml --ci-mode advisory
```

Trust model:
- No graph execution.
- No LLM calls.
- No tool calls.
- No MCP server connections.
- No scanner network calls.
- No telemetry.

Result:
- Command run: `PYTHONPATH=/Users/pengfeihu/code/shipgate/src python -m agents_shipgate scan -c libs/cli/examples/graphs/shipgate.yaml --ci-mode advisory --format json`
- Result summary: advisory exit 0; 0 critical, 0 high, 0 medium; no active findings.

Note: I originally checked `examples/customer-support`, but that directory is archived and points to the consolidated docs. This PR targets an active parseable Python example instead.

This PR intentionally does not add repo-wide CI. It is a scoped example/recipe so maintainers can decide whether release-readiness checks belong in project workflows later.