### PR TITLE
Fix interrupt resume docs link and typing extension dependency

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "langgraph-sdk>=0.1.0 ; python_version >= '3.11'",
     "pathspec>=0.11.0",
     "python-dotenv>=0.8.0",
+    "typing-extensions>=4.12.0",
     "tomli>=2.0.1 ; python_version < '3.11'",
 ]
 [tool.hatch.version]

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -768,7 +768,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary
- Point multi-interrupt runtime guidance to the current LangGraph interrupts documentation page.
- Add the missing `typing-extensions` dependency to langgraph-cli package requirements.

## Testing
- Not run (per instruction).
