### PR TITLE
fix(retry): cap sleep_time at max_interval after adding jitter

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -629,9 +629,15 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, then re-cap at max_interval so
+            # jitter cannot push the actual sleep past the configured ceiling.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    interval + random.uniform(0, 1),
+                    matching_policy.max_interval,
+                )
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -767,9 +773,15 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, then re-cap at max_interval so
+            # jitter cannot push the actual sleep past the configured ceiling.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    interval + random.uniform(0, 1),
+                    matching_policy.max_interval,
+                )
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 


### PR DESCRIPTION
## Summary

`RetryPolicy(jitter=True, max_interval=X)` could produce an actual sleep longer than `X`.

## Root cause

`max_interval` was applied as a cap on the **backoff interval** before jitter was added:

```python
# interval already capped at max_interval
interval = min(max_interval, initial_interval * backoff_factor ** (attempts - 1))

# jitter then added on top — can exceed max_interval
sleep_time = interval + random.uniform(0, 1)   # BUG
```

With `max_interval=0.5` and `jitter=True`, the actual sleep can reach `1.5 s` (`0.5 + 1.0`), violating the contract that `max_interval` is an upper bound on the sleep.

## Fix

Re-apply the `min(..., max_interval)` cap **after** adding the jitter offset:

```python
sleep_time = (
    min(interval + random.uniform(0, 1), max_interval)
    if matching_policy.jitter
    else interval
)
```

Both the sync (`_run`) and async (`_arun`) retry loops are fixed.

Fixes #7554