### PR TITLE
fix(postgres-store): cast JSON extraction to numeric for $gt/$gte/$lt/$lte filters

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -624,13 +624,15 @@ class BasePostgresStore(Generic[C]):
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
         elif op == "$gt":
-            return "value->>%s > %s", [key, str(value)]
+            # Cast to numeric so comparison is numeric, not lexicographic text.
+            # value->>key returns text; without the cast "9" > "10" is True.
+            return "(value->>%s)::numeric > %s", [key, value]
         elif op == "$gte":
-            return "value->>%s >= %s", [key, str(value)]
+            return "(value->>%s)::numeric >= %s", [key, value]
         elif op == "$lt":
-            return "value->>%s < %s", [key, str(value)]
+            return "(value->>%s)::numeric < %s", [key, value]
         elif op == "$lte":
-            return "value->>%s <= %s", [key, str(value)]
+            return "(value->>%s)::numeric <= %s", [key, value]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]
         else:


### PR DESCRIPTION
## Summary

`PostgresStore` numeric filter operators (`$gt`, `$gte`, `$lt`, `$lte`) compared values lexicographically instead of numerically.

## Root cause

`_get_filter_condition` used the PostgreSQL `->>` operator to extract the JSON field as **text** and then compared it as `str(value)`:

```python
# Before — all four operators did this:
return "value->>%s > %s", [key, str(value)]
#                                  ^^^ str — text comparison
```

Text comparison in PostgreSQL orders by ASCII value, so:
- `"9" > "10"` → **True** (wrong)
- `"100" < "9"` → **False** (wrong)

The `$eq` and `$ne` operators correctly used `->` (JSON extraction) with `::jsonb` casting and were not affected.

## Fix

Cast the extracted text to `numeric` before comparing, and pass the Python value directly so the driver binds it as a number:

```python
# After:
return "(value->>%s)::numeric > %s", [key, value]
```

The SQLite store already applies the equivalent fix (`CAST(... AS REAL)`). This brings Postgres to parity.

Fixes #7684