### PR TITLE
fix(channels): use get_origin/get_args in _strip_extras for Required/NotRequired

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -2,7 +2,7 @@ import collections.abc
 from collections.abc import Callable, Sequence
 from typing import Any, Generic
 
-from typing_extensions import NotRequired, Required, Self
+from typing_extensions import NotRequired, Required, Self, get_args, get_origin
 
 from langgraph._internal._constants import OVERWRITE
 from langgraph._internal._typing import MISSING
@@ -21,10 +21,16 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        if t.__origin__ in (Required, NotRequired):
-            return _strip_extras(t.__args__[0])
-        return _strip_extras(t.__origin__)
+    # Use get_origin/get_args from typing_extensions for reliable cross-version
+    # behavior. In some Python/typing_extensions combinations Required[X] has
+    # no __origin__ attribute, so the hasattr-based check silently returns the
+    # wrapper unchanged instead of unwrapping it.
+    origin = get_origin(t)
+    if origin in (Required, NotRequired):
+        args = get_args(t)
+        return _strip_extras(args[0]) if args else t
+    if origin is not None:
+        return _strip_extras(origin)
     return t
 
 


### PR DESCRIPTION
## Summary

In some Python/typing_extensions version combinations (confirmed on Python 3.11.12 with typing_extensions 4.15.0), `Required[X]` has no `__origin__` attribute. The existing `hasattr(t, "__origin__")` guard returns `False` and the function returns the wrapper type unchanged:

```python
_strip_extras(Required[int])                        # returns Required  (wrong, should be int)
_strip_extras(Required[Annotated[int, operator.add]])  # returns Required  (wrong)
```

The inner branch `if t.__origin__ in (Required, NotRequired)` is dead code in those environments, because it is only reached when `__origin__` exists but is not `Required`/`NotRequired`.

## Root cause

`typing_extensions.Required` is a special form. Whether `Required[X].__origin__` exists (and equals `Required`) depends on the Python version and typing_extensions version. `get_origin(Required[X])` from `typing_extensions` is the public, version-stable API and always returns `Required` correctly.

## Fix

Replace attribute access with `get_origin()` / `get_args()` from `typing_extensions`:

```python
# Before
def _strip_extras(t):
    if hasattr(t, "__origin__"):
        if t.__origin__ in (Required, NotRequired):
            return _strip_extras(t.__args__[0])
        return _strip_extras(t.__origin__)
    return t

# After
def _strip_extras(t):
    origin = get_origin(t)
    if origin in (Required, NotRequired):
        args = get_args(t)
        return _strip_extras(args[0]) if args else t
    if origin is not None:
        return _strip_extras(origin)
    return t
```

`get_args` and `get_origin` are already available from `typing_extensions` (which is already imported in this file); no new dependencies are added.

## Tests

Added `test_strip_extras_required_not_required` in `libs/langgraph/tests/test_channels.py` covering: plain types, `Required[int]`, `NotRequired[int]`, `Required[Annotated[int, ...]]`, and `NotRequired[Annotated[int, ...]]`.

Fixes #7578