### PR TITLE
fix(channels): raise InvalidUpdateError when regular value follows Overwrite in BinaryOperatorAggregate

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -125,8 +125,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
-                self.value = self.operator(self.value, value)
+            if seen_overwrite:
+                msg = create_error_message(
+                    message="Cannot apply a regular update after an Overwrite in the same super-step.",
+                    error_code=ErrorCode.INVALID_CONCURRENT_GRAPH_UPDATE,
+                )
+                raise InvalidUpdateError(msg)
+            self.value = self.operator(self.value, value)
         return True
 
     def get(self) -> Value:


### PR DESCRIPTION
## Summary

`BinaryOperatorAggregate.update()` silently dropped regular values that appeared after an `Overwrite` in the same super-step:

```python
channel = BinaryOperatorAggregate(int, operator.add)
channel.value = 0
channel.update([5, Overwrite(10), 3])  # 3 is silently lost
channel.get()  # 10 — data loss, no error
```

## Root cause

The `if not seen_overwrite:` guard in the update loop prevented the binary operator from being applied to values following an `Overwrite`, but never raised an error:

```python
# Before (silent drop)
if not seen_overwrite:
    self.value = self.operator(self.value, value)
```

Mixing an `Overwrite` with a regular accumulated update in the same atomic super-step is semantically contradictory — you cannot both wipe-and-set *and* accumulate in one step. The code already correctly rejects two concurrent `Overwrite` values; a regular value after an `Overwrite` is equally invalid.

## Fix

Raise `InvalidUpdateError` instead of silently discarding the value, consistent with the existing two-`Overwrite` guard:

```python
# After (raises on conflict)
if seen_overwrite:
    raise InvalidUpdateError(
        "Cannot apply a regular update after an Overwrite in the same super-step."
    )
self.value = self.operator(self.value, value)
```

## Tests

Added `test_binop_overwrite_then_regular_raises` in `libs/langgraph/tests/test_channels.py` verifying: standalone `Overwrite` works, standalone regular update works, `Overwrite` followed by regular raises `InvalidUpdateError`, and regular followed by `Overwrite` (currently allowed) still works.

Fixes #7580