### PR TITLE
fix(config): copy COPIABLE_KEYS values in ensure_config to prevent shared metadata mutation

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -307,6 +307,8 @@ def ensure_config(*configs: RunnableConfig | None) -> RunnableConfig:
             if _is_not_empty(v) and k in CONFIG_KEYS:
                 if k == CONF:
                     empty[k] = cast(dict, v).copy()
+                elif k in COPIABLE_KEYS:
+                    empty[k] = v.copy()  # type: ignore[attr-defined,literal-required]
                 else:
                     empty[k] = v  # type: ignore[literal-required]
         for k, v in config.items():


### PR DESCRIPTION
## Summary

`ensure_config()` assigned `"metadata"` (and other `COPIABLE_KEYS`) from the caller's config by reference — without `.copy()`. The propagation block that follows then wrote configurable keys (`thread_id`, `run_id`, etc.) into that dict, **mutating the original config the caller passed in**:

```python
original = {"metadata": {"ls_integration": "langchain_create_agent"}}
ensure_config(original, {"configurable": {"thread_id": "t-1"}})
# original["metadata"] is now {"ls_integration": "...", "thread_id": "t-1"}
```

This caused `thread_id` from one invocation to leak into the **shared** base config metadata of the graph, contaminating all subsequent calls.

## Root cause

```python
# Before: reference assignment for all non-configurable keys
if k == "configurable":
    empty[k] = v.copy()
else:
    empty[k] = v  # metadata assigned by reference
```

The `var_config` path above it already handled this correctly with `v.copy() if k in COPIABLE_KEYS`. The explicit `configs` loop had no equivalent guard.

## Fix

Apply a shallow copy for `COPIABLE_KEYS` (which includes `"metadata"` and `"tags"`) in the same way the `var_config` path does:

```python
if k == "configurable":
    empty[k] = v.copy()
elif k in COPIABLE_KEYS:
    empty[k] = v.copy()  # prevent mutation of caller's dict
else:
    empty[k] = v
```

## Tests

Added `test_ensure_config_does_not_mutate_caller_metadata` in `libs/langgraph/tests/test_utils.py` confirming: result contains propagated `thread_id`, original dict is unchanged, two sequential calls with different `thread_id` values are fully independent.

Fixes #7441