### PR TITLE
fix(retry): cap sleep_time at max_interval when jitter is enabled

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -629,9 +629,14 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, but never exceed max_interval.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -767,9 +772,14 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, but never exceed max_interval.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(
+                    matching_policy.max_interval,
+                    interval + random.uniform(0, 1),
+                )
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2267,3 +2267,48 @@ def test_node_without_error_handler_still_fails_run():
 
     with pytest.raises(ValueError, match="no handler"):
         graph.invoke({"foo": ""})
+
+
+def test_retry_jitter_does_not_exceed_max_interval() -> None:
+    """Jitter must never push sleep_time past max_interval (issue #7554)."""
+
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    def failing_node(state: State) -> State:
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count < 2:
+            raise ValueError("deliberate")
+        return {"foo": "ok"}
+
+    policy = RetryPolicy(
+        max_attempts=3,
+        initial_interval=0.5,
+        max_interval=0.5,  # tight cap — same as initial_interval
+        jitter=True,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    # Worst-case jitter: random.uniform always returns 1.0
+    with (
+        patch("random.uniform", return_value=1.0),
+        patch("time.sleep") as mock_sleep,
+    ):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "ok"
+    for call in mock_sleep.call_args_list:
+        actual_sleep = call[0][0]
+        assert actual_sleep <= 0.5, (
+            f"sleep_time {actual_sleep} exceeded max_interval 0.5 — jitter was not capped"
+        )


### PR DESCRIPTION
## Summary

`RetryPolicy.max_interval` is documented as *"the maximum amount of time that may elapse between retries"*, but the implementation violated that contract when `jitter=True`. Jitter was added **after** the `min(max_interval, ...)` cap, so the actual sleep could exceed `max_interval` by up to 1 second:

```python
# Before (broken)
interval = min(max_interval, initial_interval * backoff**n)  # cap applied
sleep_time = interval + random.uniform(0, 1)                 # ← breaks cap
```

With `max_interval=0.5` and worst-case jitter, `sleep_time` could reach `1.5 s`.

## Fix

Wrap the jitter addition in a second `min(max_interval, ...)`:

```python
# After (correct)
sleep_time = (
    min(max_interval, interval + random.uniform(0, 1))
    if matching_policy.jitter
    else interval
)
```

Applied identically to both `run_with_retry` (sync) and `arun_with_retry` (async).

## Tests

Added `test_retry_jitter_does_not_exceed_max_interval` to `tests/test_retry.py`:

- Sets `initial_interval=0.5`, `max_interval=0.5`, `jitter=True`
- Mocks `random.uniform` to always return `1.0` (worst-case jitter)
- Asserts every `time.sleep` call receives a value `<= 0.5`

The existing `test_graph_with_jitter_retry_policy` is unaffected because its `max_interval` (default `128.0`) is far above the mocked jitter amount.

Fixes #7554