### PR TITLE
fix(store/postgres): use ::numeric cast for $gt/$gte/$lt/$lte with numeric values

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -624,12 +624,23 @@ class BasePostgresStore(Generic[C]):
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
         elif op == "$gt":
+            # For numeric values use a numeric cast so comparison is arithmetic,
+            # not lexicographic.  value->>key returns TEXT; "9" > "10" in text
+            # ordering but 9 < 10 numerically.
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric > %s", [key, value]
             return "value->>%s > %s", [key, str(value)]
         elif op == "$gte":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric >= %s", [key, value]
             return "value->>%s >= %s", [key, str(value)]
         elif op == "$lt":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric < %s", [key, value]
             return "value->>%s < %s", [key, str(value)]
         elif op == "$lte":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric <= %s", [key, value]
             return "value->>%s <= %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]

--- a/libs/checkpoint-postgres/tests/test_store_filter_condition.py
+++ b/libs/checkpoint-postgres/tests/test_store_filter_condition.py
@@ -1,0 +1,64 @@
+"""Unit tests for PostgresStore._get_filter_condition numeric operators (issue #7684).
+
+These tests run without a live database by calling the method directly on an
+object instance created via object.__new__() -- no connection needed.
+"""
+import pytest
+
+from langgraph.store.postgres.base import BasePostgresStore
+
+
+def _store() -> BasePostgresStore:
+    """Return a bare BasePostgresStore instance (no DB connection required)."""
+    return object.__new__(BasePostgresStore)  # type: ignore[abstract]
+
+
+class TestGetFilterConditionNumericOperators:
+    """Numeric values must use (value->>key)::numeric so comparisons are arithmetic."""
+
+    @pytest.mark.parametrize("op,expected_op", [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ])
+    def test_integer_value_uses_numeric_cast(self, op: str, expected_op: str) -> None:
+        store = _store()
+        sql, params = store._get_filter_condition("score", op, 10)
+        assert "::numeric" in sql, (
+            f"Expected numeric cast in SQL for {op} with int value, got: {sql!r}"
+        )
+        assert params == ["score", 10], f"Unexpected params: {params}"
+
+    @pytest.mark.parametrize("op,expected_op", [
+        ("$gt", ">"),
+        ("$gte", ">="),
+        ("$lt", "<"),
+        ("$lte", "<="),
+    ])
+    def test_float_value_uses_numeric_cast(self, op: str, expected_op: str) -> None:
+        store = _store()
+        sql, params = store._get_filter_condition("score", op, 9.5)
+        assert "::numeric" in sql, (
+            f"Expected numeric cast in SQL for {op} with float value, got: {sql!r}"
+        )
+        assert params == ["score", 9.5]
+
+    @pytest.mark.parametrize("op", ["$gt", "$gte", "$lt", "$lte"])
+    def test_string_value_keeps_text_comparison(self, op: str) -> None:
+        store = _store()
+        sql, params = store._get_filter_condition("tag", op, "beta")
+        assert "::numeric" not in sql, (
+            f"String value must NOT get numeric cast for {op}, got: {sql!r}"
+        )
+        assert params == ["tag", "beta"]
+
+    def test_numeric_param_is_not_stringified(self) -> None:
+        """Regression: str(10) == "10" must NOT appear in params (causes text comparison)."""
+        store = _store()
+        sql, params = store._get_filter_condition("score", "$gte", 10)
+        assert "10" not in params, (
+            f"Numeric value was stringified in params: {params}; "
+            "this causes lexicographic comparison ('9' >= '10' == True)"
+        )
+        assert 10 in params


### PR DESCRIPTION
## Summary

`BasePostgresStore._get_filter_condition()` used `->>` (TEXT extraction) with `str(value)` for the four inequality operators:

```python
# Before (broken)
elif op == "$gt":
    return "value->>%s > %s", [key, str(value)]
```

Since `->>` returns `TEXT` in PostgreSQL, the comparison is **lexicographic**. `'9' > '10'` evaluates to `True`, so a filter `{"score": {"$gte": 10}}` would silently include items with `score=2...9`.

## Fix

When `value` is `int` or `float`, cast the extracted field to `NUMERIC` and pass the value directly (not as a string):

```python
# After (correct)
elif op == "$gt":
    if isinstance(value, (int, float)):
        return "(value->>%s)::numeric > %s", [key, value]
    return "value->>%s > %s", [key, str(value)]
```

String values keep the existing text-comparison behaviour (unchanged).
This matches the pattern `SqliteStore._get_filter_condition()` already uses (`CAST(json_extract(...) AS REAL)`).

## Tests

Added `libs/checkpoint-postgres/tests/test_store_filter_condition.py` with `TestGetFilterConditionNumericOperators`:

- Verifies all four operators produce `::numeric` in SQL for `int` and `float` values
- Verifies string values do NOT get the numeric cast
- Regression test: numeric param is NOT stringified (stringified `"10"` would reintroduce the lexicographic bug)

Tests run without a live PostgreSQL instance (`object.__new__()` pattern).

Fixes #7684