### PR TITLE
fix(pregel): update broken docs URL in multi-interrupt RuntimeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -768,7 +768,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/#resuming-with-multiple-interrupt-ids"
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary

The `RuntimeError` raised when a user tries to resume with a single value while multiple interrupts are pending contains a hard-coded docs URL that returns HTTP 404:

```
RuntimeError: When there are multiple pending interrupts, you must specify
the interrupt id when resuming. Docs:
https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop
#resume-multiple-interrupts-with-one-invocation.
```

## Fix

Update the URL to the current LangGraph concepts page that covers this topic (verified returning HTTP 200):

```
https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/
#resuming-with-multiple-interrupt-ids
```

The stale URL was likely left behind by #5192 (HITL docs consolidation) where the page was moved but this in-source reference was not updated.

Fixes #7686