### PR TITLE
fix(serde): support bson.ObjectId in msgpack serializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -71,6 +71,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("langchain_core.messages.modifier", "RemoveMessage"),
         # langchain-core document model
         ("langchain_core.documents.base", "Document"),
+        # bson (used by the MongoDB checkpointer)
+        ("bson.objectid", "ObjectId"),
         # langgraph
         ("langgraph.types", "Send"),
         ("langgraph.types", "TimeoutPolicy"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -391,6 +391,17 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, obj.hex),
             ),
         )
+    elif (bson_mod := sys.modules.get("bson")) is not None and isinstance(
+        obj, bson_mod.ObjectId
+    ):
+        # bson.ObjectId (used by the MongoDB checkpointer). Round-trip via
+        # the 24-char hex string: ObjectId(str(obj)) reconstructs the value.
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
     elif isinstance(obj, decimal.Decimal):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,

--- a/libs/checkpoint/tests/test_objectid_msgpack.py
+++ b/libs/checkpoint/tests/test_objectid_msgpack.py
@@ -1,0 +1,69 @@
+"""Tests for bson.ObjectId msgpack serialization (issue #7467).
+
+Skipped automatically when the bson package is not installed.
+"""
+import pytest
+
+bson = pytest.importorskip("bson", reason="bson package not installed")
+
+
+class TestObjectIdMsgpackRoundTrip:
+    """bson.ObjectId must survive a JsonPlusSerializer dumps/loads round-trip."""
+
+    def test_objectid_roundtrip_standalone(self) -> None:
+        from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+        obj_id = bson.ObjectId()
+        serde = JsonPlusSerializer()
+        kind, data = serde.dumps(obj_id)
+        result = serde.loads(kind, data)
+        assert isinstance(result, bson.ObjectId)
+        assert result == obj_id
+
+    def test_objectid_inside_pydantic_model(self) -> None:
+        from typing import Annotated, Any
+
+        from pydantic import BaseModel
+        from pydantic.json_schema import JsonSchemaValue
+        from pydantic_core import core_schema
+
+        from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+        class _ObjectIdAnnotation:
+            @classmethod
+            def validate(cls, v: Any, handler):
+                if isinstance(v, bson.ObjectId):
+                    return v
+                s = handler(v)
+                if bson.ObjectId.is_valid(s):
+                    return bson.ObjectId(s)
+                raise ValueError("Invalid ObjectId")
+
+            @classmethod
+            def __get_pydantic_core_schema__(cls, source_type, _handler):
+                return core_schema.no_info_wrap_validator_function(
+                    cls.validate,
+                    core_schema.str_schema(),
+                    serialization=core_schema.to_string_ser_schema(),
+                )
+
+            @classmethod
+            def __get_pydantic_json_schema__(cls, _core_schema, handler) -> JsonSchemaValue:
+                return handler(core_schema.str_schema())
+
+        PydanticObjectId = Annotated[bson.ObjectId, _ObjectIdAnnotation]
+
+        class ModelWithObjectId(BaseModel):
+            object_id: PydanticObjectId
+
+        original = ModelWithObjectId(object_id=bson.ObjectId())
+        serde = JsonPlusSerializer()
+        kind, data = serde.dumps(original)
+        result = serde.loads(kind, data)
+        assert isinstance(result, ModelWithObjectId)
+        assert result.object_id == original.object_id
+
+    def test_objectid_in_allowed_safe_types(self) -> None:
+        from langgraph.checkpoint.serde._msgpack import SAFE_MSGPACK_TYPES
+
+        assert ("bson.objectid", "ObjectId") in SAFE_MSGPACK_TYPES


### PR DESCRIPTION
## Summary

`JsonPlusSerializer` had no msgpack handler for `bson.ObjectId`. When a Pydantic model containing an `ObjectId` field was stored in graph state (e.g. with the MongoDB checkpointer), calling `.dumps()` would fail with:

```
ormsgpack.MsgpackEncodeError: Type is not serializable: ObjectId
```

The root cause: `_msgpack_default` called `model_dump()` on the Pydantic model, which returns the raw `ObjectId` Python object rather than a string (unless `mode="json"` is used). When ormsgpack then tried to encode the nested `ObjectId`, no handler existed for it.

## Fix

**`jsonplus.py`** — Add a `bson.ObjectId` branch in `_msgpack_default` using `EXT_CONSTRUCTOR_SINGLE_ARG` with `str(obj)` as the payload. Reconstruction uses `ObjectId(hex_str)`, which is the standard bson API. The check uses `sys.modules.get("bson")` so the bson package is never imported unless already loaded (same lazy pattern used for numpy).

**`_msgpack.py`** — Add `("bson.objectid", "ObjectId")` to `SAFE_MSGPACK_TYPES` so deserialization is permitted when `LANGGRAPH_STRICT_MSGPACK=true`.

## Tests

Added `libs/checkpoint/tests/test_objectid_msgpack.py` (skipped automatically if bson is not installed):

- `test_objectid_roundtrip_standalone`: bare `ObjectId` serializes and deserializes correctly
- `test_objectid_inside_pydantic_model`: full repro from the issue — Pydantic model with a custom `ObjectId` annotation roundtrips correctly
- `test_objectid_in_allowed_safe_types`: `bson.objectid.ObjectId` is in `SAFE_MSGPACK_TYPES`

Fixes #7467