### PR TITLE
fix(checkpoint-postgres): use NUMERIC cast for numeric filter comparisons (v2)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -626,28 +626,28 @@ class BasePostgresStore(Generic[C]):
         elif op == "$gt":
             if isinstance(value, (int, float)):
                 return (
-                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s)",
+                    "(jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric > %s)",
                     [key, key, value],
                 )
             return "value->>%s > %s", [key, str(value)]
         elif op == "$gte":
             if isinstance(value, (int, float)):
                 return (
-                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) >= %s)",
+                    "(jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric >= %s)",
                     [key, key, value],
                 )
             return "value->>%s >= %s", [key, str(value)]
         elif op == "$lt":
             if isinstance(value, (int, float)):
                 return (
-                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s)",
+                    "(jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric < %s)",
                     [key, key, value],
                 )
             return "value->>%s < %s", [key, str(value)]
         elif op == "$lte":
             if isinstance(value, (int, float)):
                 return (
-                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) <= %s)",
+                    "(jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric <= %s)",
                     [key, key, value],
                 )
             return "value->>%s <= %s", [key, str(value)]

--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -624,12 +624,32 @@ class BasePostgresStore(Generic[C]):
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
         elif op == "$gt":
+            if isinstance(value, (int, float)):
+                return (
+                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s)",
+                    [key, key, value],
+                )
             return "value->>%s > %s", [key, str(value)]
         elif op == "$gte":
+            if isinstance(value, (int, float)):
+                return (
+                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) >= %s)",
+                    [key, key, value],
+                )
             return "value->>%s >= %s", [key, str(value)]
         elif op == "$lt":
+            if isinstance(value, (int, float)):
+                return (
+                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s)",
+                    [key, key, value],
+                )
             return "value->>%s < %s", [key, str(value)]
         elif op == "$lte":
+            if isinstance(value, (int, float)):
+                return (
+                    "(jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) <= %s)",
+                    [key, key, value],
+                )
             return "value->>%s <= %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]

--- a/libs/checkpoint-postgres/tests/unit/conftest.py
+++ b/libs/checkpoint-postgres/tests/unit/conftest.py
@@ -1,0 +1,13 @@
+# Override autouse db fixtures for unit tests that don't need a database.
+# The parent conftest.py's autouse=True clear_test_db runs for integration
+# tests; unit tests in tests/unit/ are isolated from that requirement.
+
+import pytest
+
+
+# Override the autouse function-scoped clear_test_db so it does nothing.
+# Unit tests should never need this fixture.
+@pytest.fixture(scope="function", autouse=True)
+def clear_test_db():
+    # No-op override — prevents parent conftest from creating a DB connection
+    pass

--- a/libs/checkpoint-postgres/tests/unit/test_store_filter_conditions.py
+++ b/libs/checkpoint-postgres/tests/unit/test_store_filter_conditions.py
@@ -1,4 +1,3 @@
-# type: ignore
 """Regression tests for numeric filter operators in PostgresStore.
 
 Fixes https://github.com/langchain-ai/langgraph/issues/7684
@@ -23,7 +22,7 @@ class _MockPostgresStore(BasePostgresStore):
 
 @pytest.fixture()
 def store() -> _MockPostgresStore:
-    return object.__new__(_MockPostgresStore)
+    return object.__new__(_MockPostgresStore)  # type: ignore[arg-type,misc]
 
 
 @pytest.mark.parametrize(
@@ -33,33 +32,33 @@ def store() -> _MockPostgresStore:
         (
             "$gt",
             10,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric > %s",
         ),
         (
             "$gte",
             10,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) >= %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric >= %s",
         ),
         (
             "$lt",
             10,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric < %s",
         ),
         (
             "$lte",
             10,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) <= %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric <= %s",
         ),
         # Float values must also use numeric cast
         (
             "$gt",
             3.14,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric > %s",
         ),
         (
             "$lt",
             2.718,
-            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s",
+            "jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric < %s",
         ),
         # String values must NOT use CAST (text comparison is correct for strings)
         ("$gt", "apple", "value->>%s > %s"),
@@ -109,8 +108,10 @@ def test_numeric_filter_params_are_not_stringified(
     assert value in params, (
         f"Numeric value {value!r} should be in params, got {params!r}"
     )
-    # Confirm it's not the string version
-    assert str(value) not in params or value in params
+    # Stringified form must NOT be present for numeric inputs
+    assert str(value) not in params, (
+        f"Stringified value {str(value)!r} should NOT be in params, got {params!r}"
+    )
 
 
 @pytest.mark.parametrize("op", ["$eq", "$ne"])

--- a/libs/checkpoint-postgres/tests/unit/test_store_filter_conditions.py
+++ b/libs/checkpoint-postgres/tests/unit/test_store_filter_conditions.py
@@ -1,0 +1,130 @@
+# type: ignore
+"""Regression tests for numeric filter operators in PostgresStore.
+
+Fixes https://github.com/langchain-ai/langgraph/issues/7684
+PostgresStore numeric filter operators used text comparison (lexicographic)
+instead of numeric, causing e.g. '9' >= '10' to be True.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph.store.postgres.base import BasePostgresStore
+
+
+class _MockPostgresStore(BasePostgresStore):
+    """Minimal concrete subclass to access _get_filter_condition."""
+
+    pass
+
+
+@pytest.fixture()
+def store() -> _MockPostgresStore:
+    return object.__new__(_MockPostgresStore)
+
+
+@pytest.mark.parametrize(
+    "op,value,expected_sql_fragment",
+    [
+        # Numeric values must use CAST AS NUMERIC with jsonb_typeof guard
+        (
+            "$gt",
+            10,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s",
+        ),
+        (
+            "$gte",
+            10,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) >= %s",
+        ),
+        (
+            "$lt",
+            10,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s",
+        ),
+        (
+            "$lte",
+            10,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) <= %s",
+        ),
+        # Float values must also use numeric cast
+        (
+            "$gt",
+            3.14,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) > %s",
+        ),
+        (
+            "$lt",
+            2.718,
+            "jsonb_typeof(value->>%s) = 'number') AND (CAST(value->>%s AS NUMERIC) < %s",
+        ),
+        # String values must NOT use CAST (text comparison is correct for strings)
+        ("$gt", "apple", "value->>%s > %s"),
+        ("$gte", "banana", "value->>%s >= %s"),
+    ],
+)
+def test_filter_condition_sql_structure(
+    store: _MockPostgresStore,
+    op: str,
+    value: Any,
+    expected_sql_fragment: str,
+) -> None:
+    """Verify filter condition SQL uses correct operator and type for the value."""
+    sql, params = store._get_filter_condition("score", op, value)
+    assert expected_sql_fragment in sql
+    # Numeric values passed as-is (not str()); string values passed as str()
+    if isinstance(value, (int, float)):
+        # key appears twice: once for jsonb_typeof check, once for CAST
+        assert params.count("score") == 2
+        assert value in params
+    else:
+        assert str(value) in params
+
+
+@pytest.mark.parametrize(
+    "op,value",
+    [
+        ("$gt", 10),
+        ("$gte", 10),
+        ("$lt", 10),
+        ("$lte", 10),
+        ("$gt", 3.14),
+        ("$gte", 0.0),
+        ("$lt", -5),
+    ],
+)
+def test_numeric_filter_params_are_not_stringified(
+    store: _MockPostgresStore, op: str, value: Any
+) -> None:
+    """Numeric values must be in params as Python numbers, not strings.
+
+    Previously all values were passed as str(value), causing '9' >= '10' == True.
+    After the fix, numeric comparisons use proper NUMERIC casting.
+    """
+    _sql, params = store._get_filter_condition("score", op, value)
+    # The numeric value must be in params as-is (int/float), not as a string
+    assert value in params, (
+        f"Numeric value {value!r} should be in params, got {params!r}"
+    )
+    # Confirm it's not the string version
+    assert str(value) not in params or value in params
+
+
+@pytest.mark.parametrize("op", ["$eq", "$ne"])
+def test_equality_ops_unchanged(store: _MockPostgresStore, op: str) -> None:
+    """Equality operators use jsonb equality and should be unaffected."""
+    sql, params = store._get_filter_condition("name", op, "Alice")
+    assert "value->" in sql
+    assert "jsonb" in sql
+    # json.dumps wraps strings in quotes, so check the quoted form
+    assert '"Alice"' in params or "Alice" in params
+
+
+@pytest.mark.parametrize("op", ["$invalid", "$foo", "$unknown_op", "$regex"])
+def test_unsupported_operator_raises(store: _MockPostgresStore, op: str) -> None:
+    """Unknown operators must raise ValueError."""
+    with pytest.raises(ValueError, match="Unsupported operator"):
+        store._get_filter_condition("score", op, 10)


### PR DESCRIPTION
## Summary

v2 of #7725 — addressing all three Copilot PR Reviewer comments.

### Bug fixed

`BasePostgresStore._get_filter_condition` used text extraction (`value->>%s`) with `str(value)` for numeric comparisons. PostgreSQL compares text lexicographically, so `'9' >= '10'` is True and filters like `{"score": {"$gte": 10}}` silently return wrong results.

### Changes

**libs/checkpoint-postgres/langgraph/store/postgres/base.py**
```python
# Before (broken — lexicographic comparison)
elif op == "$gte":
    return "value->>%s >= %s", [key, str(value)]

# After (correct — numeric comparison)
elif op == "$gte":
    if isinstance(value, (int, float)):
        return "(jsonb_typeof(value->%s) = 'number') AND (value->>%s::numeric >= %s)", [key, key, value]
    return "value->>%s >= %s", [key, str(value)]
```

Key decisions:
- `jsonb_typeof(value->%s)` — uses JSONB extraction (`->`) not text (`->>`) since `jsonb_typeof` requires JSONB input
- `value->>%s::numeric` — inline `::numeric` cast on text extraction avoids the non-existent `jsonb_typeof(text)` function error
- Non-numeric values (strings) fall through to text comparison unchanged
- The `jsonb_typeof` guard prevents cast errors on non-numeric JSON values

**libs/checkpoint-postgres/tests/unit/test_store_filter_conditions.py** (new)
- 21 unit tests: SQL structure verification, parameter type checks, equality ops, unsupported operators

### Addressing bot comments from #7725

1. **`jsonb_typeof(text) does not exist`**: Fixed by using `value->%s` (JSONB extraction) instead of `value->>%s` (text) as the input to `jsonb_typeof`

2. **Always-true assertion**: `str(value) not in params or value in params` → replaced with strict `str(value) not in params` asserting the stringified form is absent for numeric inputs

3. **File-level `# type: ignore`**: Removed entirely; added targeted `# type: ignore[arg-type,misc]` only on the `object.__new__` line

### Test plan

```
uv run pytest tests/unit/test_store_filter_conditions.py -v
# → 21 passed
```

Fixes #7684