### PR TITLE
fix(checkpoint-postgres): add column aliases to seed-blob branch of delta stage-2 UNION ALL

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -279,8 +279,8 @@ def _build_delta_stage2_sql(
         )
     for _ in channels_with_seed:
         branches.append(
-            "SELECT 'b'::text, NULL, channel, "
-            "type, blob, NULL, NULL, version "
+            "SELECT 'b'::text AS _kind, NULL::text AS checkpoint_id, channel, "
+            "type, blob, NULL::text AS task_id, NULL::int AS idx, version "
             "FROM checkpoint_blobs "
             "WHERE thread_id = %s AND checkpoint_ns = %s AND channel = %s "
             "AND version = %s"


### PR DESCRIPTION
## Summary

- Ports the langgraph API checkpointer fix to the OSS Postgres checkpoint.
- The `'b'` (seed-blob) branch of `_build_delta_stage2_sql`'s `UNION ALL` was missing column aliases (`AS _kind`, `AS checkpoint_id`, `AS task_id`, `AS idx`).
- In PostgreSQL, `UNION ALL` column names are taken from the **first** `SELECT`. When `channels_with_chain` is empty but `channels_with_seed` is not (e.g. very first run of a DeltaChannel graph, or `snapshot_frequency=1`), the `'b'` branch becomes the first `SELECT`, so columns got default names (`text`, `null`) instead of the expected aliases — causing `KeyError: '_kind'` in `_build_delta_channels_writes_history`.

## Test plan

- [ ] Existing `checkpoint-postgres` delta channel tests pass (`make test` in `libs/checkpoint-postgres`)
- [ ] Manually verified fix matches the correction suggested in the upstream API PR review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)