### PR TITLE
fix(examples): correct pprint usage in adaptive rag cohere notebook

### DIFF
--- a/examples/rag/langgraph_adaptive_rag_cohere.ipynb
+++ b/examples/rag/langgraph_adaptive_rag_cohere.ipynb
@@ -604,7 +604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "b76b5ec3-0720-443d-85b1-c0e79659ca0a",
    "metadata": {
     "id": "b76b5ec3-0720-443d-85b1-c0e79659ca0a"
@@ -821,7 +821,7 @@
     "            print(\"---DECISION: GENERATION DOES NOT ADDRESS QUESTION---\")\n",
     "            return \"not useful\"\n",
     "    else:\n",
-    "        pprint(\"---DECISION: GENERATION IS NOT GROUNDED IN DOCUMENTS, RE-TRY---\")\n",
+    "        print(\"---DECISION: GENERATION IS NOT GROUNDED IN DOCUMENTS, RE-TRY---\")\n",
     "        return \"not supported\""
    ]
   },


### PR DESCRIPTION
Fixes langchain-ai/langgraph#5618

Replaced an incorrect direct call to the pprint module with print(...) in the adaptive RAG Cohere notebook to avoid TypeError: 'module' object is not callable.