### PR TITLE
feat(langgraph): add set_node_defaults() to StateGraph

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -279,21 +279,30 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         """Set default node policies that apply to every node in this graph.
 
         Per-node values passed to `add_node` always take precedence over these
-        defaults. Policies set here are **not** inherited by subgraphs.
+        defaults. Defaults are applied at `compile()` time. Policies set here
+        are **not** inherited by subgraphs.
+
+        `retry_policy` and `timeout` defaults apply to **all** nodes,
+        including error-handler nodes. `cache_policy` and `error_handler`
+        defaults only apply to regular nodes -- caching error-handler results
+        is unsafe, and handlers must never catch themselves.
 
         Args:
             retry_policy: Default retry policy for nodes that don't specify
-                their own via `add_node(..., retry_policy=...)`.
+                their own via `add_node(..., retry_policy=...)`. Also applies
+                to error-handler nodes.
             cache_policy: Default cache policy for nodes that don't specify
-                their own via `add_node(..., cache_policy=...)`.
+                their own via `add_node(..., cache_policy=...)`. Does **not**
+                apply to error-handler nodes.
             error_handler: Default error handler invoked when any regular node
                 raises and does not have its own `error_handler` set via
                 `add_node`. The handler is **not** invoked when an
                 error-handler node itself raises -- handler failures fail the
                 run.
             timeout: Default timeout policy for nodes that don't specify their
-                own via `add_node(..., timeout=...)`. Accepts a `TimeoutPolicy`,
-                a number of seconds (`float`), or a `timedelta`.
+                own via `add_node(..., timeout=...)`. Also applies to
+                error-handler nodes. Accepts a `TimeoutPolicy`, a number of
+                seconds (`float`), or a `timedelta`.
 
         Returns:
             Self: The builder instance, for chaining.

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -324,50 +324,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             defaults.timeout = coerce_timeout_policy(timeout)
         return self
 
-    def _apply_node_defaults(self) -> None:
-        """Apply builder defaults to every regular node spec.
-
-        If `error_handler` is set, a synthetic node named
-        `_DEFAULT_ERROR_HANDLER_NODE` is added to the graph and wired in as the
-        fallback handler for any node without its own. Per-node values always
-        win; error-handler nodes are skipped so a default retry policy doesn't
-        silently apply to them.
-        """
-        defaults = self._node_defaults
-
-        handler_name: str | None = None
-        if defaults.error_handler is not None:
-            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
-                raise ValueError(
-                    f"Auto-generated default error handler node "
-                    f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
-                )
-            handler_name = _DEFAULT_ERROR_HANDLER_NODE
-            self.nodes[handler_name] = StateNodeSpec[Any, ContextT](
-                coerce_to_runnable(
-                    defaults.error_handler,  # type: ignore[arg-type]
-                    name=handler_name,
-                    trace=False,
-                ),
-                metadata=None,
-                input_schema=self.state_schema,
-                retry_policy=None,
-                cache_policy=None,
-                is_error_handler=True,
-            )
-
-        for spec in self.nodes.values():
-            if spec.is_error_handler:
-                continue
-            if handler_name is not None and spec.error_handler_node is None:
-                spec.error_handler_node = handler_name
-            if defaults.retry_policy is not None and spec.retry_policy is None:
-                spec.retry_policy = defaults.retry_policy
-            if defaults.cache_policy is not None and spec.cache_policy is None:
-                spec.cache_policy = defaults.cache_policy
-            if defaults.timeout is not None and spec.timeout is None:
-                spec.timeout = defaults.timeout
-
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
         return self.edges | {
@@ -1306,7 +1262,42 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
-        self._apply_node_defaults()
+        # Apply builder defaults to every regular node spec. Per-node values
+        # always win; error-handler nodes are skipped so a default retry/cache
+        # policy doesn't silently wrap the handler itself.
+        defaults = self._node_defaults
+        default_handler_name: str | None = None
+        if defaults.error_handler is not None:
+            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+                raise ValueError(
+                    f"Auto-generated default error handler node "
+                    f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
+                )
+            default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
+            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(
+                    defaults.error_handler,  # type: ignore[arg-type]
+                    name=default_handler_name,
+                    trace=False,
+                ),
+                metadata=None,
+                input_schema=self.state_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
+        for spec in self.nodes.values():
+            if spec.is_error_handler:
+                continue
+            if default_handler_name is not None and spec.error_handler_node is None:
+                spec.error_handler_node = default_handler_name
+            if defaults.retry_policy is not None and spec.retry_policy is None:
+                spec.retry_policy = defaults.retry_policy
+            if defaults.cache_policy is not None and spec.cache_policy is None:
+                spec.cache_policy = defaults.cache_policy
+            if defaults.timeout is not None and spec.timeout is None:
+                spec.timeout = defaults.timeout
+
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1286,21 +1286,32 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=None,
                 is_error_handler=True,
             )
+
+        # Apply builder defaults to node specs. Per-node values always win.
         for spec in self.nodes.values():
+            # error_handler: regular nodes only — handlers must never
+            # catch themselves or other handlers.
             if (
                 not spec.is_error_handler
                 and default_handler_name is not None
                 and spec.error_handler_node is None
             ):
                 spec.error_handler_node = default_handler_name
+            # retry: all nodes — handlers should be retried on transient
+            # failures just like regular nodes.
             if defaults.retry_policy is not None and spec.retry_policy is None:
                 spec.retry_policy = defaults.retry_policy
+            # cache: regular nodes only — caching an error-handler result
+            # is unsafe because the input (failed-node state) may differ
+            # across failures even when the cache key matches.
             if (
                 not spec.is_error_handler
                 and defaults.cache_policy is not None
                 and spec.cache_policy is None
             ):
                 spec.cache_policy = defaults.cache_policy
+            # timeout: all nodes — a stuck handler should be cancelled the
+            # same way a stuck regular node would be.
             if defaults.timeout is not None and spec.timeout is None:
                 spec.timeout = defaults.timeout
 

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -6,7 +6,7 @@ import typing
 import warnings
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Hashable, Sequence
-from dataclasses import is_dataclass
+from dataclasses import dataclass, is_dataclass
 from datetime import timedelta
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
@@ -95,6 +95,17 @@ __all__ = ("StateGraph", "CompiledStateGraph")
 logger = logging.getLogger(__name__)
 
 _CHANNEL_BRANCH_TO = "branch:to:{}"
+_DEFAULT_ERROR_HANDLER_NODE = "__default_error_handler__"
+
+
+@dataclass(slots=True)
+class _NodeDefaults:
+    """Default node policies applied to every node at compile time."""
+
+    retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None
+    cache_policy: CachePolicy | None = None
+    error_handler: StateNode[Any, Any] | None = None
+    timeout: TimeoutPolicy | None = None
 
 
 def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
@@ -251,16 +262,13 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.output_schema = cast(type[OutputT], output_schema or state_schema)
         self.context_schema = context_schema
 
-        self._default_retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None
-        self._default_cache_policy: CachePolicy | None = None
-        self._default_error_handler: StateNode[Any, ContextT] | None = None
-        self._default_timeout: TimeoutPolicy | None = None
+        self._node_defaults: _NodeDefaults = _NodeDefaults()
 
         self._add_schema(self.state_schema)
         self._add_schema(self.input_schema, allow_managed=False)
         self._add_schema(self.output_schema, allow_managed=False)
 
-    def set_defaults(
+    def set_node_defaults(
         self,
         *,
         retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
@@ -268,10 +276,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
     ) -> Self:
-        """Set default node policies that apply to every node added to this graph.
+        """Set default node policies that apply to every node in this graph.
 
         Per-node values passed to `add_node` always take precedence over these
-        defaults.  Policies set here are **not** inherited by subgraphs.
+        defaults. Policies set here are **not** inherited by subgraphs.
 
         Args:
             retry_policy: Default retry policy for nodes that don't specify
@@ -284,9 +292,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 error-handler node itself raises -- handler failures fail the
                 run.
             timeout: Default timeout policy for nodes that don't specify their
-                own via `add_node(..., timeout=...)`.  Accepts a
-                `TimeoutPolicy`, a number of seconds (`float`), or a
-                `timedelta`.
+                own via `add_node(..., timeout=...)`. Accepts a `TimeoutPolicy`,
+                a number of seconds (`float`), or a `timedelta`.
 
         Returns:
             Self: The builder instance, for chaining.
@@ -295,7 +302,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             ```python
             graph = (
                 StateGraph(State)
-                .set_defaults(
+                .set_node_defaults(
                     retry_policy=RetryPolicy(max_attempts=3),
                     error_handler=my_fallback_handler,
                 )
@@ -306,15 +313,60 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
             ```
         """
+        defaults = self._node_defaults
         if retry_policy is not None:
-            self._default_retry_policy = retry_policy
+            defaults.retry_policy = retry_policy
         if cache_policy is not None:
-            self._default_cache_policy = cache_policy
+            defaults.cache_policy = cache_policy
         if error_handler is not None:
-            self._default_error_handler = error_handler
+            defaults.error_handler = error_handler
         if timeout is not None:
-            self._default_timeout = coerce_timeout_policy(timeout)
+            defaults.timeout = coerce_timeout_policy(timeout)
         return self
+
+    def _apply_node_defaults(self) -> None:
+        """Apply builder defaults to every regular node spec.
+
+        If `error_handler` is set, a synthetic node named
+        `_DEFAULT_ERROR_HANDLER_NODE` is added to the graph and wired in as the
+        fallback handler for any node without its own. Per-node values always
+        win; error-handler nodes are skipped so a default retry policy doesn't
+        silently apply to them.
+        """
+        defaults = self._node_defaults
+
+        handler_name: str | None = None
+        if defaults.error_handler is not None:
+            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+                raise ValueError(
+                    f"Auto-generated default error handler node "
+                    f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
+                )
+            handler_name = _DEFAULT_ERROR_HANDLER_NODE
+            self.nodes[handler_name] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(
+                    defaults.error_handler,  # type: ignore[arg-type]
+                    name=handler_name,
+                    trace=False,
+                ),
+                metadata=None,
+                input_schema=self.state_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
+
+        for spec in self.nodes.values():
+            if spec.is_error_handler:
+                continue
+            if handler_name is not None and spec.error_handler_node is None:
+                spec.error_handler_node = handler_name
+            if defaults.retry_policy is not None and spec.retry_policy is None:
+                spec.retry_policy = defaults.retry_policy
+            if defaults.cache_policy is not None and spec.cache_policy is None:
+                spec.cache_policy = defaults.cache_policy
+            if defaults.timeout is not None and spec.timeout is None:
+                spec.timeout = defaults.timeout
 
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
@@ -1155,7 +1207,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
-        default_error_handler: StateNode[Any, ContextT] | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1195,12 +1246,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 the standard `StreamTransformer` constructor shape by
                 accepting `scope` as their first argument. Appended after the
                 built-in stream transformers.
-            default_error_handler: Optional fallback node-level error handler
-                invoked when any regular node raises and does not have its own
-                `error_handler` set via `add_node`. Per-node `error_handler`
-                always takes precedence. The default handler is **not** invoked
-                when an error-handler node itself raises -- handler failures
-                fail the run. Not inherited by subgraphs.
 
         Returns:
             CompiledStateGraph: The compiled `StateGraph`.
@@ -1261,59 +1306,12 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
-        # --- apply builder defaults (set_defaults) to node specs ----------------
-        # compile() kwarg wins over set_defaults() for error_handler.
-        _effective_error_handler = default_error_handler or self._default_error_handler
-
-        default_handler_node_name: str | None = None
-        if _effective_error_handler is not None:
-            _default_eh_name = "__default_error_handler__"
-            if _default_eh_name in self.nodes:
-                raise ValueError(
-                    f"Auto-generated default error handler node "
-                    f"`{_default_eh_name}` already exists."
-                )
-            default_handler_node_name = _default_eh_name
-            self.nodes[default_handler_node_name] = StateNodeSpec[Any, ContextT](
-                coerce_to_runnable(
-                    _effective_error_handler,  # type: ignore[arg-type]
-                    name=default_handler_node_name,
-                    trace=False,
-                ),
-                metadata=None,
-                input_schema=self.state_schema,
-                retry_policy=None,
-                cache_policy=None,
-                is_error_handler=True,
-            )
-
-        for _spec in self.nodes.values():
-            if _spec.is_error_handler:
-                continue
-            if default_handler_node_name and _spec.error_handler_node is None:
-                _spec.error_handler_node = default_handler_node_name
-            if self._default_retry_policy and _spec.retry_policy is None:
-                _spec.retry_policy = self._default_retry_policy
-            if self._default_cache_policy and _spec.cache_policy is None:
-                _spec.cache_policy = self._default_cache_policy
-            if self._default_timeout and _spec.timeout is None:
-                _spec.timeout = self._default_timeout
-
+        self._apply_node_defaults()
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
-
-        # Graph-level retry/cache fallbacks (Pregel uses these for nodes that
-        # still have no per-node policy after defaults are applied).
-        _graph_retry: Sequence[RetryPolicy] = ()
-        if self._default_retry_policy is not None:
-            _graph_retry = (
-                (self._default_retry_policy,)
-                if isinstance(self._default_retry_policy, RetryPolicy)
-                else self._default_retry_policy
-            )
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
@@ -1336,8 +1334,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             debug=debug,
             store=store,
             cache=cache,
-            retry_policy=_graph_retry,
-            cache_policy=self._default_cache_policy,
             node_error_handler_map=node_error_handler_map,
             name=name or "LangGraph",
             stream_transformers=transformers,

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -90,7 +90,7 @@ from langgraph.types import (
 from langgraph.typing import ContextT, InputT, NodeInputT, OutputT, StateT
 from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
 
-__all__ = ("StateGraph", "CompiledStateGraph")
+__all__ = ("CompiledStateGraph", "NodeDefaults", "StateGraph")
 
 logger = logging.getLogger(__name__)
 
@@ -99,13 +99,29 @@ _DEFAULT_ERROR_HANDLER_NODE = "__default_error_handler__"
 
 
 @dataclass(slots=True)
-class _NodeDefaults:
-    """Default node policies applied to every node at compile time."""
+class NodeDefaults:
+    """Default node policies applied to every node added to a `StateGraph`.
+
+    Pass to `StateGraph(..., node_defaults=NodeDefaults(...))` to set policies
+    that take effect for every node that does not provide its own via
+    `add_node`. Per-node values always win.
+
+    Attributes:
+        retry_policy: Default retry policy. If a sequence is given, the first
+            matching policy is applied.
+        cache_policy: Default cache policy.
+        error_handler: Default error-handler callable invoked when any regular
+            node raises and does not have its own `error_handler`. The handler
+            is **not** invoked when an error-handler node itself raises --
+            handler failures fail the run.
+        timeout: Default timeout. Accepts a `TimeoutPolicy`, a number of
+            seconds (`float`), or a `timedelta`.
+    """
 
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None
     cache_policy: CachePolicy | None = None
     error_handler: StateNode[Any, Any] | None = None
-    timeout: TimeoutPolicy | None = None
+    timeout: float | timedelta | TimeoutPolicy | None = None
 
 
 def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
@@ -219,6 +235,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         *,
         input_schema: type[InputT] | None = None,
         output_schema: type[OutputT] | None = None,
+        node_defaults: NodeDefaults | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         if (config_schema := kwargs.get("config_schema", MISSING)) is not MISSING:
@@ -262,67 +279,26 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.output_schema = cast(type[OutputT], output_schema or state_schema)
         self.context_schema = context_schema
 
-        self._node_defaults: _NodeDefaults = _NodeDefaults()
+        self._node_defaults = node_defaults or NodeDefaults()
+        # Materialize the synthetic default error-handler node up front so
+        # `add_node` only has to point regular nodes at its name.
+        if self._node_defaults.error_handler is not None:
+            self.nodes[_DEFAULT_ERROR_HANDLER_NODE] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(
+                    self._node_defaults.error_handler,  # type: ignore[arg-type]
+                    name=_DEFAULT_ERROR_HANDLER_NODE,
+                    trace=False,
+                ),
+                metadata=None,
+                input_schema=self.state_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
 
         self._add_schema(self.state_schema)
         self._add_schema(self.input_schema, allow_managed=False)
         self._add_schema(self.output_schema, allow_managed=False)
-
-    def set_node_defaults(
-        self,
-        *,
-        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
-        cache_policy: CachePolicy | None = None,
-        error_handler: StateNode[Any, ContextT] | None = None,
-        timeout: float | timedelta | TimeoutPolicy | None = None,
-    ) -> Self:
-        """Set default node policies that apply to every node in this graph.
-
-        Per-node values passed to `add_node` always take precedence over these
-        defaults. Policies set here are **not** inherited by subgraphs.
-
-        Args:
-            retry_policy: Default retry policy for nodes that don't specify
-                their own via `add_node(..., retry_policy=...)`.
-            cache_policy: Default cache policy for nodes that don't specify
-                their own via `add_node(..., cache_policy=...)`.
-            error_handler: Default error handler invoked when any regular node
-                raises and does not have its own `error_handler` set via
-                `add_node`. The handler is **not** invoked when an
-                error-handler node itself raises -- handler failures fail the
-                run.
-            timeout: Default timeout policy for nodes that don't specify their
-                own via `add_node(..., timeout=...)`. Accepts a `TimeoutPolicy`,
-                a number of seconds (`float`), or a `timedelta`.
-
-        Returns:
-            Self: The builder instance, for chaining.
-
-        Example:
-            ```python
-            graph = (
-                StateGraph(State)
-                .set_node_defaults(
-                    retry_policy=RetryPolicy(max_attempts=3),
-                    error_handler=my_fallback_handler,
-                )
-                .add_node("a", node_a)
-                .add_node("b", node_b, retry_policy=custom_retry)  # overrides default
-                .add_edge(START, "a")
-                .compile()
-            )
-            ```
-        """
-        defaults = self._node_defaults
-        if retry_policy is not None:
-            defaults.retry_policy = retry_policy
-        if cache_policy is not None:
-            defaults.cache_policy = cache_policy
-        if error_handler is not None:
-            defaults.error_handler = error_handler
-        if timeout is not None:
-            defaults.timeout = coerce_timeout_policy(timeout)
-        return self
 
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
@@ -754,7 +730,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)
-        timeout = coerce_timeout_policy(timeout)
 
         if not isinstance(node, str):
             action = node
@@ -844,6 +819,17 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         resolved_input_schema: type[Any] = (
             input_schema or inferred_input_schema or self.state_schema
         )
+        # Resolve per-node values against the graph-level defaults. Per-node
+        # values always win.
+        defaults = self._node_defaults
+        if retry_policy is None:
+            retry_policy = defaults.retry_policy
+        if cache_policy is None:
+            cache_policy = defaults.cache_policy
+        if timeout is None:
+            timeout = defaults.timeout
+        timeout = coerce_timeout_policy(timeout)
+
         handler_node_name: str | None = None
         if error_handler is not None:
             handler_node_name = f"__error_handler__{node}"
@@ -859,6 +845,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=None,
                 is_error_handler=True,
             )
+        elif defaults.error_handler is not None:
+            handler_node_name = _DEFAULT_ERROR_HANDLER_NODE
 
         if input_schema is not None:
             self.nodes[node] = StateNodeSpec[NodeInputT, ContextT](
@@ -1262,42 +1250,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
-        # Apply builder defaults to every regular node spec. Per-node values
-        # always win; error-handler nodes are skipped so a default retry/cache
-        # policy doesn't silently wrap the handler itself.
-        defaults = self._node_defaults
-        default_handler_name: str | None = None
-        if defaults.error_handler is not None:
-            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
-                raise ValueError(
-                    f"Auto-generated default error handler node "
-                    f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
-                )
-            default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
-            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
-                coerce_to_runnable(
-                    defaults.error_handler,  # type: ignore[arg-type]
-                    name=default_handler_name,
-                    trace=False,
-                ),
-                metadata=None,
-                input_schema=self.state_schema,
-                retry_policy=None,
-                cache_policy=None,
-                is_error_handler=True,
-            )
-        for spec in self.nodes.values():
-            if spec.is_error_handler:
-                continue
-            if default_handler_name is not None and spec.error_handler_node is None:
-                spec.error_handler_node = default_handler_name
-            if defaults.retry_policy is not None and spec.retry_policy is None:
-                spec.retry_policy = defaults.retry_policy
-            if defaults.cache_policy is not None and spec.cache_policy is None:
-                spec.cache_policy = defaults.cache_policy
-            if defaults.timeout is not None and spec.timeout is None:
-                spec.timeout = defaults.timeout
-
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1094,6 +1094,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        default_error_handler: StateNode[Any, ContextT] | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1133,6 +1134,12 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 the standard `StreamTransformer` constructor shape by
                 accepting `scope` as their first argument. Appended after the
                 built-in stream transformers.
+            default_error_handler: Optional fallback node-level error handler
+                invoked when any regular node raises and does not have its own
+                `error_handler` set via `add_node`. Per-node `error_handler`
+                always takes precedence. The default handler is **not** invoked
+                when an error-handler node itself raises -- handler failures
+                fail the run. Not inherited by subgraphs.
 
         Returns:
             CompiledStateGraph: The compiled `StateGraph`.
@@ -1193,10 +1200,35 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
+        default_handler_node_name: str | None = None
+        if default_error_handler is not None:
+            _default_eh_name = "__default_error_handler__"
+            if _default_eh_name in self.nodes:
+                raise ValueError(
+                    f"Auto-generated default error handler node "
+                    f"`{_default_eh_name}` already exists."
+                )
+            default_handler_node_name = _default_eh_name
+            self.nodes[default_handler_node_name] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(
+                    default_error_handler,  # type: ignore[arg-type]
+                    name=default_handler_node_name,
+                    trace=False,
+                ),
+                metadata=None,
+                input_schema=self.state_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
+            for _spec in self.nodes.values():
+                if not _spec.is_error_handler and _spec.error_handler_node is None:
+                    _spec.error_handler_node = default_handler_node_name
+
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()
-            if spec.error_handler_node is not None
+            if not spec.is_error_handler and spec.error_handler_node is not None
         }
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -251,9 +251,70 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.output_schema = cast(type[OutputT], output_schema or state_schema)
         self.context_schema = context_schema
 
+        self._default_retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None
+        self._default_cache_policy: CachePolicy | None = None
+        self._default_error_handler: StateNode[Any, ContextT] | None = None
+        self._default_timeout: TimeoutPolicy | None = None
+
         self._add_schema(self.state_schema)
         self._add_schema(self.input_schema, allow_managed=False)
         self._add_schema(self.output_schema, allow_managed=False)
+
+    def set_defaults(
+        self,
+        *,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
+        timeout: float | timedelta | TimeoutPolicy | None = None,
+    ) -> Self:
+        """Set default node policies that apply to every node added to this graph.
+
+        Per-node values passed to `add_node` always take precedence over these
+        defaults.  Policies set here are **not** inherited by subgraphs.
+
+        Args:
+            retry_policy: Default retry policy for nodes that don't specify
+                their own via `add_node(..., retry_policy=...)`.
+            cache_policy: Default cache policy for nodes that don't specify
+                their own via `add_node(..., cache_policy=...)`.
+            error_handler: Default error handler invoked when any regular node
+                raises and does not have its own `error_handler` set via
+                `add_node`. The handler is **not** invoked when an
+                error-handler node itself raises -- handler failures fail the
+                run.
+            timeout: Default timeout policy for nodes that don't specify their
+                own via `add_node(..., timeout=...)`.  Accepts a
+                `TimeoutPolicy`, a number of seconds (`float`), or a
+                `timedelta`.
+
+        Returns:
+            Self: The builder instance, for chaining.
+
+        Example:
+            ```python
+            graph = (
+                StateGraph(State)
+                .set_defaults(
+                    retry_policy=RetryPolicy(max_attempts=3),
+                    error_handler=my_fallback_handler,
+                )
+                .add_node("a", node_a)
+                .add_node("b", node_b, retry_policy=custom_retry)  # overrides default
+                .add_edge(START, "a")
+                .compile()
+            )
+            ```
+        """
+        if retry_policy is not None:
+            self._default_retry_policy = retry_policy
+        if cache_policy is not None:
+            self._default_cache_policy = cache_policy
+        if error_handler is not None:
+            self._default_error_handler = error_handler
+        if timeout is not None:
+            self._default_timeout = coerce_timeout_policy(timeout)
+        return self
 
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
@@ -1200,8 +1261,12 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
+        # --- apply builder defaults (set_defaults) to node specs ----------------
+        # compile() kwarg wins over set_defaults() for error_handler.
+        _effective_error_handler = default_error_handler or self._default_error_handler
+
         default_handler_node_name: str | None = None
-        if default_error_handler is not None:
+        if _effective_error_handler is not None:
             _default_eh_name = "__default_error_handler__"
             if _default_eh_name in self.nodes:
                 raise ValueError(
@@ -1211,7 +1276,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             default_handler_node_name = _default_eh_name
             self.nodes[default_handler_node_name] = StateNodeSpec[Any, ContextT](
                 coerce_to_runnable(
-                    default_error_handler,  # type: ignore[arg-type]
+                    _effective_error_handler,  # type: ignore[arg-type]
                     name=default_handler_node_name,
                     trace=False,
                 ),
@@ -1221,15 +1286,34 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=None,
                 is_error_handler=True,
             )
-            for _spec in self.nodes.values():
-                if not _spec.is_error_handler and _spec.error_handler_node is None:
-                    _spec.error_handler_node = default_handler_node_name
+
+        for _spec in self.nodes.values():
+            if _spec.is_error_handler:
+                continue
+            if default_handler_node_name and _spec.error_handler_node is None:
+                _spec.error_handler_node = default_handler_node_name
+            if self._default_retry_policy and _spec.retry_policy is None:
+                _spec.retry_policy = self._default_retry_policy
+            if self._default_cache_policy and _spec.cache_policy is None:
+                _spec.cache_policy = self._default_cache_policy
+            if self._default_timeout and _spec.timeout is None:
+                _spec.timeout = self._default_timeout
 
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
+
+        # Graph-level retry/cache fallbacks (Pregel uses these for nodes that
+        # still have no per-node policy after defaults are applied).
+        _graph_retry: Sequence[RetryPolicy] = ()
+        if self._default_retry_policy is not None:
+            _graph_retry = (
+                (self._default_retry_policy,)
+                if isinstance(self._default_retry_policy, RetryPolicy)
+                else self._default_retry_policy
+            )
 
         compiled = CompiledStateGraph[StateT, ContextT, InputT, OutputT](
             builder=self,
@@ -1252,6 +1336,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             debug=debug,
             store=store,
             cache=cache,
+            retry_policy=_graph_retry,
+            cache_policy=self._default_cache_policy,
             node_error_handler_map=node_error_handler_map,
             name=name or "LangGraph",
             stream_transformers=transformers,

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1262,9 +1262,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
-        # Apply builder defaults to every regular node spec. Per-node values
-        # always win; error-handler nodes are skipped so a default retry/cache
-        # policy doesn't silently wrap the handler itself.
+        # Apply builder defaults to node specs. Per-node values always win.
+        # Error-handler routing and cache_policy are only assigned to regular
+        # nodes. Retry and timeout defaults also apply to error-handler nodes.
         defaults = self._node_defaults
         default_handler_name: str | None = None
         if defaults.error_handler is not None:
@@ -1287,13 +1287,19 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 is_error_handler=True,
             )
         for spec in self.nodes.values():
-            if spec.is_error_handler:
-                continue
-            if default_handler_name is not None and spec.error_handler_node is None:
+            if (
+                not spec.is_error_handler
+                and default_handler_name is not None
+                and spec.error_handler_node is None
+            ):
                 spec.error_handler_node = default_handler_name
             if defaults.retry_policy is not None and spec.retry_policy is None:
                 spec.retry_policy = defaults.retry_policy
-            if defaults.cache_policy is not None and spec.cache_policy is None:
+            if (
+                not spec.is_error_handler
+                and defaults.cache_policy is not None
+                and spec.cache_policy is None
+            ):
                 spec.cache_policy = defaults.cache_policy
             if defaults.timeout is not None and spec.timeout is None:
                 spec.timeout = defaults.timeout

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -90,7 +90,7 @@ from langgraph.types import (
 from langgraph.typing import ContextT, InputT, NodeInputT, OutputT, StateT
 from langgraph.warnings import LangGraphDeprecatedSinceV05, LangGraphDeprecatedSinceV10
 
-__all__ = ("CompiledStateGraph", "NodeDefaults", "StateGraph")
+__all__ = ("StateGraph", "CompiledStateGraph")
 
 logger = logging.getLogger(__name__)
 
@@ -99,29 +99,13 @@ _DEFAULT_ERROR_HANDLER_NODE = "__default_error_handler__"
 
 
 @dataclass(slots=True)
-class NodeDefaults:
-    """Default node policies applied to every node added to a `StateGraph`.
-
-    Pass to `StateGraph(..., node_defaults=NodeDefaults(...))` to set policies
-    that take effect for every node that does not provide its own via
-    `add_node`. Per-node values always win.
-
-    Attributes:
-        retry_policy: Default retry policy. If a sequence is given, the first
-            matching policy is applied.
-        cache_policy: Default cache policy.
-        error_handler: Default error-handler callable invoked when any regular
-            node raises and does not have its own `error_handler`. The handler
-            is **not** invoked when an error-handler node itself raises --
-            handler failures fail the run.
-        timeout: Default timeout. Accepts a `TimeoutPolicy`, a number of
-            seconds (`float`), or a `timedelta`.
-    """
+class _NodeDefaults:
+    """Default node policies applied to every node at compile time."""
 
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None
     cache_policy: CachePolicy | None = None
     error_handler: StateNode[Any, Any] | None = None
-    timeout: float | timedelta | TimeoutPolicy | None = None
+    timeout: TimeoutPolicy | None = None
 
 
 def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
@@ -235,7 +219,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         *,
         input_schema: type[InputT] | None = None,
         output_schema: type[OutputT] | None = None,
-        node_defaults: NodeDefaults | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         if (config_schema := kwargs.get("config_schema", MISSING)) is not MISSING:
@@ -279,26 +262,67 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.output_schema = cast(type[OutputT], output_schema or state_schema)
         self.context_schema = context_schema
 
-        self._node_defaults = node_defaults or NodeDefaults()
-        # Materialize the synthetic default error-handler node up front so
-        # `add_node` only has to point regular nodes at its name.
-        if self._node_defaults.error_handler is not None:
-            self.nodes[_DEFAULT_ERROR_HANDLER_NODE] = StateNodeSpec[Any, ContextT](
-                coerce_to_runnable(
-                    self._node_defaults.error_handler,  # type: ignore[arg-type]
-                    name=_DEFAULT_ERROR_HANDLER_NODE,
-                    trace=False,
-                ),
-                metadata=None,
-                input_schema=self.state_schema,
-                retry_policy=None,
-                cache_policy=None,
-                is_error_handler=True,
-            )
+        self._node_defaults: _NodeDefaults = _NodeDefaults()
 
         self._add_schema(self.state_schema)
         self._add_schema(self.input_schema, allow_managed=False)
         self._add_schema(self.output_schema, allow_managed=False)
+
+    def set_node_defaults(
+        self,
+        *,
+        retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
+        cache_policy: CachePolicy | None = None,
+        error_handler: StateNode[Any, ContextT] | None = None,
+        timeout: float | timedelta | TimeoutPolicy | None = None,
+    ) -> Self:
+        """Set default node policies that apply to every node in this graph.
+
+        Per-node values passed to `add_node` always take precedence over these
+        defaults. Policies set here are **not** inherited by subgraphs.
+
+        Args:
+            retry_policy: Default retry policy for nodes that don't specify
+                their own via `add_node(..., retry_policy=...)`.
+            cache_policy: Default cache policy for nodes that don't specify
+                their own via `add_node(..., cache_policy=...)`.
+            error_handler: Default error handler invoked when any regular node
+                raises and does not have its own `error_handler` set via
+                `add_node`. The handler is **not** invoked when an
+                error-handler node itself raises -- handler failures fail the
+                run.
+            timeout: Default timeout policy for nodes that don't specify their
+                own via `add_node(..., timeout=...)`. Accepts a `TimeoutPolicy`,
+                a number of seconds (`float`), or a `timedelta`.
+
+        Returns:
+            Self: The builder instance, for chaining.
+
+        Example:
+            ```python
+            graph = (
+                StateGraph(State)
+                .set_node_defaults(
+                    retry_policy=RetryPolicy(max_attempts=3),
+                    error_handler=my_fallback_handler,
+                )
+                .add_node("a", node_a)
+                .add_node("b", node_b, retry_policy=custom_retry)  # overrides default
+                .add_edge(START, "a")
+                .compile()
+            )
+            ```
+        """
+        defaults = self._node_defaults
+        if retry_policy is not None:
+            defaults.retry_policy = retry_policy
+        if cache_policy is not None:
+            defaults.cache_policy = cache_policy
+        if error_handler is not None:
+            defaults.error_handler = error_handler
+        if timeout is not None:
+            defaults.timeout = coerce_timeout_policy(timeout)
+        return self
 
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
@@ -730,6 +754,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)
+        timeout = coerce_timeout_policy(timeout)
 
         if not isinstance(node, str):
             action = node
@@ -819,17 +844,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         resolved_input_schema: type[Any] = (
             input_schema or inferred_input_schema or self.state_schema
         )
-        # Resolve per-node values against the graph-level defaults. Per-node
-        # values always win.
-        defaults = self._node_defaults
-        if retry_policy is None:
-            retry_policy = defaults.retry_policy
-        if cache_policy is None:
-            cache_policy = defaults.cache_policy
-        if timeout is None:
-            timeout = defaults.timeout
-        timeout = coerce_timeout_policy(timeout)
-
         handler_node_name: str | None = None
         if error_handler is not None:
             handler_node_name = f"__error_handler__{node}"
@@ -845,8 +859,6 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 cache_policy=None,
                 is_error_handler=True,
             )
-        elif defaults.error_handler is not None:
-            handler_node_name = _DEFAULT_ERROR_HANDLER_NODE
 
         if input_schema is not None:
             self.nodes[node] = StateNodeSpec[NodeInputT, ContextT](
@@ -1250,6 +1262,42 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 key for key, val in self.channels.items() if not is_managed_value(val)
             ]
         )
+        # Apply builder defaults to every regular node spec. Per-node values
+        # always win; error-handler nodes are skipped so a default retry/cache
+        # policy doesn't silently wrap the handler itself.
+        defaults = self._node_defaults
+        default_handler_name: str | None = None
+        if defaults.error_handler is not None:
+            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+                raise ValueError(
+                    f"Auto-generated default error handler node "
+                    f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
+                )
+            default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
+            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
+                coerce_to_runnable(
+                    defaults.error_handler,  # type: ignore[arg-type]
+                    name=default_handler_name,
+                    trace=False,
+                ),
+                metadata=None,
+                input_schema=self.state_schema,
+                retry_policy=None,
+                cache_policy=None,
+                is_error_handler=True,
+            )
+        for spec in self.nodes.values():
+            if spec.is_error_handler:
+                continue
+            if default_handler_name is not None and spec.error_handler_node is None:
+                spec.error_handler_node = default_handler_name
+            if defaults.retry_policy is not None and spec.retry_policy is None:
+                spec.retry_policy = defaults.retry_policy
+            if defaults.cache_policy is not None and spec.cache_policy is None:
+                spec.cache_policy = defaults.cache_policy
+            if defaults.timeout is not None and spec.timeout is None:
+                spec.timeout = defaults.timeout
+
         node_error_handler_map = {
             node_name: spec.error_handler_node
             for node_name, spec in self.nodes.items()

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -15,7 +15,7 @@ from langchain_core.callbacks import AsyncCallbackManagerForLLMRun, BaseCallback
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.runnables import RunnableLambda, RunnableParallel
+from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableParallel
 from langgraph.checkpoint.memory import InMemorySaver, MemorySaver
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from typing_extensions import TypedDict
@@ -2280,3 +2280,191 @@ def test_node_without_error_handler_still_fails_run():
 
     with pytest.raises(ValueError, match="no handler"):
         graph.invoke({"foo": ""})
+
+
+# ---------------------------------------------------------------------------
+# default_error_handler on compile()
+# ---------------------------------------------------------------------------
+
+
+def test_compile_default_error_handler_catches_all_nodes():
+    class State(TypedDict):
+        route: str
+        foo: Annotated[list[str], operator.add]
+
+    def route_node(state: State) -> Command:
+        return Command(goto=state["route"])
+
+    def fail_a(state: State) -> State:
+        raise RuntimeError("a failed")
+
+    def fail_b(state: State) -> State:
+        raise RuntimeError("b failed")
+
+    captured: dict[str, list[str]] = {"nodes": []}
+
+    def default_handler(state: State, error: NodeError) -> State:
+        captured["nodes"].append(error.node)
+        return {"foo": [f"handled_{error.node}"]}
+
+    graph = (
+        StateGraph(State)
+        .add_node("route_node", route_node)
+        .add_node("fail_a", fail_a)
+        .add_node("fail_b", fail_b)
+        .add_edge(START, "route_node")
+        .add_conditional_edges(
+            "route_node", lambda s: s["route"], path_map=["fail_a", "fail_b"]
+        )
+        .compile(default_error_handler=default_handler)
+    )
+
+    result_a = graph.invoke({"route": "fail_a", "foo": []})
+    result_b = graph.invoke({"route": "fail_b", "foo": []})
+    assert result_a["foo"] == ["handled_fail_a"]
+    assert result_b["foo"] == ["handled_fail_b"]
+    assert "fail_a" in captured["nodes"]
+    assert "fail_b" in captured["nodes"]
+
+
+def test_compile_default_error_handler_overridden_by_node_handler():
+    class State(TypedDict):
+        route: str
+        foo: Annotated[list[str], operator.add]
+
+    def route_node(state: State) -> Command:
+        return Command(goto=state["route"])
+
+    def fail_a(state: State) -> State:
+        raise RuntimeError("a failed")
+
+    def fail_b(state: State) -> State:
+        raise RuntimeError("b failed")
+
+    captured: dict[str, list[str]] = {"handler": []}
+
+    def node_handler(state: State, error: NodeError) -> State:
+        captured["handler"].append(f"node:{error.node}")
+        return {"foo": [f"node_handled_{error.node}"]}
+
+    def default_handler(state: State, error: NodeError) -> State:
+        captured["handler"].append(f"default:{error.node}")
+        return {"foo": [f"default_handled_{error.node}"]}
+
+    graph = (
+        StateGraph(State)
+        .add_node("route_node", route_node)
+        .add_node("fail_a", fail_a, error_handler=node_handler)
+        .add_node("fail_b", fail_b)
+        .add_edge(START, "route_node")
+        .add_conditional_edges(
+            "route_node", lambda s: s["route"], path_map=["fail_a", "fail_b"]
+        )
+        .compile(default_error_handler=default_handler)
+    )
+
+    result_a = graph.invoke({"route": "fail_a", "foo": []})
+    assert result_a["foo"] == ["node_handled_fail_a"]
+    assert "node:fail_a" in captured["handler"]
+    assert "default:fail_a" not in captured["handler"]
+
+    result_b = graph.invoke({"route": "fail_b", "foo": []})
+    assert result_b["foo"] == ["default_handled_fail_b"]
+    assert "default:fail_b" in captured["handler"]
+
+
+def test_compile_default_error_handler_skips_per_node_handler_nodes():
+    """If a per-node error handler itself raises, the default handler must NOT
+    catch it -- the run should fail."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("node boom")
+
+    def broken_handler(state: State, error: NodeError) -> State:
+        raise RuntimeError("handler boom")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": "default recovered"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing, error_handler=broken_handler)
+        .add_edge(START, "always_failing")
+        .compile(default_error_handler=default_handler)
+    )
+
+    with pytest.raises(RuntimeError, match="handler boom"):
+        graph.invoke({"foo": ""})
+
+
+def test_compile_default_error_handler_failure_fails_run():
+    """When the default handler itself raises, the run fails (no infinite
+    recursion, no double-routing)."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("node boom")
+
+    def broken_default_handler(state: State, error: NodeError) -> State:
+        raise RuntimeError("default handler boom")
+
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing)
+        .add_edge(START, "always_failing")
+        .compile(default_error_handler=broken_default_handler)
+    )
+
+    with pytest.raises(RuntimeError, match="default handler boom"):
+        graph.invoke({"foo": ""})
+
+
+def test_compile_default_error_handler_receives_runnable_config():
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    captured: dict[str, Any] = {}
+
+    def default_handler(
+        state: State, error: NodeError, config: RunnableConfig
+    ) -> State:
+        captured["thread_id"] = config["configurable"].get("thread_id")
+        return {"foo": "handled"}
+
+    checkpointer = MemorySaver()
+    graph = (
+        StateGraph(State)
+        .add_node("always_failing", always_failing)
+        .add_edge(START, "always_failing")
+        .compile(checkpointer=checkpointer, default_error_handler=default_handler)
+    )
+
+    thread_id = str(uuid4())
+    result = graph.invoke(
+        {"foo": ""}, config={"configurable": {"thread_id": thread_id}}
+    )
+    assert result["foo"] == "handled"
+    assert captured["thread_id"] == thread_id
+
+
+def test_compile_default_error_handler_collides_with_user_node():
+    class State(TypedDict):
+        foo: str
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    builder = StateGraph(State)
+    builder.add_node("__default_error_handler__", lambda s: s)
+    builder.add_edge(START, "__default_error_handler__")
+
+    with pytest.raises(ValueError, match="__default_error_handler__"):
+        builder.compile(default_error_handler=default_handler)

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -38,7 +38,6 @@ from langgraph.channels.last_value import LastValue
 from langgraph.errors import GraphInterrupt, NodeError, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph, add_messages
-from langgraph.graph.state import NodeDefaults
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
@@ -2284,11 +2283,11 @@ def test_node_without_error_handler_still_fails_run():
 
 
 # ---------------------------------------------------------------------------
-# StateGraph(node_defaults=...)
+# set_node_defaults()
 # ---------------------------------------------------------------------------
 
 
-def test_node_defaults_error_handler_catches_all_nodes():
+def test_set_node_defaults_error_handler_catches_all_nodes():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2309,7 +2308,8 @@ def test_node_defaults_error_handler_catches_all_nodes():
         return {"foo": [f"handled_{error.node}"]}
 
     graph = (
-        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a)
         .add_node("fail_b", fail_b)
@@ -2328,7 +2328,7 @@ def test_node_defaults_error_handler_catches_all_nodes():
     assert "fail_b" in captured["nodes"]
 
 
-def test_node_defaults_error_handler_overridden_by_node_handler():
+def test_set_node_defaults_error_handler_overridden_by_node_handler():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2353,7 +2353,8 @@ def test_node_defaults_error_handler_overridden_by_node_handler():
         return {"foo": [f"default_handled_{error.node}"]}
 
     graph = (
-        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a, error_handler=node_handler)
         .add_node("fail_b", fail_b)
@@ -2374,7 +2375,7 @@ def test_node_defaults_error_handler_overridden_by_node_handler():
     assert "default:fail_b" in captured["handler"]
 
 
-def test_node_defaults_error_handler_skips_per_node_handler_nodes():
+def test_set_node_defaults_error_handler_skips_per_node_handler_nodes():
     """If a per-node error handler itself raises, the default handler must NOT
     catch it -- the run should fail."""
 
@@ -2391,7 +2392,8 @@ def test_node_defaults_error_handler_skips_per_node_handler_nodes():
         return {"foo": "default recovered"}
 
     graph = (
-        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("always_failing", always_failing, error_handler=broken_handler)
         .add_edge(START, "always_failing")
         .compile()
@@ -2401,7 +2403,7 @@ def test_node_defaults_error_handler_skips_per_node_handler_nodes():
         graph.invoke({"foo": ""})
 
 
-def test_node_defaults_error_handler_failure_fails_run():
+def test_set_node_defaults_error_handler_failure_fails_run():
     """When the default handler itself raises, the run fails (no infinite
     recursion, no double-routing)."""
 
@@ -2415,9 +2417,8 @@ def test_node_defaults_error_handler_failure_fails_run():
         raise RuntimeError("default handler boom")
 
     graph = (
-        StateGraph(
-            State, node_defaults=NodeDefaults(error_handler=broken_default_handler)
-        )
+        StateGraph(State)
+        .set_node_defaults(error_handler=broken_default_handler)
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
         .compile()
@@ -2427,7 +2428,7 @@ def test_node_defaults_error_handler_failure_fails_run():
         graph.invoke({"foo": ""})
 
 
-def test_node_defaults_error_handler_receives_runnable_config():
+def test_set_node_defaults_error_handler_receives_runnable_config():
     class State(TypedDict):
         foo: str
 
@@ -2444,7 +2445,8 @@ def test_node_defaults_error_handler_receives_runnable_config():
 
     checkpointer = MemorySaver()
     graph = (
-        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
         .compile(checkpointer=checkpointer)
@@ -2458,24 +2460,25 @@ def test_node_defaults_error_handler_receives_runnable_config():
     assert captured["thread_id"] == thread_id
 
 
-def test_node_defaults_error_handler_collides_with_user_node():
-    """Adding a node named `__default_error_handler__` after a default
-    error_handler is set is rejected by add_node's existing duplicate guard."""
-
+def test_set_node_defaults_error_handler_collides_with_user_node():
     class State(TypedDict):
         foo: str
 
     def default_handler(state: State, error: NodeError) -> State:
         return {"foo": "handled"}
 
-    builder = StateGraph(
-        State, node_defaults=NodeDefaults(error_handler=default_handler)
+    builder = (
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
+        .add_node("__default_error_handler__", lambda s: s)
+        .add_edge(START, "__default_error_handler__")
     )
+
     with pytest.raises(ValueError, match="__default_error_handler__"):
-        builder.add_node("__default_error_handler__", lambda s: s)
+        builder.compile()
 
 
-def test_node_defaults_retry_policy():
+def test_set_node_defaults_retry_policy():
     class State(TypedDict):
         foo: str
 
@@ -2489,16 +2492,11 @@ def test_node_defaults_retry_policy():
         return {"foo": "ok"}
 
     graph = (
-        StateGraph(
-            State,
-            node_defaults=NodeDefaults(
-                retry_policy=RetryPolicy(
-                    max_attempts=3,
-                    initial_interval=0.01,
-                    jitter=False,
-                    retry_on=ValueError,
-                )
-            ),
+        StateGraph(State)
+        .set_node_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=3, initial_interval=0.01, jitter=False, retry_on=ValueError
+            )
         )
         .add_node("flaky", flaky_node)
         .add_edge(START, "flaky")
@@ -2512,7 +2510,7 @@ def test_node_defaults_retry_policy():
     assert attempts == 3
 
 
-def test_node_defaults_retry_policy_per_node_wins():
+def test_set_node_defaults_retry_policy_per_node_wins():
     class State(TypedDict):
         foo: str
 
@@ -2526,16 +2524,11 @@ def test_node_defaults_retry_policy_per_node_wins():
         return {"foo": "ok"}
 
     graph = (
-        StateGraph(
-            State,
-            node_defaults=NodeDefaults(
-                retry_policy=RetryPolicy(
-                    max_attempts=1,
-                    initial_interval=0.01,
-                    jitter=False,
-                    retry_on=ValueError,
-                )
-            ),
+        StateGraph(State)
+        .set_node_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=1, initial_interval=0.01, jitter=False, retry_on=ValueError
+            )
         )
         .add_node(
             "flaky",
@@ -2559,7 +2552,7 @@ def test_node_defaults_retry_policy_per_node_wins():
 
 
 @pytest.mark.anyio
-async def test_node_defaults_timeout():
+async def test_set_node_defaults_timeout():
     class State(TypedDict):
         foo: str
 
@@ -2568,9 +2561,8 @@ async def test_node_defaults_timeout():
         return {"foo": "should-not-happen"}
 
     graph = (
-        StateGraph(
-            State, node_defaults=NodeDefaults(timeout=TimeoutPolicy(run_timeout=0.05))
-        )
+        StateGraph(State)
+        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.05))
         .add_node("slow", slow_node)
         .add_edge(START, "slow")
         .compile()
@@ -2583,7 +2575,7 @@ async def test_node_defaults_timeout():
 
 
 @pytest.mark.anyio
-async def test_node_defaults_timeout_per_node_wins():
+async def test_set_node_defaults_timeout_per_node_wins():
     """Per-node timeout overrides the default; a generous per-node timeout
     allows a node to complete even when the builder default is very short."""
 
@@ -2595,9 +2587,8 @@ async def test_node_defaults_timeout_per_node_wins():
         return {"foo": "done"}
 
     graph = (
-        StateGraph(
-            State, node_defaults=NodeDefaults(timeout=TimeoutPolicy(run_timeout=0.01))
-        )
+        StateGraph(State)
+        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.01))
         .add_node("quick", quick_node, timeout=TimeoutPolicy(run_timeout=5.0))
         .add_edge(START, "quick")
         .compile()
@@ -2607,7 +2598,36 @@ async def test_node_defaults_timeout_per_node_wins():
     assert result["foo"] == "done"
 
 
-def test_node_defaults_combined_retry_and_error_handler():
+def test_set_node_defaults_chaining():
+    """set_node_defaults() is chainable and can be called in any order relative to add_node."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    def handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("a", always_failing)
+        .add_edge(START, "a")
+        .set_node_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=1, initial_interval=0.01, jitter=False
+            ),
+            error_handler=handler,
+        )
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "handled"
+
+
+def test_set_node_defaults_combined_retry_and_error_handler():
     """Retries are exhausted first, then the error handler runs."""
 
     class State(TypedDict):
@@ -2626,17 +2646,15 @@ def test_node_defaults_combined_retry_and_error_handler():
         return {"foo": "handled"}
 
     graph = (
-        StateGraph(
-            State,
-            node_defaults=NodeDefaults(
-                retry_policy=RetryPolicy(
-                    max_attempts=2,
-                    initial_interval=0.01,
-                    jitter=False,
-                    retry_on=ValueError,
-                ),
-                error_handler=handler,
+        StateGraph(State)
+        .set_node_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=2,
+                initial_interval=0.01,
+                jitter=False,
+                retry_on=ValueError,
             ),
+            error_handler=handler,
         )
         .add_node("fail", always_failing)
         .add_edge(START, "fail")

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2468,3 +2468,259 @@ def test_compile_default_error_handler_collides_with_user_node():
 
     with pytest.raises(ValueError, match="__default_error_handler__"):
         builder.compile(default_error_handler=default_handler)
+
+
+# ---------------------------------------------------------------------------
+# set_defaults()
+# ---------------------------------------------------------------------------
+
+
+def test_set_defaults_error_handler():
+    """set_defaults(error_handler=...) works the same as compile(default_error_handler=...)."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    captured: dict[str, Any] = {}
+
+    def default_handler(state: State, error: NodeError) -> State:
+        captured["node"] = error.node
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(error_handler=default_handler)
+        .add_node("always_failing", always_failing)
+        .add_edge(START, "always_failing")
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "handled"
+    assert captured["node"] == "always_failing"
+
+
+def test_set_defaults_error_handler_compile_kwarg_wins():
+    """compile(default_error_handler=...) takes precedence over set_defaults(error_handler=...)."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    captured: dict[str, str] = {}
+
+    def builder_handler(state: State, error: NodeError) -> State:
+        captured["source"] = "builder"
+        return {"foo": "builder"}
+
+    def compile_handler(state: State, error: NodeError) -> State:
+        captured["source"] = "compile"
+        return {"foo": "compile"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(error_handler=builder_handler)
+        .add_node("always_failing", always_failing)
+        .add_edge(START, "always_failing")
+        .compile(default_error_handler=compile_handler)
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "compile"
+    assert captured["source"] == "compile"
+
+
+def test_set_defaults_retry_policy():
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+
+    def flaky_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise ValueError("not yet")
+        return {"foo": "ok"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=3, initial_interval=0.01, jitter=False, retry_on=ValueError
+            )
+        )
+        .add_node("flaky", flaky_node)
+        .add_edge(START, "flaky")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "ok"
+    assert attempts == 3
+
+
+def test_set_defaults_retry_policy_per_node_wins():
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+
+    def flaky_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise ValueError("not yet")
+        return {"foo": "ok"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=1, initial_interval=0.01, jitter=False, retry_on=ValueError
+            )
+        )
+        .add_node(
+            "flaky",
+            flaky_node,
+            retry_policy=RetryPolicy(
+                max_attempts=3,
+                initial_interval=0.01,
+                jitter=False,
+                retry_on=ValueError,
+            ),
+        )
+        .add_edge(START, "flaky")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "ok"
+    assert attempts == 2
+
+
+@pytest.mark.anyio
+async def test_set_defaults_timeout():
+    class State(TypedDict):
+        foo: str
+
+    async def slow_node(state: State) -> State:
+        await asyncio.sleep(10)
+        return {"foo": "should-not-happen"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(timeout=TimeoutPolicy(run_timeout=0.05))
+        .add_node("slow", slow_node)
+        .add_edge(START, "slow")
+        .compile()
+    )
+
+    from langgraph.errors import NodeTimeoutError
+
+    with pytest.raises(NodeTimeoutError):
+        await graph.ainvoke({"foo": ""})
+
+
+@pytest.mark.anyio
+async def test_set_defaults_timeout_per_node_wins():
+    """Per-node timeout overrides the default; a generous per-node timeout
+    allows a node to complete even when the builder default is very short."""
+
+    class State(TypedDict):
+        foo: str
+
+    async def quick_node(state: State) -> State:
+        await asyncio.sleep(0.05)
+        return {"foo": "done"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(timeout=TimeoutPolicy(run_timeout=0.01))
+        .add_node("quick", quick_node, timeout=TimeoutPolicy(run_timeout=5.0))
+        .add_edge(START, "quick")
+        .compile()
+    )
+
+    result = await graph.ainvoke({"foo": ""})
+    assert result["foo"] == "done"
+
+
+def test_set_defaults_chaining():
+    """set_defaults() is chainable and can be called in any order relative to add_node."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    def handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .add_node("a", always_failing)
+        .add_edge(START, "a")
+        .set_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=1, initial_interval=0.01, jitter=False
+            ),
+            error_handler=handler,
+        )
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "handled"
+
+
+def test_set_defaults_combined_retry_and_error_handler():
+    """Retries are exhausted first, then the error handler runs."""
+
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+    captured: dict[str, Any] = {}
+
+    def always_failing(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("Always fails")
+
+    def handler(state: State, error: NodeError) -> State:
+        captured["error"] = str(error.error)
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .set_defaults(
+            retry_policy=RetryPolicy(
+                max_attempts=2,
+                initial_interval=0.01,
+                jitter=False,
+                retry_on=ValueError,
+            ),
+            error_handler=handler,
+        )
+        .add_node("fail", always_failing)
+        .add_edge(START, "fail")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "handled"
+    assert attempts == 2
+    assert captured["error"] == "Always fails"

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2283,11 +2283,11 @@ def test_node_without_error_handler_still_fails_run():
 
 
 # ---------------------------------------------------------------------------
-# default_error_handler on compile()
+# set_node_defaults()
 # ---------------------------------------------------------------------------
 
 
-def test_compile_default_error_handler_catches_all_nodes():
+def test_set_node_defaults_error_handler_catches_all_nodes():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2309,6 +2309,7 @@ def test_compile_default_error_handler_catches_all_nodes():
 
     graph = (
         StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a)
         .add_node("fail_b", fail_b)
@@ -2316,7 +2317,7 @@ def test_compile_default_error_handler_catches_all_nodes():
         .add_conditional_edges(
             "route_node", lambda s: s["route"], path_map=["fail_a", "fail_b"]
         )
-        .compile(default_error_handler=default_handler)
+        .compile()
     )
 
     result_a = graph.invoke({"route": "fail_a", "foo": []})
@@ -2327,7 +2328,7 @@ def test_compile_default_error_handler_catches_all_nodes():
     assert "fail_b" in captured["nodes"]
 
 
-def test_compile_default_error_handler_overridden_by_node_handler():
+def test_set_node_defaults_error_handler_overridden_by_node_handler():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2353,6 +2354,7 @@ def test_compile_default_error_handler_overridden_by_node_handler():
 
     graph = (
         StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a, error_handler=node_handler)
         .add_node("fail_b", fail_b)
@@ -2360,7 +2362,7 @@ def test_compile_default_error_handler_overridden_by_node_handler():
         .add_conditional_edges(
             "route_node", lambda s: s["route"], path_map=["fail_a", "fail_b"]
         )
-        .compile(default_error_handler=default_handler)
+        .compile()
     )
 
     result_a = graph.invoke({"route": "fail_a", "foo": []})
@@ -2373,7 +2375,7 @@ def test_compile_default_error_handler_overridden_by_node_handler():
     assert "default:fail_b" in captured["handler"]
 
 
-def test_compile_default_error_handler_skips_per_node_handler_nodes():
+def test_set_node_defaults_error_handler_skips_per_node_handler_nodes():
     """If a per-node error handler itself raises, the default handler must NOT
     catch it -- the run should fail."""
 
@@ -2391,16 +2393,17 @@ def test_compile_default_error_handler_skips_per_node_handler_nodes():
 
     graph = (
         StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("always_failing", always_failing, error_handler=broken_handler)
         .add_edge(START, "always_failing")
-        .compile(default_error_handler=default_handler)
+        .compile()
     )
 
     with pytest.raises(RuntimeError, match="handler boom"):
         graph.invoke({"foo": ""})
 
 
-def test_compile_default_error_handler_failure_fails_run():
+def test_set_node_defaults_error_handler_failure_fails_run():
     """When the default handler itself raises, the run fails (no infinite
     recursion, no double-routing)."""
 
@@ -2415,16 +2418,17 @@ def test_compile_default_error_handler_failure_fails_run():
 
     graph = (
         StateGraph(State)
+        .set_node_defaults(error_handler=broken_default_handler)
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
-        .compile(default_error_handler=broken_default_handler)
+        .compile()
     )
 
     with pytest.raises(RuntimeError, match="default handler boom"):
         graph.invoke({"foo": ""})
 
 
-def test_compile_default_error_handler_receives_runnable_config():
+def test_set_node_defaults_error_handler_receives_runnable_config():
     class State(TypedDict):
         foo: str
 
@@ -2442,9 +2446,10 @@ def test_compile_default_error_handler_receives_runnable_config():
     checkpointer = MemorySaver()
     graph = (
         StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
-        .compile(checkpointer=checkpointer, default_error_handler=default_handler)
+        .compile(checkpointer=checkpointer)
     )
 
     thread_id = str(uuid4())
@@ -2455,87 +2460,25 @@ def test_compile_default_error_handler_receives_runnable_config():
     assert captured["thread_id"] == thread_id
 
 
-def test_compile_default_error_handler_collides_with_user_node():
+def test_set_node_defaults_error_handler_collides_with_user_node():
     class State(TypedDict):
         foo: str
 
     def default_handler(state: State, error: NodeError) -> State:
         return {"foo": "handled"}
 
-    builder = StateGraph(State)
-    builder.add_node("__default_error_handler__", lambda s: s)
-    builder.add_edge(START, "__default_error_handler__")
+    builder = (
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
+        .add_node("__default_error_handler__", lambda s: s)
+        .add_edge(START, "__default_error_handler__")
+    )
 
     with pytest.raises(ValueError, match="__default_error_handler__"):
-        builder.compile(default_error_handler=default_handler)
+        builder.compile()
 
 
-# ---------------------------------------------------------------------------
-# set_defaults()
-# ---------------------------------------------------------------------------
-
-
-def test_set_defaults_error_handler():
-    """set_defaults(error_handler=...) works the same as compile(default_error_handler=...)."""
-
-    class State(TypedDict):
-        foo: str
-
-    def always_failing(state: State) -> State:
-        raise RuntimeError("boom")
-
-    captured: dict[str, Any] = {}
-
-    def default_handler(state: State, error: NodeError) -> State:
-        captured["node"] = error.node
-        return {"foo": "handled"}
-
-    graph = (
-        StateGraph(State)
-        .set_defaults(error_handler=default_handler)
-        .add_node("always_failing", always_failing)
-        .add_edge(START, "always_failing")
-        .compile()
-    )
-
-    result = graph.invoke({"foo": ""})
-    assert result["foo"] == "handled"
-    assert captured["node"] == "always_failing"
-
-
-def test_set_defaults_error_handler_compile_kwarg_wins():
-    """compile(default_error_handler=...) takes precedence over set_defaults(error_handler=...)."""
-
-    class State(TypedDict):
-        foo: str
-
-    def always_failing(state: State) -> State:
-        raise RuntimeError("boom")
-
-    captured: dict[str, str] = {}
-
-    def builder_handler(state: State, error: NodeError) -> State:
-        captured["source"] = "builder"
-        return {"foo": "builder"}
-
-    def compile_handler(state: State, error: NodeError) -> State:
-        captured["source"] = "compile"
-        return {"foo": "compile"}
-
-    graph = (
-        StateGraph(State)
-        .set_defaults(error_handler=builder_handler)
-        .add_node("always_failing", always_failing)
-        .add_edge(START, "always_failing")
-        .compile(default_error_handler=compile_handler)
-    )
-
-    result = graph.invoke({"foo": ""})
-    assert result["foo"] == "compile"
-    assert captured["source"] == "compile"
-
-
-def test_set_defaults_retry_policy():
+def test_set_node_defaults_retry_policy():
     class State(TypedDict):
         foo: str
 
@@ -2550,7 +2493,7 @@ def test_set_defaults_retry_policy():
 
     graph = (
         StateGraph(State)
-        .set_defaults(
+        .set_node_defaults(
             retry_policy=RetryPolicy(
                 max_attempts=3, initial_interval=0.01, jitter=False, retry_on=ValueError
             )
@@ -2567,7 +2510,7 @@ def test_set_defaults_retry_policy():
     assert attempts == 3
 
 
-def test_set_defaults_retry_policy_per_node_wins():
+def test_set_node_defaults_retry_policy_per_node_wins():
     class State(TypedDict):
         foo: str
 
@@ -2582,7 +2525,7 @@ def test_set_defaults_retry_policy_per_node_wins():
 
     graph = (
         StateGraph(State)
-        .set_defaults(
+        .set_node_defaults(
             retry_policy=RetryPolicy(
                 max_attempts=1, initial_interval=0.01, jitter=False, retry_on=ValueError
             )
@@ -2609,7 +2552,7 @@ def test_set_defaults_retry_policy_per_node_wins():
 
 
 @pytest.mark.anyio
-async def test_set_defaults_timeout():
+async def test_set_node_defaults_timeout():
     class State(TypedDict):
         foo: str
 
@@ -2619,7 +2562,7 @@ async def test_set_defaults_timeout():
 
     graph = (
         StateGraph(State)
-        .set_defaults(timeout=TimeoutPolicy(run_timeout=0.05))
+        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.05))
         .add_node("slow", slow_node)
         .add_edge(START, "slow")
         .compile()
@@ -2632,7 +2575,7 @@ async def test_set_defaults_timeout():
 
 
 @pytest.mark.anyio
-async def test_set_defaults_timeout_per_node_wins():
+async def test_set_node_defaults_timeout_per_node_wins():
     """Per-node timeout overrides the default; a generous per-node timeout
     allows a node to complete even when the builder default is very short."""
 
@@ -2645,7 +2588,7 @@ async def test_set_defaults_timeout_per_node_wins():
 
     graph = (
         StateGraph(State)
-        .set_defaults(timeout=TimeoutPolicy(run_timeout=0.01))
+        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.01))
         .add_node("quick", quick_node, timeout=TimeoutPolicy(run_timeout=5.0))
         .add_edge(START, "quick")
         .compile()
@@ -2655,8 +2598,8 @@ async def test_set_defaults_timeout_per_node_wins():
     assert result["foo"] == "done"
 
 
-def test_set_defaults_chaining():
-    """set_defaults() is chainable and can be called in any order relative to add_node."""
+def test_set_node_defaults_chaining():
+    """set_node_defaults() is chainable and can be called in any order relative to add_node."""
 
     class State(TypedDict):
         foo: str
@@ -2671,7 +2614,7 @@ def test_set_defaults_chaining():
         StateGraph(State)
         .add_node("a", always_failing)
         .add_edge(START, "a")
-        .set_defaults(
+        .set_node_defaults(
             retry_policy=RetryPolicy(
                 max_attempts=1, initial_interval=0.01, jitter=False
             ),
@@ -2684,7 +2627,7 @@ def test_set_defaults_chaining():
     assert result["foo"] == "handled"
 
 
-def test_set_defaults_combined_retry_and_error_handler():
+def test_set_node_defaults_combined_retry_and_error_handler():
     """Retries are exhausted first, then the error handler runs."""
 
     class State(TypedDict):
@@ -2704,7 +2647,7 @@ def test_set_defaults_combined_retry_and_error_handler():
 
     graph = (
         StateGraph(State)
-        .set_defaults(
+        .set_node_defaults(
             retry_policy=RetryPolicy(
                 max_attempts=2,
                 initial_interval=0.01,

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -38,6 +38,7 @@ from langgraph.channels.last_value import LastValue
 from langgraph.errors import GraphInterrupt, NodeError, NodeTimeoutError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph, add_messages
+from langgraph.graph.state import NodeDefaults
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
@@ -2283,11 +2284,11 @@ def test_node_without_error_handler_still_fails_run():
 
 
 # ---------------------------------------------------------------------------
-# set_node_defaults()
+# StateGraph(node_defaults=...)
 # ---------------------------------------------------------------------------
 
 
-def test_set_node_defaults_error_handler_catches_all_nodes():
+def test_node_defaults_error_handler_catches_all_nodes():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2308,8 +2309,7 @@ def test_set_node_defaults_error_handler_catches_all_nodes():
         return {"foo": [f"handled_{error.node}"]}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=default_handler)
+        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a)
         .add_node("fail_b", fail_b)
@@ -2328,7 +2328,7 @@ def test_set_node_defaults_error_handler_catches_all_nodes():
     assert "fail_b" in captured["nodes"]
 
 
-def test_set_node_defaults_error_handler_overridden_by_node_handler():
+def test_node_defaults_error_handler_overridden_by_node_handler():
     class State(TypedDict):
         route: str
         foo: Annotated[list[str], operator.add]
@@ -2353,8 +2353,7 @@ def test_set_node_defaults_error_handler_overridden_by_node_handler():
         return {"foo": [f"default_handled_{error.node}"]}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=default_handler)
+        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
         .add_node("route_node", route_node)
         .add_node("fail_a", fail_a, error_handler=node_handler)
         .add_node("fail_b", fail_b)
@@ -2375,7 +2374,7 @@ def test_set_node_defaults_error_handler_overridden_by_node_handler():
     assert "default:fail_b" in captured["handler"]
 
 
-def test_set_node_defaults_error_handler_skips_per_node_handler_nodes():
+def test_node_defaults_error_handler_skips_per_node_handler_nodes():
     """If a per-node error handler itself raises, the default handler must NOT
     catch it -- the run should fail."""
 
@@ -2392,8 +2391,7 @@ def test_set_node_defaults_error_handler_skips_per_node_handler_nodes():
         return {"foo": "default recovered"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=default_handler)
+        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
         .add_node("always_failing", always_failing, error_handler=broken_handler)
         .add_edge(START, "always_failing")
         .compile()
@@ -2403,7 +2401,7 @@ def test_set_node_defaults_error_handler_skips_per_node_handler_nodes():
         graph.invoke({"foo": ""})
 
 
-def test_set_node_defaults_error_handler_failure_fails_run():
+def test_node_defaults_error_handler_failure_fails_run():
     """When the default handler itself raises, the run fails (no infinite
     recursion, no double-routing)."""
 
@@ -2417,8 +2415,9 @@ def test_set_node_defaults_error_handler_failure_fails_run():
         raise RuntimeError("default handler boom")
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=broken_default_handler)
+        StateGraph(
+            State, node_defaults=NodeDefaults(error_handler=broken_default_handler)
+        )
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
         .compile()
@@ -2428,7 +2427,7 @@ def test_set_node_defaults_error_handler_failure_fails_run():
         graph.invoke({"foo": ""})
 
 
-def test_set_node_defaults_error_handler_receives_runnable_config():
+def test_node_defaults_error_handler_receives_runnable_config():
     class State(TypedDict):
         foo: str
 
@@ -2445,8 +2444,7 @@ def test_set_node_defaults_error_handler_receives_runnable_config():
 
     checkpointer = MemorySaver()
     graph = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=default_handler)
+        StateGraph(State, node_defaults=NodeDefaults(error_handler=default_handler))
         .add_node("always_failing", always_failing)
         .add_edge(START, "always_failing")
         .compile(checkpointer=checkpointer)
@@ -2460,25 +2458,24 @@ def test_set_node_defaults_error_handler_receives_runnable_config():
     assert captured["thread_id"] == thread_id
 
 
-def test_set_node_defaults_error_handler_collides_with_user_node():
+def test_node_defaults_error_handler_collides_with_user_node():
+    """Adding a node named `__default_error_handler__` after a default
+    error_handler is set is rejected by add_node's existing duplicate guard."""
+
     class State(TypedDict):
         foo: str
 
     def default_handler(state: State, error: NodeError) -> State:
         return {"foo": "handled"}
 
-    builder = (
-        StateGraph(State)
-        .set_node_defaults(error_handler=default_handler)
-        .add_node("__default_error_handler__", lambda s: s)
-        .add_edge(START, "__default_error_handler__")
+    builder = StateGraph(
+        State, node_defaults=NodeDefaults(error_handler=default_handler)
     )
-
     with pytest.raises(ValueError, match="__default_error_handler__"):
-        builder.compile()
+        builder.add_node("__default_error_handler__", lambda s: s)
 
 
-def test_set_node_defaults_retry_policy():
+def test_node_defaults_retry_policy():
     class State(TypedDict):
         foo: str
 
@@ -2492,11 +2489,16 @@ def test_set_node_defaults_retry_policy():
         return {"foo": "ok"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(
-            retry_policy=RetryPolicy(
-                max_attempts=3, initial_interval=0.01, jitter=False, retry_on=ValueError
-            )
+        StateGraph(
+            State,
+            node_defaults=NodeDefaults(
+                retry_policy=RetryPolicy(
+                    max_attempts=3,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                )
+            ),
         )
         .add_node("flaky", flaky_node)
         .add_edge(START, "flaky")
@@ -2510,7 +2512,7 @@ def test_set_node_defaults_retry_policy():
     assert attempts == 3
 
 
-def test_set_node_defaults_retry_policy_per_node_wins():
+def test_node_defaults_retry_policy_per_node_wins():
     class State(TypedDict):
         foo: str
 
@@ -2524,11 +2526,16 @@ def test_set_node_defaults_retry_policy_per_node_wins():
         return {"foo": "ok"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(
-            retry_policy=RetryPolicy(
-                max_attempts=1, initial_interval=0.01, jitter=False, retry_on=ValueError
-            )
+        StateGraph(
+            State,
+            node_defaults=NodeDefaults(
+                retry_policy=RetryPolicy(
+                    max_attempts=1,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                )
+            ),
         )
         .add_node(
             "flaky",
@@ -2552,7 +2559,7 @@ def test_set_node_defaults_retry_policy_per_node_wins():
 
 
 @pytest.mark.anyio
-async def test_set_node_defaults_timeout():
+async def test_node_defaults_timeout():
     class State(TypedDict):
         foo: str
 
@@ -2561,8 +2568,9 @@ async def test_set_node_defaults_timeout():
         return {"foo": "should-not-happen"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.05))
+        StateGraph(
+            State, node_defaults=NodeDefaults(timeout=TimeoutPolicy(run_timeout=0.05))
+        )
         .add_node("slow", slow_node)
         .add_edge(START, "slow")
         .compile()
@@ -2575,7 +2583,7 @@ async def test_set_node_defaults_timeout():
 
 
 @pytest.mark.anyio
-async def test_set_node_defaults_timeout_per_node_wins():
+async def test_node_defaults_timeout_per_node_wins():
     """Per-node timeout overrides the default; a generous per-node timeout
     allows a node to complete even when the builder default is very short."""
 
@@ -2587,8 +2595,9 @@ async def test_set_node_defaults_timeout_per_node_wins():
         return {"foo": "done"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(timeout=TimeoutPolicy(run_timeout=0.01))
+        StateGraph(
+            State, node_defaults=NodeDefaults(timeout=TimeoutPolicy(run_timeout=0.01))
+        )
         .add_node("quick", quick_node, timeout=TimeoutPolicy(run_timeout=5.0))
         .add_edge(START, "quick")
         .compile()
@@ -2598,36 +2607,7 @@ async def test_set_node_defaults_timeout_per_node_wins():
     assert result["foo"] == "done"
 
 
-def test_set_node_defaults_chaining():
-    """set_node_defaults() is chainable and can be called in any order relative to add_node."""
-
-    class State(TypedDict):
-        foo: str
-
-    def always_failing(state: State) -> State:
-        raise RuntimeError("boom")
-
-    def handler(state: State, error: NodeError) -> State:
-        return {"foo": "handled"}
-
-    graph = (
-        StateGraph(State)
-        .add_node("a", always_failing)
-        .add_edge(START, "a")
-        .set_node_defaults(
-            retry_policy=RetryPolicy(
-                max_attempts=1, initial_interval=0.01, jitter=False
-            ),
-            error_handler=handler,
-        )
-        .compile()
-    )
-
-    result = graph.invoke({"foo": ""})
-    assert result["foo"] == "handled"
-
-
-def test_set_node_defaults_combined_retry_and_error_handler():
+def test_node_defaults_combined_retry_and_error_handler():
     """Retries are exhausted first, then the error handler runs."""
 
     class State(TypedDict):
@@ -2646,15 +2626,17 @@ def test_set_node_defaults_combined_retry_and_error_handler():
         return {"foo": "handled"}
 
     graph = (
-        StateGraph(State)
-        .set_node_defaults(
-            retry_policy=RetryPolicy(
-                max_attempts=2,
-                initial_interval=0.01,
-                jitter=False,
-                retry_on=ValueError,
+        StateGraph(
+            State,
+            node_defaults=NodeDefaults(
+                retry_policy=RetryPolicy(
+                    max_attempts=2,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                ),
+                error_handler=handler,
             ),
-            error_handler=handler,
         )
         .add_node("fail", always_failing)
         .add_edge(START, "fail")


### PR DESCRIPTION
Add `StateGraph.set_node_defaults()` — a fluent builder method for setting graph-wide node policies in one place. Per-node values from `add_node()` always take precedence. Defaults are applied at `compile()` time.

```python
graph = (
    StateGraph(State)
    .set_node_defaults(
        retry_policy=RetryPolicy(max_attempts=3),
        error_handler=my_fallback_handler,
        timeout=TimeoutPolicy(run_timeout=30),
    )
    .add_node("a", node_a)
    .add_node("b", node_b, retry_policy=custom)  # overrides default
    .add_edge(START, "a")
    .compile()
)
```

Error handlers are never invoked on error-handler nodes themselves — handler failures fail the run. Not inherited by subgraphs.

## Supported defaults

| `set_node_defaults()` kwarg | Fallback for `add_node(...)` kwarg | Applies to error-handler nodes? |
|---|---|---|
| `retry_policy` | `retry_policy` | Yes |
| `cache_policy` | `cache_policy` | No — caching handler results is unsafe |
| `error_handler` | `error_handler` | No — handlers must never catch themselves |
| `timeout` | `timeout` | Yes |

## Changes

- `libs/langgraph/langgraph/graph/state.py` — new `_NodeDefaults` dataclass, `set_node_defaults()` method on `StateGraph`; `compile()` applies builder defaults to node specs with per-branch rules for which defaults apply to error-handler nodes.
- `libs/langgraph/tests/test_retry.py` — 14 new tests covering all four policy types, per-node override precedence, chaining, combined retry+handler, handler exclusion, `RunnableConfig` injection, and name collision.

## Verification

`make format`, `make lint`, `make test` all passing in `libs/langgraph`.