### PR TITLE
feat(langgraph): add graph-wide default error handler fallback

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -200,6 +200,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     context_schema: type[ContextT] | None
     input_schema: type[InputT]
     output_schema: type[OutputT]
+    default_error_handler: StateNode[Any, ContextT] | None
 
     def __init__(
         self,
@@ -245,6 +246,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.managed = {}
         self.compiled = False
         self.waiting_edges = set()
+        self.default_error_handler = None
 
         self.state_schema = state_schema
         self.input_schema = cast(type[InputT], input_schema or state_schema)
@@ -292,6 +294,40 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                         )
                 else:
                     self.managed[key] = managed
+
+    def _register_error_handler_node(
+        self,
+        *,
+        node_name: str,
+        error_handler: StateNode[Any, ContextT],
+        input_schema: type[Any],
+    ) -> str:
+        handler_node_name = f"__error_handler__{node_name}"
+        if handler_node_name in self.nodes:
+            raise ValueError(
+                f"Auto-generated error handler node `{handler_node_name}` already exists."
+            )
+        self.nodes[handler_node_name] = StateNodeSpec[Any, ContextT](
+            coerce_to_runnable(error_handler, name=handler_node_name, trace=False),  # type: ignore[arg-type]
+            metadata=None,
+            input_schema=input_schema,
+            retry_policy=None,
+            cache_policy=None,
+            is_error_handler=True,
+        )
+        return handler_node_name
+
+    def _materialize_default_error_handlers(self) -> None:
+        if self.default_error_handler is None:
+            return
+        for node_name, spec in list(self.nodes.items()):
+            if spec.is_error_handler or spec.error_handler_node is not None:
+                continue
+            spec.error_handler_node = self._register_error_handler_node(
+                node_name=node_name,
+                error_handler=self.default_error_handler,
+                input_schema=spec.input_schema,
+            )
 
     @overload
     def add_node(
@@ -777,18 +813,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         )
         handler_node_name: str | None = None
         if error_handler is not None:
-            handler_node_name = f"__error_handler__{node}"
-            if handler_node_name in self.nodes:
-                raise ValueError(
-                    f"Auto-generated error handler node `{handler_node_name}` already exists."
-                )
-            self.nodes[handler_node_name] = StateNodeSpec[Any, ContextT](
-                coerce_to_runnable(error_handler, name=handler_node_name, trace=False),  # type: ignore[arg-type]
-                metadata=None,
+            handler_node_name = self._register_error_handler_node(
+                node_name=node,
+                error_handler=error_handler,
                 input_schema=resolved_input_schema,
-                retry_policy=None,
-                cache_policy=None,
-                is_error_handler=True,
             )
 
         if input_schema is not None:
@@ -1035,6 +1063,30 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         """
         return self.add_edge(key, END)
 
+    def set_default_error_handler(
+        self, error_handler: StateNode[Any, ContextT] | None
+    ) -> Self:
+        """Sets a graph-wide default error handler for nodes without one.
+
+        The default is used only for nodes that do not pass `error_handler` to
+        `add_node`. Node-level handlers always take precedence.
+
+        Parameters:
+            error_handler: A callable/runnable with the same signature as
+                `add_node(..., error_handler=...)`, or `None` to disable the
+                graph-wide default.
+
+        Returns:
+            Self: The instance of the graph, allowing for method chaining.
+        """
+        if self.compiled:
+            logger.warning(
+                "Setting a default error handler on a graph that has already been "
+                "compiled. This will not be reflected in the compiled graph."
+            )
+        self.default_error_handler = error_handler
+        return self
+
     def validate(self, interrupt: Sequence[str] | None = None) -> Self:
         # assemble sources
         all_sources = {src for src, _ in self._all_edges}
@@ -1165,6 +1217,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         # assign default values
         interrupt_before = interrupt_before or []
         interrupt_after = interrupt_after or []
+        self._materialize_default_error_handlers()
 
         # validate the graph
         self.validate(

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2280,3 +2280,120 @@ def test_node_without_error_handler_still_fails_run():
 
     with pytest.raises(ValueError, match="no handler"):
         graph.invoke({"foo": ""})
+
+
+def test_graph_default_error_handler_applies_to_unhandled_nodes():
+    class State(TypedDict):
+        foo: str
+
+    captured: dict[str, object] = {}
+
+    def fail_node(state: State) -> State:
+        raise ValueError("node failed")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        captured["from_node_name"] = error.node
+        captured["from_node_error"] = error.error
+        return {"foo": "handled_by_default"}
+
+    graph = (
+        StateGraph(State)
+        .set_default_error_handler(default_handler)
+        .add_node("fail_node", fail_node)
+        .add_edge(START, "fail_node")
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "handled_by_default"
+    assert captured["from_node_name"] == "fail_node"
+    assert isinstance(captured["from_node_error"], BaseException)
+
+
+def test_node_error_handler_takes_precedence_over_graph_default():
+    class State(TypedDict):
+        foo: str
+
+    calls: list[str] = []
+
+    def fail_node(state: State) -> State:
+        raise ValueError("node failed")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        calls.append("default")
+        return {"foo": "default"}
+
+    def node_handler(state: State, error: NodeError) -> State:
+        calls.append("node")
+        return {"foo": "node"}
+
+    graph = (
+        StateGraph(State)
+        .set_default_error_handler(default_handler)
+        .add_node("fail_node", fail_node, error_handler=node_handler)
+        .add_edge(START, "fail_node")
+        .compile()
+    )
+
+    result = graph.invoke({"foo": ""})
+    assert result["foo"] == "node"
+    assert calls == ["node"]
+
+
+def test_graph_default_error_handler_runs_after_retry_exhaustion():
+    class State(TypedDict):
+        foo: str
+
+    attempts = 0
+
+    def always_failing_node(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError("Always fails")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": f"handled_{error.node}"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.01,
+        jitter=False,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .set_default_error_handler(default_handler)
+        .add_node("always_failing", always_failing_node, retry_policy=retry_policy)
+        .add_edge(START, "always_failing")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert attempts == 2
+    assert result["foo"] == "handled_always_failing"
+
+
+def test_graph_default_error_handler_can_be_disabled():
+    class State(TypedDict):
+        foo: str
+
+    def fail_node(state: State) -> State:
+        raise ValueError("no handler")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .set_default_error_handler(default_handler)
+        .set_default_error_handler(None)
+        .add_node("fail_node", fail_node)
+        .add_edge(START, "fail_node")
+        .compile()
+    )
+
+    with pytest.raises(ValueError, match="no handler"):
+        graph.invoke({"foo": ""})


### PR DESCRIPTION
## Summary
- add `StateGraph.set_default_error_handler(...)` to configure a graph-wide fallback for nodes without explicit `error_handler`
- preserve precedence: node-level handler overrides graph-level default
- materialize fallback handler nodes at compile time and reuse existing node error-handler scheduling flow
- add retry tests for graph-default behavior and precedence/non-regression

