### PR TITLE
ci: add codespell enforcement for typo detection (#5021)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+[codespell]
+# Skip non-text files and generated content
+skip = .git,__pycache__,.mypy_cache,.ruff_cache,*.lock,*.json,*.csv,*.png,*.jpg,*.svg,*.ico,*.ipynb,.venv
+# Ignore words that are valid in the context of this project
+ignore-words-list = infor,nd,ans,stdio,jupyter,lets,lite,uis,deque,langgraph,langchain,pydantic,typing,async,await,coroutine,iterable,iterables,serializable,deserializable,checkpointer,checkpointing,stateful,statefulness,prebuilt,supervisor,supervisory,swarm,swarming,multiactor,multiactors,subgraph,subgraphs,workflow,workflows,streaming,streamable,streamed,streamer,streamers,thead
+# Check nested directories
+count =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,15 @@ jobs:
       - name: Run check_sdk_methods script
         run: python .github/scripts/check_sdk_methods.py
 
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install codespell
+        run: pip install codespell
+      - name: Run codespell
+        run: codespell
+
   check-schema:
     needs: changes
     if: needs.changes.outputs.python == 'true'
@@ -164,6 +173,7 @@ jobs:
         test,
         test-langgraph,
         check-sdk-methods,
+        codespell,
         check-schema,
         integration-test,
       ]

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,18 @@ lock-upgrade:
 		fi; \
 	done
 
+# Spell check all projects
+.PHONY: spell_check
+spell_check:
+	@echo "Running codespell on the entire repository..."
+	@codespell
+
+# Fix spelling errors across all projects
+.PHONY: spell_fix
+spell_fix:
+	@echo "Fixing codespell errors across the entire repository..."
+	@codespell -w
+
 # Test all projects
 .PHONY: test
 test:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5855,7 +5855,7 @@ def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(ask(q).result())
 
         return {"answers": answers}
@@ -5866,13 +5866,13 @@ def test_task_before_interrupt_resume(
     result = workflow.invoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = workflow.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = workflow.invoke(Command(resume="answer2"), config=config)
@@ -5981,7 +5981,7 @@ def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -6001,13 +6001,13 @@ def test_node_before_interrupt_resume_graph_api(
     result = graph.invoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = graph.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = graph.invoke(Command(resume="answer2"), config=config)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8071,7 +8071,7 @@ async def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(await ask(q))
 
         return {"answers": answers}
@@ -8082,13 +8082,13 @@ async def test_task_before_interrupt_resume(
     result = await workflow.ainvoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await workflow.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = await workflow.ainvoke(Command(resume="answer2"), config=config)
@@ -8200,7 +8200,7 @@ async def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -8220,13 +8220,13 @@ async def test_node_before_interrupt_resume_graph_api(
     result = await graph.ainvoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await graph.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = await graph.ainvoke(Command(resume="answer2"), config=config)


### PR DESCRIPTION
## Summary

Closes #5021 — adds automated typo checking to CI to reduce the volume of docs typos fix PRs.

### Changes
- **`.codespellrc`**: repo-wide codespell config with skip patterns + domain-specific ignore list
- **`Makefile`**: `make spell_check` and `make spell_fix` targets
- **`.github/workflows/ci.yml`**: new `codespell` job in CI pipeline, gated on `ci_success`
- **Fixed existing typos**: 12 `Whats` → `What's` in test assertions

### Impact
- Every PR will now be checked for typos before merge
- Contributors get immediate feedback on spelling errors
- Maintainers spend less time fixing/reviewing typo-only PRs
