### PR TITLE
ci: disable uv cache in publish pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache-suffix: "release"
+          enable-cache: false
           working-directory: ${{ inputs.working-directory }}
 
       # We want to keep this build stage *separate* from the release stage,
@@ -268,6 +269,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache-suffix: "release"
+          enable-cache: false
           working-directory: ${{ inputs.working-directory }}
 
       - uses: actions/download-artifact@v8
@@ -309,6 +311,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache-suffix: "release"
+          enable-cache: false
           working-directory: ${{ inputs.working-directory }}
 
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
Disable `uv` dependency caching throughout the release workflow so build, validation, PyPI publish, and GitHub release jobs do not restore shared cache state.

Release jobs already pass the built distributions through explicit artifacts; keeping dependency caches out of this path avoids cache-poisoning risk and makes the existing pre-release validation comment match the actual workflow behavior.