### PR TITLE
fix(ci): avoid inline benchmark output interpolation

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,14 +58,18 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Annotation
         uses: actions/github-script@v9
+        env:
+          CHANGED_FILES: ${{ steps.files.outputs.added_modified_renamed }}
+          BENCHMARK_OUTPUT: ${{ steps.benchmark.outputs.OUTPUT }}
+          COMPARE_OUTPUT: ${{ steps.compare.outputs.OUTPUT }}
         with:
           script: |
-            const file = JSON.parse(`${{ steps.files.outputs.added_modified_renamed }}`)[0]
-            core.notice(`${{ steps.benchmark.outputs.OUTPUT }}`, {
+            const file = JSON.parse(process.env.CHANGED_FILES || "[]")[0]
+            core.notice(process.env.BENCHMARK_OUTPUT || "", {
               title: 'Benchmark results',
               file,
             })
-            core.notice(`${{ steps.compare.outputs.OUTPUT }}`, {
+            core.notice(process.env.COMPARE_OUTPUT || "", {
               title: 'Comparison against main',
               file,
             })


### PR DESCRIPTION
Avoid interpolating changed-file and benchmark outputs directly into the `github-script` source for benchmark annotations.