### PR TITLE
fix: update broken HITL docs URL in multi-interrupt RuntimeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -895,7 +895,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#resume-multiple-interrupts-with-one-invocation."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary

Fixes #7686

Resuming a graph with a single value while multiple interrupts are pending raises a `RuntimeError` with a broken documentation URL. The link pointed to `/add-human-in-the-loop#...` which returns HTTP 404.

## Root Cause

PR #5192 consolidated the HITL documentation, moving the page from `add-human-in-the-loop` to `interrupts` (with a redirect from `human-in-the-loop`). The in-source URL in `libs/langgraph/langgraph/pregel/_loop.py` line 898 was not updated during that consolidation.

## Fix

Updated the docs URL in the RuntimeError message from:
- `.../add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation`

to the canonical URL:
- `.../interrupts#resume-multiple-interrupts-with-one-invocation`

(which is the final destination after the 308 redirect from `human-in-the-loop`)

## Changes

- `libs/langgraph/langgraph/pregel/_loop.py`: 1 line changed (`+1 -1`)

## Testing

- Multi-interrupt resume with single value: RuntimeError now includes working docs URL ✅
- Broken URL verification: `add-human-in-the-loop` → HTTP 404, `interrupts` → HTTP 200 ✅
- Existing single-interrupt resume: unaffected ✅