### PR TITLE
feat(stream): add async interleave for run projections

### DIFF
--- a/libs/langgraph/langgraph/stream/run_stream.py
+++ b/libs/langgraph/langgraph/stream/run_stream.py
@@ -500,6 +500,94 @@ class AsyncGraphRunStream:
         """Subscribe to the main event log and iterate protocol events."""
         return self._mux._events.__aiter__()
 
+    async def interleave(self, *names: str) -> AsyncIterator[tuple[str, Any]]:
+        """Iterate multiple projections in arrival order, yielding ``(name, item)``.
+
+        Async counterpart to ``GraphRunStream.interleave``. Items are
+        ordered by the monotonic push stamp assigned when each transformer
+        pushes into its ``StreamChannel``.
+
+        Args:
+            *names: Projection keys to interleave. Must match keys in
+                ``extensions``.
+
+        Yields:
+            ``(name, item)`` tuples in arrival order across the named
+            projections.
+
+        Each named channel is locked for the duration of iteration and
+        released when the async generator completes, is closed, or raises.
+        Channels cannot be subscribed concurrently — use ``.atee(n)`` if
+        you need fan-out.
+
+        Raises:
+            KeyError: If a name doesn't match a registered projection.
+        """
+        from langgraph.stream.stream_channel import StreamChannel
+
+        channels: dict[str, StreamChannel[Any]] = {}
+        try:
+            for name in names:
+                ch = self.extensions[name]
+                if not isinstance(ch, StreamChannel):
+                    raise TypeError(
+                        f"interleave() requires StreamChannel projections, "
+                        f"got {type(ch).__name__} for {name!r}"
+                    )
+                if ch._is_async is None:
+                    raise TypeError(
+                        f"StreamChannel {name!r} has not been bound yet. "
+                        "Register the transformer with a StreamMux first."
+                    )
+                if not ch._is_async:
+                    raise TypeError(
+                        f"StreamChannel {name!r} is bound to sync mode — "
+                        "async interleave() cannot consume sync channels."
+                    )
+                if ch._subscribed:
+                    raise RuntimeError(
+                        f"StreamChannel {name!r} already has a subscriber; "
+                        "use .atee(n) for fan-out."
+                    )
+                ch._subscribed = True
+                channels[name] = ch
+
+            done: set[str] = set()
+
+            while len(done) < len(channels):
+                best: tuple[int, str] | None = None
+                for name, ch in channels.items():
+                    if name in done:
+                        continue
+                    if ch._closed and not ch._items:
+                        if ch._error is not None:
+                            raise ch._error
+                        done.add(name)
+                        continue
+                    if ch._items:
+                        stamp = ch._items[0][0]
+                        if best is None or stamp < best[0]:
+                            best = (stamp, name)
+
+                if best is not None:
+                    _stamp, item = channels[best[1]]._items.popleft()
+                    yield (best[1], item)
+                else:
+                    pump = self._mux._apump_fn
+                    if pump is None or not await pump():
+                        before = len(done)
+                        for name, ch in channels.items():
+                            if name not in done and not ch._items:
+                                if ch._closed:
+                                    if ch._error is not None:
+                                        raise ch._error
+                                    done.add(name)
+                        if len(done) == before:
+                            break
+        finally:
+            for ch in channels.values():
+                ch._subscribed = False
+
 
 class _SubgraphRunStreamMixin:
     """Subgraph metadata + parent-pump delegation shared by both lanes.

--- a/libs/langgraph/tests/test_interleave_arrival_order.py
+++ b/libs/langgraph/tests/test_interleave_arrival_order.py
@@ -13,7 +13,7 @@ from langgraph.graph import StateGraph
 from langgraph.stream import StreamChannel, StreamTransformer
 from langgraph.stream._mux import StreamMux
 from langgraph.stream._types import ProtocolEvent
-from langgraph.stream.run_stream import GraphRunStream
+from langgraph.stream.run_stream import AsyncGraphRunStream, GraphRunStream
 from langgraph.stream.transformers import ValuesTransformer
 
 # ---------------------------------------------------------------------------
@@ -355,5 +355,171 @@ class TestInterleaveIntegration:
 
         with pytest.raises(RuntimeError, match="already has a subscriber"):
             list(run.interleave("values", "alpha"))
+
+        assert mux.extensions["values"]._subscribed is False
+
+
+class TestAsyncInterleaveArrivalOrder:
+    @pytest.mark.anyio
+    async def test_arrival_order_not_round_robin(self) -> None:
+        mux = StreamMux(
+            factories=[ValuesTransformer, _TwoChannelTransformer],
+            is_async=True,
+        )
+        alpha = mux.extensions["alpha"]
+        beta = mux.extensions["beta"]
+        run = AsyncGraphRunStream(None, mux, wire_pump=False)
+
+        push_script = [
+            ("alpha", "a1"),
+            ("alpha", "a2"),
+            ("beta", "b1"),
+            ("alpha", "a3"),
+            ("beta", "b2"),
+        ]
+        push_iter = iter(push_script)
+        channels = {"alpha": alpha, "beta": beta}
+
+        async def fake_pump() -> bool:
+            try:
+                name, item = next(push_iter)
+                channels[name].push(item)
+                return True
+            except StopIteration:
+                await mux.aclose()
+                return False
+
+        mux.bind_apump(fake_pump)
+
+        result = [pair async for pair in run.interleave("alpha", "beta")]
+        names = [name for name, _ in result]
+        items = [item for _, item in result]
+
+        assert items == ["a1", "a2", "b1", "a3", "b2"]
+        assert names == ["alpha", "alpha", "beta", "alpha", "beta"]
+
+    @pytest.mark.anyio
+    async def test_empty_projection(self) -> None:
+        mux = StreamMux(
+            factories=[ValuesTransformer, _TwoChannelTransformer],
+            is_async=True,
+        )
+        alpha = mux.extensions["alpha"]
+        run = AsyncGraphRunStream(None, mux, wire_pump=False)
+
+        push_script = ["a1", "a2"]
+        push_iter = iter(push_script)
+
+        async def fake_pump() -> bool:
+            try:
+                alpha.push(next(push_iter))
+                return True
+            except StopIteration:
+                await mux.aclose()
+                return False
+
+        mux.bind_apump(fake_pump)
+
+        result = [pair async for pair in run.interleave("alpha", "beta")]
+        assert result == [("alpha", "a1"), ("alpha", "a2")]
+
+    @pytest.mark.anyio
+    async def test_error_propagation(self) -> None:
+        mux = StreamMux(
+            factories=[ValuesTransformer, _TwoChannelTransformer],
+            is_async=True,
+        )
+        alpha = mux.extensions["alpha"]
+        beta = mux.extensions["beta"]
+        run = AsyncGraphRunStream(None, mux, wire_pump=False)
+        err = RuntimeError("boom")
+
+        push_script = [
+            ("alpha", "a1"),
+            ("beta", "b1"),
+        ]
+        push_iter = iter(push_script)
+        channels = {"alpha": alpha, "beta": beta}
+
+        async def fake_pump() -> bool:
+            try:
+                name, item = next(push_iter)
+                channels[name].push(item)
+                return True
+            except StopIteration:
+                alpha.fail(err)
+                beta.close()
+                return False
+
+        mux.bind_apump(fake_pump)
+
+        collected = []
+        with pytest.raises(RuntimeError, match="boom"):
+            async for pair in run.interleave("alpha", "beta"):
+                collected.append(pair)
+
+        assert ("alpha", "a1") in collected
+        assert ("beta", "b1") in collected
+
+
+class TestAsyncInterleaveIntegration:
+    @pytest.mark.anyio
+    async def test_interleave_values_and_messages(self) -> None:
+        run = await _build_simple_graph().astream_events(
+            {"value": "x", "items": []}, version="v3"
+        )
+        tagged = [pair async for pair in run.interleave("values", "messages")]
+        names = [name for name, _ in tagged]
+        assert set(names).issubset({"values", "messages"})
+        assert names.count("values") >= 1
+
+    @pytest.mark.anyio
+    async def test_interleave_rejects_already_subscribed(self) -> None:
+        mux = StreamMux(
+            factories=[ValuesTransformer, _TwoChannelTransformer],
+            is_async=True,
+        )
+        alpha = mux.extensions["alpha"]
+        run = AsyncGraphRunStream(None, mux, wire_pump=False)
+
+        _ = alpha.__aiter__()
+        await mux.aclose()
+
+        with pytest.raises(RuntimeError, match="already has a subscriber"):
+            [pair async for pair in run.interleave("alpha")]
+
+    @pytest.mark.anyio
+    async def test_interleave_releases_projections_on_completion(self) -> None:
+        run = await _build_simple_graph().astream_events(
+            {"value": "x", "items": []}, version="v3"
+        )
+        [pair async for pair in run.interleave("values", "messages")]
+        assert run.extensions["values"]._subscribed is False
+        assert run.extensions["messages"]._subscribed is False
+
+    @pytest.mark.anyio
+    async def test_interleave_releases_projections_on_early_break(self) -> None:
+        run = await _build_simple_graph().astream_events(
+            {"value": "x", "items": []}, version="v3"
+        )
+        agen = run.interleave("values", "messages")
+        await anext(agen)
+        await agen.aclose()
+        assert run.extensions["values"]._subscribed is False
+        assert run.extensions["messages"]._subscribed is False
+
+    @pytest.mark.anyio
+    async def test_interleave_releases_projections_on_validation_failure(self) -> None:
+        mux = StreamMux(
+            factories=[ValuesTransformer, _TwoChannelTransformer],
+            is_async=True,
+        )
+        alpha = mux.extensions["alpha"]
+        run = AsyncGraphRunStream(None, mux, wire_pump=False)
+        await mux.aclose()
+        alpha._subscribed = True
+
+        with pytest.raises(RuntimeError, match="already has a subscriber"):
+            [pair async for pair in run.interleave("values", "alpha")]
 
         assert mux.extensions["values"]._subscribed is False


### PR DESCRIPTION
Fixes #7793

Adds `AsyncGraphRunStream.interleave()` as the async counterpart to `GraphRunStream.interleave()`. The implementation closely mirrors the existing sync path while preserving the async run stream’s caller-driven pump model.

No breaking changes. No new dependencies.

How did you verify your code works?

- `uv run --project libs/langgraph pytest libs/langgraph/tests/test_interleave_arrival_order.py -q`
- `uv run --project libs/langgraph ruff check libs/langgraph/langgraph/stream/run_stream.py libs/langgraph/tests/test_interleave_arrival_order.py`

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/