### PR TITLE
docs(langgraph): fix broken URL in RuntimeError for multiple pending …

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -895,7 +895,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary

Fixes a broken documentation URL in the `RuntimeError` raised when users attempt to resume a graph with multiple pending interrupts using a single value instead of an interrupt-ID-keyed dict.

**Before:**
Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation


(404 — page was removed when HITL docs were consolidated in #5192)

**After:**
Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts



## Changed Files

| File | Change |
|------|--------|
| `libs/langgraph/langgraph/pregel/_loop.py` | Updated broken URL in `RuntimeError` message (line 898) |

## How to trigger

```python
from langgraph.types import Command, interrupt

# graph with 2 interrupt() calls in one node
graph.invoke(Command(resume="single-value"), config)
# → RuntimeError with docs URL now pointing to correct page


---

**Note on other issues:**
- **#7417** — Root cause is `BG_JOB_HEARTBEAT = 120` hardcoded in closed-source `langgraph-api`. Not fixable in OSS.
- **#6105** — Already closed upstream.