### PR TITLE
fix: pass allowed_msgpack_modules to JsonPlusSerializer in checkpointers

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -1,10 +1,15 @@
-from __future__ import annotations
 
+from __future__ import annotations
 import threading
+from typing import Any, Literal, Sequence
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+
 from collections import defaultdict
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, cast
+from typing import Any, cast, Literal, Sequence
+
 
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -23,6 +28,8 @@ from psycopg import Capabilities, Connection, Cursor, Pipeline
 from psycopg.rows import DictRow, dict_row
 from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
+
+
 
 from langgraph.checkpoint.postgres import _internal
 from langgraph.checkpoint.postgres.base import (
@@ -46,13 +53,17 @@ class PostgresSaver(BasePostgresSaver):
         self,
         conn: _internal.Conn,
         pipe: Pipeline | None = None,
+        *,
+        allowed_msgpack_modules: Sequence[dict[str, Any]] | Literal[True] | None = None,
         serde: SerializerProtocol | None = None,
     ) -> None:
+        serde = serde or JsonPlusSerializer(allowed_msgpack_modules=allowed_msgpack_modules)
         super().__init__(serde=serde)
         if isinstance(conn, ConnectionPool) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single Connection, not ConnectionPool."
             )
+        
 
         self.conn = conn
         self.pipe = pipe
@@ -62,7 +73,8 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls, conn_string: str, *, pipeline: bool = False, 
+        allowed_msgpack_modules: Sequence[dict[str, Any]] | Literal[True] | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -1,4 +1,10 @@
+
 from __future__ import annotations
+import threading
+from typing import Any, Literal, Sequence
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+
 
 import json
 import random
@@ -21,7 +27,7 @@ from langgraph.checkpoint.base import (
     get_checkpoint_id,
     get_checkpoint_metadata,
 )
-from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
 
 from langgraph.checkpoint.sqlite._delta import (
     DELTA_STAGE1_SQL,
@@ -86,14 +92,19 @@ class SqliteSaver(BaseCheckpointSaver[str]):
         self,
         conn: sqlite3.Connection,
         *,
+        allowed_msgpack_modules: Sequence[dict[str, Any]] | Literal[True] | None = None,
         serde: SerializerProtocol | None = None,
     ) -> None:
+        # 1. Intercept and configure BEFORE calling the parent
+        serde = serde or JsonPlusSerializer(allowed_msgpack_modules=allowed_msgpack_modules)
+        
+        # 2. Pass the configured serializer up to the parent
         super().__init__(serde=serde)
-        self.jsonplus_serde = JsonPlusSerializer()
+        
+        # 3. Standard database setup (no self.jsonplus_serde needed!)
         self.conn = conn
         self.is_setup = False
         self.lock = threading.Lock()
-
     @classmethod
     @contextmanager
     def from_conn_string(cls, conn_string: str) -> Iterator[SqliteSaver]:


### PR DESCRIPTION
Fixes #7695

### Problem
The `allowed_msgpack_modules` security configuration defined in `langgraph.json` was not being correctly propagated to the underlying serializers. While the configuration was parsed at the top level, the database checkpointers (`SqliteSaver` and `PostgresSaver`) were instantiating `JsonPlusSerializer` without passing the configuration down. 

Because the checkpointers bypassed this configuration, `BaseCheckpointSaver` defaulted to an unconfigured serializer, causing `msgpack` to throw security exceptions when unpacking custom user modules.

### Changes Made
* **SQLite Checkpointer (`libs/checkpoint-sqlite/.../__init__.py`)**: 
  * Added `allowed_msgpack_modules` to the `SqliteSaver` constructor signature.
  * Implemented an interception pattern (`serde = serde or JsonPlusSerializer(...)`) before the `super().__init__()` call to ensure the fully configured serializer is passed to the base class.
* **Postgres Checkpointer (`libs/checkpoint-postgres/.../__init__.py`)**:
  * Added the missing `JsonPlusSerializer` import.
  * Added `allowed_msgpack_modules` to the `PostgresSaver` constructor.
  * Applied the identical pre-`super()` intercept pattern to align with the SQLite architecture.

### Testing
* Verified the architectural flow of parameter passing in the constructors.
* Handing off to the CI/CD pipeline for the complete async database test suite execution (local testing skipped due to Windows `ProactorEventLoop` driver constraints with `psycopg`).