### PR TITLE
fix(prebuilt): validate ToolNode wrapper responses

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1052,7 +1052,10 @@ class ToolNode(RunnableCallable):
 
         # Call wrapper with request and execute callable
         try:
-            return self._wrap_tool_call(tool_request, execute)
+            response = self._wrap_tool_call(tool_request, execute)
+            return self._validate_wrapper_response(
+                response, tool_request.tool_call, input_type
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1204,10 +1207,14 @@ class ToolNode(RunnableCallable):
         # Call wrapper with request and execute callable
         try:
             if self._awrap_tool_call is not None:
-                return await self._awrap_tool_call(tool_request, execute)
-            # None check was performed above already
-            self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
-            return self._wrap_tool_call(tool_request, _sync_execute)
+                response = await self._awrap_tool_call(tool_request, execute)
+            else:
+                # None check was performed above already
+                self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
+                response = self._wrap_tool_call(tool_request, _sync_execute)
+            return self._validate_wrapper_response(
+                response, tool_request.tool_call, input_type
+            )
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1428,6 +1435,15 @@ class ToolNode(RunnableCallable):
         }
         tool_call_copy["args"] = {**stripped_args, **injected_args}
         return tool_call_copy
+
+    def _validate_wrapper_response(
+        self,
+        response: Any,
+        tool_call: ToolCall,
+        input_type: Literal["list", "dict", "tool_calls"],
+    ) -> ToolMessage | Command | list[Command | ToolMessage]:
+        """Validate and normalize a tool-call wrapper return value."""
+        return self._normalize_tool_response(response, tool_call, input_type)
 
     def _normalize_tool_response(
         self,

--- a/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
+++ b/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
@@ -802,3 +802,71 @@ async def test_graceful_failure_even_when_handle_errors_disabled_async() -> None
         result[0].content
         == "Error: missing is not a valid tool, try one of [registered_tool]."
     )
+
+
+def test_wrap_tool_call_invalid_response_is_rejected_sync() -> None:
+    """Test that sync wrappers cannot return arbitrary invalid values."""
+
+    def invalid_interceptor(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> object:
+        return "not a tool response"
+
+    node = ToolNode(
+        [registered_tool],
+        wrap_tool_call=invalid_interceptor,  # type: ignore[arg-type]
+        handle_tool_errors=False,
+    )
+
+    with pytest.raises(TypeError, match="returned unexpected type"):
+        node.invoke(
+            [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "registered_tool",
+                            "args": {"x": 1},
+                            "id": "1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ],
+            config=_create_config_with_runtime(),
+        )
+
+
+async def test_awrap_tool_call_invalid_response_is_rejected_async() -> None:
+    """Test that async wrappers cannot return arbitrary invalid values."""
+
+    async def invalid_interceptor(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> object:
+        return "not a tool response"
+
+    node = ToolNode(
+        [registered_tool],
+        awrap_tool_call=invalid_interceptor,  # type: ignore[arg-type]
+        handle_tool_errors=False,
+    )
+
+    with pytest.raises(TypeError, match="returned unexpected type"):
+        await node.ainvoke(
+            [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "registered_tool",
+                            "args": {"x": 1},
+                            "id": "1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ],
+            config=_create_config_with_runtime(),
+        )


### PR DESCRIPTION
## Summary

- validate `wrap_tool_call` return values with the same normalization used for tool returns
- apply the same validation to `awrap_tool_call` and the sync-wrapper fallback path used by async execution
- add regression coverage for invalid sync and async wrapper return values

## Tests

- `LANGGRAPH_TEST_FAST=1 uv run pytest tests/test_tool_node_interceptor_unregistered.py`
- `uv run ruff format langgraph/prebuilt/tool_node.py tests/test_tool_node_interceptor_unregistered.py`
- `uv run ruff check langgraph/prebuilt/tool_node.py tests/test_tool_node_interceptor_unregistered.py`

## pr-value

- pre-submit-final-diff: `pr-value-r=88`, `pr-value-l=100`, gate passed
