### PR TITLE
fix uv sync --locked error on windows 10/11 .

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -60,7 +60,7 @@ test = [
     "langgraph-checkpoint-postgres",
     "langgraph-sdk",
     "psycopg[binary]",
-    "uvloop==0.22.1",
+    "uvloop==0.22.1; sys_platform != 'win32'",
     "pyperf",
     "py-spy",
     "pycryptodome",

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1420,7 +1420,7 @@ dev = [
     { name = "ruff" },
     { name = "syrupy" },
     { name = "types-requests" },
-    { name = "uvloop" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 lint = [
     { name = "mypy" },
@@ -1449,7 +1449,7 @@ test = [
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "redis" },
     { name = "syrupy" },
-    { name = "uvloop" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
 
 [package.metadata]
@@ -1490,7 +1490,7 @@ dev = [
     { name = "ruff" },
     { name = "syrupy" },
     { name = "types-requests" },
-    { name = "uvloop", specifier = "==0.22.1" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = "==0.22.1" },
 ]
 lint = [
     { name = "mypy" },
@@ -1520,7 +1520,7 @@ test = [
     { name = "pytest-xdist", extras = ["psutil"] },
     { name = "redis" },
     { name = "syrupy" },
-    { name = "uvloop", specifier = "==0.22.1" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = "==0.22.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #7814

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangGraph! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

    - feat(langgraph): add multi-tenant support
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langgraph/blob/main/.github/workflows/pr_lint.yml#L19-L43

2. PR description:
uvloop is not supported on Windows (it raises that error in its own setup.py). It is listed in the test dependency group in libs/langgraph/pyproject.toml, and dev includes test, so uv sync with dev deps tries to install uvloop on Windows and fails.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?
```

(langgraph) E:\code\github-my\langgraph\libs\langgraph>uv sync --locked
Using CPython 3.12.13 interpreter at: D:\softwares\miniconda3\envs\langgraph\python.exe
Creating virtual environment at: .venv
Resolved 185 packages in 7ms
      Built langgraph @ file:///E:/code/github-my/langgraph/libs/langgraph
      Built langgraph-sdk @ file:///E:/code/github-my/langgraph/libs/sdk-py
      Built langgraph-prebuilt @ file:///E:/code/github-my/langgraph/libs/prebuilt
      Built langgraph-cli @ file:///E:/code/github-my/langgraph/libs/cli
      Built langgraph-checkpoint-sqlite @ file:///E:/code/github-my/langgraph/libs/checkpoint-sqlite
      Built langgraph-checkpoint-postgres @ file:///E:/code/github-my/langgraph/libs/checkpoint-postgres
      Built langgraph-checkpoint @ file:///E:/code/github-my/langgraph/libs/checkpoint
  x Failed to build `uvloop==0.22.1`
  |-> The build backend returned an error
  `-> Call to `setuptools.build_meta.build_wheel` failed (exit code: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmpo7NrQX\Lib\site-packages\setuptools\build_meta.py",
      line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmpo7NrQX\Lib\site-packages\setuptools\build_meta.py",
      line 301, in _get_build_requires
          self.run_setup()
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmpo7NrQX\Lib\site-packages\setuptools\build_meta.py",
      line 317, in run_setup
          exec(code, locals())
        File "<string>", line 8, in <module>
      RuntimeError: uvloop does not support Windows at the moment

      hint: This usually indicates a problem with the package or the build environment.
  help: `uvloop` (v0.22.1) was included because `langgraph:dev` (v1.2.0) depends on `uvloop`

(langgraph) E:\code\github-my\langgraph\libs\langgraph>uv sync --locked
Resolved 185 packages in 6ms
  x Failed to build `uvloop==0.22.1`
  |-> The build backend returned an error
  `-> Call to `setuptools.build_meta.build_wheel` failed (exit code: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmphLubLb\Lib\site-packages\setuptools\build_meta.py",
      line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmphLubLb\Lib\site-packages\setuptools\build_meta.py",
      line 301, in _get_build_requires
          self.run_setup()
        File
      "C:\Users\Administrator\AppData\Local\uv\cache\builds-v0\.tmphLubLb\Lib\site-packages\setuptools\build_meta.py",
      line 317, in run_setup
          exec(code, locals())
        File "<string>", line 8, in <module>
      RuntimeError: uvloop does not support Windows at the moment

      hint: This usually indicates a problem with the package or the build environment.
  help: `uvloop` (v0.22.1) was included because `langgraph:dev` (v1.2.0) depends on `uvloop`

(langgraph) E:\code\github-my\langgraph\libs\langgraph>
```

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
