### PR TITLE
fix(langgraph): skip caching task error writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1582,6 +1582,9 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         task = self.tasks.get(task_id)
         if task is None or task.cache_key is None:
             return
+        if writes[0][0] in (INTERRUPT, ERROR):
+            # only cache successful tasks
+            return
         self.submit(
             self.cache.set,
             {

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -24,6 +24,7 @@ from langchain_core.runnables import (
 )
 from langchain_core.runnables.graph import Edge
 from langgraph.cache.base import BaseCache
+from langgraph.cache.memory import InMemoryCache
 from langgraph.checkpoint.base import (
     BaseCheckpointSaver,
     Checkpoint,
@@ -5827,6 +5828,36 @@ def test_multiple_interrupts_functional_cache(
         "values": [2, "a", 2, "b", 4, "c", 4, "d", 6, "e", 6, "f"],
     }
     assert counter == 6
+
+
+def test_functional_cache_does_not_replay_error_writes():
+    """Cached task errors must not be replayed as cached results."""
+
+    counter = 0
+
+    @task(cache_policy=CachePolicy())
+    def flaky(x: int) -> int:
+        nonlocal counter
+        counter += 1
+        if counter == 1:
+            raise RuntimeError("boom")
+        return 2 * x
+
+    @entrypoint(checkpointer=InMemorySaver(), cache=InMemoryCache())
+    def graph(state: dict) -> dict:
+        return {"value": flaky(state["x"]).result()}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        graph.invoke(
+            {"x": 7},
+            {"configurable": {"thread_id": str(uuid.uuid4())}},
+        )
+
+    assert graph.invoke(
+        {"x": 7},
+        {"configurable": {"thread_id": str(uuid.uuid4())}},
+    ) == {"value": 14}
+    assert counter == 2
 
 
 def test_task_before_interrupt_resume(

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -25,6 +25,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnablePassthrough
 from langchain_core.utils.aiter import aclosing
 from langgraph.cache.base import BaseCache
+from langgraph.cache.memory import InMemoryCache
 from langgraph.checkpoint.base import (
     BaseCheckpointSaver,
     ChannelVersions,
@@ -6861,6 +6862,37 @@ async def test_multiple_interrupts_functional_cache(
         "values": [2, "a", 2, "b", 4, "c", 4, "d", 6, "e", 6, "f"],
     }
     assert counter == 6
+
+
+@NEEDS_CONTEXTVARS
+async def test_functional_cache_does_not_replay_error_writes():
+    """Cached task errors must not be replayed as cached results."""
+
+    counter = 0
+
+    @task(cache_policy=CachePolicy())
+    def flaky(x: int) -> int:
+        nonlocal counter
+        counter += 1
+        if counter == 1:
+            raise RuntimeError("boom")
+        return 2 * x
+
+    @entrypoint(checkpointer=InMemorySaver(), cache=InMemoryCache())
+    def graph(state: dict) -> dict:
+        return {"value": flaky(state["x"]).result()}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await graph.ainvoke(
+            {"x": 7},
+            {"configurable": {"thread_id": str(uuid.uuid4())}},
+        )
+
+    assert await graph.ainvoke(
+        {"x": 7},
+        {"configurable": {"thread_id": str(uuid.uuid4())}},
+    ) == {"value": 14}
+    assert counter == 2
 
 
 @NEEDS_CONTEXTVARS


### PR DESCRIPTION
﻿## Summary

Fixes #7589.

Sync `SyncPregelLoop.put_writes` now mirrors the async path and skips caching task writes whose first write is `INTERRUPT` or `ERROR`. This prevents a cached task failure from being replayed as if it were a valid cached task result on later invocations with the same cache key.

## Root cause

`AsyncPregelLoop.put_writes` already returns early for `INTERRUPT` and `ERROR` writes before writing to the cache. The sync implementation missed that guard, so a cached sync task that raised could store its `ERROR` write. A later run with the same task input could then match that cached write, skip task execution, and replay the old failure.

## Tests

- `NO_DOCKER=true uv run --no-group dev --with pytest --with pytest-mock --with syrupy --with redis --with pytest-xdist --with pytest-dotenv --with httpx --with pycryptodome --with psycopg[binary] --with-editable ..\checkpoint-sqlite --with-editable ..\checkpoint-postgres pytest tests/test_pregel.py::test_multiple_interrupts_functional_cache tests/test_pregel.py::test_functional_cache_does_not_replay_error_writes tests/test_pregel_async.py::test_multiple_interrupts_functional_cache tests/test_pregel_async.py::test_functional_cache_does_not_replay_error_writes -q`
- `uv run --no-group dev --with ruff ruff format langgraph\pregel\_loop.py tests\test_pregel.py tests\test_pregel_async.py`
- `uv run --no-group dev --with ruff ruff check --fix langgraph\pregel\_loop.py tests\test_pregel.py tests\test_pregel_async.py`
- `uv run --no-group dev --with mypy --with types-requests --with-editable ..\checkpoint-sqlite --with-editable ..\checkpoint-postgres mypy langgraph --cache-dir .mypy_cache`

Also ran broader file-level checks with `NO_DOCKER=true`:

- `pytest tests/test_pregel.py -q`: 457 passed, 1 unrelated timing assertion failed in `test_sync_streaming_with_functional_api` (`0.046s > 0.05s`).
- `pytest tests/test_pregel_async.py -q`: 304 passed, 7 unrelated failures in existing `test_imp_nested[...]` cases and `test_async_streaming_with_functional_api` timing assertion.

The repository `make format` / `make lint` path was not used locally because the current Windows environment hits the known `uvloop` dev dependency installation failure (`uvloop does not support Windows`).
