### PR TITLE
fix(langgraph): preserve binop overwrite ordering

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -109,12 +109,9 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
-            self.value = values[0]
-            values = values[1:]
         seen_overwrite: bool = False
         for value in values:
-            is_overwrite, overwrite_value = _get_overwrite(value)
+            is_overwrite, _ = _get_overwrite(value)
             if is_overwrite:
                 if seen_overwrite:
                     msg = create_error_message(
@@ -122,6 +119,23 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                         error_code=ErrorCode.INVALID_CONCURRENT_GRAPH_UPDATE,
                     )
                     raise InvalidUpdateError(msg)
+                seen_overwrite = True
+            elif seen_overwrite:
+                msg = create_error_message(
+                    message="Cannot receive a regular update after an Overwrite value in the same super-step.",
+                    error_code=ErrorCode.INVALID_CONCURRENT_GRAPH_UPDATE,
+                )
+                raise InvalidUpdateError(msg)
+        if self.value is MISSING:
+            is_overwrite, overwrite_value = _get_overwrite(values[0])
+            self.value = overwrite_value if is_overwrite else values[0]
+            values = values[1:]
+            seen_overwrite = is_overwrite
+        else:
+            seen_overwrite = False
+        for value in values:
+            is_overwrite, overwrite_value = _get_overwrite(value)
+            if is_overwrite:
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -65,6 +65,7 @@ from langgraph._internal._constants import (
 from langgraph._internal._scratchpad import PregelScratchpad
 from langgraph._internal._typing import EMPTY_SEQ, MISSING
 from langgraph.channels.base import BaseChannel
+from langgraph.channels.binop import BinaryOperatorAggregate, _get_overwrite
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.constants import TAG_HIDDEN
@@ -316,10 +317,15 @@ def apply_writes(
     updated_channels: set[str] = set()
     for chan, vals in pending_writes_by_channel.items():
         if chan in channels:
-            if channels[chan].update(vals) and next_version is not None:
+            channel = channels[chan]
+            if isinstance(channel, BinaryOperatorAggregate):
+                # Preserve the graph-level contract that one overwrite wins over
+                # concurrent reducer writes for the same channel.
+                vals = sorted(vals, key=lambda val: _get_overwrite(val)[0])
+            if channel.update(vals) and next_version is not None:
                 checkpoint["channel_versions"][chan] = next_version
                 # unavailable channels can't trigger tasks, so don't add them
-                if channels[chan].is_available():
+                if channel.is_available():
                     updated_channels.add(chan)
 
     # Channels that weren't updated in this step are notified of a new step

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -105,6 +105,31 @@ def test_binop() -> None:
     assert channel.get() == 10
 
 
+@pytest.mark.parametrize(
+    "overwrite",
+    [
+        Overwrite(10),
+        {"__overwrite__": 10},
+    ],
+)
+def test_binop_overwrite_rejects_subsequent_updates(overwrite: object) -> None:
+    channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(MISSING)
+
+    with pytest.raises(
+        InvalidUpdateError,
+        match="Cannot receive a regular update after an Overwrite value",
+    ):
+        channel.update([5, overwrite, 3])
+
+
+def test_binop_overwrite_allows_prior_updates() -> None:
+    channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(MISSING)
+
+    channel.update([5, Overwrite(10)])
+
+    assert channel.get() == 10
+
+
 def test_untracked_value() -> None:
     channel = UntrackedValue(dict).from_checkpoint(MISSING)
     assert channel.ValueType is dict


### PR DESCRIPTION
## Summary
- reject `BinaryOperatorAggregate.update()` batches that contain a regular update after an `Overwrite`
- keep direct channel updates atomic by validating the batch before mutating the channel value
- preserve existing graph-level overwrite behavior by applying reducer writes before the single overwrite when Pregel groups concurrent writes

Fixes #7580.

## Testing
- `NO_DOCKER=true make test TEST="tests/test_channels.py tests/test_pregel.py::test_overwrite_sequential tests/test_pregel.py::test_overwrite_parallel tests/test_pregel.py::test_overwrite_parallel_error -k 'not postgres'"`
- `uv run mypy langgraph/channels/binop.py langgraph/pregel/_algo.py --cache-dir .mypy_cache`
- `make format`
- `git diff --check`

## Notes
- The regression test fails before the fix with the reported silent-drop behavior.
- I also checked `make lint`; it is blocked by an existing unrelated Python 3.11 mypy issue in `langgraph/_internal/_future.py` (`asyncio.eager_task_factory`).
