### PR TITLE
fix(langgraph): cap retry jitter by max_interval

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -631,7 +631,9 @@ def run_with_retry(
 
             # Apply jitter if configured
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -769,7 +771,9 @@ async def arun_with_retry(
 
             # Apply jitter if configured
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -356,6 +356,81 @@ def test_graph_with_jitter_retry_policy():
     mock_sleep.assert_called_with(0.01 + 0.05)  # Sleep should include jitter
 
 
+def test_retry_jitter_does_not_exceed_max_interval():
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    def failing_node(state: State):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=1.0),
+        patch("time.sleep") as mock_sleep,
+    ):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "success"
+    mock_sleep.assert_called_once_with(0.5)
+
+
+@pytest.mark.anyio
+async def test_async_retry_jitter_does_not_exceed_max_interval():
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    async def failing_node(state: State):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=1.0),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        result = await graph.ainvoke({"foo": ""})
+
+    assert result["foo"] == "success"
+    mock_sleep.assert_awaited_once_with(0.5)
+
+
 def test_graph_with_multiple_retry_policies():
     """Test a graph with multiple retry policies for a node."""
 


### PR DESCRIPTION
Fixes #7554

Caps the final retry backoff sleep after jitter is added so RetryPolicy.max_interval remains an upper bound for both sync and async retry execution.

How did you verify your code works?

- NO_DOCKER=true uv run pytest tests/test_retry.py -k jitter
- make format
- make lint
- NO_DOCKER=true TEST="tests/test_retry.py -k jitter" make test
- git diff --check