### PR TITLE
fix(langgraph): cap retry jitter by max_interval

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -631,7 +631,9 @@ def run_with_retry(
 
             # Apply jitter if configured
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -769,7 +771,9 @@ async def arun_with_retry(
 
             # Apply jitter if configured
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -356,6 +356,81 @@ def test_graph_with_jitter_retry_policy():
     mock_sleep.assert_called_with(0.01 + 0.05)  # Sleep should include jitter
 
 
+def test_retry_jitter_does_not_exceed_max_interval():
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    def failing_node(state: State):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=1.0),
+        patch("time.sleep") as mock_sleep,
+    ):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "success"
+    mock_sleep.assert_called_once_with(0.5)
+
+
+@pytest.mark.anyio
+async def test_async_retry_jitter_does_not_exceed_max_interval():
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    async def failing_node(state: State):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count == 1:
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    retry_policy = RetryPolicy(
+        max_attempts=2,
+        initial_interval=0.5,
+        max_interval=0.5,
+        jitter=True,
+        retry_on=ValueError,
+    )
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=1.0),
+        patch("asyncio.sleep") as mock_sleep,
+    ):
+        result = await graph.ainvoke({"foo": ""})
+
+    assert result["foo"] == "success"
+    mock_sleep.assert_awaited_once_with(0.5)
+
+
 def test_graph_with_multiple_retry_policies():
     """Test a graph with multiple retry policies for a node."""
 


### PR DESCRIPTION
Fixes #7554

Caps the final retry backoff sleep after jitter is added so  remains an upper bound for both sync and async retry execution.

How did you verify your code works?

- 
- Running format in libs/checkpoint
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
uv run ruff format .
25 files left unchanged
uv run ruff check --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
Running format in libs/checkpoint-conformance
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
uv run ruff format .
18 files left unchanged
uv run ruff check --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
Running format in libs/checkpoint-postgres
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
uv run ruff format .
16 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
Running format in libs/checkpoint-sqlite
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
uv run ruff format .
17 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
Running format in libs/cli
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
uv run ruff format .
64 files left unchanged
uv run ruff check --select I --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
Running format in libs/langgraph
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
uv run ruff format .
142 files left unchanged
uv run ruff check --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
Running format in libs/prebuilt
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
uv run ruff format .
25 files left unchanged
uv run ruff check --fix .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
Running format in libs/sdk-py
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
uv run ruff check --select I --fix .
All checks passed!
uv run ruff format .
44 files left unchanged
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
- Running lint in libs/checkpoint
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
tests/test_conformance_delta.py:14: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_conformance_delta.py:14: note: Use "-> None" if function does not return a value
tests/test_conformance_delta.py:15: error: Skipping analyzing "langgraph.checkpoint.conformance": module is installed, but missing library stubs or py.typed marker  [import-untyped]
tests/test_conformance_delta.py:16: error: Skipping analyzing "langgraph.checkpoint.conformance.initializer": module is installed, but missing library stubs or py.typed marker  [import-untyped]
tests/test_conformance_delta.py:16: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tests/test_conformance_delta.py:21: error: Function is missing a return type annotation  [no-untyped-def]
Found 4 errors in 1 file (checked 25 source files)
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
Running lint in libs/checkpoint-conformance
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
uv run ruff check .
All checks passed!
uv run ty check
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
Running lint in libs/checkpoint-postgres
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
Success: no issues found in 16 source files
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
Running lint in libs/checkpoint-sqlite
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy . --cache-dir .mypy_cache
tests/test_conformance_delta.py:15: error: Function is missing a return type annotation  [no-untyped-def]
tests/test_conformance_delta.py:15: note: Use "-> None" if function does not return a value
tests/test_conformance_delta.py:16: error: Skipping analyzing "langgraph.checkpoint.conformance": module is installed, but missing library stubs or py.typed marker  [import-untyped]
tests/test_conformance_delta.py:17: error: Skipping analyzing "langgraph.checkpoint.conformance.initializer": module is installed, but missing library stubs or py.typed marker  [import-untyped]
tests/test_conformance_delta.py:17: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
tests/test_conformance_delta.py:22: error: Function is missing a return type annotation  [no-untyped-def]
Found 4 errors in 1 file (checked 17 source files)
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
Running lint in libs/cli
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache || uv run mypy . --cache-dir .mypy_cache
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
Running lint in libs/langgraph
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy langgraph --cache-dir .mypy_cache
Success: no issues found in 77 source files
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
Running lint in libs/prebuilt
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
[ "." = "" ] || mkdir -p .mypy_cache
[ "." = "" ] || uv run mypy langgraph --cache-dir .mypy_cache
Success: no issues found in 7 source files
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
Running lint in libs/sdk-py
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
uv run ruff check .
All checks passed!
[ "." = "" ] || uv run ruff format . --diff
[ "." = "" ] || uv run ruff check --select I .
All checks passed!
uv run ty check .
All checks passed!
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
- Running test in libs/checkpoint
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
uv run pytest tests/test_retry.py -k jitter
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.31, asyncio-1.3.0, mock-3.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.08s =============================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint'
Running test in libs/checkpoint-conformance
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
uv run pytest tests/test_retry.py -k jitter
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance
configfile: pyproject.toml
plugins: langsmith-0.8.2, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.01s =============================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-conformance'
Running test in libs/checkpoint-postgres
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
make[2]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
Testing PostgreSQL 15
make[3]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
POSTGRES_VERSION= docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
	echo "Failed to start PostgreSQL, printing logs..."; \
	docker compose -f tests/compose-postgres.yml logs; \
	exit 1 \
)
Failed to start PostgreSQL, printing logs...
make[3]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
make[2]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
Test failed for PostgreSQL 15
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-postgres'
Running test in libs/checkpoint-sqlite
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
uv run pytest tests/test_retry.py -k jitter
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.31, asyncio-1.3.0, mock-3.15.1, retry-1.7.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.01s =============================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/checkpoint-sqlite'
Running test in libs/cli
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
uv run pytest tests/test_retry.py -k jitter
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli
configfile: pyproject.toml
plugins: asyncio-1.3.0, mock-3.15.1, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 0 items

============================ no tests ran in 0.00s =============================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/cli'
Running test in libs/langgraph
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
if [ "true" = "false" ]; then \
	make start-services &&\
	make start-dev-server &&\
	uv run pytest tests/test_retry.py -k jitter; \
	EXIT_CODE=$?; \
	make stop-services; \
	make stop-dev-server; \
	exit $EXIT_CODE; \
else \
	NO_DOCKER=true uv run pytest tests/test_retry.py -k jitter ; \
	EXIT_CODE=$?; \
	exit $EXIT_CODE; \
fi
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0, cov-7.1.0, langsmith-0.7.31, repeat-0.9.4, mock-3.15.1, dotenv-0.5.2, syrupy-5.1.0
collected 102 items / 99 deselected / 3 selected

tests/test_retry.py ...                                                  [100%]

============================= slowest 5 durations ==============================
0.03s call     tests/test_retry.py::test_graph_with_jitter_retry_policy
0.01s call     tests/test_retry.py::test_async_retry_jitter_does_not_exceed_max_interval
0.01s call     tests/test_retry.py::test_retry_jitter_does_not_exceed_max_interval

(2 durations < 0.005s hidden.  Use -vv to show these durations.)
======================= 3 passed, 99 deselected in 0.96s =======================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/langgraph'
Running test in libs/prebuilt
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
make start-services && LANGGRAPH_TEST_FAST=0 uv run --active pytest tests/test_retry.py -k jitter; \
EXIT_CODE=$?; \
make stop-services; \
exit $EXIT_CODE
make[2]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
docker compose -f tests/compose-postgres.yml -f tests/compose-redis.yml up -V --force-recreate --wait --remove-orphans
make[2]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
make[2]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
docker compose -f tests/compose-postgres.yml -f tests/compose-redis.yml down -v
make[2]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/prebuilt'
Running test in libs/sdk-py
make[1]: Entering directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
uv run pytest tests
============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0 -- /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.31, asyncio-1.3.0, mock-3.15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 96 items

tests/test_api_parity.py::test_sync_api_matches_async[AssistantsClient-SyncAssistantsClient] PASSED [  1%]
tests/test_api_parity.py::test_sync_api_matches_async[ThreadsClient-SyncThreadsClient] PASSED [  2%]
tests/test_api_parity.py::test_sync_api_matches_async[RunsClient-SyncRunsClient] PASSED [  3%]
tests/test_api_parity.py::test_sync_api_matches_async[CronClient-SyncCronClient] PASSED [  4%]
tests/test_api_parity.py::test_sync_api_matches_async[StoreClient-SyncStoreClient] PASSED [  5%]
tests/test_assistants_client.py::test_assistants_search_returns_list_by_default PASSED [  6%]
tests/test_assistants_client.py::test_assistants_search_can_return_object_with_pagination_metadata PASSED [  7%]
tests/test_assistants_client.py::test_sync_assistants_search_can_return_object_with_pagination_metadata PASSED [  8%]
tests/test_cache.py::test_swr_proxies_to_server_impl PASSED              [  9%]
tests/test_cache.py::test_swr_requires_server_runtime PASSED             [ 10%]
tests/test_cache.py::test_swr_defaults PASSED                            [ 11%]
tests/test_client_exports.py::test_client_exports PASSED                 [ 12%]
tests/test_client_exports.py::test_public_api_exports PASSED             [ 13%]
tests/test_client_exports.py::test_client_instantiation PASSED           [ 14%]
tests/test_client_stream.py::test_stream_sse PASSED                      [ 15%]
tests/test_client_stream.py::test_http_client_stream_flushes_trailing_event PASSED [ 16%]
tests/test_client_stream.py::test_sync_http_client_stream_flushes_trailing_event PASSED [ 17%]
tests/test_client_stream.py::test_sync_http_client_stream_recovers_after_disconnect PASSED [ 18%]
tests/test_client_stream.py::test_http_client_stream_recovers_after_disconnect PASSED [ 19%]
tests/test_client_stream.py::test_sse_to_v2_dict_basic PASSED            [ 20%]
tests/test_client_stream.py::test_sse_to_v2_dict_with_namespace PASSED   [ 21%]
tests/test_client_stream.py::test_sse_to_v2_dict_with_multiple_ns PASSED [ 22%]
tests/test_client_stream.py::test_sse_to_v2_dict_end_event PASSED        [ 23%]
tests/test_client_stream.py::test_sse_to_v2_dict_metadata_event PASSED   [ 25%]
tests/test_client_stream.py::test_sse_to_v2_dict_messages_partial PASSED [ 26%]
tests/test_client_stream.py::test_sse_to_v2_dict_values_with_interrupts PASSED [ 27%]
tests/test_client_stream.py::test_async_stream_v2_client_side_conversion PASSED [ 28%]
tests/test_client_stream.py::test_sync_stream_v2_client_side_conversion PASSED [ 29%]
tests/test_crons_client.py::test_async_create_for_thread PASSED          [ 30%]
tests/test_crons_client.py::test_async_create_for_thread_with_end_time PASSED [ 31%]
tests/test_crons_client.py::test_async_create PASSED                     [ 32%]
tests/test_crons_client.py::test_async_create_with_end_time PASSED       [ 33%]
tests/test_crons_client.py::test_sync_create_for_thread PASSED           [ 34%]
tests/test_crons_client.py::test_sync_create_for_thread_with_end_time PASSED [ 35%]
tests/test_crons_client.py::test_sync_create PASSED                      [ 36%]
tests/test_crons_client.py::test_sync_create_with_end_time PASSED        [ 37%]
tests/test_crons_client.py::test_sync_create_with_enabled_parameter[enabled] PASSED [ 38%]
tests/test_crons_client.py::test_sync_create_with_enabled_parameter[disabled] PASSED [ 39%]
tests/test_crons_client.py::test_async_update PASSED                     [ 40%]
tests/test_crons_client.py::test_async_update_with_end_time PASSED       [ 41%]
tests/test_crons_client.py::test_sync_update PASSED                      [ 42%]
tests/test_crons_client.py::test_sync_update_with_end_time PASSED        [ 43%]
tests/test_crons_client.py::test_sync_update_with_enabled_parameter[enabled] PASSED [ 44%]
tests/test_crons_client.py::test_sync_update_with_enabled_parameter[disabled] PASSED [ 45%]
tests/test_crons_client.py::test_async_search_with_metadata PASSED       [ 46%]
tests/test_crons_client.py::test_async_search_omits_empty_metadata PASSED [ 47%]
tests/test_crons_client.py::test_async_count_with_metadata PASSED        [ 48%]
tests/test_crons_client.py::test_async_count_omits_empty_metadata PASSED [ 50%]
tests/test_crons_client.py::test_sync_search_with_metadata PASSED        [ 51%]
tests/test_crons_client.py::test_sync_search_omits_empty_metadata PASSED [ 52%]
tests/test_crons_client.py::test_sync_count_with_metadata PASSED         [ 53%]
tests/test_crons_client.py::test_sync_count_omits_empty_metadata PASSED  [ 54%]
tests/test_encryption.py::TestHandlerValidation::test_duplicate_handlers_raise_error PASSED [ 55%]
tests/test_encryption.py::TestHandlerValidation::test_handlers_must_be_async PASSED [ 56%]
tests/test_encryption.py::TestHandlerValidation::test_handlers_must_have_two_params PASSED [ 57%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[400-BadRequestError] PASSED [ 58%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[401-AuthenticationError] PASSED [ 59%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[403-PermissionDeniedError] PASSED [ 60%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[404-NotFoundError] PASSED [ 61%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[409-ConflictError] PASSED [ 62%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[422-UnprocessableEntityError] PASSED [ 63%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[429-RateLimitError] PASSED [ 64%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[500-InternalServerError] PASSED [ 65%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[503-InternalServerError] PASSED [ 66%]
tests/test_errors.py::test_raise_for_status_typed_maps_exceptions_and_sets_status_code[418-APIStatusError] PASSED [ 67%]
tests/test_errors.py::test_request_id_is_extracted_when_present PASSED   [ 68%]
tests/test_errors.py::test_non_json_body_does_not_break_mapping PASSED   [ 69%]
tests/test_errors.py::test_field_extraction_from_json_body PASSED        [ 70%]
tests/test_errors.py::test_error_message_in_str_and_args PASSED          [ 71%]
tests/test_errors.py::test_all_error_types_display_message[400-BadRequestError] PASSED [ 72%]
tests/test_errors.py::test_all_error_types_display_message[401-AuthenticationError] PASSED [ 73%]
tests/test_errors.py::test_all_error_types_display_message[403-PermissionDeniedError] PASSED [ 75%]
tests/test_errors.py::test_all_error_types_display_message[404-NotFoundError] PASSED [ 76%]
tests/test_errors.py::test_all_error_types_display_message[409-ConflictError] PASSED [ 77%]
tests/test_errors.py::test_all_error_types_display_message[422-UnprocessableEntityError] PASSED [ 78%]
tests/test_errors.py::test_all_error_types_display_message[429-RateLimitError] PASSED [ 79%]
tests/test_errors.py::test_all_error_types_display_message[500-InternalServerError] PASSED [ 80%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_async_create_includes_langsmith_tracer PASSED [ 81%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_sync_create_includes_langsmith_tracer PASSED [ 82%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_sync_wait_includes_langsmith_tracer PASSED [ 83%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_create_without_langsmith_tracing_excludes_key PASSED [ 84%]
tests/test_langsmith_tracing.py::TestLangSmithTracingPayload::test_langsmith_tracing_project_name_only PASSED [ 85%]
tests/test_serde.py::test_serde_basic PASSED                             [ 86%]
tests/test_serde.py::test_serde_pydantic PASSED                          [ 87%]
tests/test_serde.py::test_serde_dataclass PASSED                         [ 88%]
tests/test_serde.py::test_serde_pydantic_cls_fails PASSED                [ 89%]
tests/test_serde_schema.py::test_base_model_like PASSED                  [ 90%]
tests/test_serde_schema.py::test_dataclass_like PASSED                   [ 91%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_loads_from_env_by_default PASSED [ 92%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_skips_env_when_sentinel_used PASSED [ 93%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_uses_explicit_key_when_provided PASSED [ 94%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_loads_from_env_by_default PASSED [ 95%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_skips_env_when_sentinel_used PASSED [ 96%]
tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_uses_explicit_key_when_provided PASSED [ 97%]
tests/test_threads_client.py::test_async_threads_update_return_minimal PASSED [ 98%]
tests/test_threads_client.py::test_sync_threads_update_return_minimal PASSED [100%]

=============================== warnings summary ===============================
tests/test_encryption.py::TestHandlerValidation::test_duplicate_handlers_raise_error
  /home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py/.venv/lib/python3.13/site-packages/_pytest/python.py:166: LangGraphBetaWarning: The Encryption API is in beta and may change in future versions.
    result = testfunction(**testargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations ==============================
0.17s call     tests/test_client_exports.py::test_client_instantiation
0.06s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_skips_env_when_sentinel_used
0.05s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_uses_explicit_key_when_provided
0.04s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_client_loads_from_env_by_default
0.04s call     tests/test_skip_auto_load_api_key.py::TestSkipAutoLoadApiKey::test_get_sync_client_loads_from_env_by_default
======================== 96 passed, 1 warning in 1.24s =========================
make[1]: Leaving directory '/home/ubuntu/gh-pr/langgraph-python-worker-next/libs/sdk-py'
- 