### PR TITLE
fix(langgraph): accept message sequences in add_messages

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -33,9 +33,27 @@ __all__ = (
     "REMOVE_ALL_MESSAGES",
 )
 
-Messages = list[MessageLikeRepresentation] | MessageLikeRepresentation
+Messages = Sequence[MessageLikeRepresentation] | MessageLikeRepresentation
 
 REMOVE_ALL_MESSAGES = "__remove_all__"
+
+
+def _is_message_sequence(messages: Messages) -> bool:
+    return (
+        isinstance(messages, Sequence)
+        and not isinstance(messages, (str, BaseMessage, dict))
+        and not (
+            isinstance(messages, tuple)
+            and len(messages) == 2
+            and all(isinstance(item, str) for item in messages)
+        )
+    )
+
+
+def _coerce_messages(messages: Messages) -> Sequence[MessageLikeRepresentation]:
+    if _is_message_sequence(messages):
+        return messages
+    return [cast(MessageLikeRepresentation, messages)]
 
 
 def _add_messages_wrapper(func: Callable) -> Callable[[Messages, Messages], Messages]:
@@ -186,10 +204,8 @@ def add_messages(
     """
     remove_all_idx = None
     # coerce to list
-    if not isinstance(left, list):
-        left = [left]  # type: ignore[assignment]
-    if not isinstance(right, list):
-        right = [right]  # type: ignore[assignment]
+    left = _coerce_messages(left)
+    right = _coerce_messages(right)
     # coerce to message
     left = [
         message_chunk_to_message(cast(BaseMessageChunk, m))

--- a/libs/langgraph/tests/test_messages_state.py
+++ b/libs/langgraph/tests/test_messages_state.py
@@ -52,6 +52,17 @@ def test_add_multiple_messages():
     assert result == expected_result
 
 
+def test_add_messages_accepts_sequence():
+    left = (HumanMessage(content="Hello", id="1"),)
+    right = (AIMessage(content="Hi there!", id="2"),)
+    result = add_messages(left, right)
+    expected_result = [
+        HumanMessage(content="Hello", id="1"),
+        AIMessage(content="Hi there!", id="2"),
+    ]
+    assert result == expected_result
+
+
 def test_update_existing_message():
     left = [HumanMessage(content="Hello", id="1")]
     right = HumanMessage(content="Hello again", id="1")


### PR DESCRIPTION
Fixes #6207

`add_messages` now accepts any `Sequence[MessageLikeRepresentation]` instead of only `list[MessageLikeRepresentation]`, which allows statically typed `list[BaseMessage]` callers to pass Pyright/Pylance. Runtime coercion was updated to treat generic message sequences as multiple messages while preserving tuple role/content inputs as a single message representation.

How did you verify your code works?

- `make format` in `libs/langgraph`
- `make lint` in `libs/langgraph`
- `NO_DOCKER=true TEST=tests/test_messages_state.py make test` in `libs/langgraph`
- `uvx pyright <repro snippet from #6207> --pythonpath .venv/bin/python`
- `git diff --check`
