### PR TITLE
fix(checkpoint): evaluate LANGGRAPH_STRICT_MSGPACK at use time instead of import time

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -9,11 +9,21 @@ import os
 from collections.abc import Iterable
 from typing import cast
 
-STRICT_MSGPACK_ENABLED = os.getenv("LANGGRAPH_STRICT_MSGPACK", "false").lower() in (
-    "1",
-    "true",
-    "yes",
-)
+_STRICT_MSGPACK_TRUE_VALUES = frozenset({"1", "true", "yes"})
+
+
+def strict_msgpack_enabled() -> bool:
+    """Return the current ``LANGGRAPH_STRICT_MSGPACK`` setting.
+
+    This is evaluated at call time so that applications which set the
+    environment variable during startup (after ``_msgpack`` was imported
+    as a side effect of another import) still get strict deserialization.
+    """
+    return os.getenv("LANGGRAPH_STRICT_MSGPACK", "false").lower() in _STRICT_MSGPACK_TRUE_VALUES
+
+
+# Backwards-compatible snapshot for callers that imported the constant.
+STRICT_MSGPACK_ENABLED = strict_msgpack_enabled()
 
 
 _SENTINEL = cast(None, object())

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -105,7 +105,7 @@ class JsonPlusSerializer(SerializerProtocol):
         __unpack_ext_hook__: Callable[[int, bytes], Any] | None = None,
     ) -> None:
         if allowed_msgpack_modules is _lg_msgpack._SENTINEL:
-            if _lg_msgpack.STRICT_MSGPACK_ENABLED:
+            if _lg_msgpack.strict_msgpack_enabled():
                 # Strict: only SAFE_MSGPACK_TYPES are allowed.
                 allowed_msgpack_modules = None
             else:

--- a/libs/checkpoint/tests/test_encrypted.py
+++ b/libs/checkpoint/tests/test_encrypted.py
@@ -140,10 +140,11 @@ class TestEncryptedSerializerMsgpackAllowlist:
             )
             assert result is not None
 
-    def test_pydantic_warns_by_default(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_pydantic_warns_by_default(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Pydantic models not in allowlist should log warning but still deserialize."""
-        current = _lg_msgpack.STRICT_MSGPACK_ENABLED
-        _lg_msgpack.STRICT_MSGPACK_ENABLED = False
+        monkeypatch.setenv("LANGGRAPH_STRICT_MSGPACK", "false")
         serde = _make_encrypted_serde()
 
         obj = MyPydantic(foo="test", bar=42, inner=InnerPydantic(hello="world"))
@@ -156,7 +157,6 @@ class TestEncryptedSerializerMsgpackAllowlist:
         assert "unregistered type" in caplog.text.lower()
         assert "allowed_msgpack_modules" in caplog.text
         assert result == obj
-        _lg_msgpack.STRICT_MSGPACK_ENABLED = current
 
     def test_strict_mode_blocks_unregistered(
         self, caplog: pytest.LogCaptureFixture

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -641,10 +641,11 @@ def _reset_warned_types() -> None:
     _warned_blocked_types.clear()
 
 
-def test_msgpack_pydantic_warns_by_default(caplog: pytest.LogCaptureFixture) -> None:
+def test_msgpack_pydantic_warns_by_default(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Pydantic models not in allowlist should log warning but still deserialize."""
-    current = _lg_msgpack.STRICT_MSGPACK_ENABLED
-    _lg_msgpack.STRICT_MSGPACK_ENABLED = False
+    monkeypatch.setenv("LANGGRAPH_STRICT_MSGPACK", "false")
     serde = JsonPlusSerializer()
 
     obj = MyPydantic(foo="test", bar=42, inner=InnerPydantic(hello="world"))
@@ -662,15 +663,13 @@ def test_msgpack_pydantic_warns_by_default(caplog: pytest.LogCaptureFixture) -> 
     result2 = serde.loads_typed(dumped)
     assert "unregistered type" not in caplog.text.lower()
     assert result2 == obj
-    _lg_msgpack.STRICT_MSGPACK_ENABLED = current
 
 
 def test_msgpack_env_strict_default(
-    caplog: pytest.LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Strict msgpack env should default to blocking unregistered types."""
-    current = _lg_msgpack.STRICT_MSGPACK_ENABLED
-    _lg_msgpack.STRICT_MSGPACK_ENABLED = True
+    monkeypatch.setenv("LANGGRAPH_STRICT_MSGPACK", "true")
     serde = JsonPlusSerializer()
 
     obj = MyPydantic(foo="test", bar=42, inner=InnerPydantic(hello="world"))
@@ -681,7 +680,6 @@ def test_msgpack_env_strict_default(
 
     assert "blocked" in caplog.text.lower()
     assert result == obj.model_dump()
-    _lg_msgpack.STRICT_MSGPACK_ENABLED = current
 
 
 def test_msgpack_allowlist_silences_warning(caplog: pytest.LogCaptureFixture) -> None:

--- a/libs/langgraph/langgraph/_internal/_serde.py
+++ b/libs/langgraph/langgraph/_internal/_serde.py
@@ -22,11 +22,14 @@ from pydantic import BaseModel
 from typing_extensions import NotRequired, Required, is_typeddict
 
 try:
-    from langgraph.checkpoint.serde._msgpack import (  # noqa: F401
-        STRICT_MSGPACK_ENABLED,
-    )
+    from langgraph.checkpoint.serde._msgpack import strict_msgpack_enabled  # noqa: F401
 except ImportError:
-    STRICT_MSGPACK_ENABLED = False
+
+    def strict_msgpack_enabled() -> bool:
+        return False
+
+
+STRICT_MSGPACK_ENABLED = strict_msgpack_enabled()
 
 _warned_allowlist_unsupported = False
 

--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -607,7 +607,7 @@ class entrypoint(Generic[ContextT]):
             retry_policy=self.retry_policy or (),
             context_schema=self.context_schema,
         )
-        if _serde.STRICT_MSGPACK_ENABLED:
+        if _serde.strict_msgpack_enabled():
             serde_allowlist = _serde.build_serde_allowlist(
                 schemas=[input_type, output_type, save_type]
                 + ([self.context_schema] if self.context_schema is not None else []),

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1218,7 +1218,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         checkpointer = ensure_valid_checkpointer(checkpointer)
 
         serde_allowlist: set[tuple[str, ...]] | None = None
-        if _serde.STRICT_MSGPACK_ENABLED:
+        if _serde.strict_msgpack_enabled():
             schema_types: list[type[Any]] = [
                 self.state_schema,
                 self.input_schema,

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -836,7 +836,7 @@ class Pregel(
     def _apply_checkpointer_allowlist(
         self, checkpointer: BaseCheckpointSaver | None
     ) -> BaseCheckpointSaver | None:
-        if not _serde.STRICT_MSGPACK_ENABLED:
+        if not _serde.strict_msgpack_enabled():
             return checkpointer
         return _serde.apply_checkpointer_allowlist(checkpointer, self._serde_allowlist)
 


### PR DESCRIPTION
Fixes #7847

## Summary

`LANGGRAPH_STRICT_MSGPACK` is documented as a security control that restricts msgpack checkpoint deserialization to a built-in allowlist of safe types. However, the env var is only read once at module import time. Applications that set the env var during startup (after a dependency has already imported `_msgpack`) get permissive deserialization silently.

## Problem

```python
# _msgpack.py — evaluated once at import time
STRICT_MSGPACK_ENABLED = os.getenv("LANGGRAPH_STRICT_MSGPACK", "false").lower() in (...)
```

If any code path imports `langgraph.checkpoint.serde._msgpack` before `os.environ["LANGGRAPH_STRICT_MSGPACK"] = "true"` executes, the strict mode is permanently off for the lifetime of the process. This is easy to hit when an app sets env vars in `main()` but a transitive dependency triggers an early import.

## Fix

Replace the module-level constant with a `strict_msgpack_enabled()` function that reads the env var at use time — specifically at `JsonPlusSerializer` construction and at graph/checkpointer allowlist setup. The original `STRICT_MSGPACK_ENABLED` name is kept as a backwards-compatible snapshot so existing callers that imported it continue to work.

## Backwards Compatibility

- `STRICT_MSGPACK_ENABLED` is still importable and returns the env var value at import time, matching the old behavior for callers that use it.
- All internal call sites now use `strict_msgpack_enabled()` for lazy evaluation.
- Test fixtures replaced direct constant mutation with `monkeypatch.setenv`, which is the intended usage pattern.

## Test Plan

- [x] `make test` in `libs/checkpoint` — 150 passed, 17 skipped
- [x] `make test` in `libs/langgraph` — 1819 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)