### PR TITLE
fix(retry): cap jittered sleep_time at max_interval in RetryPolicy

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -629,9 +629,11 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, capped at max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -767,9 +769,11 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, capped at max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 


### PR DESCRIPTION
Fixes #7850.

## Summary

`RetryPolicy` computes the backoff interval correctly with `min(max_interval, ...)`, but then adds the jitter value **after** the cap, so `sleep_time` can silently exceed `max_interval` by up to 1 second on every jittered retry — violating the documented contract of `max_interval`.

## Root cause

In both `run_with_retry` (sync) and `arun_with_retry` (async) in `langgraph/pregel/_retry.py`:

```python
# BEFORE — jitter applied after max_interval cap
interval = min(matching_policy.max_interval, interval * backoff_factor)
sleep_time = interval + random.uniform(0, 1) if matching_policy.jitter else interval
#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can exceed max_interval
```

## Fix

Wrap the jitter addition inside the `min` so the final `sleep_time` is always `≤ max_interval`:

```python
# AFTER
sleep_time = (
    min(matching_policy.max_interval, interval + random.uniform(0, 1))
    if matching_policy.jitter
    else interval
)
```

Applied to both the sync path (~line 633) and the async path (~line 771). No other behavior changes.