### PR TITLE
fix(sdk-py): strip body headers on reconnect GET

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/http.py
+++ b/libs/sdk-py/langgraph_sdk/_async/http.py
@@ -176,10 +176,15 @@ class HttpClient:
                     stacklevel=2,
                 )
                 await r.aclose()
+                reconnect_headers = {
+                    key: value
+                    for key, value in request_headers.items()
+                    if key.lower() not in {"content-length", "content-type"}
+                }
                 return await self.request_reconnect(
                     loc,
                     "GET",
-                    headers=request_headers,
+                    headers=reconnect_headers,
                     # don't pass on_response so it's only called once
                     reconnect_limit=reconnect_limit - 1,
                 )

--- a/libs/sdk-py/langgraph_sdk/_sync/http.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/http.py
@@ -147,7 +147,10 @@ class SyncHttpClient:
         reconnect_limit: int = 5,
     ) -> Any:
         """Send a request that automatically reconnects to Location header."""
-        request_headers, content = _encode_json(json)
+        if json is not None:
+            request_headers, content = _encode_json(json)
+        else:
+            request_headers, content = {}, None
         if headers:
             request_headers.update(headers)
         with self.client.stream(
@@ -176,10 +179,15 @@ class SyncHttpClient:
                     stacklevel=2,
                 )
                 r.close()
+                reconnect_headers = {
+                    key: value
+                    for key, value in request_headers.items()
+                    if key.lower() not in {"content-length", "content-type"}
+                }
                 return self.request_reconnect(
                     loc,
                     "GET",
-                    headers=request_headers,
+                    headers=reconnect_headers,
                     # don't pass on_response so it's only called once
                     reconnect_limit=reconnect_limit - 1,
                 )

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -8,7 +8,9 @@ import httpx
 import pytest
 from typing_extensions import assert_type
 
+from langgraph_sdk._async import http as async_http
 from langgraph_sdk._shared.utilities import _sse_to_v2_dict
+from langgraph_sdk._sync import http as sync_http
 from langgraph_sdk.client import HttpClient, SyncHttpClient
 from langgraph_sdk.schema import (
     CheckpointPayload,
@@ -288,6 +290,123 @@ async def test_http_client_stream_recovers_after_disconnect():
         StreamPart(event="values", data={"step": 2}, id="2"),
         StreamPart(event="end", data=None, id="2"),
     ]
+
+
+def test_sync_http_client_request_reconnect_strips_body_headers(monkeypatch):
+    reconnect_path = "/reconnect"
+    decode_count = 0
+    call_count = 0
+    original_decode = sync_http._decode_json
+
+    def flaky_decode(response: httpx.Response) -> Any:
+        nonlocal decode_count
+        decode_count += 1
+        if decode_count == 1:
+            raise httpx.RemoteProtocolError("incomplete response")
+        return original_decode(response)
+
+    monkeypatch.setattr(sync_http, "_decode_json", flaky_decode)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        request_headers = {key.lower(): value for key, value in request.headers.items()}
+        if call_count == 1:
+            assert request.method == "POST"
+            assert request.url.path == "/runs"
+            assert request_headers["content-type"] == "application/json"
+            assert "content-length" in request_headers
+            assert request_headers["x-client"] == "sdk-test"
+            assert request.read() == b'{"payload":"value"}'
+            return httpx.Response(
+                200,
+                headers={"Location": reconnect_path},
+                json={"pending": True},
+            )
+        if call_count == 2:
+            assert request.method == "GET"
+            assert request.url.path == reconnect_path
+            assert request_headers["x-client"] == "sdk-test"
+            assert "content-length" not in request_headers
+            assert "content-type" not in request_headers
+            assert request.read() == b""
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError("unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://example.com") as client:
+        http_client = SyncHttpClient(client)
+        with pytest.warns(UserWarning, match="attempting reconnect"):
+            result = http_client.request_reconnect(
+                "/runs",
+                "POST",
+                json={"payload": "value"},
+                headers={"X-Client": "sdk-test"},
+            )
+
+    assert call_count == 2
+    assert decode_count == 2
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_http_client_request_reconnect_strips_body_headers(monkeypatch):
+    reconnect_path = "/reconnect"
+    decode_count = 0
+    call_count = 0
+    original_decode = async_http._adecode_json
+
+    async def flaky_decode(response: httpx.Response) -> Any:
+        nonlocal decode_count
+        decode_count += 1
+        if decode_count == 1:
+            raise httpx.RemoteProtocolError("incomplete response")
+        return await original_decode(response)
+
+    monkeypatch.setattr(async_http, "_adecode_json", flaky_decode)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        request_headers = {key.lower(): value for key, value in request.headers.items()}
+        if call_count == 1:
+            assert request.method == "POST"
+            assert request.url.path == "/runs"
+            assert request_headers["content-type"] == "application/json"
+            assert "content-length" in request_headers
+            assert request_headers["x-client"] == "sdk-test"
+            assert await request.aread() == b'{"payload":"value"}'
+            return httpx.Response(
+                200,
+                headers={"Location": reconnect_path},
+                json={"pending": True},
+            )
+        if call_count == 2:
+            assert request.method == "GET"
+            assert request.url.path == reconnect_path
+            assert request_headers["x-client"] == "sdk-test"
+            assert "content-length" not in request_headers
+            assert "content-type" not in request_headers
+            assert await request.aread() == b""
+            return httpx.Response(200, json={"ok": True})
+        raise AssertionError("unexpected request")
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://example.com"
+    ) as client:
+        http_client = HttpClient(client)
+        with pytest.warns(UserWarning, match="attempting reconnect"):
+            result = await http_client.request_reconnect(
+                "/runs",
+                "POST",
+                json={"payload": "value"},
+                headers={"X-Client": "sdk-test"},
+            )
+
+    assert call_count == 2
+    assert decode_count == 2
+    assert result == {"ok": True}
 
 
 # --- _sse_to_v2_dict conversion ---


### PR DESCRIPTION
## Summary
- Strip stale `Content-Length` and `Content-Type` headers before `request_reconnect()` retries through a body-less GET.
- Align sync and async `request_reconnect(json=None)` behavior so reconnect GETs do not synthesize a JSON `null` body.
- Share body-header stripping across sync/async reconnect and stream reconnect paths.
- Add sync and async regressions that preserve custom headers while proving the reconnect GET sends no body headers or body.

Fixes #7858

## Why
`request_reconnect()` reuses headers from the original request when a response body read fails and a `Location` reconnect URL is present. For a POST with JSON, that includes body-specific headers. The recursive reconnect switches to `GET` with no body, but stale headers or an accidentally encoded `json=None` body can still advertise/send a request body, which triggers `h11.LocalProtocolError: Too little data for declared Content-Length` in real transports.

The patch handles this at the request-construction boundary shared by sync, async, and stream reconnect paths. It strips only body-derived descriptors before building a body-less reconnect request while preserving caller-supplied custom headers.

The streaming path already strips these headers for reconnects; this applies the same boundary to `request_reconnect()` and centralizes the helper.

## Validation
- `uv run pytest tests/test_client_stream.py -k request_reconnect` -> 2 passed
- `uv run pytest tests/test_client_stream.py` -> 16 passed
- `uv run ruff check langgraph_sdk/_shared/utilities.py langgraph_sdk/_async/http.py langgraph_sdk/_sync/http.py tests/test_client_stream.py`
- `uv run ruff format --check langgraph_sdk/_shared/utilities.py langgraph_sdk/_async/http.py langgraph_sdk/_sync/http.py tests/test_client_stream.py`
- `make lint`
- `make test` -> 98 passed, 1 warning
- `git diff --check origin/main...HEAD`