### PR TITLE
fix(prebuilt): raise ValueError for empty state list in tools_condition

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1646,6 +1646,9 @@ def tools_condition(
         language models.
     """
     if isinstance(state, list):
+        if not state:
+            msg = f"No messages found in input state to tool_edge: {state}"
+            raise ValueError(msg)
         ai_message = state[-1]
     elif (isinstance(state, dict) and (messages := state.get(messages_key, []))) or (
         messages := getattr(state, messages_key, [])


### PR DESCRIPTION
## Summary

- `tools_condition()` accessed `state[-1]` without first checking if the list was non-empty
- Passing an empty list raised an `IndexError` instead of the descriptive `ValueError` raised for all other invalid state shapes
- Added an explicit empty-list guard that raises `ValueError` with a message consistent with the existing error handling

## Reproduction

```python
from langgraph.prebuilt import tools_condition

tools_condition([])  # Before: IndexError; After: ValueError("No messages found in input state to tool_edge: []")
```

## Test plan

- [ ] Run `make test` in `libs/prebuilt/`
- [ ] Verify `tools_condition([])` now raises `ValueError` with a clear message