### PR TITLE
fix(prebuilt): raise ValueError for empty list in ToolNode._parse_input

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1227,6 +1227,9 @@ class ToolNode(RunnableCallable):
     ) -> tuple[list[ToolCall], Literal["list", "dict", "tool_calls"]]:
         input_type: Literal["list", "dict", "tool_calls"]
         if isinstance(input, list):
+            if not input:
+                msg = "No message found in input"
+                raise ValueError(msg)
             if isinstance(input[-1], dict) and input[-1].get("type") == "tool_call":
                 input_type = "tool_calls"
                 tool_calls = cast("list[ToolCall]", input)


### PR DESCRIPTION
## Summary

- `ToolNode._parse_input()` accessed `input[-1]` without first checking if the list was non-empty
- Passing an empty list caused an `IndexError` instead of the descriptive `ValueError` raised for dict/BaseModel inputs with no messages
- Added an explicit empty-list guard consistent with the `"No message found in input"` error raised for other invalid input shapes

## Reproduction

```python
from langgraph.prebuilt import ToolNode
from langchain_core.tools import tool

@tool
def my_tool(x: int) -> str:
    """A tool."""
    return str(x)

node = ToolNode([my_tool])
node.invoke([])  # Before: IndexError; After: ValueError("No message found in input")
```

## Test plan

- [ ] Run `make test` in `libs/prebuilt/`
- [ ] Verify `ToolNode.invoke([])` now raises `ValueError` with a clear message