### PR TITLE
fix(langgraph): use elif in map_output_updates value-collapsing loop

### DIFF
--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -167,7 +167,7 @@ def map_output_updates(
     for node, value in grouped.items():
         if len(value) == 0:
             grouped[node] = None
-        if len(value) == 1:
+        elif len(value) == 1:
             grouped[node] = value[0]
     if cached:
         grouped["__metadata__"] = {"cached": cached}


### PR DESCRIPTION
## Summary

- In `map_output_updates` (`libs/langgraph/langgraph/pregel/_io.py`), the two branches that collapse the per-node value list used two separate `if` statements instead of `if`/`elif`
- The conditions `len(value) == 0` and `len(value) == 1` are mutually exclusive, so the second should be `elif`
- With separate `if` statements a reader must check whether the first assignment (`grouped[node] = None`) could affect the second check — it cannot (`value` still refers to the original list) — but the intent is opaque
- More importantly, a future addition of an `else` clause to the first `if` would silently also run when `len(value) == 1`, introducing a latent bug

## Test plan

- [ ] Run `make test` in `libs/langgraph/`
- [ ] Behavior is identical to before; this is a correctness-clarity fix