### PR TITLE
fix(checkpoint): skip non-comparable values in InMemoryStore range filters

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -578,14 +578,22 @@ def _apply_operator(value: Any, operator: str, op_value: Any) -> bool:
     """Apply a comparison operator, matching PostgreSQL's JSONB behavior."""
     if operator == "$eq":
         return value == op_value
-    elif operator == "$gt":
-        return float(value) > float(op_value)
-    elif operator == "$gte":
-        return float(value) >= float(op_value)
-    elif operator == "$lt":
-        return float(value) < float(op_value)
-    elif operator == "$lte":
-        return float(value) <= float(op_value)
+    elif operator in ("$gt", "$gte", "$lt", "$lte"):
+        # Values that can't be coerced to a number (e.g. a missing key arrives
+        # as None, or a non-numeric string) simply don't match, mirroring the
+        # NULL-safe behavior of the Postgres backend rather than raising.
+        try:
+            a, b = float(value), float(op_value)
+        except (TypeError, ValueError):
+            return False
+        if operator == "$gt":
+            return a > b
+        elif operator == "$gte":
+            return a >= b
+        elif operator == "$lt":
+            return a < b
+        else:
+            return a <= b
     elif operator == "$ne":
         return value != op_value
     else:

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -717,6 +717,48 @@ async def test_async_vector_update_with_embedding(
     assert not any(r.key == "doc4" for r in results_new)
 
 
+@pytest.mark.parametrize(
+    ("operator", "expected"),
+    [
+        ("$gt", {"high"}),
+        ("$gte", {"equal", "high"}),
+        ("$lt", {"low"}),
+        ("$lte", {"low", "equal"}),
+    ],
+)
+def test_search_comparison_skips_non_comparable_values(
+    operator: str, expected: set[str]
+) -> None:
+    """Items missing the key or holding a non-numeric value are excluded.
+
+    They must not raise and abort the whole search, matching the NULL-safe
+    behavior of the Postgres backend.
+    """
+    store = InMemoryStore()
+    store.put(("docs",), "low", {"score": 1})
+    store.put(("docs",), "equal", {"score": 5})
+    store.put(("docs",), "high", {"score": 10})
+    store.put(("docs",), "missing", {"title": "no score field"})
+    store.put(("docs",), "non_numeric", {"score": "high"})
+
+    results = store.search(("docs",), filter={"score": {operator: 5}})
+
+    assert {item.key for item in results} == expected
+
+
+async def test_async_search_comparison_skips_non_comparable_values() -> None:
+    """Async search excludes non-comparable values instead of raising."""
+    store = InMemoryStore()
+    store.put(("docs",), "low", {"score": 1})
+    store.put(("docs",), "high", {"score": 10})
+    store.put(("docs",), "missing", {"title": "no score field"})
+    store.put(("docs",), "non_numeric", {"score": "high"})
+
+    results = await store.asearch(("docs",), filter={"score": {"$gt": 5}})
+
+    assert {item.key for item in results} == {"high"}
+
+
 def test_vector_search_with_filters(fake_embeddings: CharacterEmbeddings) -> None:
     """Test combining vector search with filters."""
     inmem_store = InMemoryStore(


### PR DESCRIPTION
Fixes #7880

`InMemoryStore.search()` aborted with a TypeError/ValueError whenever an item in
the searched namespace was missing the filtered key or stored a non-numeric value
for it, because the `$gt`/`$gte`/`$lt`/`$lte` operators called `float()`
unconditionally. A single bad item poisoned the whole search.

This guards the numeric coercion and treats values that can't be compared as
non-matches, so they're excluded from the results instead of raising — matching
the NULL-safe behavior of the Postgres backend and `_apply_operator`'s documented
"PostgreSQL's JSONB behavior".

Added tests covering both a missing key and a non-numeric value across all four
comparison operators (sync and async).

How verified: `make format`, `make lint`, and `make test` pass for
`libs/checkpoint`; the new tests fail on `main` and pass with this change.