### PR TITLE
release(langgraph): 1.2.1

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.0"
+version = "1.2.1"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
releasing 1.2.1

Notable changes since 1.2.0:

- feat(langgraph): add `before_builtins` opt-in for stream transformers (#7882)
- fix(langgraph): keep tool results out of v3 messages (#7838)
- chore(deps): bump langsmith from 0.7.31 to 0.8.0 (#7788)
- chore(deps): bump idna from 3.11 to 3.15 (#7866)