### PR TITLE
fix(memory-store): support dotted filter keys for parity with SqliteStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -244,7 +244,7 @@ class InMemoryStore(BaseStore):
                 return True
 
             return all(
-                _compare_values(item.value.get(key), filter_value)
+                _compare_values(_resolve_path(item.value, key), filter_value)
                 for key, filter_value in op.filter.items()
             )
 
@@ -546,6 +546,25 @@ def _does_match(match_condition: MatchCondition, key: tuple[str, ...]) -> bool:
         return True
     else:
         raise ValueError(f"Unsupported match type: {match_type}")
+
+
+def _resolve_path(value: Any, key: str) -> Any:
+    """Resolve a filter key against an item value, walking dotted paths.
+
+    Mirrors the dotted-path semantics used by ``SqliteStore`` (via
+    ``json_extract(value, '$.<key>')``) so a filter like ``{"user.id": "abc"}``
+    matches a value of ``{"user": {"id": "abc"}}``. Returns ``None`` when any
+    segment of the path is missing or traverses a non-dict, preserving the
+    existing miss semantics of ``dict.get``.
+    """
+    if "." not in key:
+        return value.get(key) if isinstance(value, dict) else None
+    current: Any = value
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
 
 
 def _compare_values(item_value: Any, filter_value: Any) -> bool:

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -580,6 +580,74 @@ async def test_async_batch_store_deduplication(mocker: MockerFixture) -> None:
     abatch.reset_mock()
 
 
+def test_search_supports_dotted_filter_keys() -> None:
+    """Dotted filter keys should resolve nested values, matching SqliteStore.
+
+    See https://github.com/langchain-ai/langgraph/issues/7795. Previously
+    ``InMemoryStore`` treated ``"user.access-level"`` as a literal top-level
+    key, while ``SqliteStore`` already walked the dotted path via
+    ``json_extract``.
+    """
+    store = InMemoryStore()
+    store.put(
+        ("docs",),
+        "hyphen",
+        {"access-level": "public", "user": {"access-level": "nested"}},
+    )
+    store.put(("docs",), "digit", {"123abc": "ok", "user": {"123abc": "ok2"}})
+    store.put(
+        ("docs",),
+        "deep",
+        {"user": {"profile": {"id": "abc"}}},
+    )
+
+    # Top-level hyphenated key still matches literally
+    results = store.search(("docs",), filter={"access-level": "public"})
+    assert [r.key for r in results] == ["hyphen"]
+
+    # Nested hyphenated key via dotted path
+    results = store.search(("docs",), filter={"user.access-level": "nested"})
+    assert [r.key for r in results] == ["hyphen"]
+
+    # Top-level digit-starting key
+    results = store.search(("docs",), filter={"123abc": "ok"})
+    assert [r.key for r in results] == ["digit"]
+
+    # Nested digit-starting key via dotted path
+    results = store.search(("docs",), filter={"user.123abc": "ok2"})
+    assert [r.key for r in results] == ["digit"]
+
+    # Multi-level dotted path
+    results = store.search(("docs",), filter={"user.profile.id": "abc"})
+    assert [r.key for r in results] == ["deep"]
+
+    # Missing nested key does not match
+    results = store.search(("docs",), filter={"user.missing": "nope"})
+    assert results == []
+
+    # Dotted path through a non-dict does not match
+    store.put(("docs",), "scalar", {"user": "string-value"})
+    results = store.search(("docs",), filter={"user.access-level": "nested"})
+    assert [r.key for r in results] == ["hyphen"]
+
+
+def test_search_dotted_filter_keys_with_operators() -> None:
+    """Dotted filter keys should compose with comparison operators."""
+    store = InMemoryStore()
+    store.put(("docs",), "a", {"user": {"score": 10}})
+    store.put(("docs",), "b", {"user": {"score": 5}})
+    store.put(("docs",), "c", {"user": {"score": 1}})
+
+    results = store.search(("docs",), filter={"user.score": {"$gt": 4}})
+    assert sorted(r.key for r in results) == ["a", "b"]
+
+    results = store.search(("docs",), filter={"user.score": {"$lte": 5}})
+    assert sorted(r.key for r in results) == ["b", "c"]
+
+    results = store.search(("docs",), filter={"user.score": {"$ne": 5}})
+    assert sorted(r.key for r in results) == ["a", "c"]
+
+
 @pytest.fixture
 def fake_embeddings() -> CharacterEmbeddings:
     return CharacterEmbeddings(dims=500)


### PR DESCRIPTION
Fixes #7795.

InMemoryStore _filter_items resolved filter keys with a single dict.get, so a filter like {"user.id": "abc"} only ever matched top-level keys literally named "user.id". SqliteStore already walks dotted paths and matches against the nested value. This PR brings InMemoryStore in line by walking dotted keys with a small helper that preserves the existing sentinel-on-miss semantics. Added tests in libs/checkpoint/tests covering single, nested, and missing dotted-key paths.