### PR TITLE
fix(sqlite): add in-loop guard to AsyncSqliteSaver.put() and put_writes()

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -239,6 +239,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             RunnableConfig: Updated configuration after storing the checkpoint.
         """
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput(config, checkpoint, metadata, new_versions), self.loop
         ).result()
@@ -250,6 +260,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         task_id: str,
         task_path: str = "",
     ) -> None:
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput_writes(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput_writes(config, writes, task_id, task_path), self.loop
         ).result()

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,32 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_put_raises_in_loop_sync_call() -> None:
+    """put() and put_writes() must raise InvalidStateError when called
+    synchronously from within the saver's own event loop.
+
+    Previously these two methods were missing the in-loop guard that all other
+    sync bridge methods have, causing them to deadlock the event loop instead
+    of raising a fast, descriptive error (issue #7857).
+    """
+    import asyncio
+    from langgraph.checkpoint.base import create_checkpoint, empty_checkpoint
+
+    async def _run() -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            await saver.setup()
+            config = {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+            chkpnt = create_checkpoint(empty_checkpoint(), {}, 1)
+
+            # put() must raise, not deadlock
+            with pytest.raises(asyncio.InvalidStateError):
+                saver.put(config, chkpnt, {"source": "loop", "step": 1, "writes": None, "parents": {}}, {})
+
+            # put_writes() must raise, not deadlock
+            with pytest.raises(asyncio.InvalidStateError):
+                saver.put_writes(config, [("ch", "val")], "task-1")
+
+    await _run()


### PR DESCRIPTION
## Summary

`AsyncSqliteSaver.put()` and `AsyncSqliteSaver.put_writes()` deadlock the asyncio event loop when called synchronously from within the saver's own loop, instead of raising a descriptive error.

Closes #7857.

## Root cause

Six sync-bridge methods wrap their async counterparts with `run_coroutine_threadsafe(...).result()`. Four of them guard against in-loop calls:

| Method | Guarded? |
|---|---|
| `get_tuple` | ✅ |
| `list` | ✅ |
| `delete_thread` | ✅ |
| `get_delta_channel_history` | ✅ |
| **`put`** | ❌ |
| **`put_writes`** | ❌ |

Without the guard, `run_coroutine_threadsafe(...).result()` submits a coroutine to the saver's loop, then blocks the *current thread* waiting for `.result()`. Because the current thread **is** the event loop thread, the coroutine can never run → silent deadlock.

## Fix

Add the same `try/except asyncio.get_running_loop()` guard block already present in the four covered methods to `put()` and `put_writes()`. An in-loop synchronous call now raises `asyncio.InvalidStateError` with a message directing the caller to the async interface.

The comment `# we don't check in other methods to avoid the overhead` was added in `get_tuple` before the other methods had guards; `put` and `put_writes` are write paths that serialize, encode, and persist data — one `get_running_loop()` call is negligible, and a fast clear error is far better than an indefinite hang.

## Tests

`libs/checkpoint-sqlite/tests/test_aiosqlite.py` — `test_put_raises_in_loop_sync_call`:

- Creates an `AsyncSqliteSaver` from an in-memory DB inside an `async` function.
- Calls `saver.put(...)` and `saver.put_writes(...)` synchronously.
- Asserts `asyncio.InvalidStateError` is raised (not a deadlock).
- Fails on the unfixed code (hangs forever), passes with the fix.