### PR TITLE
release(sdk-py): 0.3.15

### DIFF
--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -3,6 +3,6 @@ from langgraph_sdk.client import get_client, get_sync_client
 from langgraph_sdk.encryption import Encryption
 from langgraph_sdk.encryption.types import EncryptionContext
 
-__version__ = "0.3.14"
+__version__ = "0.3.15"
 
 __all__ = ["Auth", "Encryption", "EncryptionContext", "get_client", "get_sync_client"]


### PR DESCRIPTION
## Summary

Bumps `langgraph-sdk` `0.3.14` → `0.3.15`.

## Test plan

- [x] `make format` / `make lint` / `make test` from `libs/sdk-py/`