### PR TITLE
fix(langgraph): cap retry sleep at max_interval after jitter

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -624,14 +624,13 @@ def run_with_retry(
             # sleep before retrying
             interval = matching_policy.initial_interval
             # Apply backoff factor based on attempt count
-            interval = min(
-                matching_policy.max_interval,
-                interval * (matching_policy.backoff_factor ** (attempts - 1)),
-            )
+            interval *= matching_policy.backoff_factor ** (attempts - 1)
 
-            # Apply jitter if configured
+            # Apply jitter if configured, then cap at max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else min(matching_policy.max_interval, interval)
             )
             time.sleep(sleep_time)
 
@@ -762,14 +761,13 @@ async def arun_with_retry(
             # sleep before retrying
             interval = matching_policy.initial_interval
             # Apply backoff factor based on attempt count
-            interval = min(
-                matching_policy.max_interval,
-                interval * (matching_policy.backoff_factor ** (attempts - 1)),
-            )
+            interval *= matching_policy.backoff_factor ** (attempts - 1)
 
-            # Apply jitter if configured
+            # Apply jitter if configured, then cap at max_interval
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else min(matching_policy.max_interval, interval)
             )
             await asyncio.sleep(sleep_time)
 


### PR DESCRIPTION
@
## Summary

RetryPolicy computed sleep_time as `min(max_interval, interval) + jitter`, which could exceed `max_interval` by up to 1 second when jitter is enabled. This PR moves the `min` cap after jitter addition so `sleep_time` never exceeds `max_interval`.

Fixes #7850.

## Test plan

- [x] `make format`
- [x] `make lint`
- [x] `make test TEST=tests/test_retry.py` (97 passed, 0 failed)
@