### PR TITLE
fix: validate encryption context handlers

### DIFF
--- a/libs/sdk-py/langgraph_sdk/encryption/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/encryption/__init__.py
@@ -38,7 +38,11 @@ class DuplicateHandlerError(Exception):
     pass
 
 
-def _validate_handler(fn: typing.Callable, handler_type: str) -> None:
+def _validate_handler(
+    fn: typing.Callable,
+    handler_type: str,
+    parameter_names: str = "(ctx, data)",
+) -> None:
     """Validate that a handler function has the correct signature.
 
     Args:
@@ -60,7 +64,7 @@ def _validate_handler(fn: typing.Callable, handler_type: str) -> None:
     if len(params) != 2:
         raise TypeError(
             f"{handler_type} must accept exactly 2 parameters "
-            f"(ctx, data), got {len(params)}"
+            f"{parameter_names}, got {len(params)}"
         )
 
 
@@ -418,6 +422,7 @@ class Encryption:
         Returns:
             The registered handler function
         """
+        _validate_handler(fn, "Context handler", "(user, ctx)")
         self._context_handler = fn
         return fn
 

--- a/libs/sdk-py/tests/test_encryption.py
+++ b/libs/sdk-py/tests/test_encryption.py
@@ -70,3 +70,26 @@ class TestHandlerValidation:
             @encryption.encrypt.blob  # ty: ignore[invalid-argument-type]
             async def wrong_params(ctx):
                 return ctx
+
+    def test_context_handler_must_be_async(self):
+        """Sync context handlers raise TypeError."""
+        encryption = Encryption()
+
+        with pytest.raises(TypeError, match="Context handler must be an async function"):
+
+            @encryption.context
+            def sync_context(_user, ctx):
+                return ctx.metadata
+
+    def test_context_handler_must_have_two_params(self):
+        """Context handlers must accept user and context."""
+        encryption = Encryption()
+
+        with pytest.raises(
+            TypeError,
+            match=r"Context handler must accept exactly 2 parameters \(user, ctx\)",
+        ):
+
+            @encryption.context  # ty: ignore[invalid-argument-type]
+            async def wrong_context_params(ctx):
+                return ctx.metadata


### PR DESCRIPTION
Fixes #7906

## Summary
- validate `Encryption.context` handlers at registration time
- report context-specific `(user, ctx)` arity errors
- add focused tests for sync and wrong-arity context handlers

## Validation
- `PYTHONPATH=. /tmp/langgraph-sdk-pytest312/bin/python -m pytest tests/test_encryption.py -q`
- `git diff --check`

## Note
This PR was auto-closed by the required issue-link workflow before issue #7906 existed. If maintainers approve and assign #7906 to me, the workflow says the PR can be reopened automatically.