### PR TITLE
fix(checkpoint-postgres): use numeric comparison for filter operators (fixes #7684)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -623,14 +623,12 @@ class BasePostgresStore(Generic[C]):
         """Helper to generate filter conditions."""
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
-        elif op == "$gt":
-            return "value->>%s > %s", [key, str(value)]
-        elif op == "$gte":
-            return "value->>%s >= %s", [key, str(value)]
-        elif op == "$lt":
-            return "value->>%s < %s", [key, str(value)]
-        elif op == "$lte":
-            return "value->>%s <= %s", [key, str(value)]
+        elif op in ("$gt", "$gte", "$lt", "$lte"):
+            if isinstance(value, (int, float)):
+                ops = {"$gt": ">", "$gte": ">=", "$lt": "<", "$lte": "<="}
+                return f"(value->>%s)::numeric {ops[op]} %s::numeric", [key, str(value)]
+            ops = {"$gt": ">", "$gte": ">=", "$lt": "<", "$lte": "<="}
+            return f"value->>%s {ops[op]} %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]
         else:


### PR DESCRIPTION
## Summary
Fix PostgresStore numeric filter operators to use proper numeric comparison instead of lexicographic comparison.

## Root Cause
The $gt, $gte, $lt, $lte filter operators used `value->>%s` (text extraction) for SQL WHERE comparisons. PostgreSQL's text comparison is lexicographic, causing incorrect ordering like "9" > "10".

## Changes
- `libs/checkpoint-postgres/langgraph/store/postgres/base.py`: When comparing numeric values (int/float), cast both sides to numeric with `(value->>%s)::numeric` and `%s::numeric`. Non-numeric values continue to use text comparison.

## Testing
- [x] ruff format/check pass
- [ ] Manual test with numeric filter queries

## Related Issue
Closes #7684
