### PR TITLE
docs(langgraph): fix broken docs URL in multi-interrupt RuntimeError (fixes #7686)

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -895,7 +895,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary
Fix broken documentation URL in the RuntimeError message raised when resuming with multiple pending interrupts.

## Root Cause
The error message referenced an incorrect or broken URL (`add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation`). The HITL docs were consolidated in PR #5192, moving the content to a new page without updating this in-source reference.

## Changes
- Fixed the URL from `docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation` to `docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts`

## Testing
- [x] Ruff clean

## Related Issue
Closes #7686
