### PR TITLE
fix(checkpoint): resolve dotted nested filter keys in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -244,7 +244,7 @@ class InMemoryStore(BaseStore):
                 return True
 
             return all(
-                _compare_values(item.value.get(key), filter_value)
+                _compare_values(_get_filter_value(item.value, key), filter_value)
                 for key, filter_value in op.filter.items()
             )
 
@@ -572,6 +572,16 @@ def _compare_values(item_value: Any, filter_value: Any) -> bool:
         )
     else:
         return item_value == filter_value
+
+
+def _get_filter_value(item_value: Any, key: str) -> Any:
+    """Resolve a filter key against an item value, supporting dotted paths."""
+    current = item_value
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
 
 
 def _apply_operator(value: Any, operator: str, op_value: Any) -> bool:

--- a/libs/checkpoint/tests/test_inmemory_store_dotted_filters.py
+++ b/libs/checkpoint/tests/test_inmemory_store_dotted_filters.py
@@ -1,0 +1,10 @@
+from langgraph.store.memory import InMemoryStore
+
+
+def test_inmemory_store_search_supports_dotted_filter_keys() -> None:
+    store = InMemoryStore()
+    store.put(("docs",), "hyphen", {"user": {"access-level": "nested"}})
+
+    results = store.search(("docs",), filter={"user.access-level": "nested"})
+
+    assert [result.key for result in results] == ["hyphen"]


### PR DESCRIPTION
## Summary

`InMemoryStore._filter_items()` treats dotted filter keys like `"user.access-level"` as literal top-level keys, so nested filters never match. `SqliteStore` already resolves dotted paths, making the two backends inconsistent.

The fix adds a small `_get_filter_value()` helper that traverses dotted paths before comparing, and wires it into `_filter_items()`.


## Changes

- `libs/checkpoint/langgraph/store/memory/__init__.py` — replace `item.value.get(key)` with `_get_filter_value(item.value, key)` in `_filter_items`, and add the `_get_filter_value` helper.
- `libs/checkpoint/tests/test_inmemory_store_dotted_filters.py` — regression test for dotted nested filter keys.

## Test plan

```bash
python -m pytest libs/checkpoint/tests/test_inmemory_store_dotted_filters.py -q
```