### PR TITLE
chore: improve langgraph maintenance path

### DIFF
--- a/libs/prebuilt/tests/model.py
+++ b/libs/prebuilt/tests/model.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import (
     Any,
     Literal,
@@ -59,7 +59,7 @@ class FakeToolCallingModel(BaseChatModel):
 
     def bind_tools(
         self,
-        tools: Sequence[dict[str, Any] | type[BaseModel] | Callable | BaseTool],
+        tools: Sequence[dict[str, Any] | BaseTool],
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, BaseMessage]:
         if len(tools) == 0:

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -368,6 +368,22 @@ def test_model_with_tools(tool_style: str, version: str, include_builtin: bool):
         create_react_agent(model.bind_tools([tool1]), [tool2])
 
 
+def test_fake_tool_calling_model_bind_tools_rejects_unsupported_types() -> None:
+    model = FakeToolCallingModel()
+
+    class DummySchema(BaseModel):
+        pass
+
+    with pytest.raises(TypeError):
+        model.bind_tools([DummySchema])
+
+    def dummy_func() -> None:
+        pass
+
+    with pytest.raises(TypeError):
+        model.bind_tools([dummy_func])
+
+
 def test__validate_messages():
     # empty input
     _validate_chat_history([])


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in libs/prebuilt/tests/model.py, libs/langgraph/tests/agents.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.