### PR TITLE
release(sdk-py): 0.4.0

### DIFF
--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -3,6 +3,6 @@ from langgraph_sdk.client import get_client, get_sync_client
 from langgraph_sdk.encryption import Encryption
 from langgraph_sdk.encryption.types import EncryptionContext
 
-__version__ = "0.3.15"
+__version__ = "0.4.0"
 
 __all__ = ["Auth", "Encryption", "EncryptionContext", "get_client", "get_sync_client"]


### PR DESCRIPTION
## Summary

Bumps `langgraph-sdk` `0.3.15` → `0.4.0`.

Minor bump to reflect the v3 streaming public API that landed across #7818–#7833 since 0.3.15:

- `client.threads.stream(...)` — new thread-centric streaming entry point (async + sync)
- SSE and WebSocket transports (`ProtocolSseTransport`, `ProtocolWebSocketTransport`) with reconnect handling and stream selection
- Shared stream subscriptions, lifecycle / interrupts state, output / values projections, messages / tool-call projections, scoped subgraph handles, thread stream helpers

## Test plan

- [x] `make format` / `make lint` / `make test` from `libs/sdk-py/`