### PR TITLE
fix(sdk-py): make `tools_agent` fake model stateless

### DIFF
--- a/libs/sdk-py/integration/graph/tools_agent.py
+++ b/libs/sdk-py/integration/graph/tools_agent.py
@@ -1,13 +1,13 @@
-"""create_agent-based example exercising the v3 ``tools`` channel.
+"""create_agent-based example exercising the v3 `tools` channel.
 
-`thread.tool_calls` and the underlying ``tools`` channel only emit
+`thread.tool_calls` and the underlying `tools` channel only emit
 events when an actual model issues a tool call through langchain's
-agent stack. The synthetic ``streaming_graph.py`` hand-builds
+agent stack. The synthetic `streaming_graph.py` hand-builds
 `AIMessage(tool_calls=[...])` and a `ToolMessage` via the messages
 reducer — that gets persisted in state but never produces tool-call
 telemetry on the wire. This graph fixes that by going through
-`create_agent` with a real tool, driven by a `GenericFakeChatModel` so
-the test stays hermetic (no `ANTHROPIC_API_KEY` required).
+`create_agent` with a real tool, driven by a hermetic fake chat model
+(no `ANTHROPIC_API_KEY` required).
 
 Flow on `run.start`:
 
@@ -25,7 +25,8 @@ from typing import Any
 
 from langchain.agents import create_agent
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import tool
 
 
@@ -36,51 +37,56 @@ def search(query: str) -> str:
 
 
 class _ToolBindingFakeChatModel(FakeMessagesListChatModel):
-    """Fake chat model that satisfies `create_agent`'s ``bind_tools`` call.
+    """Stateless fake chat model driving a single `search` tool call.
 
-    ``create_agent`` calls ``model.bind_tools(tools)`` to attach the tool
-    schema (``langchain/agents/factory.py:1284``). The base
-    ``FakeMessagesListChatModel`` inherits ``BaseChatModel.bind_tools``,
-    which raises ``NotImplementedError``. We don't actually need the
-    bound schema — the fake replays scripted ``AIMessage``s with their
-    own ``tool_calls`` field — so override ``bind_tools`` as a no-op.
+    `create_agent` calls `model.bind_tools(tools)` to attach the tool
+    schema (`langchain/agents/factory.py:1284`). The base
+    `FakeMessagesListChatModel` inherits `BaseChatModel.bind_tools`,
+    which raises `NotImplementedError`, so `bind_tools` is overridden as
+    a no-op (the reply is hand-built and already carries `tool_calls`).
 
-    ``FakeMessagesListChatModel`` is preferred over
-    ``GenericFakeChatModel`` here because the latter's ``_stream``
-    breaks the message into content chunks and **drops ``tool_calls``**
-    when content is empty, causing the v2 streaming path inside
-    ``create_agent`` to raise ``RuntimeError("v2 stream finished
-    without producing a message")``. ``FakeMessagesListChatModel``
-    falls back to the default ``_stream`` that yields the whole
-    message in one chunk, preserving ``tool_calls``.
+    The reply is derived from conversation state rather than a cycling
+    response list: the `search` tool call is issued until a `ToolMessage`
+    appears, then a terminating `AIMessage`. This avoids the response-index
+    parity flake where `FakeMessagesListChatModel.responses` is shared
+    process-wide and cycles `0 -> 1 -> 0`; a run that started mid-cycle
+    (e.g. on a reused server worker) would reply `"done."` first and emit
+    no tool call. Being order-independent, every run emits exactly one
+    tool call regardless of how many times the model was previously called.
+
+    `FakeMessagesListChatModel` is subclassed (rather than
+    `GenericFakeChatModel`) because the latter's `_stream` breaks the
+    message into content chunks and drops `tool_calls` when content is
+    empty, causing the v2 streaming path inside `create_agent` to raise
+    `RuntimeError("v2 stream finished without producing a message")`.
+    The inherited `_stream` yields the whole message in one chunk,
+    preserving `tool_calls`.
     """
 
     def bind_tools(self, tools: Any, **kwargs: Any) -> _ToolBindingFakeChatModel:
         return self
 
-
-# Two scripted turns. ``FakeMessagesListChatModel`` cycles through
-# ``responses`` (resetting to index 0 after the last) so the graph
-# can be run many times without restart; per run, ``create_agent``
-# invokes the model exactly twice (once to issue the tool call,
-# once after the tool result to produce the terminating answer).
-_supervisor_responses: list[AIMessage] = [
-    AIMessage(
-        content="",
-        id="ai-tools-1",
-        tool_calls=[
-            {
-                "id": "tc-1",
-                "name": "search",
-                "args": {"query": "v3"},
-            }
-        ],
-    ),
-    AIMessage(content="done.", id="ai-tools-2"),
-]
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if any(isinstance(m, ToolMessage) for m in messages):
+            response = AIMessage(content="done.", id="ai-tools-done")
+        else:
+            response = AIMessage(
+                content="",
+                id="ai-tools-call",
+                tool_calls=[{"id": "tc-1", "name": "search", "args": {"query": "v3"}}],
+            )
+        return ChatResult(generations=[ChatGeneration(message=response)])
 
 
-_supervisor_model = _ToolBindingFakeChatModel(responses=_supervisor_responses)
+# `responses` is a required field on `FakeMessagesListChatModel`, but the
+# overridden `_generate` derives its reply from state and never reads it.
+_supervisor_model = _ToolBindingFakeChatModel(responses=[])
 
 
 graph = create_agent(


### PR DESCRIPTION
## Problem

`test_tools.py::test_tools_async` (sdk-py integration suite) flakes with `AssertionError: expected at least one tool call handle` (`assert []`), while `test_tools_sync` passes. Observed on #7927's CI but the test predates that PR (added in #7833) and is unchanged on its branch — this is a pre-existing flake.

## Root cause

`integration/graph/tools_agent.py` drives `create_agent` with a **module-global** `FakeMessagesListChatModel`. That model keeps an instance counter `i` that persists and cycles `0 -> 1 -> 0` across runs. The graph only works if every run starts at an even index (first model call issues the `search` tool call). On the licensed server (multiple queue workers / graph warmup), a run can start mid-cycle at an odd index — the model then replies `"done."` first, `create_agent` ends after one model call, and **zero `tools`-channel events** reach the wire. `thread.tool_calls` correctly yields nothing and the assertion fails.

This is why only the async test flaked: it runs before the sync test, absorbs the odd-parity run (one model call), and flips the shared cursor back to even, so the sync test then passes.

### Evidence
- Reproduced the exact graph outside Docker: at even `i` the run emits 1 tool call + 1 `ToolMessage`; at odd `i` it emits **0** of each. Verified the state-based replacement emits exactly one tool call across repeated runs with `i` flipped each time.
- The failing CI run's server logs show the `tools_agent` run **succeeded** (`run_exec_ms=15`) with **no** tool-channel events — the server emitted none because the graph made no tool call. Not an SDK delivery bug.

## Fix

Derive the reply from conversation state rather than a cycling response list: issue the `search` tool call until a `ToolMessage` is present, then a terminating `AIMessage`. Order-independent, so every run emits exactly one tool call regardless of prior invocation count. Still subclasses `FakeMessagesListChatModel` (not `GenericFakeChatModel`) to preserve the `_stream` behavior that keeps `tool_calls` intact.

## Test plan
- [x] `sdk-py integration test` green (the flaky check)
- Local: `ruff format` / `ruff check` clean; graph compiles.