### PR TITLE
test(langgraph): add faulthandler_timeout to capture intermittent CI hang tracebacks

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -122,6 +122,12 @@ packages = ["langgraph"]
 
 [tool.pytest.ini_options]
 addopts = "--full-trace --strict-markers --strict-config --durations=5 --snapshot-warn-unused"
+# Dump tracebacks of all threads if any test runs longer than 300s. Diagnostic
+# for an intermittent CI-only hang in the postgres checkpointer fixtures: faulthandler
+# uses a watchdog thread, so it dumps even when the main thread is blocked in a
+# C-level socket read (e.g. psycopg waiting on the server). No normal test runs
+# this long, so a dump unambiguously marks the hung test and where it is stuck.
+faulthandler_timeout = 300
 
 [tool.codespell]
 # Ignore words specific to the LangGraph library code


### PR DESCRIPTION
## Problem

`libs/langgraph`'s `make test_parallel` job intermittently **hangs in CI** (CI-only; runs ~75 min until the job timeout cancels it, producing **no traceback**). Observed across multiple PRs and on a *different* Python version each time, always at ~99% of the run inside the postgres checkpointer fixtures (`test_interruption_without_state_updates`). Because there is no `pytest-timeout` or `faulthandler` configured, the hang leaves no stack trace, so the exact blocking call is unknown.

## Change

Add `faulthandler_timeout = 300` to `[tool.pytest.ini_options]`. pytest's **built-in** faulthandler support dumps tracebacks of all threads if any test exceeds 300s.

- **No new dependency** (built into pytest).
- faulthandler uses a watchdog thread, so it dumps **even when the main thread is blocked in a C-level socket read** — exactly the suspected psycopg-on-postgres case.
- No normal test runs anywhere near 300s, so a dump unambiguously marks the hung test and where it is stuck.

## Why

Pure diagnostic: capture the stack trace the next time the hang occurs so we can fix the root cause. Safe to merge regardless of the investigation outcome.