### PR TITLE
fix(sdk-py): join repeated SSE data fields with newlines (#7915)

### DIFF
--- a/libs/sdk-py/langgraph_sdk/sse.py
+++ b/libs/sdk-py/langgraph_sdk/sse.py
@@ -124,6 +124,12 @@ class SSEDecoder:
         if fieldname == b"event":
             self._event = value.decode()
         elif fieldname == b"data":
+            # Per the SSE spec, repeated `data:` fields in the same event are
+            # joined with a newline. Inserting `\n` between values keeps the
+            # original payload bytes intact when the server splits a multi-line
+            # JSON string across several `data:` lines.
+            if self._data:
+                self._data.extend(b"\n")
             self._data.extend(value)
         elif fieldname == b"id":
             if b"\0" in value:

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -89,6 +89,47 @@ def _assert_v2_shape(part: Any) -> None:
 # --- SSE parsing ---
 
 
+def test_decoder_joins_repeated_data_fields_with_newline(monkeypatch):
+    """Per the SSE spec, repeated ``data:`` lines in a single event are joined
+    with ``\\n`` before being handed to the JSON loader. Regression test for
+    #7915 where the decoder concatenated the values directly, so a multi-line
+    payload was reassembled as if it had no separators at all."""
+
+    captured: list[bytes] = []
+
+    def fake_loads(payload: Any) -> Any:
+        captured.append(bytes(payload))
+        return None
+
+    monkeypatch.setattr("langgraph_sdk.sse.orjson.loads", fake_loads)
+
+    decoder = SSEDecoder()
+    for line in (b"event: custom", b"data: hi", b"data: world"):
+        assert decoder.decode(line) is None
+    decoder.decode(b"")
+
+    assert captured == [b"hi\nworld"]
+
+
+def test_decoder_single_data_field_unchanged(monkeypatch):
+    """A single ``data:`` line should still reach the JSON loader without any
+    extra separators tacked on."""
+
+    captured: list[bytes] = []
+
+    def fake_loads(payload: Any) -> Any:
+        captured.append(bytes(payload))
+        return None
+
+    monkeypatch.setattr("langgraph_sdk.sse.orjson.loads", fake_loads)
+
+    decoder = SSEDecoder()
+    assert decoder.decode(b'data: {"x": 1}') is None
+    decoder.decode(b"")
+
+    assert captured == [b'{"x": 1}']
+
+
 def test_stream_sse():
     for groups in (
         [RESPONSE_PAYLOAD],


### PR DESCRIPTION
Closes #7915.

## What's wrong

`SSEDecoder.decode` in `libs/sdk-py/langgraph_sdk/sse.py` was extending its byte buffer directly for each `data:` field it saw on a single event. The SSE spec says repeated `data:` lines belong to the same event and must be joined with `\n` before being handed to the consumer, so when a server split a JSON payload across several `data:` lines the SDK reassembled it without any separators and orjson saw a different value than the one the server sent.

## What changed

`libs/sdk-py/langgraph_sdk/sse.py`:

```diff
 elif fieldname == b"data":
+    if self._data:
+        self._data.extend(b"\n")
     self._data.extend(value)
```

The newline is inserted only between values, so events with a single `data:` line keep their existing bytes unchanged.

## Tests

`libs/sdk-py/tests/test_client_stream.py`:

- `test_decoder_joins_repeated_data_fields_with_newline` patches `orjson.loads` to record the raw bytes it receives, then feeds the decoder a two-line `data:` event and asserts the captured payload is `b\"hi\\nworld\"`. This fails on `main` and passes on this branch.
- `test_decoder_single_data_field_unchanged` is the negative control, confirming a single `data:` event still hands the loader its bytes unchanged.

Full suite:

```
16 passed in 0.06s
```

`ruff check` and `ruff format --check` clean.