### PR TITLE
fix(langgraph): rename ProtocolEvent.eventId to event_id to match the wire field

### DIFF
--- a/libs/langgraph/langgraph/stream/_types.py
+++ b/libs/langgraph/langgraph/stream/_types.py
@@ -35,7 +35,7 @@ class ProtocolEvent(TypedDict):
     """
 
     type: Literal["event"]
-    eventId: NotRequired[str]
+    event_id: NotRequired[str]  # snake_case to match the langchain-protocol wire field
     seq: NotRequired[int]
     method: str  # StreamMode value: "values", "messages", "custom", etc.
     params: _ProtocolEventParams


### PR DESCRIPTION
## Summary

`ProtocolEvent` (`langgraph/stream/_types.py`) is langgraph's typed mirror of the [`langchain-protocol`](https://pypi.org/project/langchain-protocol/) streaming event envelope. The protocol's id field is `event_id` (snake_case), but the local `TypedDict` declared it as `eventId` (camelCase). That mismatch means a consumer type-checking against `ProtocolEvent` would expect the wrong key, and it's inconsistent with the sibling fields (`seq`, `method`, `params`) which already match the wire shape.

This renames `eventId` → `event_id`.

## Why it's safe

The field is `NotRequired` and **never read or written anywhere** in the codebase — only `seq` is used for ordering, and `convert_to_protocol_event` / the `StreamMux` injection path set `type`/`method`/`params`/`seq` but never the id. A repo-wide search finds `eventId` only in the `TypedDict` definition, and no test constructs or asserts on it. So this is a pure type-surface correction with no runtime behavior change.

## Context

Surfaced while wiring v3 streaming into `RemoteGraph` (#7927): the SDK's wire events (`langchain_protocol.Event`) carry `event_id`, while the local `ProtocolEvent` used `eventId` — the only divergence between the two envelopes once `params` shapes were confirmed identical. With this rename, raw-event iteration shapes line up across local `Graph` and `RemoteGraph` with no adapter-side conversion.

## Test plan

- [x] `make format` / `make lint` (ruff + mypy) clean for the changed file
- [x] Stream-event suites pass (`test_stream_events_v3.py`, `test_pregel_stream_events_v3.py`, `test_interleave_arrival_order.py`): 175 passed