### PR TITLE
release(langgraph): 1.2.3

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.2"
+version = "1.2.3"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "langchain-core>=1.4.0,<2",
     "langgraph-checkpoint>=4.1.0,<5.0.0",
-    "langgraph-sdk>=0.4.1,<0.5.0",
+    "langgraph-sdk>=0.4.2,<0.5.0",
     "langgraph-prebuilt>=1.1.0,<1.2.0",
     "xxhash>=3.5.0",
     "pydantic>=2.7.4",

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Release `langgraph` 1.2.3 (patch bump from 1.2.2).

Also raises the `langgraph-sdk` floor to `>=0.4.2,<0.5.0`. RemoteGraph v3 streaming (shipped in this release line via #7927/#7938) drives the SDK's **default** v3 transport paths, and sdk-py 0.4.2 (#7954) percent-encodes `thread_id` in those paths — preventing a `thread_id` with reserved characters / dot-segments (e.g. `../assistants/abc`) from being normalized onto a different resource. Not an API change; the floor bump ensures a clean install of 1.2.3 pairs the streaming feature with the patched transport.

Rebased on `main`, which already carries the `>=0.4.1` floor (#7938) and the sdk-py 0.4.2 workspace bump (#7955); `uv lock --check` is clean across all three libs.
