### PR TITLE
fix(langgraph): seed reducer field defaults from Pydantic/dataclass schemas (#5225)

### DIFF
--- a/libs/langgraph/langgraph/_internal/_fields.py
+++ b/libs/langgraph/langgraph/_internal/_fields.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import types
 import weakref
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
+from inspect import signature
 from typing import Annotated, Any, Optional, Union, get_origin, get_type_hints
 
 from pydantic import BaseModel
@@ -120,6 +122,45 @@ def get_field_default(name: str, type_: Any, schema: type[Any]) -> Any:
     if _is_optional_type(type_):
         return None
     return ...
+
+
+def get_field_default_factory(name: str, schema: type[Any]) -> Callable[[], Any] | None:
+    """Return a zero-arg factory producing a fresh declared default for ``name``.
+
+    Supports Pydantic ``BaseModel`` and dataclass schemas. Returns ``None`` when
+    the field has no explicit default (so callers fall back to existing
+    behavior). Mutable scalar defaults are deep-copied on each call so values
+    are never shared across invocations.
+    """
+    model_fields = getattr(schema, "model_fields", None)
+    if model_fields is not None and name in model_fields:
+        field = model_fields[name]
+        if field.is_required():
+            return None
+        if field.default_factory is not None:
+            factory = field.default_factory
+            try:
+                nparams = len(signature(factory).parameters)
+            except (TypeError, ValueError):
+                nparams = 0
+            # Pydantic >=2.10 allows a data-dependent factory; we can only seed
+            # from the zero-arg form, since validated data isn't available here.
+            return factory if nparams == 0 else None
+        default = field.default
+        return lambda: copy.deepcopy(default)
+    if dataclasses.is_dataclass(schema):
+        for dc_field in dataclasses.fields(schema):
+            if dc_field.name == name:
+                if dc_field.default_factory is not dataclasses.MISSING:
+                    return dc_field.default_factory
+                if (
+                    dc_field.default is not dataclasses.MISSING
+                    and dc_field.default is not ...
+                ):
+                    default = dc_field.default
+                    return lambda: copy.deepcopy(default)
+                return None
+    return None
 
 
 def get_enhanced_type_hints(

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
 from langgraph._internal._fields import (
     get_cached_annotated_keys,
     get_field_default,
+    get_field_default_factory,
     get_update_as_tuples,
 )
 from langgraph._internal._pydantic import create_model
@@ -1493,11 +1494,50 @@ class CompiledStateGraph(
 
         # add node and output channel
         if key == START:
+            # Issue #5225: seed declared defaults for reducer
+            # (BinaryOperatorAggregate) fields so node updates reduce on top of
+            # the default rather than on a zero-value (`typ()`). An explicitly
+            # provided input value for a field still overrides its default.
+            reducer_defaults: dict[str, Callable[[], Any]] = {}
+            start_schema = self.builder.input_schema
+            if isclass(start_schema) and (
+                issubclass(start_schema, BaseModel) or is_dataclass(start_schema)
+            ):
+                for k in output_keys:
+                    if isinstance(self.channels.get(k), BinaryOperatorAggregate) and (
+                        factory := get_field_default_factory(k, start_schema)
+                    ):
+                        reducer_defaults[k] = factory
+
+            if reducer_defaults:
+
+                def _get_input_updates(
+                    input: None | dict | Any,
+                ) -> Sequence[tuple[str, Any]] | None:
+                    updates = _get_updates(input)
+                    if updates is None:
+                        return None
+                    updates = list(updates)
+                    provided = {k for k, _ in updates}
+                    for field_name, factory in reducer_defaults.items():
+                        if field_name not in provided:
+                            updates.append((field_name, factory()))
+                    return updates
+
+                start_entries: tuple[
+                    ChannelWriteEntry | ChannelWriteTupleEntry, ...
+                ] = (
+                    ChannelWriteTupleEntry(mapper=_get_input_updates),
+                    *write_entries[1:],
+                )
+            else:
+                start_entries = write_entries
+
             self.nodes[key] = PregelNode(
                 tags=[TAG_HIDDEN],
                 triggers=[START],
                 channels=START,
-                writers=[ChannelWrite(write_entries)],
+                writers=[ChannelWrite(start_entries)],
             )
         elif node is not None:
             input_schema = node.input_schema if node else self.builder.state_schema

--- a/libs/langgraph/tests/test_pydantic.py
+++ b/libs/langgraph/tests/test_pydantic.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import ipaddress
+import operator
 import pathlib
 import re
 import sys
@@ -360,3 +361,89 @@ def test_interrupt_functional_pydantic(sync_checkpointer: BaseCheckpointSaver) -
     res = graph.invoke(Command(resume="bar"), config)
     assert res == {"a": "foobar", "b": "bar"}
     assert called_count == 1
+
+
+def _extend(left: list, right: list) -> list:
+    left.extend(right)
+    return left
+
+
+def test_reducer_field_seeds_scalar_default_when_omitted() -> None:
+    """Issue #5225: a reducer field's declared default should seed the channel,
+    so node updates reduce on top of the default instead of on ``typ()``."""
+
+    class State(BaseModel):
+        counter: Annotated[int, operator.add] = Field(default=10)
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 15}
+
+
+def test_reducer_field_seeds_default_factory_when_omitted() -> None:
+    class State(BaseModel):
+        items: Annotated[list[str], _extend] = Field(
+            default_factory=lambda: ["default"]
+        )
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"items": ["from_node"]})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+
+
+def test_reducer_field_explicit_input_overrides_default() -> None:
+    """105 semantics: an explicitly-provided input value replaces the default
+    (like a function-parameter default), then node updates reduce on top."""
+
+    class State(BaseModel):
+        counter: Annotated[int, operator.add] = Field(default=10)
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({"counter": 100}) == {"counter": 105}
+
+
+def test_reducer_field_default_not_shared_across_runs() -> None:
+    """A mutable default must not leak between separate invocations."""
+
+    class State(BaseModel):
+        items: Annotated[list[str], _extend] = Field(
+            default_factory=lambda: ["default"]
+        )
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"items": ["from_node"]})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+
+
+def test_reducer_field_without_default_unchanged() -> None:
+    """Non-regression: a reducer field with no declared default keeps its
+    existing ``typ()``-seeded behavior."""
+
+    class State(BaseModel):
+        counter: Annotated[int, operator.add]
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 5}

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -371,3 +371,22 @@ def test_is_field_channel() -> None:
     # No channel cases
     assert _is_field_channel(int) is None
     assert _is_field_channel(Annotated[int, "just_metadata"]) is None
+
+
+def test_reducer_field_seeds_dataclass_default_when_omitted() -> None:
+    """Issue #5225 parity: a dataclass reducer-field default seeds the channel
+    so node updates reduce on top of it instead of on a zero-value."""
+
+    @dataclass
+    class DataclassState:
+        counter: Annotated[int, operator.add] = field(default=10)
+
+    builder = StateGraph(DataclassState)
+    builder.add_node("n", lambda s: {"counter": 5})
+    builder.add_edge("__start__", "n")
+    builder.add_edge("n", "__end__")
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 15}
+    # Explicit input overrides the default (105 semantics).
+    assert graph.invoke({"counter": 100}) == {"counter": 105}


### PR DESCRIPTION
## Summary

Fixes #5225. A state field that pairs a reducer with a declared default — e.g. `Annotated[int, operator.add] = Field(default=10)` — ignored the default. The reducer channel seeded `typ()` (`0` / `[]` / `{}`) and reduced node updates onto that, so `invoke({})` returned `5` instead of `15`.

This was **not** Pydantic-specific — a dataclass field (`Annotated[int, operator.add] = field(default=10)`) failed identically. `BinaryOperatorAggregate` simply never received the field's declared default.

## Behavior

The declared default now seeds the channel's initial value, and node updates reduce on top. An explicitly provided input value overrides the default — like a function-parameter default:

| | `invoke({})` | `invoke({"counter": 100})` |
|---|---|---|
| before | `5` | `105` |
| after | **`15`** | `105` |

Scoped to reducer (`BinaryOperatorAggregate`) fields, so `LastValue` behavior is unchanged.

> Alternative semantics — "default always seeds, everything reduces" — would make `invoke({"counter": 100})` return `115`. That's a small change to switch to; see the issue discussion. This PR implements the "explicit input overrides default" direction.

## Changes

- **`_internal/_fields.py`** — new `get_field_default_factory(name, schema)`: returns a zero-arg factory that produces a *fresh* declared default for Pydantic `BaseModel` and dataclass fields, or `None` when there's no explicit default. Mutable scalar defaults are deep-copied per call; data-dependent Pydantic `default_factory` forms are skipped (fall back to current behavior).
- **`graph/state.py`** — at the `START` node, seed declared defaults for reducer-typed fields the input omits. It keys off the already-computed input updates, so an explicitly provided value naturally overrides the default, and it works for both `dict` and model inputs.

## Tests

- `tests/test_pydantic.py`: scalar default + `operator.add`, `default_factory` + list reducer, explicit-input-overrides, cross-run isolation of a mutable default, and non-regression for a reducer field with no default.
- `tests/test_state.py`: dataclass parity (default seeded + explicit override).

Verified with `make format`, `make lint`, `make test`.
