### PR TITLE
fix(sdk-py): join multi-line SSE data fields with newlines per spec

### DIFF
--- a/libs/sdk-py/langgraph_sdk/sse.py
+++ b/libs/sdk-py/langgraph_sdk/sse.py
@@ -92,9 +92,10 @@ class SSEDecoder:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
 
         if not line:
+            data = self._data[:-1] if self._data.endswith(b"\n") else self._data
             if (
                 not self._event
-                and not self._data
+                and not data
                 and not self._last_event_id
                 and self._retry is None
             ):
@@ -102,7 +103,7 @@ class SSEDecoder:
 
             sse = StreamPart(
                 event=self._event,
-                data=orjson.loads(self._data) if self._data else None,  # ty: ignore[invalid-argument-type]
+                data=orjson.loads(data) if data else None,  # ty: ignore[invalid-argument-type]
                 id=self.last_event_id,
             )
 
@@ -125,6 +126,7 @@ class SSEDecoder:
             self._event = value.decode()
         elif fieldname == b"data":
             self._data.extend(value)
+            self._data.extend(b"\n")
         elif fieldname == b"id":
             if b"\0" in value:
                 pass

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from typing_extensions import assert_type
 
+import langgraph_sdk.sse as sse_module
 from langgraph_sdk._shared.utilities import _sse_to_v2_dict
 from langgraph_sdk.client import HttpClient, SyncHttpClient
 from langgraph_sdk.schema import (
@@ -106,6 +107,21 @@ def test_stream_sse():
 
         assert decoder.decode(b"") is None
         assert len(parts) == 79
+
+
+def test_sse_decoder_joins_multiline_data_with_newlines(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(sse_module.orjson, "loads", lambda data: {"raw": data})
+    decoder = SSEDecoder()
+
+    assert decoder.decode(b"event: custom") is None
+    assert decoder.decode(b'data: "hello') is None
+    assert decoder.decode(b'data: world"') is None
+
+    assert decoder.decode(b"") == StreamPart(
+        event="custom", data={"raw": b'"hello\nworld"'}
+    )
 
 
 # --- HTTP client streaming ---


### PR DESCRIPTION
Fixes #7915

## Summary
`SSEDecoder` in `libs/sdk-py/langgraph_sdk/sse.py` concatenated repeated `data:` lines with no separator, so a spec-compliant multi-line payload like

```text
event: custom
data: "hello
data: world"

```

was silently decoded to `b'"helloworld"'` before being handed to `orjson.loads`, corrupting any multi-line JSON string. Per the [WHATWG SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), repeated `data:` fields must be joined with U+000A LINE FEED and the final synthetic trailing newline trimmed once at dispatch.

## Root cause
In `SSEDecoder.decode()`:

- each `data:` line is appended directly to `self._data`
- no newline is inserted between repeated `data:` lines
- on dispatch, the buffer is passed to `orjson.loads` as-is

So `"hello\nworld"` round-trips as `"helloworld"`.

## Fix
- Append `b"\n"` after every `data:` value when extending the decode buffer.
- Strip the synthetic trailing newline once when the event is dispatched:
  `data = self._data[:-1] if self._data.endswith(b"\n") else self._data`.
- Update the empty-event guard to compare against the stripped `data` instead of the raw buffer, so an event whose only contents is a synthetic newline is still treated as empty.

The whole change is 4 lines in `sse.py`.

## Scope of impact
The fix is in the shared `SSEDecoder`, so it covers every consumer in the SDK:

- the existing sync/async paths in `libs/sdk-py/langgraph_sdk/_async/http.py`
- the newly added v3 streaming transports in `libs/sdk-py/langgraph_sdk/stream/transport/http.py` and `libs/sdk-py/langgraph_sdk/stream/transport/sync_http.py`

All three instantiate the same `SSEDecoder`, so any server emitting multi-line SSE `data:` payloads to a Python SDK client is affected today and is fixed by this patch.

## Tests
Added `test_sse_decoder_joins_multiline_data_with_newlines` in `libs/sdk-py/tests/test_client_stream.py`. It monkeypatches `orjson.loads` so the assertion inspects the exact bytes the decoder hands to the JSON parser, locking down the spec-correct `b'"hello\nworld"'` output:

```python
def test_sse_decoder_joins_multiline_data_with_newlines(
    monkeypatch: pytest.MonkeyPatch,
):
    monkeypatch.setattr(sse_module.orjson, "loads", lambda data: {"raw": data})
    decoder = SSEDecoder()

    assert decoder.decode(b"event: custom") is None
    assert decoder.decode(b'data: "hello') is None
    assert decoder.decode(b'data: world"') is None

    assert decoder.decode(b"") == StreamPart(
        event="custom", data={"raw": b'"hello\nworld"'}
    )
```

This test fails against `main` before the patch and passes after.

## Verification
From `libs/sdk-py`:

```text
make format    # ruff format: 2 files left unchanged
make lint      # ruff check + ty check: all checks passed
make test      # 483 passed, 53 deselected, 1 warning
```

## Compatibility
Pure correctness fix; no public API change. Consumers that previously received the buggy concatenated payload now receive the spec-correct one. Single-line `data:` events, empty events, comment lines (`:`), `event:`, `id:`, and `retry:` handling are all unchanged.

## Checklist
- [x] Conventional Commits message (`fix(sdk-py): ...`)
- [x] Issue referenced (`Fixes #7915`)
- [x] Regression test added
- [x] `make format`, `make lint`, `make test` pass in `libs/sdk-py`
- [x] Branch rebased on latest `main`
