### PR TITLE
fix(langgraph): cap RetryPolicy jitter at max_interval

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -667,9 +667,12 @@ def run_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, re-capping so jitter cannot push the
+            # sleep above max_interval.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             time.sleep(sleep_time)
 
@@ -823,9 +826,12 @@ async def arun_with_retry(
                 interval * (matching_policy.backoff_factor ** (attempts - 1)),
             )
 
-            # Apply jitter if configured
+            # Apply jitter if configured, re-capping so jitter cannot push the
+            # sleep above max_interval.
             sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
+                min(matching_policy.max_interval, interval + random.uniform(0, 1))
+                if matching_policy.jitter
+                else interval
             )
             await asyncio.sleep(sleep_time)
 

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -375,6 +375,51 @@ def test_graph_with_jitter_retry_policy():
     mock_sleep.assert_called_with(0.01 + 0.05)  # Sleep should include jitter
 
 
+def test_jitter_respects_max_interval():
+    """Jitter must not push the sleep above max_interval (issues #7554, #7850)."""
+
+    class State(TypedDict):
+        foo: str
+
+    attempt_count = 0
+
+    def failing_node(state):
+        nonlocal attempt_count
+        attempt_count += 1
+        if attempt_count < 2:  # Fail the first attempt
+            raise ValueError("Intentional failure")
+        return {"foo": "success"}
+
+    # max_interval is tighter than the jitter that random.uniform can add, so an
+    # uncapped implementation would sleep for more than max_interval.
+    retry_policy = RetryPolicy(
+        max_attempts=3,
+        initial_interval=0.01,
+        max_interval=0.01,
+        jitter=True,
+        retry_on=ValueError,
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing_node", failing_node, retry_policy=retry_policy)
+        .add_edge(START, "failing_node")
+        .compile()
+    )
+
+    with (
+        patch("random.uniform", return_value=0.05),
+        patch("time.sleep") as mock_sleep,
+    ):
+        result = graph.invoke({"foo": ""})
+
+    assert attempt_count == 2
+    assert result["foo"] == "success"
+
+    # The sleep is capped at max_interval despite the 0.05 jitter.
+    mock_sleep.assert_called_with(0.01)
+
+
 def test_graph_with_multiple_retry_policies():
     """Test a graph with multiple retry policies for a node."""
 


### PR DESCRIPTION
## Problem

`RetryPolicy` clamps the backoff interval to `max_interval` **before** adding jitter, so the actual sleep can exceed `max_interval` by up to 1 second on every jittered retry. This violates the documented contract of `max_interval` ("Maximum amount of time that may elapse between retries").

```python
interval = min(matching_policy.max_interval, ...)        # cap applied
sleep_time = interval + random.uniform(0, 1)             # jitter breaks the cap
```

## Fix

Re-apply the `min(max_interval, ...)` cap to the jittered value in both `run_with_retry` (sync) and `arun_with_retry` (async) in `langgraph/pregel/_retry.py`.

## Test

Adds `test_jitter_respects_max_interval`: with `max_interval=0.01`, `jitter=True`, and `random.uniform` mocked to `0.05`, the sleep is asserted to be capped at `0.01` (fails before the fix, passes after). Existing `test_graph_with_jitter_retry_policy` is unaffected (it uses the default `max_interval=128.0`).

`make format`, `make lint` (incl. mypy), and `make test` (`tests/test_retry.py`) all pass.

Fixes #7554
Closes #7850

🤖 Generated with [Claude Code](https://claude.com/claude-code)