### PR TITLE
Guard AsyncSqliteSaver sync writes in event loop

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -239,6 +239,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             RunnableConfig: Updated configuration after storing the checkpoint.
         """
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput(config, checkpoint, metadata, new_versions), self.loop
         ).result()
@@ -250,6 +260,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         task_id: str,
         task_path: str = "",
     ) -> None:
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput_writes(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput_writes(config, writes, task_id, task_path), self.loop
         ).result()

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pytest
@@ -55,6 +56,22 @@ class TestAsyncSqliteSaver:
             "score": None,
         }
         self.metadata_3: CheckpointMetadata = {}
+
+    async def test_sync_put_raises_in_loop_thread(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            with pytest.raises(
+                asyncio.InvalidStateError,
+                match="Synchronous calls to AsyncSqliteSaver",
+            ):
+                saver.put(self.config_1, self.chkpnt_1, self.metadata_1, {})
+
+    async def test_sync_put_writes_raises_in_loop_thread(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            with pytest.raises(
+                asyncio.InvalidStateError,
+                match="Synchronous calls to AsyncSqliteSaver",
+            ):
+                saver.put_writes(self.config_1, [("channel", "value")], "task-1")
 
     async def test_combined_metadata(self) -> None:
         async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:


### PR DESCRIPTION
## Summary
- add event-loop thread guards to AsyncSqliteSaver.put and put_writes
- make those sync bridge methods raise InvalidStateError instead of deadlocking when called from the owning loop
- add regression tests for both sync write paths

Fixes #7857

## Testing
- python3 -m py_compile libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py libs/checkpoint-sqlite/tests/test_aiosqlite.py
- Not run: pytest, because this local Python environment is missing pytest and project test dependencies.