### PR TITLE
release(sdk-py): 0.4.2

### DIFF
--- a/libs/sdk-py/langgraph_sdk/__init__.py
+++ b/libs/sdk-py/langgraph_sdk/__init__.py
@@ -3,6 +3,6 @@ from langgraph_sdk.client import get_client, get_sync_client
 from langgraph_sdk.encryption import Encryption
 from langgraph_sdk.encryption.types import EncryptionContext
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 __all__ = ["Auth", "Encryption", "EncryptionContext", "get_client", "get_sync_client"]


### PR DESCRIPTION
Release `langgraph-sdk` 0.4.2.

### Changes since 0.4.1

- **fix(sdk-py): percent-encode `thread_id` in v3 stream transport default paths** (#7954, closes #7953) — the v3 SSE and WebSocket stream transports interpolated `thread_id` directly into their default `/threads/{thread_id}/commands` and `/stream/events` paths, skipping the `_quote_path_param` escaping used elsewhere in the SDK. A `thread_id` containing reserved characters or dot-segments could escape the `/threads/{id}/` namespace once normalized by the HTTP/WebSocket stack.

Version bump only (`langgraph_sdk/__init__.py`: 0.4.1 → 0.4.2).