### PR TITLE
fix(langgraph): add missing stacklevel to warnings.warn() calls

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -383,7 +383,7 @@ def _format_messages(messages: Sequence[BaseMessage]) -> list[BaseMessage]:
             "version or remove the 'format' flag. Returning un-formatted "
             "messages."
         )
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
         return list(messages)
     else:
         return convert_to_messages(convert_to_openai_messages(messages))

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -116,7 +116,8 @@ def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
     warnings.warn(
         f"Invalid state_schema: {schema}. Expected a type or Annotated[type, reducer]. "
         "Please provide a valid schema to ensure correct updates.\n"
-        " See: https://langchain-ai.github.io/langgraph/reference/graphs/#stategraph"
+        " See: https://langchain-ai.github.io/langgraph/reference/graphs/#stategraph",
+        stacklevel=4,
     )
 
 
@@ -752,6 +753,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             warnings.warn(
                 "`retry` is deprecated and will be removed. Please use `retry_policy` instead.",
                 category=LangGraphDeprecatedSinceV05,
+                stacklevel=2,
             )
             if retry_policy is None:
                 retry_policy = retry  # type: ignore[assignment]
@@ -760,6 +762,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             warnings.warn(
                 "`input` is deprecated and will be removed. Please use `input_schema` instead.",
                 category=LangGraphDeprecatedSinceV05,
+                stacklevel=2,
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2773,6 +2773,7 @@ class Pregel(
             if checkpointer is None and durability is not None:
                 warnings.warn(
                     "`durability` has no effect when no checkpointer is present.",
+                    stacklevel=2,
                 )
             # set up subgraph checkpointing
             if self.checkpointer is True:
@@ -3198,6 +3199,7 @@ class Pregel(
             if checkpointer is None and durability is not None:
                 warnings.warn(
                     "`durability` has no effect when no checkpointer is present.",
+                    stacklevel=2,
                 )
             # set up subgraph checkpointing
             if self.checkpointer is True:


### PR DESCRIPTION
Fixes #7776

Six `warnings.warn()` calls were missing `stacklevel`, causing Python to report the warning source as a framework-internal file instead of the user's call site.

The affected calls and their fixes:

| File | Line | stacklevel added |
|---|---|---|
| `graph/state.py` | 116 | `4` — `_warn_invalid_state_schema` sits two private frames below user code |
| `graph/state.py` | 752 | `2` — deprecated `retry` param in `add_node()` |
| `graph/state.py` | 760 | `2` — deprecated `input` param in `add_node()` |
| `graph/message.py` | 386 | `2` — unsupported format flag warning in `_format_messages()` |
| `pregel/main.py` | 2774 | `2` — `durability` without checkpointer (sync `stream()`) |
| `pregel/main.py` | 3199 | `2` — `durability` without checkpointer (async `astream()`) |

All other `warn()` calls in the library already had the correct `stacklevel`.

Tested with the reproduction script from the issue — the `input` deprecation warning now points to user code rather than `graph/state.py:760`.

Run `make format`, `make lint`, and `make test` in `libs/langgraph/` — all pass.