### PR TITLE
fix(langgraph): update broken docs URL in multiple-interrupt RuntimeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -904,7 +904,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts"
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
Fixes #7686

The HITL documentation was reorganized in #5192 and the `add-human-in-the-loop` page was merged into the `interrupts` page, but the in-source URL embedded in this `RuntimeError` was not updated. The old URL returns HTTP 404.

**Change:** one-line URL update in `libs/langgraph/langgraph/pregel/_loop.py`.

Old (404):
```
https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation
```

New (working):
```
https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts
```

Run `make lint` in `libs/langgraph/` — passes.