### PR TITLE
fix(checkpoint-sqlite): guard AsyncSqliteSaver.put/put_writes against in-loop sync calls

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -239,6 +239,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             RunnableConfig: Updated configuration after storing the checkpoint.
         """
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput(config, checkpoint, metadata, new_versions), self.loop
         ).result()
@@ -250,6 +260,16 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         task_id: str,
         task_path: str = "",
     ) -> None:
+        try:
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncSqliteSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface. "
+                    "For example, use `await checkpointer.aput_writes(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
         return asyncio.run_coroutine_threadsafe(
             self.aput_writes(config, writes, task_id, task_path), self.loop
         ).result()

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pytest
@@ -129,6 +130,21 @@ class TestAsyncSqliteSaver:
             ]
             assert len(search_results_7) == 1
             assert search_results_7[0].config["configurable"]["thread_id"] == "thread-1"
+
+    async def test_put_and_put_writes_raise_in_event_loop(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            await saver.setup()
+            cfg: RunnableConfig = {
+                "configurable": {"thread_id": "t1", "checkpoint_ns": ""}
+            }
+            checkpoint = empty_checkpoint()
+            metadata: CheckpointMetadata = {"source": "input", "step": 0, "writes": {}}
+
+            with pytest.raises(asyncio.InvalidStateError):
+                saver.put(cfg, checkpoint, metadata, {})
+
+            with pytest.raises(asyncio.InvalidStateError):
+                saver.put_writes(cfg, [("channel", "value")], "task-1")
 
     async def test_limit_parameter_sql_injection_prevention(self) -> None:
         """Test that the limit parameter properly uses parameterized queries to prevent SQL injection."""


### PR DESCRIPTION
Fixes #7857

`AsyncSqliteSaver.put()` and `put_writes()` called synchronously from within the saver's own event loop deadlock silently — `run_coroutine_threadsafe(...).result()` waits on a coroutine that only the currently-blocked loop can run.

Four of the six sync bridge methods (`get_tuple`, `list`, `delete_thread`, `get_delta_channel_history`) already guard against this and raise `asyncio.InvalidStateError`. This PR adds the identical guard to `put()` and `put_writes()` so all six methods behave consistently.

**Changes:**
- `libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py`: add `asyncio.get_running_loop() is self.loop` guard to `put()` and `put_writes()`
- `libs/checkpoint-sqlite/tests/test_aiosqlite.py`: regression test that verifies both methods raise `InvalidStateError` when called from inside the event loop (the test previously caused a deadlock on `main`)

Run `make lint` and `uv run pytest tests/test_aiosqlite.py` in `libs/checkpoint-sqlite/` — all pass.