### PR TITLE
fix(checkpoint-postgres): use ::numeric cast for $gt/$gte/$lt/$lte filter operators

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -624,12 +624,20 @@ class BasePostgresStore(Generic[C]):
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
         elif op == "$gt":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric > %s", [key, value]
             return "value->>%s > %s", [key, str(value)]
         elif op == "$gte":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric >= %s", [key, value]
             return "value->>%s >= %s", [key, str(value)]
         elif op == "$lt":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric < %s", [key, value]
             return "value->>%s < %s", [key, str(value)]
         elif op == "$lte":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric <= %s", [key, value]
             return "value->>%s <= %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]

--- a/libs/checkpoint-postgres/tests/test_store_filter_condition.py
+++ b/libs/checkpoint-postgres/tests/test_store_filter_condition.py
@@ -1,0 +1,66 @@
+"""Unit tests for PostgresStore._get_filter_condition — no Postgres required."""
+import pytest
+
+from langgraph.store.postgres.base import BasePostgresStore
+
+
+class _MockStore(BasePostgresStore):
+    pass
+
+
+store = object.__new__(_MockStore)
+
+
+# Override the autouse conftest fixture so this file doesn't need a Postgres connection.
+@pytest.fixture(autouse=True)
+async def clear_test_db():
+    pass
+
+
+@pytest.mark.parametrize(
+    "op,value,expected_sql,expected_cast",
+    [
+        ("$gt", 10, "(value->>%s)::numeric > %s", True),
+        ("$gte", 10, "(value->>%s)::numeric >= %s", True),
+        ("$lt", 10, "(value->>%s)::numeric < %s", True),
+        ("$lte", 10, "(value->>%s)::numeric <= %s", True),
+        ("$gt", 3.14, "(value->>%s)::numeric > %s", True),
+        ("$gte", 3.14, "(value->>%s)::numeric >= %s", True),
+        # String values should use text comparison (no cast)
+        ("$gt", "b", "value->>%s > %s", False),
+        ("$gte", "b", "value->>%s >= %s", False),
+        ("$lt", "b", "value->>%s < %s", False),
+        ("$lte", "b", "value->>%s <= %s", False),
+    ],
+)
+def test_numeric_operators_use_numeric_cast(op, value, expected_sql, expected_cast):
+    sql, params = store._get_filter_condition("score", op, value)
+    assert sql == expected_sql, f"{op} with {type(value).__name__}: got {sql!r}"
+    if expected_cast:
+        # param should be the raw numeric value, not a stringified one
+        assert params[1] == value
+        assert isinstance(params[1], type(value))
+    else:
+        assert params[1] == str(value)
+
+
+def test_numeric_cast_prevents_lexicographic_comparison():
+    """9 > 10 lexicographically but not numerically — the cast must be present."""
+    sql, params = store._get_filter_condition("score", "$gte", 10)
+    assert "::numeric" in sql
+    # If the value were stringified, '9' >= '10' would be True in Postgres text ordering.
+    # Verify the param is numeric, not a string.
+    assert params[1] == 10
+    assert not isinstance(params[1], str)
+
+
+def test_eq_and_ne_use_jsonb():
+    sql_eq, _ = store._get_filter_condition("key", "$eq", "val")
+    assert "::jsonb" in sql_eq
+    sql_ne, _ = store._get_filter_condition("key", "$ne", "val")
+    assert "::jsonb" in sql_ne
+
+
+def test_unsupported_operator_raises():
+    with pytest.raises(ValueError, match="Unsupported operator"):
+        store._get_filter_condition("key", "$regex", ".*")


### PR DESCRIPTION
Fixes #7684

`PostgresStore._get_filter_condition()` was generating text comparisons for `$gt`, `$gte`, `$lt`, and `$lte` operators:

```python
# Before (broken — text ordering)
return "value->>%s > %s", [key, str(value)]
```

Because `value->>key` returns `TEXT` in PostgreSQL, numeric values are compared lexicographically. This causes `'9' >= '10'` to evaluate as `True`, so items with `score=2..9` incorrectly pass a `{"score": {"$gte": 10}}` filter.

**Fix:** cast to `::numeric` when the filter value is `int` or `float`, matching the `CAST(...AS REAL)` approach already used by `SqliteStore`:

```python
# After (correct — numeric ordering)
if isinstance(value, (int, float)):
    return "(value->>%s)::numeric > %s", [key, value]
return "value->>%s > %s", [key, str(value)]   # strings: text comparison unchanged
```

**Tests:** added `tests/test_store_filter_condition.py` — 13 unit tests that verify the generated SQL and parameter types without requiring a live Postgres connection (the autouse `clear_test_db` fixture is overridden locally). All 13 pass.

Run `uv run ruff check langgraph/` in `libs/checkpoint-postgres/` — passes.