### PR TITLE
fix(langgraph): add None-safe key to sorted() in draw_graph to prevent TypeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_draw.py
+++ b/libs/langgraph/langgraph/pregel/_draw.py
@@ -200,7 +200,10 @@ def draw_graph(
         for task in tasks.values():
             added = False
             for trigger in task.triggers:
-                for src, cond, label in sorted(trigger_to_sources[trigger]):
+                for src, cond, label in sorted(
+                    trigger_to_sources[trigger],
+                    key=lambda t: (t[0], t[1], t[2] or ""),
+                ):
                     # record edge to be reviewed later
                     if task.name in deferred_nodes:
                         edges_to_deferred_nodes.add(Edge(src, task.name, cond, label))
@@ -235,7 +238,9 @@ def draw_graph(
         for task in start_tasks.values():
             add_edge(graph, START, task.name)
     # add discovered edges
-    for src, dest, is_conditional, label in sorted(edges):
+    for src, dest, is_conditional, label in sorted(
+        edges, key=lambda e: (e.source, e.target, e.conditional, e.data or "")
+    ):
         add_edge(
             graph,
             src,

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8921,6 +8921,38 @@ def test_get_graph_nonterminal_last_step_source(snapshot: SnapshotAssertion) -> 
     assert json.dumps(graph_json, indent=2, sort_keys=True) == snapshot
 
 
+def test_get_graph_command_with_conditional_edges_no_typeerror() -> None:
+    """get_graph() must not raise TypeError when a node uses both Command[Literal[...]]
+    and add_conditional_edges from the same source node (mixing None/str edge labels)."""
+
+    class State(TypedDict):
+        x: int
+
+    def router(state: State) -> Command[Literal["a", "b"]]:
+        return Command(goto="a")
+
+    def a(state: State) -> State:
+        return {"x": 1}
+
+    def b(state: State) -> State:
+        return {"x": 2}
+
+    def cond(_: State) -> str:
+        return "a"
+
+    workflow = StateGraph(State)
+    workflow.add_node("router", router)
+    workflow.add_node("a", a)
+    workflow.add_node("b", b)
+    workflow.add_edge(START, "router")
+    workflow.add_conditional_edges("router", cond, {"a": "a", "b": "b"})
+
+    app = workflow.compile()
+    # Previously raised: TypeError: '<' not supported between NoneType and str
+    graph = app.get_graph()
+    assert graph is not None
+
+
 def test_null_resume_disallowed_with_multiple_interrupts(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
Fixes #7691

`graph.get_graph()` raises `TypeError: '<' not supported between instances of 'NoneType' and 'str'` when a node both returns `Command[Literal[...]]` and is also the source of `add_conditional_edges`. The combination produces `Edge`/`TriggerEdge` NamedTuples whose `data` field mixes `str` and `None` values in the same sort position.

**Root cause:** `_draw.py` uses bare `sorted()` on these NamedTuples. Python's default tuple comparison cannot compare `None < str`, so it raises.

**Fix:** add an explicit `key=` lambda to both `sorted()` calls that substitutes `""` for `None` in the `data`/`label` field:

```python
# line 203 — TriggerEdge sort
sorted(trigger_to_sources[trigger], key=lambda t: (t[0], t[1], t[2] or ""))

# line 238 — Edge sort
sorted(edges, key=lambda e: (e.source, e.target, e.conditional, e.data or ""))
```

**Test:** added `test_get_graph_command_with_conditional_edges_no_typeerror` in `tests/test_pregel.py` — reproduces the exact scenario from the issue and verifies no exception is raised. All 5 `get_graph` tests pass.

Run `make lint` and `uv run pytest tests/test_pregel.py -k get_graph` in `libs/langgraph/` — all pass.