### PR TITLE
fix(langgraph): copy mutable containers in channel from_checkpoint

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -50,7 +50,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            empty.seen = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -128,7 +128,8 @@ class NamedBarrierValueAfterFinish(
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            seen, empty.finished = checkpoint
+            empty.seen = seen.copy()
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -69,9 +69,9 @@ class Topic(
         if checkpoint is not MISSING:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
-                empty.values = checkpoint[1]
+                empty.values = checkpoint[1].copy()
             else:
-                empty.values = checkpoint
+                empty.values = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value | list[Value]]) -> bool:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -12,6 +12,10 @@ from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
+from langgraph.channels.named_barrier_value import (
+    NamedBarrierValue,
+    NamedBarrierValueAfterFinish,
+)
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
@@ -87,6 +91,50 @@ def test_topic_accumulate() -> None:
     assert channel.get() == ["a", "b", "b", "c", "d", "d"]
     assert channel.update(["e"])
     assert channel.get() == ["a", "b", "b", "c", "d", "d", "e"]
+
+
+def test_topic_accumulate_from_checkpoint_does_not_alias() -> None:
+    # Restoring two channels from the same checkpoint, then updating one, must
+    # not mutate the checkpoint or the sibling channel (from_checkpoint must copy).
+    source = Topic(str, accumulate=True)
+    source.update(["a", "b"])
+    checkpoint = source.checkpoint()
+
+    one = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    two = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    one.update(["c"])
+
+    assert one.get() == ["a", "b", "c"]
+    assert two.get() == ["a", "b"]
+    assert checkpoint == ["a", "b"]
+
+
+def test_named_barrier_value_from_checkpoint_does_not_alias() -> None:
+    source = NamedBarrierValue(str, {"a", "b"})
+    source.update(["a"])
+    checkpoint = source.checkpoint()
+
+    one = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(checkpoint)
+    two = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(checkpoint)
+    one.update(["b"])
+
+    assert one.seen == {"a", "b"}
+    assert two.seen == {"a"}
+    assert checkpoint == {"a"}
+
+
+def test_named_barrier_value_after_finish_from_checkpoint_does_not_alias() -> None:
+    source = NamedBarrierValueAfterFinish(str, {"a", "b"})
+    source.update(["a"])
+    checkpoint = source.checkpoint()
+
+    one = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(checkpoint)
+    two = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(checkpoint)
+    one.update(["b"])
+
+    assert one.seen == {"a", "b"}
+    assert two.seen == {"a"}
+    assert checkpoint[0] == {"a"}
 
 
 def test_binop() -> None:


### PR DESCRIPTION
Fixes #7992

`Topic.from_checkpoint` and `NamedBarrierValue.from_checkpoint` (and the `AfterFinish` variant) assigned the checkpoint's list/set directly to the restored channel instead of copying it, so two channels restored from the same checkpoint shared one container and an in-place update mutated the checkpoint and the sibling. This copies the container in `from_checkpoint`, matching what `copy()` already does and the `BaseChannel.from_checkpoint` contract ("complex data structures should be copied").

Added regression tests in `tests/test_channels.py` for Topic accumulate, NamedBarrierValue, and NamedBarrierValueAfterFinish that restore two channels from one checkpoint, update one, and assert the other channel and the checkpoint are untouched. They fail before the change and pass after; the full `test_channels.py` suite stays green.
