### PR TITLE
fix: accept raw tool content blocks

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1444,6 +1444,16 @@ class ToolNode(RunnableCallable):
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
+            if all(
+                isinstance(item, dict)
+                and item.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for item in response
+            ):
+                return ToolMessage(
+                    content=cast("str | list", msg_content_output(response)),
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                )
             msg = (
                 f"Tool {tool_call['name']} returned a list with invalid element "
                 "types: expected all Command or ToolMessage"

--- a/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
+++ b/libs/prebuilt/tests/test_tool_node_interceptor_unregistered.py
@@ -802,3 +802,20 @@ async def test_graceful_failure_even_when_handle_errors_disabled_async() -> None
         result[0].content
         == "Error: missing is not a valid tool, try one of [registered_tool]."
     )
+
+
+def test_normalize_tool_response_accepts_raw_content_blocks() -> None:
+    """Raw LangChain content blocks should normalize into a ToolMessage."""
+
+    node = ToolNode([registered_tool])
+    result = node._normalize_tool_response(
+        [{"type": "text", "text": "Handled by interceptor"}],
+        {"name": "registered_tool", "args": {"x": 42}, "id": "1", "type": "tool_call"},
+        "tool_calls",
+    )
+
+    assert result == ToolMessage(
+        content=[{"type": "text", "text": "Handled by interceptor"}],
+        name="registered_tool",
+        tool_call_id="1",
+    )


### PR DESCRIPTION
Fixes #7985.

## Summary
- accept raw LangChain content block lists in `ToolNode._normalize_tool_response`
- wrap them in a success `ToolMessage` using the outer tool call id/name
- add regression coverage for the raw-content-block normalization path

## Testing
- uv run pytest tests/test_tool_node_interceptor_unregistered.py -q
- uv run pytest tests/test_tool_node.py -q -k "tool_node and not large"
