### PR TITLE
fix(prebuilt): raise on duplicate tool names in ToolNode (#7988)

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -781,6 +781,13 @@ class ToolNode(RunnableCallable):
                 tool_ = create_tool(cast("type[BaseTool]", tool))
             else:
                 tool_ = tool
+            if tool_.name in self._tools_by_name:
+                msg = (
+                    f"Duplicate tool name {tool_.name!r} is not allowed in ToolNode. "
+                    "Tool names must be unique so model tool calls bind to "
+                    "exactly one tool."
+                )
+                raise ValueError(msg)
             self._tools_by_name[tool_.name] = tool_
             # Build injected args mapping once during initialization in a single pass
             self._injected_args[tool_.name] = _get_all_injected_args(tool_)

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -219,6 +219,27 @@ async def test_tool_node() -> None:
     assert tool_message.tool_call_id == "some 3"
 
 
+def test_tool_node_rejects_duplicate_tool_names() -> None:
+    """ToolNode should refuse construction when two tools share a name.
+
+    Without this check, the second tool silently overwrites the first in
+    `tools_by_name`, so a model tool call no longer binds to a single tool.
+    """
+
+    @dec_tool("account_action")
+    def safe_lookup(account_id: str) -> str:
+        """Look up an account without side effects."""
+        return f"SAFE_LOOKUP:{account_id}"
+
+    @dec_tool("account_action")
+    def privileged_delete(account_id: str) -> str:
+        """Delete an account."""
+        return f"PRIVILEGED_DELETE:{account_id}"
+
+    with pytest.raises(ValueError, match="Duplicate tool name 'account_action'"):
+        ToolNode([safe_lookup, privileged_delete])
+
+
 async def test_tool_node_tool_call_input() -> None:
     # Single tool call
     tool_call_1 = {


### PR DESCRIPTION
## Summary

Fixes #7988.

`ToolNode([tool_a, tool_b])` where `tool_a.name == tool_b.name` silently overwrote the first tool in `self._tools_by_name`, leaving only the second tool bound to the model-visible name. This is dangerous: a tool call no longer dispatches deterministically. The issue's repro is striking — a privileged-delete tool replaces a safe-lookup tool that share the name `account_action`, with no error or warning.

This PR detects duplicate names during construction and raises a clear `ValueError` before tool-call dispatch, injected-argument binding, or runtime tool enumeration consume the name map. The error message tells the user exactly what's wrong:

```
ValueError: Duplicate tool name 'account_action' is not allowed in ToolNode.
Tool names must be unique so model tool calls bind to exactly one tool.
```

## Why fail-fast at construction

The bug already manifests at construction time — the second tool wins in the dict. Pushing the failure later (e.g., at first invocation) would be strictly worse: dispatch ambiguity is the root cause, and runtime users would see a fuzzy error far from the actual mistake. Failing in `__init__` is consistent with how the repo already handles other invalid configurations (e.g., `_get_handle_tool_errors_handler` raises `ValueError` on a malformed `handle_tool_errors` value).

## Test plan

Added `test_tool_node_rejects_duplicate_tool_names` in `libs/prebuilt/tests/test_tool_node.py` using the exact repro from the issue (two `@tool("account_action")` functions). The test asserts a `ValueError` matching `Duplicate tool name 'account_action'`.

- [x] New test passes.
- [x] `LANGGRAPH_TEST_FAST=1 pytest libs/prebuilt/tests/test_tool_node.py` — 45/45 pass.
- [x] `LANGGRAPH_TEST_FAST=1 pytest libs/prebuilt/tests/` (excluding the slow `react_agent` suites that gate on docker services) — 132/132 pass.
- [x] `ruff format` — clean.
- [x] `ruff check` — clean.

## Backwards compatibility

This is a behaviour change for code that *depended on* the silent overwrite. In practice that pattern is almost certainly a bug (see issue), but if there's a use case I missed, we could relax it to a `warnings.warn(...)` plus keep-last-wins. Happy to switch if maintainers prefer.
