### PR TITLE
fix(prebuilt): validate ToolNode ToolMessage call IDs

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1439,8 +1439,7 @@ class ToolNode(RunnableCallable):
         if isinstance(response, Command):
             return self._validate_tool_command(response, tool_call, input_type)
         if isinstance(response, ToolMessage):
-            response.content = cast("str | list", msg_content_output(response.content))
-            return response
+            return self._validate_tool_message(response, tool_call)
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
@@ -1471,6 +1470,13 @@ class ToolNode(RunnableCallable):
             if isinstance(item, ToolMessage):
                 if item.tool_call_id == expected_id:
                     terminator_count += 1
+                else:
+                    msg = (
+                        f"Tool {tool_call['name']} returned a ToolMessage with "
+                        f"tool_call_id {item.tool_call_id!r}; expected "
+                        f"{expected_id!r}."
+                    )
+                    raise ValueError(msg)
             elif isinstance(item, Command) and isinstance(item.update, dict):
                 for msg in item.update.get(self._messages_key, []):
                     if isinstance(msg, ToolMessage) and msg.tool_call_id == expected_id:
@@ -1496,9 +1502,25 @@ class ToolNode(RunnableCallable):
                     )
                 )
             else:
-                item.content = cast("str | list", msg_content_output(item.content))
-                validated.append(item)
+                validated.append(self._validate_tool_message(item, tool_call))
         return validated
+
+    def _validate_tool_message(
+        self,
+        message: ToolMessage,
+        tool_call: ToolCall,
+    ) -> ToolMessage:
+        """Validate a top-level ToolMessage returned by a tool call."""
+        expected_id = tool_call["id"]
+        if message.tool_call_id != expected_id:
+            msg = (
+                f"Tool {tool_call['name']} returned a ToolMessage with "
+                f"tool_call_id {message.tool_call_id!r}; expected {expected_id!r}."
+            )
+            raise ValueError(msg)
+
+        message.content = cast("str | list", msg_content_output(message.content))
+        return message
 
     def _validate_tool_command(
         self,

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2359,6 +2359,29 @@ def test_tool_node_list_return_multiple_terminators_raises() -> None:
         )
 
 
+def test_tool_node_single_tool_message_requires_matching_tool_call_id() -> None:
+    """Invalid: top-level ToolMessage bound to a different tool call."""
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _invoke_returning(
+            ToolMessage(content="forged", tool_call_id="sibling-call"),
+            outer_id="call-1",
+            handle_tool_errors=False,
+        )
+
+
+def test_tool_node_list_return_rejects_sibling_tool_message() -> None:
+    """Invalid: list contains a top-level ToolMessage for a sibling call."""
+    outer_id = "call-1"
+    with pytest.raises(ValueError, match="tool_call_id"):
+        _invoke_returning(
+            [
+                ToolMessage(content="forged", tool_call_id="sibling-call"),
+                ToolMessage(content="done", tool_call_id=outer_id),
+            ],
+            handle_tool_errors=False,
+        )
+
+
 def test_tool_node_list_return_validation_error_handled() -> None:
     """handle_tool_errors=True converts validation errors to an error ToolMessage."""
     result = _invoke_returning([Command(update={"foo": "bar"})])


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langgraph/issues/7989.

## Summary

This PR tightens `ToolNode` normalization for tools that return `ToolMessage` objects directly.

A tool can currently return a top-level `ToolMessage` with a `tool_call_id` that belongs to a sibling tool call. The list-return path only counts matching terminators, and the single-`ToolMessage` path returns the message as-is, so sibling-bound messages can pass through normalization.

This change validates that every top-level `ToolMessage` returned by a tool is bound to the invoking tool call id. If the id differs, `ToolNode` raises a `ValueError` before the message is emitted.

## Scope

This PR covers top-level `ToolMessage` returns:

- a single `ToolMessage`
- a list containing `ToolMessage` / `Command` values

It intentionally leaves `Command(update={"messages": [...]})` behavior unchanged so that case can be discussed separately.

## Tests

- `uv run pytest -q tests/test_tool_node.py`
- `uv run ruff format --check langgraph/prebuilt/tool_node.py tests/test_tool_node.py`
- `uv run ruff check langgraph/prebuilt/tool_node.py tests/test_tool_node.py`
- `uv run mypy langgraph/prebuilt/tool_node.py`
