### PR TITLE
ci: allow deps-dev scope in PR title lint

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -41,6 +41,7 @@ jobs:
             docs
             ci
             deps
+            deps-dev
           requireScope: false
           ignoreLabels: |
             ignore-lint-pr-title


### PR DESCRIPTION
## Problem

Dependabot opens dev-dependency PRs with titles like `chore(deps-dev): bump mypy ...`. The `lint-pr-title` check (amannn/action-semantic-pull-request) rejects them because **`deps-dev` is not in the allowed scopes**:

```
Unknown scope "deps-dev" found in pull request title ...
Scope must match one of: checkpoint, checkpoint-postgres, checkpoint-sqlite, cli, langgraph, prebuilt, scheduler-kafka, sdk-py, docs, ci, deps.
```

This is the **only** failing check on several open Dependabot PRs (#7977, #7966, #7967, #7968) and adds noise to others (#7969, #7970, #7974).

## Change

Add `deps-dev` to the allowed `scopes:` list in `.github/workflows/pr_lint.yml` (one line). No other changes; workflow permissions remain `pull-requests: read`.

## Effect

Existing and future `chore(deps-dev):` Dependabot PRs pass title validation. PRs blocked *only* by this become mergeable once their (passing) checks re-run.
