### PR TITLE
fix(prebuilt): handle content block tool responses

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1444,6 +1444,15 @@ class ToolNode(RunnableCallable):
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
+            if response and all(
+                isinstance(item, dict) and item.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for item in response
+            ):
+                return ToolMessage(
+                    content=response,
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                )
             msg = (
                 f"Tool {tool_call['name']} returned a list with invalid element "
                 "types: expected all Command or ToolMessage"

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2272,6 +2272,34 @@ def _invoke_returning(
     )
 
 
+def test_tool_node_raw_content_block_list_return() -> None:
+    """Raw tool responses may be LangChain content block lists."""
+    content = [{"type": "image_url", "image_url": {"url": "https://example.com/a.png"}}]
+
+    tool_message = ToolNode([])._normalize_tool_response(
+        content, _list_tool_call(), "dict"
+    )
+
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == content
+    assert tool_message.name == "list_tool"
+    assert tool_message.tool_call_id == "call-1"
+
+
+def test_tool_node_raw_invalid_list_return_raises() -> None:
+    """Non-content-block lists are still invalid raw tool responses."""
+    with pytest.raises(TypeError, match="expected all Command or ToolMessage"):
+        ToolNode([])._normalize_tool_response(
+            [{"key": "value"}], _list_tool_call(), "dict"
+        )
+
+
+def test_tool_node_raw_empty_list_return_raises() -> None:
+    """Empty lists are not treated as raw content block responses."""
+    with pytest.raises(ValueError, match="expected exactly one terminating ToolMessage"):
+        ToolNode([])._normalize_tool_response([], _list_tool_call(), "dict")
+
+
 def test_tool_node_list_return_command_and_tool_message() -> None:
     """Valid: tool returns [Command(update={...}), ToolMessage(...)]."""
     outer_id = "call-1"


### PR DESCRIPTION
## Summary
- allow ToolNode to normalize raw LangChain content block list responses into ToolMessage instances
- keep existing Command/ToolMessage list validation unchanged
- preserve invalid and empty list error paths

Fixes #7985

## Tests
- ./.venv/bin/python -m pytest libs/prebuilt/tests/test_tool_node.py -k "raw_content_block_list_return or raw_invalid_list_return_raises or raw_empty_list_return_raises or list_return_command_and_tool_message" -q