### PR TITLE
fix(langgraph): use except Exception instead of BaseException in cleanup paths

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -82,7 +82,7 @@ class BackgroundExecutor(AbstractContextManager):
             # This exception is an interruption signal, not an error
             # so we don't want to re-raise it on exit
             self.tasks.pop(task)
-        except BaseException:
+        except Exception:
             pass
         else:
             self.tasks.pop(task)

--- a/libs/langgraph/langgraph/stream/_mux.py
+++ b/libs/langgraph/langgraph/stream/_mux.py
@@ -337,7 +337,7 @@ class StreamMux:
         for transformer in self._transformers:
             try:
                 transformer.fail(err)
-            except BaseException:
+            except Exception:
                 pass
         for ch in self._channels:
             if not ch._closed:
@@ -440,7 +440,7 @@ class StreamMux:
         for transformer in self._transformers:
             try:
                 await transformer.afail(err)
-            except BaseException:
+            except Exception:
                 pass
         for ch in self._channels:
             if not ch._closed:


### PR DESCRIPTION
Closes #7900

  ## What

  Three `except BaseException: pass` blocks in cleanup/error-handling paths catch too broadly — `BaseException` includes
  `KeyboardInterrupt` and `SystemExit`, which should propagate rather than being silently swallowed.

  Changed to `except Exception` at:
  - `libs/langgraph/langgraph/stream/_mux.py` — `fail()` method (Line 340)
  - `libs/langgraph/langgraph/stream/_mux.py` — `afail()` method (Line 443)
  - `libs/langgraph/langgraph/pregel/_executor.py` — `done()` method (Line 85)

  ## Why not change the others

  The `finalize()`/`afinalize()` paths at lines 316 and 414 also catch `BaseException` but they store the exception in
  `first_error` and re-raise it after cleanup — those are intentional and correct.

  ## Verification

  Ran `make format`, `make lint`, and `make test` in `libs/langgraph/`. All passing.