### PR TITLE
fix(checkpoint-postgres): handle CREATE INDEX CONCURRENTLY inside transactions in setup()

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -89,6 +89,11 @@ class PostgresSaver(BasePostgresSaver):
         already exist and runs database migrations. It MUST be called directly by the user
         the first time checkpointer is used.
         """
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+        # When the connection is not in autocommit mode, fall back to regular CREATE INDEX.
+        in_transaction = not getattr(self.conn, "autocommit", True)
         with self._cursor() as cur:
             cur.execute(self.MIGRATIONS[0])
             results = cur.execute(
@@ -104,7 +109,8 @@ class PostgresSaver(BasePostgresSaver):
                 self.MIGRATIONS[version + 1 :],
                 strict=False,
             ):
-                cur.execute(migration)
+                sql = _strip_concurrently(migration) if in_transaction else migration
+                cur.execute(sql)
                 cur.execute("INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,))
         if self.pipe:
             self.pipe.sync()

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -94,6 +94,11 @@ class AsyncPostgresSaver(BasePostgresSaver):
         already exist and runs database migrations. It MUST be called directly by the user
         the first time checkpointer is used.
         """
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+        # When the connection is not in autocommit mode, fall back to regular CREATE INDEX.
+        in_transaction = not getattr(self.conn, "autocommit", True)
         async with self._cursor() as cur:
             await cur.execute(self.MIGRATIONS[0])
             results = await cur.execute(
@@ -109,7 +114,8 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 self.MIGRATIONS[version + 1 :],
                 strict=False,
             ):
-                await cur.execute(migration)
+                sql = _strip_concurrently(migration) if in_transaction else migration
+                await cur.execute(sql)
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -40,6 +40,16 @@ except Exception:
 To add a new migration, add a new string to the MIGRATIONS list.
 The position of the migration in the list is the version number.
 """
+
+
+def _strip_concurrently(sql: str) -> str:
+    """Strip CONCURRENTLY from CREATE INDEX statements.
+
+    CREATE INDEX CONCURRENTLY cannot run inside a transaction. When the
+    connection is not in autocommit mode, we fall back to a regular
+    CREATE INDEX so that setup() works regardless of transaction state.
+    """
+    return sql.replace("CREATE INDEX CONCURRENTLY", "CREATE INDEX")
 MIGRATIONS = [
     """CREATE TABLE IF NOT EXISTS checkpoint_migrations (
     v INTEGER PRIMARY KEY

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -236,6 +236,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
         already exist and runs database migrations. It MUST be called directly by the user
         the first time checkpointer is used.
         """
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        in_transaction = not getattr(self.conn, "autocommit", True)
         with self._cursor() as cur:
             cur.execute(self.MIGRATIONS[0])
             results = cur.execute(
@@ -251,7 +254,8 @@ class ShallowPostgresSaver(BasePostgresSaver):
                 self.MIGRATIONS[version + 1 :],
                 strict=False,
             ):
-                cur.execute(migration)
+                sql = _strip_concurrently(migration) if in_transaction else migration
+                cur.execute(sql)
                 cur.execute("INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,))
         if self.pipe:
             self.pipe.sync()
@@ -600,6 +604,9 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         already exist and runs database migrations. It MUST be called directly by the user
         the first time checkpointer is used.
         """
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        in_transaction = not getattr(self.conn, "autocommit", True)
         async with self._cursor() as cur:
             await cur.execute(self.MIGRATIONS[0])
             results = await cur.execute(
@@ -615,7 +622,8 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 self.MIGRATIONS[version + 1 :],
                 strict=False,
             ):
-                await cur.execute(migration)
+                sql = _strip_concurrently(migration) if in_transaction else migration
+                await cur.execute(sql)
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )

--- a/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/aio.py
@@ -248,10 +248,14 @@ class AsyncPostgresStore(AsyncBatchedBaseStore, BasePostgresStore[_ainternal.Con
                 version = row["v"]
             return version
 
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        in_transaction = not getattr(self.conn, "autocommit", True)
         async with self._cursor() as cur:
             version = await _get_version(cur, table="store_migrations")
             for v, sql in enumerate(self.MIGRATIONS[version + 1 :], start=version + 1):
-                await cur.execute(sql)
+                migration = _strip_concurrently(sql) if in_transaction else sql
+                await cur.execute(migration)
                 await cur.execute("INSERT INTO store_migrations (v) VALUES (%s)", (v,))
 
             if self.index_config:

--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -1109,11 +1109,15 @@ class PostgresStore(BaseStore, BasePostgresStore[_pg_internal.Conn]):
                 version = row["v"]
             return version
 
+        from langgraph.checkpoint.postgres.base import _strip_concurrently
+
+        in_transaction = not getattr(self.conn, "autocommit", True)
         with self._cursor() as cur:
             version = _get_version(cur, table="store_migrations")
             for v, sql in enumerate(self.MIGRATIONS[version + 1 :], start=version + 1):
                 try:
-                    cur.execute(sql)
+                    migration = _strip_concurrently(sql) if in_transaction else sql
+                    cur.execute(migration)
                     cur.execute("INSERT INTO store_migrations (v) VALUES (%s)", (v,))
                 except Exception as e:
                     logger.error(


### PR DESCRIPTION
Closes #7630

  When `setup()` is called on a connection with `autocommit=False`, the entire migration loop runs inside a single
  transaction, and PostgreSQL rejects `CREATE INDEX CONCURRENTLY` with `ActiveSqlTransaction`. Added a
  `_strip_concurrently()` helper that falls back to regular `CREATE INDEX` when the connection is not in autocommit
  mode. Applies to all checkpoint and store setup methods (sync, async, shallow).

  ## Verification

  Ran `make format`, `make lint`, and `make test` in `libs/checkpoint-postgres/`. All passing.