### PR TITLE
fix(prebuilt): normalize raw content block tool responses

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1441,6 +1441,18 @@ class ToolNode(RunnableCallable):
         if isinstance(response, ToolMessage):
             response.content = cast("str | list", msg_content_output(response.content))
             return response
+        if isinstance(response, str) or (
+            isinstance(response, list)
+            and all(
+                isinstance(item, dict) and item.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for item in response
+            )
+        ):
+            return ToolMessage(
+                content=cast("str | list", msg_content_output(response)),
+                name=tool_call["name"],
+                tool_call_id=tool_call["id"],
+            )
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2391,6 +2391,22 @@ async def test_tool_node_list_return_async_smoke() -> None:
     assert len(commands) == 1 and commands[0].update == {"foo": "bar"}
 
 
+def test_tool_node_normalize_raw_content_block_list_response() -> None:
+    response = [{"type": "text", "text": "test content"}]
+    node = ToolNode([_ReturningTool()])
+
+    result = node._normalize_tool_response(
+        response=response,
+        tool_call=_list_tool_call(),
+        input_type="tool_calls",
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == response
+    assert result.name == "list_tool"
+    assert result.tool_call_id == "call-1"
+
+
 def test_tool_node_list_return_mixed_with_regular_tool() -> None:
     """List-returning tool and a regular tool dispatched from the same AIMessage."""
     list_tool_id = "call-list"


### PR DESCRIPTION
Fixes #7985

Handle raw LangChain content block lists in `ToolNode._normalize_tool_response` by wrapping them in a `ToolMessage` instead of raising `TypeError`. Added a regression test covering MCP-style `list[dict]` tool responses that reach the normalization path directly.

Verified by running `python -m pytest F:\ZPtarget\langgraph\libs\prebuilt\tests\test_tool_node.py -k "test_tool_node or test_tool_node_tool_call_input or test_tool_node_normalize_raw_content_block_list_response"`, plus `ruff check` and `ruff format --check` on the modified files.

