### PR TITLE
fix: persist DeltaChannel writes on fresh threads

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -108,6 +108,7 @@ from langgraph.callbacks import (
     get_sync_graph_callback_manager_for_config,
 )
 from langgraph.channels.base import BaseChannel
+from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.topic import Topic
 from langgraph.config import get_config
 from langgraph.constants import END
@@ -2009,7 +2010,24 @@ class Pregel(
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            # On a fresh thread with no prior checkpoint, snapshot all
+            # available DeltaChannels because there are no ancestor writes
+            # to replay from (put_writes requires a checkpoint_id from
+            # a parent checkpoint that does not exist yet).
+            if saved is None:
+                channels_to_snapshot = {
+                    k
+                    for k, ch in channels.items()
+                    if isinstance(ch, DeltaChannel) and ch.is_available()
+                } or None
+            else:
+                channels_to_snapshot = None
+            checkpoint = create_checkpoint(
+                checkpoint,
+                channels,
+                step + 1,
+                channels_to_snapshot=channels_to_snapshot,
+            )
             next_config = checkpointer.put(
                 checkpoint_config,
                 checkpoint,
@@ -2456,7 +2474,24 @@ class Pregel(
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            # On a fresh thread with no prior checkpoint, snapshot all
+            # available DeltaChannels because there are no ancestor writes
+            # to replay from (put_writes requires a checkpoint_id from
+            # a parent checkpoint that does not exist yet).
+            if saved is None:
+                channels_to_snapshot = {
+                    k
+                    for k, ch in channels.items()
+                    if isinstance(ch, DeltaChannel) and ch.is_available()
+                } or None
+            else:
+                channels_to_snapshot = None
+            checkpoint = create_checkpoint(
+                checkpoint,
+                channels,
+                step + 1,
+                channels_to_snapshot=channels_to_snapshot,
+            )
             # save checkpoint, after applying writes
             next_config = await checkpointer.aput(
                 checkpoint_config,


### PR DESCRIPTION
On fresh threads with no prior checkpoint, `update_state`/`aupdate_state` silently dropped the first write to `DeltaChannel`-backed state keys (e.g., `messages` in `DeepAgentState`).

## Root cause

In the `update_state` path, pending channel writes are saved via `checkpointer.put_writes` only when a prior checkpoint (`saved`) exists:
```python
if saved and channel_writes:
    checkpointer.put_writes(checkpoint_config, channel_writes, task_id)
```

On a fresh thread, `saved is None`, so writes are applied to the live channel but never checkpointed. `create_checkpoint` then calls `DeltaChannel.checkpoint()` which returns `MISSING` for non-snapshot steps, omitting the value from the checkpoint blob. With no stored writes and no snapshot in the checkpoint, the DeltaChannel value is lost on the next read.

## Fix

When no prior checkpoint exists, compute the set of available DeltaChannels and force-snapshot them via `create_checkpoint(channels_to_snapshot=...)`. This ensures the initial checkpoint includes a `_DeltaSnapshot` blob so the value survives the write-read roundtrip.

This is applied in both the sync (`bulk_update_state`) and async (`abulk_update_state`) paths.

## Testing

- DeltaChannel writes now persist on fresh threads via both `update_state` and `aupdate_state`
- Multiple writes accumulate correctly via the snapshot blob
- Non-DeltaChannel channels are unaffected
- Normal `ainvoke` flow is unchanged

Fixes #8012

🤖 Generated with [Claude Code](https://claude.com/claude-code)