### PR TITLE
fix: persist DeltaChannel writes on fresh threads

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -108,6 +108,7 @@ from langgraph.callbacks import (
     get_sync_graph_callback_manager_for_config,
 )
 from langgraph.channels.base import BaseChannel
+from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.topic import Topic
 from langgraph.config import get_config
 from langgraph.constants import END
@@ -2009,7 +2010,24 @@ class Pregel(
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            # On a fresh thread with no prior checkpoint, snapshot all
+            # available DeltaChannels because there are no ancestor writes
+            # to replay from (put_writes requires a checkpoint_id from
+            # a parent checkpoint that does not exist yet).
+            if saved is None:
+                channels_to_snapshot = {
+                    k
+                    for k, ch in channels.items()
+                    if isinstance(ch, DeltaChannel) and ch.is_available()
+                } or None
+            else:
+                channels_to_snapshot = None
+            checkpoint = create_checkpoint(
+                checkpoint,
+                channels,
+                step + 1,
+                channels_to_snapshot=channels_to_snapshot,
+            )
             next_config = checkpointer.put(
                 checkpoint_config,
                 checkpoint,
@@ -2456,7 +2474,24 @@ class Pregel(
                 checkpointer.get_next_version,
                 self.trigger_to_nodes,
             )
-            checkpoint = create_checkpoint(checkpoint, channels, step + 1)
+            # On a fresh thread with no prior checkpoint, snapshot all
+            # available DeltaChannels because there are no ancestor writes
+            # to replay from (put_writes requires a checkpoint_id from
+            # a parent checkpoint that does not exist yet).
+            if saved is None:
+                channels_to_snapshot = {
+                    k
+                    for k, ch in channels.items()
+                    if isinstance(ch, DeltaChannel) and ch.is_available()
+                } or None
+            else:
+                channels_to_snapshot = None
+            checkpoint = create_checkpoint(
+                checkpoint,
+                channels,
+                step + 1,
+                channels_to_snapshot=channels_to_snapshot,
+            )
             # save checkpoint, after applying writes
             next_config = await checkpointer.aput(
                 checkpoint_config,


### PR DESCRIPTION
## Summary

Fixes #8012 — `update_state` on a fresh `DeepAgentState` thread silently drops the first `messages` write.

## Root Cause

`bulk_update_state` only persists DeltaChannel writes via `checkpointer.put_writes` when a prior checkpoint (`saved`) exists. On a fresh thread, `saved` is `None`, so writes are applied to the in-memory channel but never persisted. `create_checkpoint` then omits non-snapshot `DeltaChannel` values.

## Fix

When `saved is None`, compute the set of available DeltaChannels and pass them as `channels_to_snapshot` to `create_checkpoint`, forcing a `_DeltaSnapshot` blob into the initial checkpoint.

Fixes #8012