### PR TITLE
fix: disable autocommit when using AsyncPipeline to prevent SSL error (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, autocommit=not pipeline, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
`AsyncPostgresSaver.from_conn_string` with `pipeline=True` fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This happens because `AsyncPipeline` is incompatible with `autocommit=True`; pipelining requires explicit transaction management.

## Fix
Set `autocommit=False` when `pipeline=True` is requested, ensuring the connection is not in autocommit mode. The default `autocommit=True` remains for the non-pipeline path.

Closes #5675