### PR TITLE
feat(cli): support compatible api version ranges

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -163,9 +163,9 @@ OPT_API_VERSION = click.option(
         "API server version to use for the base image. If unspecified, the "
         "latest stable version will be used. Compatible ranges like "
         "~=0.11.0.dev5 stay on 0.11.0.dev5 while only newer dev builds exist, "
-        "then resolve to the newest matching rc or stable release. "
-        "Stable-floating ranges like >~=0.11.0.dev5 can also pick up future "
-        "stable releases."
+        "then resolve to the newest matching rc or stable release, for example "
+        "0.11.0rc1 or 0.11.0. Stable-floating ranges like >~=0.11.0.dev5 "
+        "can also pick up future stable releases, for example 0.12.0."
     ),
 )
 

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -159,7 +159,12 @@ OPT_POSTGRES_URI = click.option(
 OPT_API_VERSION = click.option(
     "--api-version",
     type=str,
-    help="API server version to use for the base image. If unspecified, the latest version will be used.",
+    help=(
+        "API server version to use for the base image. If unspecified, the "
+        "latest version will be used. Compatible ranges like ~=0.11.0.dev5 "
+        "resolve to the newest matching image tag. Stable-floating ranges "
+        "like >~=0.11.0.dev5 can also pick up future stable releases."
+    ),
 )
 
 OPT_ENGINE_RUNTIME_MODE = click.option(

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -161,9 +161,11 @@ OPT_API_VERSION = click.option(
     type=str,
     help=(
         "API server version to use for the base image. If unspecified, the "
-        "latest version will be used. Compatible ranges like ~=0.11.0.dev5 "
-        "resolve to the newest matching image tag. Stable-floating ranges "
-        "like >~=0.11.0.dev5 can also pick up future stable releases."
+        "latest stable version will be used. Compatible ranges like "
+        "~=0.11.0.dev5 stay on 0.11.0.dev5 while only newer dev builds exist, "
+        "then resolve to the newest matching rc or stable release. "
+        "Stable-floating ranges like >~=0.11.0.dev5 can also pick up future "
+        "stable releases."
     ),
 )
 

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -47,7 +47,7 @@ _API_VERSION_PART_PATTERN = re.compile(
     r"^(?P<major>\d+)"
     r"(?:\.(?P<minor>\d+))?"
     r"(?:\.(?P<patch>\d+))?"
-    r"(?:(?:\.|)(?P<pre>dev|a|b|rc)(?P<pre_n>\d+))?$"
+    r"(?:(?:\.|)(?P<pre>dev|rc)(?P<pre_n>\d+))?$"
 )
 
 
@@ -64,10 +64,8 @@ class _ApiVersionRange(NamedTuple):
 
 _PRERELEASE_ORDER = {
     "dev": 0,
-    "a": 1,
-    "b": 2,
-    "rc": 3,
-    None: 4,
+    "rc": 1,
+    None: 2,
 }
 
 
@@ -222,42 +220,31 @@ def _is_compatible_api_version_candidate(
     return True
 
 
-def _docker_hub_repository(base_image: str) -> str:
+def _ensure_compatible_api_version_base_image(base_image: str) -> None:
     if ":" in base_image:
         raise click.UsageError(
             "Compatible api_version ranges cannot be used with a tagged base_image."
         )
-    parts = base_image.split("/")
-    if len(parts) == 1:
-        return f"library/{base_image}"
-    if len(parts) == 2:
-        return base_image
-    raise click.UsageError(
-        "Compatible api_version ranges are only supported for Docker Hub images."
-    )
 
 
-def _get_docker_hub_tags(repository: str, tag_prefix: str) -> list[str]:
-    tags: list[str] = []
-    url = f"https://hub.docker.com/v2/repositories/{repository}/tags"
-    params: dict[str, str | int] | None = {"page_size": 100, "name": tag_prefix}
-    while url:
-        try:
-            response = httpx.get(url, params=params, timeout=10)
-            params = None
-            response.raise_for_status()
-        except httpx.HTTPError as exc:
-            raise click.UsageError(
-                f"Failed to fetch Docker image tags for {repository}: {exc}"
-            ) from None
-        payload = response.json()
-        tags.extend(
-            result["name"]
-            for result in payload.get("results", [])
-            if isinstance(result, dict) and isinstance(result.get("name"), str)
+def _get_pypi_versions(package_name: str) -> list[str]:
+    try:
+        response = httpx.get(
+            f"https://pypi.org/pypi/{package_name}/json",
+            timeout=10,
         )
-        url = payload.get("next")
-    return tags
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise click.UsageError(
+            f"Failed to fetch PyPI versions for {package_name}: {exc}"
+        ) from None
+    payload = response.json()
+    releases = payload.get("releases", {})
+    if not isinstance(releases, dict):
+        raise click.UsageError(
+            f"Failed to fetch PyPI versions for {package_name}: invalid response."
+        )
+    return [version for version in releases if isinstance(version, str)]
 
 
 def _resolve_compatible_api_version(
@@ -285,17 +272,12 @@ def _resolve_compatible_api_version(
         floor=floor,
         allow_future_stable=match.group("operator") == ">~=",
     )
-    repository = _docker_hub_repository(base_image)
-    tag_suffix = f"-{version_distro_tag}"
-    tag_prefix = f"{floor.release[0]}."
-    tags = _get_docker_hub_tags(repository, tag_prefix)
+    _ensure_compatible_api_version_base_image(base_image)
+    pypi_versions = _get_pypi_versions("langgraph-api")
 
     candidates: list[tuple[_ParsedApiVersion, str]] = []
     upper_bound = _api_version_upper_bound(floor)
-    for tag in tags:
-        if not tag.endswith(tag_suffix):
-            continue
-        candidate_str = tag[: -len(tag_suffix)]
+    for candidate_str in pypi_versions:
         try:
             candidate = _parse_api_version(candidate_str)
         except ValueError:
@@ -305,8 +287,8 @@ def _resolve_compatible_api_version(
 
     if not candidates:
         raise click.UsageError(
-            f"No Docker image tags match compatible api_version range {api_version!r} "
-            f"for {base_image} with suffix {tag_suffix!r}."
+            f"No PyPI releases match compatible api_version range {api_version!r} "
+            f"for {base_image} with {version_distro_tag!r}."
         )
 
     return max(candidates, key=lambda item: _api_version_sort_key(item[0]))[1]

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -9,6 +9,7 @@ from collections import Counter
 from typing import Literal, NamedTuple
 
 import click
+import httpx
 
 from langgraph_cli.schemas import Config, Distros
 from langgraph_cli.uv_lock import python_config_to_docker_uv_lock
@@ -41,6 +42,33 @@ _API_VERSION_PATTERN = re.compile(
     r"(?:\.(?P<patch>\d+))?"
     r"(?:(?:\.|)(?:[A-Za-z][0-9A-Za-z]*))?$"
 )
+_API_VERSION_RANGE_PATTERN = re.compile(r"^(?P<operator>~=|>~=)\s*(?P<version>.+)$")
+_API_VERSION_PART_PATTERN = re.compile(
+    r"^(?P<major>\d+)"
+    r"(?:\.(?P<minor>\d+))?"
+    r"(?:\.(?P<patch>\d+))?"
+    r"(?:(?:\.|)(?P<pre>dev|a|b|rc)(?P<pre_n>\d+))?$"
+)
+
+
+class _ParsedApiVersion(NamedTuple):
+    release: tuple[int, ...]
+    prerelease: str | None
+    prerelease_number: int
+
+
+class _ApiVersionRange(NamedTuple):
+    floor: _ParsedApiVersion
+    allow_future_stable: bool
+
+
+_PRERELEASE_ORDER = {
+    "dev": 0,
+    "a": 1,
+    "b": 2,
+    "rc": 3,
+    None: 4,
+}
 
 
 def has_disallowed_build_command_content(command: str) -> bool:
@@ -141,6 +169,149 @@ def _parse_api_version_parts(version_str: str) -> tuple[int, ...]:
     return tuple(int(part) for part in match.groups() if part is not None)
 
 
+def _parse_api_version(version_str: str) -> _ParsedApiVersion:
+    match = _API_VERSION_PART_PATTERN.fullmatch(version_str)
+    if not match:
+        raise ValueError("Version must be major or major.minor or major.minor.patch.")
+    release = tuple(
+        int(part)
+        for part in (
+            match.group("major"),
+            match.group("minor"),
+            match.group("patch"),
+        )
+        if part is not None
+    )
+    prerelease = match.group("pre")
+    prerelease_number = int(match.group("pre_n") or 0)
+    return _ParsedApiVersion(release, prerelease, prerelease_number)
+
+
+def _api_version_sort_key(
+    version: _ParsedApiVersion,
+) -> tuple[tuple[int, ...], int, int]:
+    return (
+        version.release,
+        _PRERELEASE_ORDER[version.prerelease],
+        version.prerelease_number,
+    )
+
+
+def _api_version_upper_bound(version: _ParsedApiVersion) -> tuple[int, ...]:
+    release = version.release
+    if len(release) <= 2:
+        return (release[0] + 1,)
+    return (release[0], release[1] + 1)
+
+
+def _is_compatible_api_version_candidate(
+    candidate: _ParsedApiVersion,
+    version_range: _ApiVersionRange,
+    upper_bound: tuple[int, ...],
+) -> bool:
+    floor = version_range.floor
+    if _api_version_sort_key(candidate) < _api_version_sort_key(floor):
+        return False
+    outside_compatible_range = candidate.release[: len(upper_bound)] >= upper_bound
+    if outside_compatible_range and not version_range.allow_future_stable:
+        return False
+    if outside_compatible_range and candidate.prerelease is not None:
+        return False
+    if floor.prerelease == "dev" and candidate.prerelease == "dev":
+        return candidate == floor
+    return True
+
+
+def _docker_hub_repository(base_image: str) -> str:
+    if ":" in base_image:
+        raise click.UsageError(
+            "Compatible api_version ranges cannot be used with a tagged base_image."
+        )
+    parts = base_image.split("/")
+    if len(parts) == 1:
+        return f"library/{base_image}"
+    if len(parts) == 2:
+        return base_image
+    raise click.UsageError(
+        "Compatible api_version ranges are only supported for Docker Hub images."
+    )
+
+
+def _get_docker_hub_tags(repository: str, tag_prefix: str) -> list[str]:
+    tags: list[str] = []
+    url = f"https://hub.docker.com/v2/repositories/{repository}/tags"
+    params: dict[str, str | int] | None = {"page_size": 100, "name": tag_prefix}
+    while url:
+        try:
+            response = httpx.get(url, params=params, timeout=10)
+            params = None
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise click.UsageError(
+                f"Failed to fetch Docker image tags for {repository}: {exc}"
+            ) from None
+        payload = response.json()
+        tags.extend(
+            result["name"]
+            for result in payload.get("results", [])
+            if isinstance(result, dict) and isinstance(result.get("name"), str)
+        )
+        url = payload.get("next")
+    return tags
+
+
+def _resolve_compatible_api_version(
+    api_version: str,
+    base_image: str,
+    version_distro_tag: str,
+) -> str:
+    match = _API_VERSION_RANGE_PATTERN.fullmatch(api_version)
+    if not match:
+        return api_version
+
+    floor_str = match.group("version").strip()
+    try:
+        floor = _parse_api_version(floor_str)
+    except ValueError:
+        raise click.UsageError(
+            f"Invalid compatible api_version range: {api_version}.\n\n"
+            "Use a compatible version range, e.g.:\n"
+            '  "api_version": "~=0.11.0.dev5"\n'
+            "or a stable-floating range, e.g.:\n"
+            '  "api_version": ">~=0.11.0.dev5"'
+        ) from None
+
+    version_range = _ApiVersionRange(
+        floor=floor,
+        allow_future_stable=match.group("operator") == ">~=",
+    )
+    repository = _docker_hub_repository(base_image)
+    tag_suffix = f"-{version_distro_tag}"
+    tag_prefix = f"{floor.release[0]}."
+    tags = _get_docker_hub_tags(repository, tag_prefix)
+
+    candidates: list[tuple[_ParsedApiVersion, str]] = []
+    upper_bound = _api_version_upper_bound(floor)
+    for tag in tags:
+        if not tag.endswith(tag_suffix):
+            continue
+        candidate_str = tag[: -len(tag_suffix)]
+        try:
+            candidate = _parse_api_version(candidate_str)
+        except ValueError:
+            continue
+        if _is_compatible_api_version_candidate(candidate, version_range, upper_bound):
+            candidates.append((candidate, candidate_str))
+
+    if not candidates:
+        raise click.UsageError(
+            f"No Docker image tags match compatible api_version range {api_version!r} "
+            f"for {base_image} with suffix {tag_suffix!r}."
+        )
+
+    return max(candidates, key=lambda item: _api_version_sort_key(item[0]))[1]
+
+
 def _is_node_graph(spec: str | dict) -> bool:
     """Check if a graph is a Node.js graph based on the file extension."""
     if isinstance(spec, dict):
@@ -194,7 +365,12 @@ def validate_config(config: Config) -> Config:
             )
     if api_version:
         try:
-            parts = _parse_api_version_parts(api_version)
+            compatible_match = _API_VERSION_RANGE_PATTERN.fullmatch(api_version)
+            parts = _parse_api_version_parts(
+                compatible_match.group("version").strip()
+                if compatible_match
+                else api_version
+            )
             if len(parts) > 3:
                 raise ValueError(
                     "Version must be major or major.minor or major.minor.patch."
@@ -1430,6 +1606,9 @@ def docker_tag(
 
     # Prepend API version if provided
     if api_version:
+        api_version = _resolve_compatible_api_version(
+            api_version, base_image, f"{language}{version_distro_tag}"
+        )
         full_tag = f"{api_version}-{language}{version_distro_tag}"
     elif "/langgraph-server" in base_image and version_distro_tag not in base_image:
         return f"{base_image}-{language}{version_distro_tag}"

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2961,6 +2961,163 @@ def test_docker_tag_with_prerelease_api_version(version: str, in_config: bool):
     assert tag == f"langchain/langgraph-api:{version}-py3.11"
 
 
+def test_docker_tag_with_compatible_api_version_promotes_to_latest_patch():
+    config = validate_config(
+        {
+            "python_version": "3.12",
+            "dependencies": ["."],
+            "graphs": {"agent": "./agent.py:graph"},
+            "image_distro": "wolfi",
+            "api_version": "~=0.11.0.dev5",
+        }
+    )
+
+    with patch(
+        "langgraph_cli.config._get_docker_hub_tags",
+        return_value=[
+            "0.11.0.dev5-py3.12-wolfi",
+            "0.11.0.dev6-py3.12-wolfi",
+            "0.11.0rc1-py3.12-wolfi",
+            "0.11.0-py3.12-wolfi",
+            "0.11.1rc1-py3.12-wolfi",
+            "0.11.1-py3.12-wolfi",
+            "0.12.0rc1-py3.12-wolfi",
+        ],
+    ) as get_tags:
+        tag = docker_tag(config)
+
+    get_tags.assert_called_once_with("langchain/langgraph-api", "0.")
+    assert tag == "langchain/langgraph-api:0.11.1-py3.12-wolfi"
+
+
+def test_docker_tag_with_compatible_api_version_freezes_dev_until_rc():
+    config = validate_config(
+        {
+            "python_version": "3.12",
+            "dependencies": ["."],
+            "graphs": {"agent": "./agent.py:graph"},
+            "api_version": "~=0.11.0.dev5",
+        }
+    )
+
+    with patch(
+        "langgraph_cli.config._get_docker_hub_tags",
+        return_value=[
+            "0.11.0.dev5-py3.12",
+            "0.11.0.dev6-py3.12",
+            "0.11.0.dev7-py3.12",
+        ],
+    ):
+        tag = docker_tag(config)
+
+    assert tag == "langchain/langgraph-api:0.11.0.dev5-py3.12"
+
+
+def test_docker_tag_with_stable_floating_api_version_promotes_to_future_stable():
+    config = validate_config(
+        {
+            "python_version": "3.12",
+            "dependencies": ["."],
+            "graphs": {"agent": "./agent.py:graph"},
+            "image_distro": "wolfi",
+            "api_version": ">~=0.11.0.dev5",
+        }
+    )
+
+    with patch(
+        "langgraph_cli.config._get_docker_hub_tags",
+        return_value=[
+            "0.11.0.dev5-py3.12-wolfi",
+            "0.11.0.dev6-py3.12-wolfi",
+            "0.11.0rc1-py3.12-wolfi",
+            "0.11.0-py3.12-wolfi",
+            "0.11.1-py3.12-wolfi",
+            "0.12.0rc1-py3.12-wolfi",
+            "0.12.0-py3.12-wolfi",
+            "0.13.0.dev1-py3.12-wolfi",
+            "0.13.0-py3.12-wolfi",
+        ],
+    ) as get_tags:
+        tag = docker_tag(config)
+
+    get_tags.assert_called_once_with("langchain/langgraph-api", "0.")
+    assert tag == "langchain/langgraph-api:0.13.0-py3.12-wolfi"
+
+
+def test_docker_tag_with_stable_floating_api_version_ignores_future_prereleases():
+    config = validate_config(
+        {
+            "python_version": "3.12",
+            "dependencies": ["."],
+            "graphs": {"agent": "./agent.py:graph"},
+            "api_version": ">~=0.11.0.dev5",
+        }
+    )
+
+    with patch(
+        "langgraph_cli.config._get_docker_hub_tags",
+        return_value=[
+            "0.11.0.dev5-py3.12",
+            "0.11.0-py3.12",
+            "0.12.0rc1-py3.12",
+            "0.12.0.dev1-py3.12",
+        ],
+    ):
+        tag = docker_tag(config)
+
+    assert tag == "langchain/langgraph-api:0.11.0-py3.12"
+
+
+def test_validate_config_rejects_unrecognized_api_version_range_operator():
+    with pytest.raises(click.UsageError, match="Invalid version format"):
+        validate_config(
+            {
+                "python_version": "3.12",
+                "dependencies": ["."],
+                "graphs": {"agent": "./agent.py:graph"},
+                "api_version": "~>=0.11.0.dev5",
+            }
+        )
+
+
+def test_docker_tag_with_compatible_api_version_supports_node_images():
+    config = validate_config(
+        {
+            "node_version": "20",
+            "graphs": {"agent": "./agent.js:graph"},
+            "image_distro": "wolfi",
+            "api_version": "~=1.2.4",
+        }
+    )
+
+    with patch(
+        "langgraph_cli.config._get_docker_hub_tags",
+        return_value=[
+            "1.2.4-node20-wolfi",
+            "1.2.5-node20-wolfi",
+            "1.3.0-node20-wolfi",
+        ],
+    ) as get_tags:
+        tag = docker_tag(config)
+
+    get_tags.assert_called_once_with("langchain/langgraphjs-api", "1.")
+    assert tag == "langchain/langgraphjs-api:1.2.5-node20-wolfi"
+
+
+def test_docker_tag_with_compatible_api_version_rejects_tagged_base_image():
+    config = validate_config(
+        {
+            "python_version": "3.11",
+            "dependencies": ["."],
+            "graphs": {"agent": "./agent.py:graph"},
+            "api_version": "~=0.11.0.dev5",
+        }
+    )
+
+    with pytest.raises(click.UsageError, match="tagged base_image"):
+        docker_tag(config, base_image="langchain/langgraph-api:0.11.0")
+
+
 def test_config_to_docker_with_api_version():
     """Test config_to_docker function with api_version parameter."""
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -2973,20 +2973,20 @@ def test_docker_tag_with_compatible_api_version_promotes_to_latest_patch():
     )
 
     with patch(
-        "langgraph_cli.config._get_docker_hub_tags",
+        "langgraph_cli.config._get_pypi_versions",
         return_value=[
-            "0.11.0.dev5-py3.12-wolfi",
-            "0.11.0.dev6-py3.12-wolfi",
-            "0.11.0rc1-py3.12-wolfi",
-            "0.11.0-py3.12-wolfi",
-            "0.11.1rc1-py3.12-wolfi",
-            "0.11.1-py3.12-wolfi",
-            "0.12.0rc1-py3.12-wolfi",
+            "0.11.0.dev5",
+            "0.11.0.dev6",
+            "0.11.0rc1",
+            "0.11.0",
+            "0.11.1rc1",
+            "0.11.1",
+            "0.12.0rc1",
         ],
-    ) as get_tags:
+    ) as get_versions:
         tag = docker_tag(config)
 
-    get_tags.assert_called_once_with("langchain/langgraph-api", "0.")
+    get_versions.assert_called_once_with("langgraph-api")
     assert tag == "langchain/langgraph-api:0.11.1-py3.12-wolfi"
 
 
@@ -3001,11 +3001,11 @@ def test_docker_tag_with_compatible_api_version_freezes_dev_until_rc():
     )
 
     with patch(
-        "langgraph_cli.config._get_docker_hub_tags",
+        "langgraph_cli.config._get_pypi_versions",
         return_value=[
-            "0.11.0.dev5-py3.12",
-            "0.11.0.dev6-py3.12",
-            "0.11.0.dev7-py3.12",
+            "0.11.0.dev5",
+            "0.11.0.dev6",
+            "0.11.0.dev7",
         ],
     ):
         tag = docker_tag(config)
@@ -3025,22 +3025,22 @@ def test_docker_tag_with_stable_floating_api_version_promotes_to_future_stable()
     )
 
     with patch(
-        "langgraph_cli.config._get_docker_hub_tags",
+        "langgraph_cli.config._get_pypi_versions",
         return_value=[
-            "0.11.0.dev5-py3.12-wolfi",
-            "0.11.0.dev6-py3.12-wolfi",
-            "0.11.0rc1-py3.12-wolfi",
-            "0.11.0-py3.12-wolfi",
-            "0.11.1-py3.12-wolfi",
-            "0.12.0rc1-py3.12-wolfi",
-            "0.12.0-py3.12-wolfi",
-            "0.13.0.dev1-py3.12-wolfi",
-            "0.13.0-py3.12-wolfi",
+            "0.11.0.dev5",
+            "0.11.0.dev6",
+            "0.11.0rc1",
+            "0.11.0",
+            "0.11.1",
+            "0.12.0rc1",
+            "0.12.0",
+            "0.13.0.dev1",
+            "0.13.0",
         ],
-    ) as get_tags:
+    ) as get_versions:
         tag = docker_tag(config)
 
-    get_tags.assert_called_once_with("langchain/langgraph-api", "0.")
+    get_versions.assert_called_once_with("langgraph-api")
     assert tag == "langchain/langgraph-api:0.13.0-py3.12-wolfi"
 
 
@@ -3055,12 +3055,12 @@ def test_docker_tag_with_stable_floating_api_version_ignores_future_prereleases(
     )
 
     with patch(
-        "langgraph_cli.config._get_docker_hub_tags",
+        "langgraph_cli.config._get_pypi_versions",
         return_value=[
-            "0.11.0.dev5-py3.12",
-            "0.11.0-py3.12",
-            "0.12.0rc1-py3.12",
-            "0.12.0.dev1-py3.12",
+            "0.11.0.dev5",
+            "0.11.0",
+            "0.12.0rc1",
+            "0.12.0.dev1",
         ],
     ):
         tag = docker_tag(config)
@@ -3091,16 +3091,16 @@ def test_docker_tag_with_compatible_api_version_supports_node_images():
     )
 
     with patch(
-        "langgraph_cli.config._get_docker_hub_tags",
+        "langgraph_cli.config._get_pypi_versions",
         return_value=[
-            "1.2.4-node20-wolfi",
-            "1.2.5-node20-wolfi",
-            "1.3.0-node20-wolfi",
+            "1.2.4",
+            "1.2.5",
+            "1.3.0",
         ],
-    ) as get_tags:
+    ) as get_versions:
         tag = docker_tag(config)
 
-    get_tags.assert_called_once_with("langchain/langgraphjs-api", "1.")
+    get_versions.assert_called_once_with("langgraph-api")
     assert tag == "langchain/langgraphjs-api:1.2.5-node20-wolfi"
 
 


### PR DESCRIPTION
Adds `api_version` ranges for LangGraph API base image tags. `~=0.11.0.dev5` resolves to the newest matching compatible image while freezing later dev prereleases until rc/final/patch tags exist; `>~=0.11.0.dev5` uses the same floor but can also float to future stable releases while ignoring future prereleases.

Verified with `make format`, `make lint`, and `make test` from `libs/cli`.