### PR TITLE
fix: add __aenter__ and __aexit__ to AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -87,6 +87,16 @@ class AsyncPostgresSaver(BasePostgresSaver):
             else:
                 yield cls(conn=conn, serde=serde)
 
+    async def __aenter__(self) -> AsyncPostgresSaver:
+        await self.setup()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if isinstance(self.conn, AsyncConnectionPool):
+            await self.conn.close()
+        else:
+            await self.conn.close()
+
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
 
@@ -113,8 +123,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
-        if self.pipe:
-            await self.pipe.sync()
+        if self.pipe:   await self.pipe.sync()
 
     async def alist(
         self,


### PR DESCRIPTION
## What
`AsyncPostgresSaver` was missing async context manager methods (`__aenter__` and `__aexit__`), causing it to fail when used in an `async with` block. The SSL connection error reported in issue #5675 was a symptom of unclosed connections and missing initialization.

## Fix
Added `__aenter__` method that calls `setup()` and returns `self`, and `__aexit__` method that properly closes the connection (whether it's a pool or a single connection). This ensures the checkpointer initializes the database schema on entry and cleans up resources on exit.

Closes #5675