### PR TITLE
chore(sdk-py): allow websockets 16

### DIFF
--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "orjson>=3.11.5",
     "langchain-protocol>=0.0.15",
     "langchain-core>=1.4.0,<2",
-    "websockets>=14,<16",
+    "websockets>=14,<17",
 ]
 
 [tool.hatch.version]

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -522,7 +522,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.4.0,<2" },
     { name = "langchain-protocol", specifier = ">=0.0.15" },
     { name = "orjson", specifier = ">=3.11.5" },
-    { name = "websockets", specifier = ">=14,<16" },
+    { name = "websockets", specifier = ">=14,<17" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
Fixes https://github.com/langchain-ai/langgraph/issues/8021

Loosen the Python SDK `websockets` dependency range from `>=14,<16` to `>=14,<17` so installations can resolve `websockets` 16.x.

Updated both `pyproject.toml` and the lock metadata range. The lock remains resolved to `websockets` 15.0.1 because `uv` is not available in this environment to regenerate it to 16.x.

## Testing
- `git diff --check`
- Parsed `libs/sdk-py/pyproject.toml` with Python `tomllib`

Could not run focused pytest because `pytest` is not installed in this environment, and could not regenerate `uv.lock` because `uv` is not installed.

## Status
Waiting for maintainer assignment on https://github.com/langchain-ai/langgraph/issues/8021 so this external contribution can be reopened by the repository automation.