### PR TITLE
feat(langgraph): add metadata parameter to @task decorator

### DIFF
--- a/libs/langgraph/langgraph/func/__init__.py
+++ b/libs/langgraph/langgraph/func/__init__.py
@@ -65,6 +65,7 @@ class _TaskFunction(Generic[P, T]):
         cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
         timeout: TimeoutPolicy | None = None,
         name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         if name is not None:
             if hasattr(func, "__func__"):
@@ -81,6 +82,7 @@ class _TaskFunction(Generic[P, T]):
         self.retry_policy = retry_policy
         self.cache_policy = cache_policy
         self.timeout = timeout
+        self.metadata = metadata
         functools.update_wrapper(self, func)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> SyncAsyncFuture[T]:
@@ -91,6 +93,7 @@ class _TaskFunction(Generic[P, T]):
             retry_policy=self.retry_policy,
             cache_policy=self.cache_policy,
             timeout=self.timeout,
+            metadata=self.metadata,
         )
 
     def clear_cache(self, cache: BaseCache) -> None:
@@ -114,6 +117,7 @@ def task(
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
     timeout: float | timedelta | TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     **kwargs: Unpack[DeprecatedKwargs],
 ) -> Callable[
     [Callable[P, Awaitable[T]] | Callable[P, T]],
@@ -136,6 +140,7 @@ def task(
     retry_policy: RetryPolicy | Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy[Callable[P, str | bytes]] | None = None,
     timeout: float | timedelta | TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     **kwargs: Unpack[DeprecatedKwargs],
 ) -> (
     Callable[[Callable[P, Awaitable[T]] | Callable[P, T]], _TaskFunction[P, T]]
@@ -167,6 +172,10 @@ def task(
             timeout fires, `NodeTimeoutError` is raised and the retry policy (if
             any) decides whether to retry. Supported only for async tasks; sync
             tasks cannot be safely cancelled in-process.
+        metadata: The metadata associated with the task. Merged into the task's
+            config metadata at run time, making it accessible inside the task
+            via `get_config()["metadata"]` and visible to tracing callbacks and
+            `debug` stream events.
 
     Returns:
         A callable function when used as a decorator.
@@ -243,6 +252,7 @@ def task(
             cache_policy=cache_policy,
             timeout=timeout_policy,
             name=name,
+            metadata=metadata,
         )
 
     if __func_or_none__ is not None:

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -125,6 +125,7 @@ class Call:
         "cache_policy",
         "callbacks",
         "timeout",
+        "metadata",
     )
 
     func: Callable
@@ -133,6 +134,7 @@ class Call:
     cache_policy: CachePolicy | None
     callbacks: Callbacks
     timeout: TimeoutPolicy | None
+    metadata: dict[str, Any] | None
 
     def __init__(
         self,
@@ -143,6 +145,7 @@ class Call:
         cache_policy: CachePolicy | None,
         callbacks: Callbacks,
         timeout: TimeoutPolicy | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         self.func = func
         self.input = input
@@ -150,6 +153,7 @@ class Call:
         self.cache_policy = cache_policy
         self.callbacks = callbacks
         self.timeout = timeout
+        self.metadata = metadata
 
 
 def should_interrupt(
@@ -851,6 +855,8 @@ def prepare_push_task_functional(
         "langgraph_path": in_progress_task_path,
         "langgraph_checkpoint_ns": task_checkpoint_ns,
     }
+    if call.metadata:
+        metadata.update(call.metadata)
     if task_id_checksum is not None:
         assert task_id == task_id_checksum, f"{task_id} != {task_id_checksum}"
     if for_execution:

--- a/libs/langgraph/langgraph/pregel/_call.py
+++ b/libs/langgraph/langgraph/pregel/_call.py
@@ -261,6 +261,7 @@ def call(
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
     timeout: float | timedelta | TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> SyncAsyncFuture[T]:
     return _call_with_options(
@@ -270,6 +271,7 @@ def call(
         retry_policy=retry_policy,
         cache_policy=cache_policy,
         timeout=coerce_timeout_policy(timeout),
+        metadata=metadata,
     )
 
 
@@ -281,6 +283,7 @@ def _call_with_options(
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
     timeout: TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> SyncAsyncFuture[T]:
     if timeout is not None and not is_async_callable(func):
         name = getattr(func, "__name__", func.__class__.__name__)
@@ -294,5 +297,6 @@ def _call_with_options(
         cache_policy=cache_policy,
         callbacks=config["callbacks"],
         timeout=timeout,
+        metadata=metadata,
     )
     return fut

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -705,6 +705,7 @@ def _call(
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
     timeout: TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     callbacks: Callbacks = None,
     futures: weakref.ref[FuturesDict],
     schedule_task: Callable[
@@ -729,6 +730,7 @@ def _call(
             cache_policy=cache_policy,
             callbacks=callbacks,
             timeout=timeout,
+            metadata=metadata,
         ),
     ):
         if fut := next(
@@ -794,6 +796,7 @@ def _acall(
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
     timeout: TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict],
@@ -828,6 +831,7 @@ def _acall(
             retry_policy=retry_policy,
             cache_policy=cache_policy,
             timeout=timeout,
+            metadata=metadata,
             callbacks=callbacks,
             futures=futures,
             schedule_task=schedule_task,
@@ -850,6 +854,7 @@ async def _acall_impl(
     retry_policy: Sequence[RetryPolicy] | None = None,
     cache_policy: CachePolicy | None = None,
     timeout: TimeoutPolicy | None = None,
+    metadata: dict[str, Any] | None = None,
     callbacks: Callbacks = None,
     # injected dependencies
     futures: weakref.ref[FuturesDict[asyncio.Future, asyncio.Event]],
@@ -876,6 +881,7 @@ async def _acall_impl(
                 cache_policy=cache_policy,
                 callbacks=callbacks,
                 timeout=timeout,
+                metadata=metadata,
             ),
         ):
             if fut := next(

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -46,7 +46,7 @@ from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
-from langgraph.config import get_stream_writer
+from langgraph.config import get_config, get_stream_writer
 from langgraph.errors import GraphRecursionError, InvalidUpdateError, ParentCommand
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
@@ -6891,6 +6891,32 @@ def test_named_tasks_functional() -> None:
         {"qux": "foo|bar|baz|custom_baz|qux"},
         {"workflow": "foo|bar|baz|custom_baz|qux"},
     ]
+
+
+def test_task_metadata_functional() -> None:
+    task_metadata: dict = {}
+
+    @task(metadata={"courier": "fedex", "shared": "task"})
+    def deliver(value: str) -> str:
+        task_metadata.update(get_config()["metadata"])
+        return value + "|delivered"
+
+    @entrypoint()
+    def workflow(value: str) -> str:
+        return deliver(value).result()
+
+    assert (
+        workflow.invoke("package", {"metadata": {"shared": "run", "run_only": True}})
+        == "package|delivered"
+    )
+    # custom metadata is merged into the task's config metadata
+    assert task_metadata["courier"] == "fedex"
+    # task-level metadata wins over invoke-time metadata for colliding keys
+    assert task_metadata["shared"] == "task"
+    # invoke-time metadata is still present
+    assert task_metadata["run_only"] is True
+    # framework keys are preserved
+    assert task_metadata["langgraph_node"] == "deliver"
 
 
 def test_tags_stream_mode_messages() -> None:

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -46,6 +46,7 @@ from langgraph._internal._queue import AsyncQueue
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
+from langgraph.config import get_config
 from langgraph.errors import (
     GraphRecursionError,
     InvalidUpdateError,
@@ -7548,6 +7549,35 @@ async def test_named_tasks_functional() -> None:
         {"qux": "foo|bar|baz|custom_baz|qux"},
         {"workflow": "foo|bar|baz|custom_baz|qux"},
     ]
+
+
+@NEEDS_CONTEXTVARS
+async def test_task_metadata_functional() -> None:
+    task_metadata: dict = {}
+
+    @task(metadata={"courier": "fedex", "shared": "task"})
+    async def deliver(value: str) -> str:
+        task_metadata.update(get_config()["metadata"])
+        return value + "|delivered"
+
+    @entrypoint()
+    async def workflow(value: str) -> str:
+        return await deliver(value)
+
+    assert (
+        await workflow.ainvoke(
+            "package", {"metadata": {"shared": "run", "run_only": True}}
+        )
+        == "package|delivered"
+    )
+    # custom metadata is merged into the task's config metadata
+    assert task_metadata["courier"] == "fedex"
+    # task-level metadata wins over invoke-time metadata for colliding keys
+    assert task_metadata["shared"] == "task"
+    # invoke-time metadata is still present
+    assert task_metadata["run_only"] is True
+    # framework keys are preserved
+    assert task_metadata["langgraph_node"] == "deliver"
 
 
 @NEEDS_CONTEXTVARS


### PR DESCRIPTION
Add a `metadata` parameter to the functional API's `@task` decorator, mirroring `add_node(metadata=...)` in the graph API. The metadata is merged into the task's config metadata at run time (after the framework `langgraph_*` keys, same precedence as graph nodes), so it is readable inside the task via `get_config()["metadata"]` and visible to tracing callbacks and `debug` stream events.

Requested in https://forum.langchain.com/t/feature-request-task-metadata/3584 — avoids keeping a separate task-name-to-options mapping when tasks need custom per-task options.

Verified with new sync/async tests (`test_task_metadata_functional`) and `make format`, `make lint`, `make test` in `libs/langgraph`.

Fixes: #8042

🤖 Generated with [Claude Code](https://claude.com/claude-code)