### PR TITLE
feat(cli): add support for passing certfile and cert key to run dev server under HTTPS

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -724,6 +724,30 @@ def dockerfile(
     default="WARNING",
     help="Set the log level for the API server.",
 )
+@click.option(
+    "--ssl-certfile",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=pathlib.Path,
+    ),
+    default=None,
+    help="Path to an SSL certificate file for serving the development server over HTTPS.",
+)
+@click.option(
+    "--ssl-keyfile",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+        path_type=pathlib.Path,
+    ),
+    default=None,
+    help="Path to an SSL key file for serving the development server over HTTPS.",
+)
 @cli.command(
     "dev",
     help="🏃‍♀️‍➡️ Run LangGraph API server in development mode with hot reloading and debugging support",
@@ -742,8 +766,15 @@ def dev(
     allow_blocking: bool,
     tunnel: bool,
     server_log_level: str,
+    ssl_certfile: pathlib.Path | None,
+    ssl_keyfile: pathlib.Path | None,
 ):
     """CLI entrypoint for running the LangGraph API server."""
+    if (ssl_certfile is None) != (ssl_keyfile is None):
+        raise click.UsageError(
+            "Both --ssl-certfile and --ssl-keyfile must be provided to enable HTTPS."
+        )
+
     try:
         from langgraph_api.cli import run_server  # type: ignore
     except ImportError:
@@ -814,6 +845,8 @@ def dev(
         server_level=server_log_level,
         checkpointer=config_json.get("checkpointer"),
         disable_persistence=config_json.get("disable_persistence", False),
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
     )
 
 

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -775,6 +775,11 @@ def dev(
             "Both --ssl-certfile and --ssl-keyfile must be provided to enable HTTPS."
         )
 
+    if ssl_certfile and ssl_keyfile and tunnel:
+        raise click.UsageError(
+            "Cannot use --tunnel with SSL options. Please choose either to serve over HTTPS or to expose via a tunnel, but not both."
+        )
+
     try:
         from langgraph_api.cli import run_server  # type: ignore
     except ImportError:

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -2,8 +2,10 @@ import json
 import pathlib
 import re
 import shutil
+import sys
 import tempfile
 import textwrap
+import types
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -318,6 +320,31 @@ def test_top_level_help_truncates_command_descriptions_to_single_line() -> None:
     assert not lines[lines.index(deploy_line) + 1].startswith("               ")
     assert "..." in deploy_line
     assert "[Beta] List LangSmith Deployments." in deploy_list_line
+
+
+def test_dev_command_requires_ssl_certfile_and_keyfile_together(tmp_path) -> None:
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_text(
+        json.dumps({"dependencies": [], "graphs": {"agent": "./agent.py:graph"}}),
+        encoding="utf-8",
+    )
+    certfile = tmp_path / "cert.pem"
+    certfile.write_text("cert", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "dev",
+            "--config",
+            str(config_path),
+            "--ssl-certfile",
+            str(certfile),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Both --ssl-certfile and --ssl-keyfile must be provided" in result.output
 
 
 def test_deploy_list_command(monkeypatch) -> None:

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -2,10 +2,8 @@ import json
 import pathlib
 import re
 import shutil
-import sys
 import tempfile
 import textwrap
-import types
 from contextlib import contextmanager
 from pathlib import Path
 

--- a/libs/langgraph/tests/test_tool_stream_handler.py
+++ b/libs/langgraph/tests/test_tool_stream_handler.py
@@ -13,12 +13,12 @@ from typing import Annotated, Any
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
+from langgraph.prebuilt import ToolNode, ToolRuntime
 from typing_extensions import TypedDict
 
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
-from langgraph.prebuilt import ToolNode, ToolRuntime
 from langgraph.pregel._tools import _tool_call_writer
 
 

--- a/libs/langgraph/tests/test_tool_stream_handler.py
+++ b/libs/langgraph/tests/test_tool_stream_handler.py
@@ -13,12 +13,12 @@ from typing import Annotated, Any
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
-from langgraph.prebuilt import ToolNode, ToolRuntime
 from typing_extensions import TypedDict
 
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode, ToolRuntime
 from langgraph.pregel._tools import _tool_call_writer
 
 


### PR DESCRIPTION
This allows running the dev server under HTTPS, which is a requirement for running local server under Safari.