### PR TITLE
fix(sdk-py): support websockets 16

### DIFF
--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "orjson>=3.11.5",
     "langchain-protocol>=0.0.15",
     "langchain-core>=1.4.0,<2",
-    "websockets>=14,<16",
+    "websockets>=14,<17",
 ]
 
 [tool.hatch.version]

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -522,7 +522,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.4.0,<2" },
     { name = "langchain-protocol", specifier = ">=0.0.15" },
     { name = "orjson", specifier = ">=3.11.5" },
-    { name = "websockets", specifier = ">=14,<16" },
+    { name = "websockets", specifier = ">=14,<17" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- widen `sdk-py` websockets upper bound from `<16` to `<17`
- refresh `uv.lock` to match the updated constraint

## Verification
- `make format` in `libs/sdk-py`
- `make lint` in `libs/sdk-py`
- `TEST=tests/streaming/test_transport_ws.py make test` in `libs/sdk-py`

## Notes
- This addresses issue #8021.