### PR TITLE
fix: persist DeltaChannel writes on empty thread

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -108,6 +108,7 @@ from langgraph.callbacks import (
     get_sync_graph_callback_manager_for_config,
 )
 from langgraph.channels.base import BaseChannel
+from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.topic import Topic
 from langgraph.config import get_config
 from langgraph.constants import END
@@ -1995,11 +1996,28 @@ class Pregel(
                         },
                     ),
                 )
+            created_root = False
+            if saved is None:
+                needs_root = any(
+                    isinstance(channels.get(chan), DeltaChannel)
+                    for task in run_tasks
+                    for chan, _ in task.writes
+                    if chan != PUSH and chan in channels
+                )
+                if needs_root:
+                    root_checkpoint = create_checkpoint(checkpoint, channels, step)
+                    checkpoint_config = checkpointer.put(
+                        checkpoint_config,
+                        root_checkpoint,
+                        {"source": "update", "step": step, "parents": {}},
+                        {},
+                    )
+                    created_root = True
             # save task writes
             for task_id, task in zip(run_task_ids, run_tasks):
                 # channel writes are saved to current checkpoint
                 channel_writes = [w for w in task.writes if w[0] != PUSH]
-                if saved and channel_writes:
+                if (saved is not None or created_root) and channel_writes:
                     checkpointer.put_writes(checkpoint_config, channel_writes, task_id)
             # apply to checkpoint and save
             apply_writes(
@@ -2440,11 +2458,28 @@ class Pregel(
                         },
                     ),
                 )
+            created_root = False
+            if saved is None:
+                needs_root = any(
+                    isinstance(channels.get(chan), DeltaChannel)
+                    for task in run_tasks
+                    for chan, _ in task.writes
+                    if chan != PUSH and chan in channels
+                )
+                if needs_root:
+                    root_checkpoint = create_checkpoint(checkpoint, channels, step)
+                    checkpoint_config = await checkpointer.aput(
+                        checkpoint_config,
+                        root_checkpoint,
+                        {"source": "update", "step": step, "parents": {}},
+                        {},
+                    )
+                    created_root = True
             # save task writes
             for task_id, task in zip(run_task_ids, run_tasks):
                 # channel writes are saved to current checkpoint
                 channel_writes = [w for w in task.writes if w[0] != PUSH]
-                if saved and channel_writes:
+                if (saved is not None or created_root) and channel_writes:
                     await checkpointer.aput_writes(
                         checkpoint_config, channel_writes, task_id
                     )

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -397,6 +397,52 @@ def test_delta_channel_inmemory_saver_assembles_writes() -> None:
     assert len(state.values["messages"]) == 4  # 2 human + 2 AI
 
 
+def test_update_state_persists_delta_channel_on_empty_thread() -> None:
+    class State(TypedDict):
+        messages: Annotated[list, DeltaChannel(_messages_delta_reducer, list)]
+
+    def writer(state: State) -> dict:
+        return state
+
+    saver = InMemorySaver()
+    graph = (
+        StateGraph(State)
+        .add_node("writer", writer)
+        .add_edge(START, "writer")
+        .compile(checkpointer=saver)
+    )
+
+    config = {"configurable": {"thread_id": "t1"}}
+    updated_config = graph.update_state(
+        config, {"messages": [HumanMessage(content="hi", id="h1")]}, as_node="writer"
+    )
+    state = graph.get_state(updated_config)
+    assert state.values["messages"] == [HumanMessage(content="hi", id="h1")]
+
+
+async def test_aupdate_state_persists_delta_channel_on_empty_thread() -> None:
+    class State(TypedDict):
+        messages: Annotated[list, DeltaChannel(_messages_delta_reducer, list)]
+
+    def writer(state: State) -> dict:
+        return state
+
+    saver = InMemorySaver()
+    graph = (
+        StateGraph(State)
+        .add_node("writer", writer)
+        .add_edge(START, "writer")
+        .compile(checkpointer=saver)
+    )
+
+    config = {"configurable": {"thread_id": "t1"}}
+    updated_config = await graph.aupdate_state(
+        config, {"messages": [HumanMessage(content="hi", id="h1")]}, as_node="writer"
+    )
+    state = await graph.aget_state(updated_config)
+    assert state.values["messages"] == [HumanMessage(content="hi", id="h1")]
+
+
 # ---------------------------------------------------------------------------
 # DeltaChannel — dict reducer
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #8044

This PR ensures that DeltaChannel writes are correctly persisted when calling graph.update_state() on a thread that does not yet have an existing checkpoint.

Changes

- Updated main.py to detect if DeltaChannel writes are being made to a new thread and proactively create a root checkpoint to store them.
- Refined the write-saving logic in both sync ( perform_superstep ) and async ( aperform_superstep ) loops to support this persistence.
Verification

- Added new test cases in test_channels.py :
  - test_update_state_persists_delta_channel_on_empty_thread
  - test_aupdate_state_persists_delta_channel_on_empty_thread
- These tests verify that messages sent to a DeltaChannel via update_state are properly retrieved on the first get_state call for a fresh thread.
