### PR TITLE
fix: prevent premature connection close in AsyncPostgresSaver.from_conn_string (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -78,14 +78,17 @@ class AsyncPostgresSaver(BasePostgresSaver):
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
+        conn = await AsyncConnection.connect(
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
-            else:
-                yield cls(conn=conn, serde=serde)
+        )
+        if pipeline:
+            pipe = conn.pipeline()
+            await pipe.__aenter__()
+            yield cls(conn=conn, pipe=pipe, serde=serde)
+            await pipe.__aexit__(None, None, None)
+        else:
+            yield cls(conn=conn, serde=serde)
+        await conn.close()
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## What
`AsyncPostgresSaver.from_conn_string` used `async with AsyncConnection.connect(...)` which closed the connection when the context manager exited, but the saver instance was returned and used later. This caused psycopg.OperationalError: SSL connection has been closed unexpectedly when the saver tried to use the closed connection.

## Fix
Replace the `async with` context manager with explicit connection management: open the connection, yield the saver, and close the connection after the async generator exits. Also handle pipeline lifecycle manually. This ensures the connection remains open while the saver is in use.

Closes #5675