### PR TITLE
fix(prebuilt): handle content block lists in ToolNode for MCP tools

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1444,6 +1444,16 @@ class ToolNode(RunnableCallable):
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
+            # Handle content block lists (e.g. from MCP tools or other frameworks
+            # that bypass _format_output). This mirrors the format recognized by
+            # msg_content_output() — a list of dicts each with a "type" in
+            # TOOL_MESSAGE_BLOCK_TYPES — and wraps them into a ToolMessage.
+            if all(
+                isinstance(r, dict) and r.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for r in response
+            ):
+                content = cast("str | list", msg_content_output(response))
+                return ToolMessage(content=content, tool_call_id=tool_call["id"])
             msg = (
                 f"Tool {tool_call['name']} returned a list with invalid element "
                 "types: expected all Command or ToolMessage"


### PR DESCRIPTION
Fixes #7985

---

ToolNode._normalize_tool_response raises TypeError when an MCP tool (or any framework bypassing _format_output) returns a list of content blocks like `[{"type": "text", "text": "..."}]`. This is the standard LangChain Core message content format already recognized by msg_content_output() elsewhere in the same file.

The fix adds a branch that detects content block lists (dicts with `type` in `TOOL_MESSAGE_BLOCK_TYPES`) and wraps them into a ToolMessage, matching the existing behavior when the same format flows through the normal BaseTool.ainvoke path.

Edge cases handled:
- Empty list -> falls through to existing _validate_tool_command_list (correct error)
- Unknown dict types -> falls through to existing TypeError
- Non-dicts in list -> falls through to existing TypeError
- Multiple content blocks -> correctly wrapped into one ToolMessage

This PR was created with AI assistance.