### PR TITLE
fix(pregel): update broken docs URL in multiple-interrupt RuntimeError

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -904,7 +904,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary

Fixes the broken docs URL embedded in the `RuntimeError` raised when a user resumes execution with a single `Command.resume` value while multiple interrupts are pending.

**Old URL (HTTP 404):**
```
https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation
```

**New URL (live, confirmed):**
```
https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts
```

## Root Cause

The HITL documentation was consolidated in PR #5192, which moved and merged the "resume multiple interrupts" content into the `interrupts` page. The in-source URL reference in `libs/langgraph/langgraph/pregel/_loop.py` (line 907) was not updated at that time.

## Changes

- `libs/langgraph/langgraph/pregel/_loop.py`: 1 URL replaced in the `RuntimeError` message body.

No logic changes. No API surface changes.

## Verification

The replacement URL `https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts` is live and contains the **"Handling multiple interrupts"** section that documents the `{interrupt_id: resume_value}` map pattern referenced by the error message.

Closes #7686