### PR TITLE
fix(langgraph): make pending writes durable before the superseding checkpoint

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -196,15 +196,17 @@ class PregelLoop:
     _migrate_checkpoint: Callable[[Checkpoint], None] | None
     submit: Submit
     channels: Mapping[str, BaseChannel]
-    # Futures from `checkpointer.put_writes` calls that produced delta-channel
-    # writes. `_checkpointer_put_after_previous` drains this list (swap to a
-    # local `futs` then reset to `[]` and wait/gather) before putting the
-    # next checkpoint, so a checkpoint never becomes durable before the
-    # writes that produced it. Initialised to `[]` in both sync and async
-    # `__enter__`; stays `None` only when no checkpointer.
-    _delta_write_futs: list[Any] | None = None
+    # Futures from `checkpointer.put_writes` calls. `_checkpointer_put_after_previous`
+    # drains this list (swap to a local `futs` then reset to `[]` and
+    # wait/gather) before putting the next checkpoint, so a checkpoint never
+    # becomes durable before the writes that produced it (otherwise crash
+    # recovery would be host-dependent: replay vs re-execute decided by which
+    # of the two concurrent saver calls committed first). Initialised to `[]`
+    # in both sync and async `__enter__`; stays `None` only when no
+    # checkpointer.
+    _pending_write_futs: list[Any] | None = None
 
-    # Same pattern as `_delta_write_futs` but for error-handler writes.
+    # Same pattern as `_pending_write_futs` but for error-handler writes.
     # When `put_writes` persists an ERROR_SOURCE_NODE marker, the future is
     # appended here.  `schedule_error_handler` / `aschedule_error_handler`
     # drain this list so the write is durable before the handler starts.
@@ -485,10 +487,8 @@ class PregelLoop:
                     writes_to_save,
                     task_id,
                 )
-            if self._delta_write_futs is not None and any(
-                isinstance(self.specs.get(c), DeltaChannel) for c, _ in writes_to_save
-            ):
-                self._delta_write_futs.append(fut)
+            if self._pending_write_futs is not None:
+                self._pending_write_futs.append(fut)
             # ERROR_SOURCE_NODE is only appended by commit() when the task
             # has an error handler (_should_route_to_error_handler), so this
             # check naturally limits future collection to those tasks.
@@ -1288,8 +1288,8 @@ class PregelLoop:
                     entries,
                     synth_tid,
                 )
-            if self._delta_write_futs is not None:
-                self._delta_write_futs.append(fut)
+            if self._pending_write_futs is not None:
+                self._pending_write_futs.append(fut)
 
     def _suppress_interrupt(
         self,
@@ -1512,8 +1512,8 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         metadata: CheckpointMetadata,
         new_versions: ChannelVersions,
     ) -> RunnableConfig:
-        if self._delta_write_futs:
-            futs, self._delta_write_futs = self._delta_write_futs, []
+        if self._pending_write_futs:
+            futs, self._pending_write_futs = self._pending_write_futs, []
             concurrent.futures.wait(futs)
         try:
             if prev is not None:
@@ -1659,7 +1659,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             if saved.pending_writes is not None
             else []
         )
-        self._delta_write_futs = []
+        self._pending_write_futs = []
         self._error_handler_write_futs = []
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None
@@ -1764,10 +1764,10 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         metadata: CheckpointMetadata,
         new_versions: ChannelVersions,
     ) -> RunnableConfig:
-        # Drain DeltaChannel write futures before committing the checkpoint so
+        # Drain pending-write futures before committing the checkpoint so
         # ancestor walks never see a checkpoint without its backing writes.
-        if self._delta_write_futs:
-            futs, self._delta_write_futs = self._delta_write_futs, []
+        if self._pending_write_futs:
+            futs, self._pending_write_futs = self._pending_write_futs, []
             await asyncio.gather(*futs)
         try:
             if prev is not None:
@@ -1916,7 +1916,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             if saved.pending_writes is not None
             else []
         )
-        self._delta_write_futs = []
+        self._pending_write_futs = []
         self._error_handler_write_futs = []
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -26,6 +26,7 @@ from langchain_core.runnables.graph import Edge
 from langgraph.cache.base import BaseCache
 from langgraph.checkpoint.base import (
     BaseCheckpointSaver,
+    ChannelVersions,
     Checkpoint,
     CheckpointMetadata,
     CheckpointTuple,
@@ -3381,6 +3382,72 @@ def test_subgraph_checkpoint_true_interrupt(
     assert graph.invoke(Command(resume="baz"), config, durability=durability) == {
         "foo": "hi! foobaz"
     }
+
+
+def test_pending_writes_durable_before_superseding_checkpoint_put() -> None:
+    """A task's pending writes must be durable before the superseding
+    checkpoint is put, so post-crash recovery (replay the writes vs re-execute
+    the node) does not depend on a thread race in the background executor.
+
+    The delay in `put_writes` makes the superseding `put` reliably commit
+    first when the ordering is not enforced.
+    """
+    events: list[tuple[str, str | None]] = []
+    events_lock = threading.Lock()
+
+    class OrderTrackingSaver(InMemorySaver):
+        def put_writes(
+            self,
+            config: RunnableConfig,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> None:
+            time.sleep(0.05)
+            super().put_writes(config, writes, task_id, task_path)
+            with events_lock:
+                events.append(("writes_done", config["configurable"]["checkpoint_id"]))
+
+        def put(
+            self,
+            config: RunnableConfig,
+            checkpoint: Checkpoint,
+            metadata: CheckpointMetadata,
+            new_versions: ChannelVersions,
+        ) -> RunnableConfig:
+            with events_lock:
+                events.append(
+                    ("put_start", config["configurable"].get("checkpoint_id"))
+                )
+            return super().put(config, checkpoint, metadata, new_versions)
+
+    class State(TypedDict):
+        count: int
+
+    def worker(state: State) -> State:
+        return {"count": state["count"] + 1}
+
+    builder = StateGraph(State)
+    builder.add_node("worker", worker)
+    builder.add_edge(START, "worker")
+    builder.add_conditional_edges(
+        "worker", lambda state: "worker" if state["count"] < 3 else END
+    )
+    graph = builder.compile(checkpointer=OrderTrackingSaver())
+
+    result = graph.invoke(
+        {"count": 0}, {"configurable": {"thread_id": "1"}}, durability="sync"
+    )
+    assert result == {"count": 3}
+
+    # once a checkpoint has been superseded (a put with it as parent has
+    # started), all writes attached to it must already be durable
+    for i, (kind, checkpoint_id) in enumerate(events):
+        if kind == "put_start" and checkpoint_id is not None:
+            assert ("writes_done", checkpoint_id) not in events[i:], (
+                f"checkpoint {checkpoint_id} was superseded before the writes"
+                " that produced it were durable"
+            )
 
 
 def test_stream_subgraphs_during_execution(

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8,6 +8,7 @@ import random
 import sys
 import uuid
 from collections import Counter, deque
+from collections.abc import Sequence
 from dataclasses import replace
 from time import perf_counter
 from typing import (
@@ -5064,6 +5065,67 @@ async def test_subgraph_durability_inherited(
     else:
         checkpoints = list(async_checkpointer.list(config))
         assert len(checkpoints) == 1
+
+
+async def test_pending_writes_durable_before_superseding_checkpoint_put() -> None:
+    """A task's pending writes must be durable before the superseding
+    checkpoint is put, so post-crash recovery (replay the writes vs re-execute
+    the node) does not depend on a race between the saver calls.
+
+    The delay in `aput_writes` makes the superseding `aput` reliably commit
+    first when the ordering is not enforced.
+    """
+    events: list[tuple[str, str | None]] = []
+
+    class OrderTrackingSaver(InMemorySaver):
+        async def aput_writes(
+            self,
+            config: RunnableConfig,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> None:
+            await asyncio.sleep(0.05)
+            await super().aput_writes(config, writes, task_id, task_path)
+            events.append(("writes_done", config["configurable"]["checkpoint_id"]))
+
+        async def aput(
+            self,
+            config: RunnableConfig,
+            checkpoint: Checkpoint,
+            metadata: CheckpointMetadata,
+            new_versions: ChannelVersions,
+        ) -> RunnableConfig:
+            events.append(("put_start", config["configurable"].get("checkpoint_id")))
+            return await super().aput(config, checkpoint, metadata, new_versions)
+
+    class State(TypedDict):
+        count: int
+
+    def worker(state: State) -> State:
+        return {"count": state["count"] + 1}
+
+    builder = StateGraph(State)
+    builder.add_node("worker", worker)
+    builder.add_edge(START, "worker")
+    builder.add_conditional_edges(
+        "worker", lambda state: "worker" if state["count"] < 3 else END
+    )
+    graph = builder.compile(checkpointer=OrderTrackingSaver())
+
+    result = await graph.ainvoke(
+        {"count": 0}, {"configurable": {"thread_id": "1"}}, durability="sync"
+    )
+    assert result == {"count": 3}
+
+    # once a checkpoint has been superseded (a put with it as parent has
+    # started), all writes attached to it must already be durable
+    for i, (kind, checkpoint_id) in enumerate(events):
+        if kind == "put_start" and checkpoint_id is not None:
+            assert ("writes_done", checkpoint_id) not in events[i:], (
+                f"checkpoint {checkpoint_id} was superseded before the writes"
+                " that produced it were durable"
+            )
 
 
 @NEEDS_CONTEXTVARS


### PR DESCRIPTION
Fixes #8039

Under `durability="sync"`, `checkpointer.put_writes` (a completed task's pending writes) and `checkpointer.put` (the superseding checkpoint) were both submitted to the shared `BackgroundExecutor` with no ordering between them. If the process crashed while `put` was in flight, whether the task's writes were already durable — and therefore whether resume replays them (exactly-once) or re-executes the node (duplicating its side effects) — was decided by the OS thread scheduler, varying across hosts running identical code (confirmed: both interleavings reproduce with the issue's `probe_race.py`, including naturally on a 10-core arm64 macOS host).

**Fix.** The loop already enforces writes-before-put for delta-channel writes via `_delta_write_futs` (comment: "so a checkpoint never becomes durable before the writes that produced it") — but only for `DeltaChannel` writes. This PR extends that existing barrier to all `put_writes` futures, renaming the list to `_pending_write_futs`. The wait happens inside the background put task (`_checkpointer_put_after_previous`, sync + async), so:

- `durability="async"` keeps its non-blocking behavior — only background work is ordered;
- under `durability="sync"`, the existing main-loop wait on the put future now transitively guarantees the superstep's writes are durable before the checkpoint that supersedes them.

No deadlock is introduced: checkpoint puts are chained (at most one drain-wait in flight), and per-superstep write futures are always submitted to the executor before the superseding put.

**Tests.** `test_pending_writes_durable_before_superseding_checkpoint_put` (sync + async): an order-tracking `InMemorySaver` with a delay in `put_writes` that reliably makes `put` win the race when ordering is not enforced. Both tests fail on `main` and pass with the fix.

**Verification.**
- Issue's `probe_race.py`: `natural` and `writes-delay` modes previously produced a duplicated side effect on this host; with the fix all three modes give exactly-once.
- `make format`, `make lint`: clean.
- Full `libs/langgraph` suite (no docker): 1933 passed, 4 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)