### PR TITLE
fix(langgraph): suppress internal context in _get_node_name

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -124,7 +124,7 @@ def _get_node_name(node: StateNode[Any, ContextT]) -> str:
     try:
         return getattr(node, "__name__", node.__class__.__name__)
     except AttributeError:
-        raise TypeError(f"Unsupported node type: {type(node)}")
+        raise TypeError(f"Unsupported node type: {type(node)}") from None
 
 
 class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -272,6 +272,19 @@ def test__get_node_name() -> None:
     assert _get_node_name(MyClass().class_method) == "class_method"
 
 
+def test__get_node_name_suppresses_internal_attribute_error() -> None:
+    class BadNode:
+        def __getattribute__(self, name: str) -> Any:
+            if name == "__class__":
+                raise AttributeError("hidden class")
+            return super().__getattribute__(name)
+
+    with pytest.raises(TypeError, match="Unsupported node type") as exc_info:
+        _get_node_name(BadNode())
+
+    assert exc_info.value.__suppress_context__ is True
+
+
 def test_input_schema_conditional_edge():
     class OverallState(TypedDict):
         foo: Annotated[int, operator.add]


### PR DESCRIPTION
## Summary
- suppress the internal `AttributeError` context when `_get_node_name()` rewrites unsupported node lookup failures to `TypeError`
- add regression coverage for the exceptional path in `tests/test_state.py`

Fixes #7899

## Testing
- `uv run --group test pytest tests/test_state.py -q`
- `uv run --group lint ruff check langgraph/graph/state.py tests/test_state.py`
- `uv run --group lint ruff format --check langgraph/graph/state.py tests/test_state.py`
