### PR TITLE
ci(deps): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/uv_setup/action.yml
+++ b/.github/actions/uv_setup/action.yml
@@ -24,7 +24,7 @@ runs:
   using: composite
   steps:
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: ${{ inputs.python-version }}
         enable-cache: ${{ inputs.enable-cache }}

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -37,7 +37,7 @@ jobs:
       run:
         working-directory: libs/cli
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Get changed files
         id: changed-files
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -31,7 +31,7 @@ jobs:
           - "3.12"
     name: "lint #${{ matrix.python-version }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Get changed files
         id: changed-files
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/_sdk_integration_test.yml
+++ b/.github/workflows/_sdk_integration_test.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       HAS_LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY != '' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: ./.github/actions/uv_setup

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -25,7 +25,7 @@ jobs:
 
     name: "test #${{ matrix.python-version }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python ${{ matrix.python-version }}
         uses: ./.github/actions/uv_setup
         with:

--- a/.github/workflows/_test_langgraph.yml
+++ b/.github/workflows/_test_langgraph.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: libs/langgraph
     name: "test #${{ matrix.python-version }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python ${{ matrix.python-version }}
         uses: ./.github/actions/uv_setup
         with:

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{ steps.check-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: ./.github/actions/uv_setup
@@ -48,7 +48,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-dist
           path: ${{ inputs.working-directory }}/dist/
@@ -74,9 +74,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-dist
           path: ${{ inputs.working-directory }}/dist/

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         working-directory: libs/langgraph
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: SHA=$(git rev-parse HEAD) && echo "SHA=$SHA" >> $GITHUB_ENV
       - name: Set up Python 3.11
         uses: ./.github/actions/uv_setup
@@ -30,7 +30,7 @@ jobs:
       - name: Run benchmarks
         run: OUTPUT=out/benchmark-baseline.json make -s benchmark
       - name: Save outputs
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ runner.os }}-benchmark-baseline-${{ env.SHA }}
           path: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: libs/langgraph
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - id: files
         name: Get changed files
         uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group test
       - name: Download baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ runner.os }}-benchmark-baseline
           restore-keys: |
@@ -57,7 +57,7 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Annotation
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHANGED_FILES: ${{ steps.files.outputs.added_modified_renamed }}
           BENCHMARK_OUTPUT: ${{ steps.benchmark.outputs.OUTPUT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       deps: ${{ steps.filter.outputs.deps || 'true' }}
       sdk_py: ${{ steps.filter.outputs.sdk_py || 'true' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         if: github.event_name != 'workflow_dispatch'
         id: filter
@@ -112,9 +112,9 @@ jobs:
     name: "Check SDK methods matching"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - name: Run check_sdk_methods script
@@ -130,7 +130,7 @@ jobs:
         python-version:
           - "3.13"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Python ${{ matrix.python-version }}
         uses: ./.github/actions/uv_setup
         with:

--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -37,13 +37,13 @@ jobs:
         run: python docs/generate_redirects.py
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: 'docs/_site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       tag: ${{ steps.check-version.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: ./.github/actions/uv_setup
@@ -51,7 +51,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/
@@ -87,7 +87,7 @@ jobs:
     outputs:
       release-body: ${{ steps.generate-release-body.outputs.release-body }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: langchain-ai/langgraph
           path: langgraph
@@ -158,7 +158,7 @@ jobs:
       - test-pypi-publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # We explicitly *don't* set up caching here. This ensures our tests are
       # maximally sensitive to catching breakage.
@@ -262,7 +262,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: ./.github/actions/uv_setup
@@ -272,7 +272,7 @@ jobs:
           enable-cache: false
           working-directory: ${{ inputs.working-directory }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/
@@ -304,7 +304,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Python
         uses: ./.github/actions/uv_setup
@@ -314,7 +314,7 @@ jobs:
           enable-cache: false
           working-directory: ${{ inputs.working-directory }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: ${{ inputs.working-directory }}/dist/

--- a/.github/workflows/reopen_on_assignment.yml
+++ b/.github/workflows/reopen_on_assignment.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Find and reopen matching PRs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Check for issue link and assignee
         id: check-link
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -283,7 +283,7 @@ jobs:
         if: >-
           env.ENFORCE_ISSUE_LINK == 'true' &&
           (steps.check-link.outputs.has-link != 'true' || steps.check-link.outputs.is-assigned != 'true')
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -312,7 +312,7 @@ jobs:
         if: >-
           env.ENFORCE_ISSUE_LINK == 'true' &&
           steps.check-link.outputs.has-link == 'true' && steps.check-link.outputs.is-assigned == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -366,7 +366,7 @@ jobs:
         if: >-
           env.ENFORCE_ISSUE_LINK == 'true' &&
           (steps.check-link.outputs.has-link != 'true' || steps.check-link.outputs.is-assigned != 'true')
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/tag-external-issues.yml
+++ b/.github/workflows/tag-external-issues.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
@@ -63,7 +63,7 @@ jobs:
       - name: Check if contributor is external
         if: steps.app-token.outcome == 'success'
         id: check-membership
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: Apply contributor tier label
         if: steps.check-membership.outputs.is-external == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -155,7 +155,7 @@ jobs:
 
       - name: Add external label
         if: steps.check-membership.outputs.is-external == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -168,7 +168,7 @@ jobs:
 
       - name: Add internal label
         if: steps.check-membership.outputs.is-external == 'false'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -190,13 +190,13 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
 
       - name: Backfill labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/tag-external-prs.yml
+++ b/.github/workflows/tag-external-prs.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
           private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
@@ -48,7 +48,7 @@ jobs:
       - name: Check if contributor is external
         if: steps.app-token.outcome == 'success'
         id: check-membership
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -90,7 +90,7 @@ jobs:
       # event fires and triggers require_issue_link.yml.
       - name: Apply contributor tier label
         if: steps.check-membership.outputs.is-external == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Use App token so the "labeled" event propagates to downstream
           # workflows (e.g. require_issue_link.yml).
@@ -145,7 +145,7 @@ jobs:
 
       - name: Add external label
         if: steps.check-membership.outputs.is-external == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Use App token so the "labeled" event propagates to downstream
           # workflows (e.g. require_issue_link.yml). Events created by the
@@ -161,7 +161,7 @@ jobs:
 
       - name: Add internal label
         if: steps.check-membership.outputs.is-external == 'false'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/uv_lock_ugprade.yml
+++ b/.github/workflows/uv_lock_ugprade.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       
       - name: Set up uv
         uses: ./.github/actions/uv_setup


### PR DESCRIPTION
Every third-party GitHub Action in the workflows is now pinned to a full commit SHA instead of a floating major tag, closing a supply-chain gap where a mutable tag like `@v6` could be force-pushed to point at malicious code. Seven actions were already SHA-pinned; this brings the remaining first-party `actions/*` and `astral-sh/setup-uv` references in line.

## Changes
- Pinned all previously tag-referenced actions to their current commit SHA with the exact release as a trailing comment (the format Dependabot reads and updates): `actions/checkout` → `v6.0.3`, `actions/setup-python` → `v6.2.0`, `actions/github-script` → `v9.0.0`, `actions/upload-artifact` → `v7.0.1`, `actions/download-artifact` → `v8.0.1`, `actions/cache/{restore,save}` → `v5.0.5`, `actions/configure-pages` → `v6.0.0`, `actions/deploy-pages` → `v5.0.0`, `actions/upload-pages-artifact` → `v5.0.0`, `actions/create-github-app-token` → `v3.2.0`, and `astral-sh/setup-uv` → `v7.6.0`.
- Applied across all workflow files plus the `uv_setup` composite action; local same-repo references (`./.github/workflows/_*.yml`, `./.github/actions/uv_setup`) left as path refs since they resolve from the same commit.
