### PR TITLE
fix(checkpoint): pass serializer through connection helpers

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -62,7 +62,11 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
@@ -78,9 +82,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -209,7 +209,11 @@ class ShallowPostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator["ShallowPostgresSaver"]:
         """Create a new ShallowPostgresSaver instance from a connection string.
 
@@ -225,9 +229,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -96,7 +96,9 @@ class SqliteSaver(BaseCheckpointSaver[str]):
 
     @classmethod
     @contextmanager
-    def from_conn_string(cls, conn_string: str) -> Iterator[SqliteSaver]:
+    def from_conn_string(
+        cls, conn_string: str, *, serde: SerializerProtocol | None = None
+    ) -> Iterator[SqliteSaver]:
         """Create a new SqliteSaver instance from a connection string.
 
         Args:
@@ -124,7 +126,7 @@ class SqliteSaver(BaseCheckpointSaver[str]):
                 check_same_thread=False,
             )
         ) as conn:
-            yield cls(conn)
+            yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database.

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -131,7 +131,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
     @classmethod
     @asynccontextmanager
     async def from_conn_string(
-        cls, conn_string: str
+        cls, conn_string: str, *, serde: SerializerProtocol | None = None
     ) -> AsyncIterator[AsyncSqliteSaver]:
         """Create a new AsyncSqliteSaver instance from a connection string.
 
@@ -142,7 +142,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             AsyncSqliteSaver: A new AsyncSqliteSaver instance.
         """
         async with aiosqlite.connect(conn_string) as conn:
-            yield cls(conn)
+            yield cls(conn, serde=serde)
 
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database.

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -10,6 +11,14 @@ from langgraph.checkpoint.base import (
 )
 
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+
+class CustomJsonSerializer:
+    def dumps_typed(self, obj: Any) -> tuple[str, bytes]:
+        return "custom-json", json.dumps(obj).encode()
+
+    def loads_typed(self, data: tuple[str, bytes]) -> Any:
+        return json.loads(data[1].decode())
 
 
 class TestAsyncSqliteSaver:
@@ -72,6 +81,22 @@ class TestAsyncSqliteSaver:
                 **self.metadata_2,
                 "run_id": "my_run_id",
             }
+
+    async def test_from_conn_string_accepts_custom_serializer(self) -> None:
+        async with AsyncSqliteSaver.from_conn_string(
+            ":memory:", serde=CustomJsonSerializer()
+        ) as saver:
+            saved_config = await saver.aput(
+                self.config_1, self.chkpnt_1, self.metadata_1, {}
+            )
+
+            async with saver.conn.execute("SELECT type FROM checkpoints") as cur:
+                (type_,) = await cur.fetchone()
+
+            checkpoint = await saver.aget_tuple(saved_config)
+            assert type_ == "custom-json"
+            assert checkpoint is not None
+            assert checkpoint.checkpoint == self.chkpnt_1
 
     async def test_asearch(self) -> None:
         async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:

--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, cast
 
 import pytest
@@ -11,6 +12,14 @@ from langgraph.checkpoint.base import (
 
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.checkpoint.sqlite.utils import _metadata_predicate, search_where
+
+
+class CustomJsonSerializer:
+    def dumps_typed(self, obj: Any) -> tuple[str, bytes]:
+        return "custom-json", json.dumps(obj).encode()
+
+    def loads_typed(self, data: tuple[str, bytes]) -> Any:
+        return json.loads(data[1].decode())
 
 
 class TestSqliteSaver:
@@ -74,6 +83,20 @@ class TestSqliteSaver:
                 **self.metadata_2,
                 "run_id": "my_run_id",
             }
+
+    def test_from_conn_string_accepts_custom_serializer(self) -> None:
+        with SqliteSaver.from_conn_string(
+            ":memory:", serde=CustomJsonSerializer()
+        ) as saver:
+            saved_config = saver.put(self.config_1, self.chkpnt_1, self.metadata_1, {})
+
+            with saver.cursor(transaction=False) as cur:
+                (type_,) = cur.execute("SELECT type FROM checkpoints").fetchone()
+
+            checkpoint = saver.get_tuple(saved_config)
+            assert type_ == "custom-json"
+            assert checkpoint is not None
+            assert checkpoint.checkpoint == self.chkpnt_1
 
     def test_search(self) -> None:
         with SqliteSaver.from_conn_string(":memory:") as saver:


### PR DESCRIPTION
## Summary
- pass custom serializers through SQLite `from_conn_string` helpers
- pass custom serializers through sync Postgres `from_conn_string` helpers, matching existing async helpers
- add sync/async SQLite regression coverage proving the helper stores and loads with the provided serializer

Fixes #7714

## Tests
- `cd libs/checkpoint-sqlite && make format && make lint && TEST='tests/test_sqlite.py::TestSqliteSaver::test_from_conn_string_accepts_custom_serializer tests/test_aiosqlite.py::TestAsyncSqliteSaver::test_from_conn_string_accepts_custom_serializer' make test`
- `cd libs/checkpoint-postgres && make format && make lint && uv run python - <<'PY' ... PY`