### PR TITLE
fix(langgraph): seed reducer defaults from state schema

### DIFF
--- a/libs/langgraph/langgraph/_internal/_fields.py
+++ b/libs/langgraph/langgraph/_internal/_fields.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import types
 import weakref
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
+from inspect import signature
 from typing import Annotated, Any, Optional, Union, get_origin, get_type_hints
 
 from pydantic import BaseModel
@@ -120,6 +122,39 @@ def get_field_default(name: str, type_: Any, schema: type[Any]) -> Any:
     if _is_optional_type(type_):
         return None
     return ...
+
+
+def get_field_default_factory(name: str, schema: type[Any]) -> Callable[[], Any] | None:
+    """Return a zero-arg factory for a field's declared default value."""
+    model_fields = getattr(schema, "model_fields", None)
+    if model_fields is not None and name in model_fields:
+        field = model_fields[name]
+        if field.is_required():
+            return None
+        if field.default_factory is not None:
+            factory = field.default_factory
+            try:
+                nparams = len(signature(factory).parameters)
+            except (TypeError, ValueError):
+                nparams = 0
+            # Pydantic can expose data-dependent factories; they need validated
+            # data that is not available while seeding graph input.
+            return factory if nparams == 0 else None
+        default = field.default
+        return lambda: copy.deepcopy(default)
+
+    if dataclasses.is_dataclass(schema):
+        for field in dataclasses.fields(schema):
+            if field.name != name:
+                continue
+            if field.default_factory is not dataclasses.MISSING:
+                return field.default_factory
+            if field.default is not dataclasses.MISSING and field.default is not ...:
+                default = field.default
+                return lambda: copy.deepcopy(default)
+            return None
+
+    return None
 
 
 def get_enhanced_type_hints(

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
 from langgraph._internal._fields import (
     get_cached_annotated_keys,
     get_field_default,
+    get_field_default_factory,
     get_update_as_tuples,
 )
 from langgraph._internal._pydantic import create_model
@@ -1493,11 +1494,46 @@ class CompiledStateGraph(
 
         # add node and output channel
         if key == START:
+            reducer_defaults: dict[str, Callable[[], Any]] = {}
+            start_schema = self.builder.input_schema
+            if isclass(start_schema) and (
+                issubclass(start_schema, BaseModel) or is_dataclass(start_schema)
+            ):
+                for k in output_keys:
+                    if isinstance(self.channels.get(k), BinaryOperatorAggregate) and (
+                        factory := get_field_default_factory(k, start_schema)
+                    ):
+                        reducer_defaults[k] = factory
+
+            if reducer_defaults:
+
+                def _get_input_updates(
+                    input: None | dict | Any,
+                ) -> Sequence[tuple[str, Any]] | None:
+                    updates = _get_updates(input)
+                    if updates is None:
+                        return None
+                    updates = list(updates)
+                    provided = {k for k, _ in updates}
+                    for field_name, factory in reducer_defaults.items():
+                        if field_name not in provided:
+                            updates.append((field_name, factory()))
+                    return updates
+
+                start_entries: tuple[
+                    ChannelWriteEntry | ChannelWriteTupleEntry, ...
+                ] = (
+                    ChannelWriteTupleEntry(mapper=_get_input_updates),
+                    *write_entries[1:],
+                )
+            else:
+                start_entries = write_entries
+
             self.nodes[key] = PregelNode(
                 tags=[TAG_HIDDEN],
                 triggers=[START],
                 channels=START,
-                writers=[ChannelWrite(write_entries)],
+                writers=[ChannelWrite(start_entries)],
             )
         elif node is not None:
             input_schema = node.input_schema if node else self.builder.state_schema

--- a/libs/langgraph/tests/test_pydantic.py
+++ b/libs/langgraph/tests/test_pydantic.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import ipaddress
+import operator
 import pathlib
 import re
 import sys
@@ -360,3 +361,82 @@ def test_interrupt_functional_pydantic(sync_checkpointer: BaseCheckpointSaver) -
     res = graph.invoke(Command(resume="bar"), config)
     assert res == {"a": "foobar", "b": "bar"}
     assert called_count == 1
+
+
+def _extend(left: list, right: list) -> list:
+    left.extend(right)
+    return left
+
+
+def test_reducer_field_seeds_scalar_default_when_omitted() -> None:
+    class State(BaseModel):
+        counter: Annotated[int, operator.add] = Field(default=10)
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda _: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 15}
+
+
+def test_reducer_field_seeds_default_factory_when_omitted() -> None:
+    class State(BaseModel):
+        items: Annotated[list[str], _extend] = Field(
+            default_factory=lambda: ["default"]
+        )
+
+    def node(state: State) -> dict[str, list[str]]:
+        assert state.items == ["default"]
+        return {"items": ["from_node"]}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+
+
+def test_reducer_field_explicit_input_overrides_default() -> None:
+    class State(BaseModel):
+        counter: Annotated[int, operator.add] = Field(default=10)
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda _: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({"counter": 100}) == {"counter": 105}
+
+
+def test_reducer_field_default_not_shared_across_runs() -> None:
+    class State(BaseModel):
+        items: Annotated[list[str], _extend] = Field(
+            default_factory=lambda: ["default"]
+        )
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda _: {"items": ["from_node"]})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+    assert graph.invoke({}) == {"items": ["default", "from_node"]}
+
+
+def test_reducer_field_without_default_unchanged() -> None:
+    class State(BaseModel):
+        counter: Annotated[int, operator.add]
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda _: {"counter": 5})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 5}

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -371,3 +371,18 @@ def test_is_field_channel() -> None:
     # No channel cases
     assert _is_field_channel(int) is None
     assert _is_field_channel(Annotated[int, "just_metadata"]) is None
+
+
+def test_reducer_field_seeds_dataclass_default_when_omitted() -> None:
+    @dataclass
+    class DataclassState:
+        counter: Annotated[int, operator.add] = field(default=10)
+
+    builder = StateGraph(DataclassState)
+    builder.add_node("n", lambda _: {"counter": 5})
+    builder.add_edge("__start__", "n")
+    builder.add_edge("n", "__end__")
+    graph = builder.compile()
+
+    assert graph.invoke({}) == {"counter": 15}
+    assert graph.invoke({"counter": 100}) == {"counter": 105}


### PR DESCRIPTION
## Summary
- seed reducer state fields from Pydantic/dataclass defaults when graph input omits them
- preserve explicit input override semantics before later reducer updates
- add regression coverage for scalar defaults, default_factory, mutable default isolation, no-default behavior, and dataclass defaults

Fixes #5225

## Testing
- `make format`
- `make lint`
- `TEST='tests/test_pydantic.py -k reducer_field -q' make test`
- `TEST='tests/test_state.py -k reducer_field -q' make test`