### PR TITLE
fix: remove spurious pipeline capability check (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -58,7 +58,6 @@ class AsyncPostgresSaver(BasePostgresSaver):
         self.pipe = pipe
         self.lock = asyncio.Lock()
         self.loop = asyncio.get_running_loop()
-        self.supports_pipeline = Capabilities().has_pipeline()
 
     @classmethod
     @asynccontextmanager


### PR DESCRIPTION
## What
The `AsyncPostgresSaver` class performs a `Capabilities().has_pipeline()` check during initialization, which always returns True regardless of the actual server capability (psycopg's `Capabilities` is a client-side stub that doesn't reflect server support). This leads to SSL connection closure when pipeline commands are sent to servers like Supabase via PgBouncer that don't support pipelining.

## Fix
Remove the `supports_pipeline` attribute and the `Capabilities().has_pipeline()` call from `__init__`. Pipelining is now controlled solely by the user-provided `pipeline` flag in `from_conn_string`. This prevents false positives and allows users to disable pipeline mode when connecting through connection poolers that don't support it.

Closes #5675