### PR TITLE
fix(langgraph): avoid cache-key collisions for byte-like inputs

### DIFF
--- a/libs/langgraph/langgraph/_internal/_cache.py
+++ b/libs/langgraph/langgraph/_internal/_cache.py
@@ -15,10 +15,25 @@ def _freeze(obj: Any, depth: int = 10) -> Hashable:
         return tuple(_freeze(x, depth - 1) for x in obj)
     # numpy / pandas etc. can provide their own .tobytes()
     elif hasattr(obj, "tobytes"):
+        # Include metadata that distinguishes objects sharing the same raw
+        # bytes but differing semantically; otherwise distinct inputs collide
+        # to the same cache key (e.g. numpy arrays with the same bytes/shape
+        # but different dtype, or PIL images with the same pixels but a
+        # different mode/size/palette). See #8009.
+        palette = None
+        if hasattr(obj, "getpalette"):
+            try:
+                palette = tuple(obj.getpalette() or ())
+            except Exception:
+                palette = None
         return (
             type(obj).__name__,
             obj.tobytes(),
             obj.shape if hasattr(obj, "shape") else None,
+            str(obj.dtype) if hasattr(obj, "dtype") else None,
+            obj.mode if hasattr(obj, "mode") else None,
+            obj.size if hasattr(obj, "size") else None,
+            palette,
         )
     return obj  # strings, ints, dataclasses with frozen=True, etc.
 

--- a/libs/langgraph/tests/test_cache_key.py
+++ b/libs/langgraph/tests/test_cache_key.py
@@ -1,0 +1,65 @@
+"""Unit tests for the default cache key function (`langgraph._internal._cache`)."""
+
+from langgraph._internal._cache import _freeze, default_cache_key
+
+
+class _FakeArray:
+    """Minimal numpy-like object: exposes ``tobytes()``, ``shape`` and ``dtype``.
+
+    Like real numpy arrays, instances are unhashable, so ``_freeze`` reaches the
+    ``tobytes()`` branch instead of returning the object unchanged.
+    """
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __init__(self, data: bytes, dtype: str, shape: tuple[int, ...]) -> None:
+        self._data = data
+        self.dtype = dtype
+        self.shape = shape
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+class _FakeImage:
+    """Minimal PIL-like object: same pixel bytes, distinguished by mode/size/palette."""
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __init__(self, data: bytes, mode: str, size: tuple[int, int], palette: list[int]) -> None:
+        self._data = data
+        self.mode = mode
+        self.size = size
+        self._palette = palette
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+    def getpalette(self) -> list[int]:
+        return self._palette
+
+
+def test_tobytes_objects_with_different_dtype_get_distinct_keys() -> None:
+    # Regression for #8009: identical bytes + shape but a different dtype must
+    # not collide to the same cache key.
+    x = _FakeArray(b"\xc8", dtype="uint8", shape=(1,))
+    y = _FakeArray(b"\xc8", dtype="int8", shape=(1,))
+    assert _freeze(x) != _freeze(y)
+    assert default_cache_key(arr=x) != default_cache_key(arr=y)
+
+
+def test_identical_tobytes_objects_get_identical_keys() -> None:
+    x = _FakeArray(b"\xc8", dtype="uint8", shape=(1,))
+    x2 = _FakeArray(b"\xc8", dtype="uint8", shape=(1,))
+    assert default_cache_key(arr=x) == default_cache_key(arr=x2)
+
+
+def test_image_like_objects_distinguished_by_palette() -> None:
+    a = _FakeImage(b"\x00\x01", mode="P", size=(1, 2), palette=[0, 0, 0, 255, 255, 255])
+    b = _FakeImage(b"\x00\x01", mode="P", size=(1, 2), palette=[255, 0, 0, 0, 255, 0])
+    assert default_cache_key(img=a) != default_cache_key(img=b)
+
+
+def test_plain_arguments_unaffected() -> None:
+    assert default_cache_key(1, "a", flag=True) == default_cache_key(1, "a", flag=True)
+    assert default_cache_key(1) != default_cache_key(2)


### PR DESCRIPTION
**Fixes #8009**

## Problem

`langgraph._internal._cache._freeze` (the default `CachePolicy.key_func`) reduces any object exposing `.tobytes()` to:

```python
(type(obj).__name__, obj.tobytes(), obj.shape if hasattr(obj, "shape") else None)
```

This drops the metadata that distinguishes objects sharing the same raw bytes, so **distinct inputs collide to the same cache key** and the second call silently returns the first call's cached result (the node body never re-runs):

- **numpy**: same bytes + same shape, different `dtype` → identical key (e.g. `frombuffer(b"\xc8", uint8)` = `[200]` vs `int8` = `[-56]`).
- **PIL**: `P`-mode images with the same pixel bytes but a different `mode`/`size`/**palette** → identical key.

## Fix

Include the distinguishing metadata (`dtype`, `mode`, `size`, `palette`) in the frozen representation, read defensively via `hasattr`/`getpalette` so no hard dependency on numpy/PIL is introduced. Distinct inputs now get distinct keys; identical inputs still map to identical keys (determinism preserved); plain hashable arguments are unaffected.

`_freeze` is used only by `default_cache_key`, which `pickle.dumps` the result, so this change is self-contained.

## Tests

Adds `libs/langgraph/tests/test_cache_key.py` — dependency-free (uses small unhashable stubs mirroring the numpy/PIL `tobytes()` contract, so no new test deps):

- distinct dtype / palette → distinct keys (the regression)
- identical inputs → identical keys
- plain arguments unaffected

All pass against the patched module.

---

I'm aware external PRs must be assigned to the linked issue first — happy to be assigned to #8009 so this can be reviewed (a validated fix + tests are ready here).
