### PR TITLE
fix: pass additional connection kwargs to AsyncConnection.connect (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -68,18 +68,24 @@ class AsyncPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        **kwargs: Any,
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use AsyncPipeline
+            **kwargs: Additional connection parameters passed to AsyncConnection.connect.
 
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+            **kwargs,
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True` over an SSL connection (e.g., to Supabase), idle time during LLM inference can cause the server to close the SSL connection, resulting in `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`.

## Fix
Allow users to pass additional connection parameters (like `keepalives_idle=300`) via `**kwargs` to `AsyncConnection.connect`. This enables setting keepalive options to prevent the server from closing idle connections. Also added a note in the docstring.

Closes #5675