### PR TITLE
perf: remove version metadata lookup

### DIFF
--- a/libs/langgraph/langgraph/version.py
+++ b/libs/langgraph/langgraph/version.py
@@ -1,12 +1,6 @@
 """Exports package version."""
 
-from importlib import metadata
-
 __all__ = ("__version__",)
 
-try:
-    __version__ = metadata.version(__package__)
-except metadata.PackageNotFoundError:
-    # Case where package metadata is not available.
-    __version__ = ""
-del metadata  # optional, avoids polluting the results of dir(__package__)
+# Keep this in sync with `libs/langgraph/pyproject.toml`.
+__version__ = "1.2.5"

--- a/libs/langgraph/tests/test_version.py
+++ b/libs/langgraph/tests/test_version.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import tomllib
+
+from langgraph.version import __version__
+
+
+def test_version_matches_pyproject() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        project_config = tomllib.load(handle)
+
+    assert __version__ == project_config["project"]["version"]


### PR DESCRIPTION
Fixes #5040

Replace the import-time `importlib.metadata` version lookup in `langgraph.version` with a static package version to avoid unnecessary overhead on import. Add a regression test to keep `__version__` in sync with `libs/langgraph/pyproject.toml`.

## How I verified it
- `uv run --no-sync ruff check .`
- `uv run --no-sync python -m pytest tests/test_version.py`
