### PR TITLE
fix(cli): convert URLError in _upload_to_gcs to ClickException

### DIFF
--- a/libs/cli/langgraph_cli/deploy.py
+++ b/libs/cli/langgraph_cli/deploy.py
@@ -841,6 +841,10 @@ def _upload_to_gcs(signed_url: str, file_path: str, file_size: int) -> None:
             raise click.ClickException(
                 f"Upload failed with status {err.code}: {detail}"
             ) from None
+        except urllib.error.URLError as err:
+            raise click.ClickException(
+                f"Upload failed due to a network error: {err.reason}"
+            ) from None
     if not em.json_mode:
         click.echo()
 

--- a/libs/cli/tests/unit_tests/test_deploy_helpers.py
+++ b/libs/cli/tests/unit_tests/test_deploy_helpers.py
@@ -19,6 +19,7 @@ from langgraph_cli.deploy import (
     _resolve_env_path,
     _resolve_pushed_image_digest,
     _smith_dashboard_base_url,
+    _upload_to_gcs,
     normalize_image_tag,
     normalize_name,
 )
@@ -687,3 +688,27 @@ class TestResolvePushedImageDigest:
         frame_locals = captured["coro"].cr_frame.f_locals
         assert "--config" not in frame_locals["args"]
         captured["coro"].close()
+
+
+class TestUploadToGcs:
+    def test_url_error_raises_click_exception(self, tmp_path, mocker):
+        # Network failures (DNS, connection reset, timeout) should surface as
+        # a structured ClickException, matching the existing HTTPError path.
+        import urllib.error
+
+        file_path = tmp_path / "build.tar.gz"
+        file_path.write_bytes(b"abc")
+
+        mocker.patch("langgraph_cli.deploy._get_emitter", return_value=MagicMock())
+        mocker.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("simulated connection reset"),
+        )
+
+        with pytest.raises(click.ClickException, match="network error") as exc_info:
+            _upload_to_gcs(
+                "https://storage.example/upload",
+                str(file_path),
+                file_path.stat().st_size,
+            )
+        assert "simulated connection reset" in exc_info.value.message


### PR DESCRIPTION
## Summary

`libs/cli/langgraph_cli/deploy.py` already converts upload `HTTPError`s into a structured `click.ClickException`, but bare network failures (DNS errors, connection resets, timeout wrappers) raised as `urllib.error.URLError` bubble up as raw Python tracebacks during `langgraph deploy`. This adds a parallel `URLError` handler next to the existing one so users get the same concise CLI error in either case.

The change is intentionally minimal: one extra `except` branch in `_upload_to_gcs` plus a focused regression test.

## Validation

Run from `libs/cli/`:

- `make format` — clean
- `make lint` — clean (one pre-existing `ty` warning in an unrelated `examples/graphs/storm.py` file)
- `TEST="tests/unit_tests/test_deploy_helpers.py" make test` — 72 passed (including the new `TestUploadToGcs::test_url_error_raises_click_exception`)

Per `AGENTS.md`, `make format`, `make lint`, and the relevant `make test` were run in the modified library (`libs/cli`); no other libraries were touched.

Closes #8076


Made with [Cursor](https://cursor.com)