### PR TITLE
fix(sdk-py): support v2 streaming in runs.join_stream

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_async/runs.py
@@ -1094,6 +1094,7 @@ class RunsClient:
             params=params,
         )
 
+    @overload
     def join_stream(
         self,
         thread_id: str,
@@ -1104,7 +1105,35 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         last_event_id: str | None = None,
-    ) -> AsyncIterator[StreamPart]:
+        version: Literal["v1"] = "v1",
+    ) -> AsyncIterator[StreamPart]: ...
+
+    @overload
+    def join_stream(
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        cancel_on_disconnect: bool = False,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        last_event_id: str | None = None,
+        version: Literal["v2"],
+    ) -> AsyncIterator[StreamPartV2]: ...
+
+    def join_stream(
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        cancel_on_disconnect: bool = False,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        last_event_id: str | None = None,
+        version: StreamVersion = "v1",
+    ) -> AsyncIterator[StreamPart | StreamPartV2]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
         not be received here.
@@ -1119,6 +1148,8 @@ class RunsClient:
             headers: Optional custom headers to include with the request.
             params: Optional query parameters to include with the request.
             last_event_id: The last event ID to use for the stream.
+            version: Stream format version. "v1" (default) returns raw SSE StreamPart
+                NamedTuples. "v2" returns typed dicts with `type`, `ns`, and `data` keys.
 
         Returns:
             The stream of parts.
@@ -1142,7 +1173,7 @@ class RunsClient:
         }
         if params:
             query_params.update(params)
-        return self.http.stream(
+        raw = self.http.stream(
             f"/threads/{_quote_path_param(thread_id)}/runs/{_quote_path_param(run_id)}/stream",
             "GET",
             params=query_params,
@@ -1152,6 +1183,9 @@ class RunsClient:
             }
             or None,
         )
+        if version == "v2":
+            return _wrap_stream_v2(raw)
+        return raw
 
     async def delete(
         self,

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -1076,6 +1076,7 @@ class SyncRunsClient:
             params=params,
         )
 
+    @overload
     def join_stream(
         self,
         thread_id: str,
@@ -1086,7 +1087,35 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         last_event_id: str | None = None,
-    ) -> Iterator[StreamPart]:
+        version: Literal["v1"] = "v1",
+    ) -> Iterator[StreamPart]: ...
+
+    @overload
+    def join_stream(
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        cancel_on_disconnect: bool = False,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        last_event_id: str | None = None,
+        version: Literal["v2"],
+    ) -> Iterator[StreamPartV2]: ...
+
+    def join_stream(
+        self,
+        thread_id: str,
+        run_id: str,
+        *,
+        cancel_on_disconnect: bool = False,
+        stream_mode: StreamMode | Sequence[StreamMode] | None = None,
+        headers: Mapping[str, str] | None = None,
+        params: QueryParamTypes | None = None,
+        last_event_id: str | None = None,
+        version: StreamVersion = "v1",
+    ) -> Iterator[StreamPart | StreamPartV2]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
         not be received here.
@@ -1101,6 +1130,8 @@ class SyncRunsClient:
             headers: Optional custom headers to include with the request.
             params: Optional query parameters to include with the request.
             last_event_id: The last event ID to use for the stream.
+            version: Stream format version. "v1" (default) returns raw SSE StreamPart
+                NamedTuples. "v2" returns typed dicts with `type`, `ns`, and `data` keys.
 
         Returns:
             `None`
@@ -1123,7 +1154,7 @@ class SyncRunsClient:
         }
         if params:
             query_params.update(params)
-        return self.http.stream(
+        raw = self.http.stream(
             f"/threads/{_quote_path_param(thread_id)}/runs/{_quote_path_param(run_id)}/stream",
             "GET",
             params=query_params,
@@ -1133,6 +1164,9 @@ class SyncRunsClient:
             }
             or None,
         )
+        if version == "v2":
+            return _wrap_stream_v2_sync(raw)
+        return raw
 
     def delete(
         self,

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -440,6 +440,104 @@ def test_sync_stream_v2_client_side_conversion() -> None:
     }
 
 
+# --- join_stream v2 wrapping ---
+
+
+@pytest.mark.asyncio
+async def test_async_join_stream_v2_wraps_raw_iterator() -> None:
+    from langgraph_sdk._async.runs import RunsClient
+
+    raw_parts = [
+        StreamPart(event="metadata", data={"run_id": "r1"}),
+        StreamPart(
+            event="values", data={"messages": [{"role": "user", "content": "hi"}]}
+        ),
+        StreamPart(event="updates|sub:abc", data={"node": {"out": 1}}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(*args: Any, **kwargs: Any) -> Any:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        for part in raw_parts:
+            yield part
+
+    class _FakeHttp:
+        stream = staticmethod(fake_stream)
+
+    client = RunsClient(_FakeHttp())  # ty: ignore[invalid-argument-type]
+    parts: list[StreamPartV2] = [
+        part async for part in client.join_stream("thread-1", "run-1", version="v2")
+    ]
+
+    assert captured["args"][0] == "/threads/thread-1/runs/run-1/stream"
+    assert captured["args"][1] == "GET"
+    assert len(parts) == 3
+    for part in parts:
+        _assert_v2_shape(part)
+    assert parts[0] == {
+        "type": "metadata",
+        "ns": [],
+        "data": {"run_id": "r1"},
+        "interrupts": [],
+    }
+    assert parts[1] == {
+        "type": "values",
+        "ns": [],
+        "data": {"messages": [{"role": "user", "content": "hi"}]},
+        "interrupts": [],
+    }
+    assert parts[2] == {
+        "type": "updates",
+        "ns": ["sub:abc"],
+        "data": {"node": {"out": 1}},
+        "interrupts": [],
+    }
+
+
+def test_sync_join_stream_v2_wraps_raw_iterator() -> None:
+    from langgraph_sdk._sync.runs import SyncRunsClient
+
+    raw_parts = [
+        StreamPart(event="metadata", data={"run_id": "r1"}),
+        StreamPart(event="values", data={"state": "full"}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    captured: dict[str, Any] = {}
+
+    def fake_stream(*args: Any, **kwargs: Any) -> Iterator[StreamPart]:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        yield from raw_parts
+
+    class _FakeHttp:
+        stream = staticmethod(fake_stream)
+
+    client = SyncRunsClient(_FakeHttp())  # ty: ignore[invalid-argument-type]
+    parts: list[StreamPartV2] = list(
+        client.join_stream("thread-1", "run-1", version="v2")
+    )
+
+    assert captured["args"][0] == "/threads/thread-1/runs/run-1/stream"
+    assert captured["args"][1] == "GET"
+    assert len(parts) == 2
+    for part in parts:
+        _assert_v2_shape(part)
+    assert parts[0] == {
+        "type": "metadata",
+        "ns": [],
+        "data": {"run_id": "r1"},
+        "interrupts": [],
+    }
+    assert parts[1] == {
+        "type": "values",
+        "ns": [],
+        "data": {"state": "full"},
+        "interrupts": [],
+    }
+
+
 # --- type narrowing compile-time checks ---
 
 


### PR DESCRIPTION
## Summary
- Adds a `version: StreamVersion = "v1"` keyword argument to `client.runs.join_stream` (sync and async) so re-attaching to a background run with v2 streaming returns the typed v2 dict shape, matching `client.runs.stream(version="v2")`.
- `v1` remains the default — no behavior change for existing callers. The raw iterator is wrapped with the already-defined `_wrap_stream_v2` / `_wrap_stream_v2_sync` helpers when v2 is requested.
- Adds unit tests for both sync and async `join_stream` v2 wrapping in `tests/test_client_stream.py`.

## Validation
Run from `libs/sdk-py/`:
- `make format` — clean
- `make lint` — clean
- `TEST="tests/test_client_stream.py" make test` — all tests pass (including the new `join_stream` v2 coverage)

Per `AGENTS.md`, `make format`, `make lint`, and the relevant `make test` were run in the modified library (`libs/sdk-py`); no other libraries were touched.

Fixes #8087

Made with [Cursor](https://cursor.com)