### PR TITLE
fix(cli): route distributed services to external postgres_uri

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -968,6 +968,7 @@ def prepare_args_and_stdin(
         api_version=api_version,
         image=image,
         engine_runtime_mode=engine_runtime_mode,
+        postgres_uri=postgres_uri,
     )
     return args, stdin
 

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1495,6 +1495,7 @@ def config_to_compose(
     image: str | None = None,
     watch: bool = False,
     engine_runtime_mode: str = "combined_queue_worker",
+    postgres_uri: str | None = None,
 ) -> str:
     base_image = base_image or default_base_image(config)
 
@@ -1582,22 +1583,30 @@ def config_to_compose(
                 additional_contexts:
 {executor_additional_contexts_str}"""
 
-            postgres_uri = "postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
+            if postgres_uri is None:
+                # No external Postgres: the base compose includes the local
+                # langgraph-postgres service, so depend on it as before.
+                postgres_uri = "postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
+                postgres_depends_on = (
+                    "\n            langgraph-postgres:"
+                    "\n                condition: service_healthy"
+                )
+            else:
+                # An external Postgres URI was supplied, so the base compose omits
+                # the local langgraph-postgres service; route the distributed
+                # services to the same DB and drop the dangling dependency.
+                postgres_depends_on = ""
             result += f"""    langgraph-orchestrator:
         image: langchain/langgraph-orchestrator-licensed:latest
         depends_on:
             langgraph-api:
-                condition: service_healthy
-            langgraph-postgres:
-                condition: service_healthy
+                condition: service_healthy{postgres_depends_on}
         environment:
             DATABASE_URI: {postgres_uri}
             EXECUTOR_TARGET: langgraph-executor:8188
         {env_file_str}
     langgraph-executor:
-        depends_on:
-            langgraph-postgres:
-                condition: service_healthy
+        depends_on:{postgres_depends_on}
             langgraph-api:
                 condition: service_healthy
         entrypoint: ["sh", "/storage/executor_entrypoint.sh"]

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -3133,6 +3133,43 @@ def test_config_to_compose_distributed_mode():
     assert "REDIS_URI: redis://langgraph-redis:6379" in actual_compose_stdin
 
 
+def test_config_to_compose_distributed_mode_external_postgres():
+    """Distributed services must use an external postgres_uri and not reference the
+    local langgraph-postgres service the base compose omits (regression for #8080)."""
+    graphs = {"agent": "./agent.py:graph"}
+    external_uri = "postgresql://user:pass@db.example.com:5432/langgraph"
+    actual_compose_stdin = config_to_compose(
+        PATH_TO_CONFIG,
+        validate_config({"dependencies": ["."], "graphs": graphs}),
+        "langchain/langgraph-api",
+        engine_runtime_mode="distributed",
+        postgres_uri=external_uri,
+    )
+
+    # Both distributed services route to the external database.
+    assert actual_compose_stdin.count(f"DATABASE_URI: {external_uri}") == 2
+    # The local langgraph-postgres service is omitted by the base compose, so the
+    # distributed services must not depend on (or point at) it.
+    assert "langgraph-postgres" not in actual_compose_stdin
+
+
+def test_config_to_compose_distributed_mode_default_postgres_depends_on_local():
+    """Without an external postgres_uri, distributed services keep the local
+    langgraph-postgres dependency (unchanged behavior)."""
+    graphs = {"agent": "./agent.py:graph"}
+    actual_compose_stdin = config_to_compose(
+        PATH_TO_CONFIG,
+        validate_config({"dependencies": ["."], "graphs": graphs}),
+        "langchain/langgraph-api",
+        engine_runtime_mode="distributed",
+    )
+    assert "langgraph-postgres:\n                condition: service_healthy" in actual_compose_stdin
+    assert (
+        "DATABASE_URI: postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
+        in actual_compose_stdin
+    )
+
+
 def test_config_to_compose_distributed_mode_with_env_file():
     """Test config_to_compose distributed mode propagates env_file to all services."""
     graphs = {"agent": "./agent.py:graph"}


### PR DESCRIPTION
`config_to_compose` hardcoded the local `langgraph-postgres` `DATABASE_URI` for the orchestrator and executor services and always added a `depends_on: langgraph-postgres`. When `langgraph up --postgres-uri ...` is supplied, the base compose intentionally omits the local `langgraph-postgres` service, so the distributed services pointed at the wrong database and referenced an undefined service.

This threads `postgres_uri` through `config_to_compose` (and the `prepare_args_and_stdin` call site), uses it for the distributed services, and drops the `langgraph-postgres` dependency when an external URI is provided. Combined-mode and default-distributed output are unchanged. Adds unit tests for the external-postgres and default-postgres distributed cases. Fixes #8080.