### PR TITLE
fix(cli): pass postgres uri to distributed services

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -975,6 +975,7 @@ def prepare_args_and_stdin(
         api_version=api_version,
         image=image,
         engine_runtime_mode=engine_runtime_mode,
+        postgres_uri=postgres_uri,
     )
     return args, stdin
 

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -82,6 +82,9 @@ MIN_PYTHON_VERSION = "3.11"
 DEFAULT_PYTHON_VERSION = "3.11"
 
 DEFAULT_IMAGE_DISTRO = "debian"
+DEFAULT_POSTGRES_URI = (
+    "postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
+)
 
 
 _BUILD_TOOLS = ("pip", "setuptools", "wheel")
@@ -1656,6 +1659,7 @@ def config_to_compose(
     image: str | None = None,
     watch: bool = False,
     engine_runtime_mode: str = "combined_queue_worker",
+    postgres_uri: str | None = None,
 ) -> str:
     base_image = base_image or default_base_image(config)
 
@@ -1743,27 +1747,45 @@ def config_to_compose(
                 additional_contexts:
 {executor_additional_contexts_str}"""
 
-            postgres_uri = "postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
+            database_uri = (
+                DEFAULT_POSTGRES_URI if postgres_uri is None else postgres_uri
+            )
+            local_postgres_depends_on = (
+                [
+                    "            langgraph-postgres:",
+                    "                condition: service_healthy",
+                ]
+                if postgres_uri is None
+                else []
+            )
+            orchestrator_depends_on = "\n".join(
+                [
+                    "            langgraph-api:",
+                    "                condition: service_healthy",
+                    *local_postgres_depends_on,
+                ]
+            )
+            executor_depends_on = "\n".join(
+                [
+                    *local_postgres_depends_on,
+                    "            langgraph-api:",
+                    "                condition: service_healthy",
+                ]
+            )
             result += f"""    langgraph-orchestrator:
         image: langchain/langgraph-orchestrator-licensed:latest
         depends_on:
-            langgraph-api:
-                condition: service_healthy
-            langgraph-postgres:
-                condition: service_healthy
+{orchestrator_depends_on}
         environment:
-            DATABASE_URI: {postgres_uri}
+            DATABASE_URI: {database_uri}
             EXECUTOR_TARGET: langgraph-executor:8188
         {env_file_str}
     langgraph-executor:
         depends_on:
-            langgraph-postgres:
-                condition: service_healthy
-            langgraph-api:
-                condition: service_healthy
+{executor_depends_on}
         entrypoint: ["sh", "/storage/executor_entrypoint.sh"]
         environment:
-            DATABASE_URI: {postgres_uri}
+            DATABASE_URI: {database_uri}
             REDIS_URI: redis://langgraph-redis:6379
             EXECUTOR_GRPC_PORT: "8188"
             ENGINE_GRPC_ADDRESS: "langgraph-orchestrator:50054"

--- a/libs/cli/langgraph_cli/docker.py
+++ b/libs/cli/langgraph_cli/docker.py
@@ -12,9 +12,7 @@ import langgraph_cli.config
 from langgraph_cli.exec import subp_exec
 
 ROOT = pathlib.Path(__file__).parent.resolve()
-DEFAULT_POSTGRES_URI = (
-    "postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable"
-)
+DEFAULT_POSTGRES_URI = langgraph_cli.config.DEFAULT_POSTGRES_URI
 
 
 class Version(NamedTuple):

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -1354,3 +1354,27 @@ def test_prepare_args_and_stdin_distributed_mode() -> None:
     assert "langgraph-executor:" in actual_stdin
     assert "FROM langchain/langgraph-executor:" in actual_stdin
     assert "executor_entrypoint.sh" in actual_stdin
+
+
+def test_prepare_args_and_stdin_distributed_mode_with_postgres_uri() -> None:
+    """Test distributed mode uses custom Postgres URI for all services."""
+    config_path = pathlib.Path(__file__).parent / "langgraph.json"
+    config = validate_config(
+        Config(dependencies=["."], graphs={"agent": "agent.py:graph"})
+    )
+    postgres_uri = "postgresql://user:password@external-db:5432/app"
+
+    _, actual_stdin = prepare_args_and_stdin(
+        capabilities=DEFAULT_DOCKER_CAPABILITIES,
+        config_path=config_path,
+        config=config,
+        docker_compose=None,
+        port=8000,
+        watch=False,
+        postgres_uri=postgres_uri,
+        engine_runtime_mode="distributed",
+    )
+
+    assert f"POSTGRES_URI: {postgres_uri}" in actual_stdin
+    assert actual_stdin.count(f"DATABASE_URI: {postgres_uri}") == 2
+    assert "langgraph-postgres:" not in actual_stdin

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -3308,6 +3308,22 @@ def test_config_to_compose_distributed_mode_with_env_file():
     )
 
 
+def test_config_to_compose_distributed_mode_with_postgres_uri():
+    """Test distributed services use custom Postgres URI and no local DB dependency."""
+    graphs = {"agent": "./agent.py:graph"}
+    postgres_uri = "postgresql://user:password@external-db:5432/app"
+    actual_compose_stdin = config_to_compose(
+        PATH_TO_CONFIG,
+        validate_config({"dependencies": ["."], "graphs": graphs}),
+        "langchain/langgraph-api",
+        engine_runtime_mode="distributed",
+        postgres_uri=postgres_uri,
+    )
+
+    assert actual_compose_stdin.count(f"DATABASE_URI: {postgres_uri}") == 2
+    assert "langgraph-postgres:" not in actual_compose_stdin
+
+
 def test_config_to_compose_distributed_mode_generates_two_dockerfiles():
     """Test that distributed mode generates separate Dockerfiles for API and executor."""
     graphs = {"agent": "./agent.py:graph"}


### PR DESCRIPTION
Fixes #8080

Pass the configured Postgres URI through the distributed local compose generator so langgraph-api, langgraph-orchestrator, and langgraph-executor use the same database. When an external Postgres URI is supplied, the generated orchestrator/executor services no longer depend on the omitted local langgraph-postgres service.

Verification:
- `uv run ruff format langgraph_cli/config.py langgraph_cli/docker.py langgraph_cli/cli.py tests/unit_tests/cli/test_cli.py tests/unit_tests/test_config.py`
- `uv run ruff check .`
- `uv run ruff format . --diff`
- `uv run ruff check --select I .`
- `uv run pytest tests/unit_tests/cli/test_cli.py::test_prepare_args_and_stdin_distributed_mode_with_postgres_uri tests/unit_tests/cli/test_cli.py::test_prepare_args_and_stdin_distributed_mode tests/unit_tests/test_config.py::test_config_to_compose_distributed_mode_with_postgres_uri tests/unit_tests/test_config.py::test_config_to_compose_distributed_mode`

Notes:
- `make` is not available in this Windows environment, so I ran the equivalent commands from `libs/cli/Makefile` directly with `uv run`.
- Full `uv run pytest tests/unit_tests` is blocked locally by Docker Desktop daemon not running for Docker-dependent CLI tests, and by an existing Windows CRLF-sensitive assertion in `tests/unit_tests/test_config.py::test_config_to_docker_with_api_version`.