### PR TITLE
fix(langgraph): improve remote exception details

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import asdict
+from pprint import pformat
 from typing import (
     Any,
     Literal,
@@ -112,7 +113,70 @@ def _sanitize_config_value(v: Any) -> Any:
 class RemoteException(Exception):
     """Exception raised when an error occurs in the remote graph."""
 
-    pass
+    def __init__(
+        self,
+        data: Any,
+        *,
+        event: str | None = None,
+        namespace: Sequence[str] = (),
+        assistant_id: str | None = None,
+    ) -> None:
+        super().__init__(data)
+        self.data = data
+        self.event = event
+        self.namespace = tuple(namespace)
+        self.assistant_id = assistant_id
+
+    def __str__(self) -> str:
+        if not isinstance(self.data, Mapping):
+            return str(self.data)
+
+        lines = ["Remote graph raised an error"]
+        if self.assistant_id:
+            lines.append(f"assistant_id: {self.assistant_id}")
+        if self.event:
+            lines.append(f"stream_event: {self.event}")
+        if self.namespace:
+            lines.append(f"namespace: {self.namespace!r}")
+
+        handled = set()
+        for key, label in (
+            ("error", "error"),
+            ("type", "type"),
+            ("message", "message"),
+            ("detail", "detail"),
+        ):
+            if key in self.data:
+                lines.append(f"{label}: {self.data[key]}")
+                handled.add(key)
+
+        for key in (
+            "node",
+            "task",
+            "task_id",
+            "task_path",
+            "checkpoint_ns",
+            "checkpoint_id",
+            "run_id",
+        ):
+            if key in self.data:
+                lines.append(f"{key}: {self.data[key]}")
+                handled.add(key)
+
+        for key in ("traceback", "stacktrace", "stack", "details"):
+            if key in self.data:
+                lines.append(f"{key}:")
+                lines.append(pformat(self.data[key]))
+                handled.add(key)
+
+        remaining = {
+            key: value for key, value in self.data.items() if key not in handled
+        }
+        if remaining:
+            lines.append("payload:")
+            lines.append(pformat(remaining))
+
+        return "\n".join(lines)
 
 
 class RemoteGraph(PregelProtocol):
@@ -843,7 +907,12 @@ class RemoteGraph(PregelProtocol):
                             [Interrupt(**i) for i in chunk.data[INTERRUPT]]
                         )
             elif chunk.event.startswith("error"):
-                raise RemoteException(chunk.data)
+                raise RemoteException(
+                    chunk.data,
+                    event=chunk.event,
+                    namespace=ns,
+                    assistant_id=self.assistant_id,
+                )
             # filter for what was actually requested
             if mode not in requested:
                 continue
@@ -998,7 +1067,12 @@ class RemoteGraph(PregelProtocol):
                             [Interrupt(**i) for i in chunk.data[INTERRUPT]]
                         )
             elif chunk.event.startswith("error"):
-                raise RemoteException(chunk.data)
+                raise RemoteException(
+                    chunk.data,
+                    event=chunk.event,
+                    namespace=ns,
+                    assistant_id=self.assistant_id,
+                )
             # filter for what was actually requested
             if mode not in requested:
                 continue

--- a/libs/langgraph/tests/test_remote_graph_v3.py
+++ b/libs/langgraph/tests/test_remote_graph_v3.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from langgraph_sdk.schema import StreamPart
 
 from langgraph.pregel._remote_run_stream import (
     _AsyncRemoteGraphRunStream,
@@ -13,6 +14,7 @@ from langgraph.pregel._remote_run_stream import (
 )
 from langgraph.pregel.remote import (
     _V3_SUPPORTED_KWARGS,
+    RemoteException,
     RemoteGraph,
 )
 from langgraph.types import Command
@@ -415,6 +417,110 @@ def _make_remote_graph() -> RemoteGraph:
         sync_client=sync_client,
     )
     return rg
+
+
+def test_remote_exception_formats_structured_payload():
+    payload = {
+        "error": "InvalidUpdateError",
+        "message": "Expected node `extract` to update one of ['people']",
+        "node": "extract",
+        "task_id": "task-123",
+        "traceback": ["line 1", "line 2"],
+        "extra": {"checkpoint": "cp-1"},
+    }
+    exc = RemoteException(
+        payload,
+        event="error|extract",
+        namespace=("parent", "extract"),
+        assistant_id="people_extractor",
+    )
+
+    assert exc.args == (payload,)
+    assert exc.data is payload
+    assert exc.event == "error|extract"
+    assert exc.namespace == ("parent", "extract")
+    assert exc.assistant_id == "people_extractor"
+
+    message = str(exc)
+    assert "Remote graph raised an error" in message
+    assert "assistant_id: people_extractor" in message
+    assert "stream_event: error|extract" in message
+    assert "namespace: ('parent', 'extract')" in message
+    assert "error: InvalidUpdateError" in message
+    assert "message: Expected node `extract` to update one of ['people']" in message
+    assert "node: extract" in message
+    assert "task_id: task-123" in message
+    assert "traceback:" in message
+    assert "payload:" in message
+    assert "checkpoint" in message
+
+
+def test_stream_error_raises_remote_exception_with_context():
+    payload = {
+        "error": "InvalidUpdateError",
+        "message": "Expected node `extract` to update one of ['people']",
+    }
+    sync_client = MagicMock()
+    sync_client.runs.stream.return_value = [
+        StreamPart(event="error|extract", data=payload)
+    ]
+    rg = RemoteGraph("people_extractor", client=MagicMock(), sync_client=sync_client)
+
+    with pytest.raises(RemoteException) as exc_info:
+        list(
+            rg.stream(
+                {"url": "https://example.com"},
+                config={
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": "caller",
+                    }
+                },
+                stream_mode="values",
+            )
+        )
+
+    exc = exc_info.value
+    assert exc.data is payload
+    assert exc.event == "error|extract"
+    assert exc.namespace == ("caller", "extract")
+    assert exc.assistant_id == "people_extractor"
+    assert "namespace: ('caller', 'extract')" in str(exc)
+
+
+@pytest.mark.anyio
+async def test_astream_error_raises_remote_exception_with_context():
+    payload = {
+        "error": "InvalidUpdateError",
+        "message": "Expected node `extract` to update one of ['people']",
+    }
+    async_iter = MagicMock()
+    async_iter.__aiter__.return_value = [
+        StreamPart(event="error|extract", data=payload)
+    ]
+    client = MagicMock()
+    client.runs.stream.return_value = async_iter
+    rg = RemoteGraph("people_extractor", client=client, sync_client=MagicMock())
+
+    with pytest.raises(RemoteException) as exc_info:
+        async for _ in rg.astream(
+            {"url": "https://example.com"},
+            config={
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "checkpoint_ns": "caller",
+                }
+            },
+            stream_mode="values",
+        ):
+            pass
+
+    exc = exc_info.value
+    assert exc.data is payload
+    assert exc.event == "error|extract"
+    assert exc.namespace == ("caller", "extract")
+    assert exc.assistant_id == "people_extractor"
+    assert "namespace: ('caller', 'extract')" in str(exc)
 
 
 def test_reject_v3_unsupported_passes_when_all_clear():


### PR DESCRIPTION
Fixes #2559

Improves RemoteException raised by RemoteGraph so structured remote error payloads include useful context in the exception message, including assistant id, stream event, namespace, known error fields, and traceback/details payload data. The original payload remains available as exc.args[0] and exc.data.

Validation:
- ruff check libs/langgraph/langgraph/pregel/remote.py libs/langgraph/tests/test_remote_graph_v3.py
- python -m py_compile libs/langgraph/langgraph/pregel/remote.py libs/langgraph/tests/test_remote_graph_v3.py
- pytest tests/test_remote_graph_v3.py