### PR TITLE
feat: support multiple extra LangSmith trace projects in SDK

### DIFF
--- a/libs/sdk-py/langgraph_sdk/schema.py
+++ b/libs/sdk-py/langgraph_sdk/schema.py
@@ -112,7 +112,13 @@ class LangSmithTracing(TypedDict, total=False):
     """Configuration for LangSmith tracing."""
 
     project_name: str
-    """The LangSmith project name to trace to."""
+    """A single extra LangSmith project name to trace to."""
+    project_names: list[str]
+    """Multiple extra LangSmith project names to trace to.
+
+    Combined with `project_name` (if both are provided) to form the full set of
+    extra projects. The server also traces to its primary tracing project.
+    """
     example_id: str
     """The LangSmith example/dataset ID to associate with the trace."""
 

--- a/libs/sdk-py/tests/test_langsmith_tracing.py
+++ b/libs/sdk-py/tests/test_langsmith_tracing.py
@@ -144,3 +144,57 @@ class TestLangSmithTracingPayload:
         assert captured["json"]["langsmith_tracer"] == {
             "project_name": "my-project",
         }
+
+    def test_langsmith_tracing_project_names_only(self):
+        """Test that langsmith_tracing works with multiple project_names."""
+        from langgraph_sdk._sync.runs import SyncRunsClient
+
+        captured: dict[str, Any] = {}
+
+        def mock_post(_path, *, json=None, **_kwargs):
+            captured["json"] = json
+            return {"run_id": "r1", "status": "pending"}
+
+        http = MagicMock()
+        http.post = MagicMock(side_effect=mock_post)
+        client = SyncRunsClient(http)
+
+        client.create(
+            thread_id="t1",
+            assistant_id="a1",
+            langsmith_tracing={"project_names": ["first", "second"]},
+        )
+
+        assert captured["json"]["langsmith_tracer"] == {
+            "project_names": ["first", "second"],
+        }
+
+    def test_langsmith_tracing_project_name_and_project_names(self):
+        """Test that langsmith_tracing passes both project_name and project_names."""
+        from langgraph_sdk._sync.runs import SyncRunsClient
+
+        captured: dict[str, Any] = {}
+
+        def mock_post(_path, *, json=None, **_kwargs):
+            captured["json"] = json
+            return {"run_id": "r1", "status": "pending"}
+
+        http = MagicMock()
+        http.post = MagicMock(side_effect=mock_post)
+        client = SyncRunsClient(http)
+
+        client.create(
+            thread_id="t1",
+            assistant_id="a1",
+            langsmith_tracing={
+                "project_name": "first",
+                "project_names": ["second", "third"],
+                "example_id": "example-123",
+            },
+        )
+
+        assert captured["json"]["langsmith_tracer"] == {
+            "project_name": "first",
+            "project_names": ["second", "third"],
+            "example_id": "example-123",
+        }


### PR DESCRIPTION
LangGraph Python SDK: `langsmith_tracing` now accepts `project_names` to trace a run to multiple extra LangSmith projects.

---

Adds an optional `project_names: list[str]` field to the `LangSmithTracing` TypedDict so callers can request multiple extra LangSmith trace replica projects on a run. The singular `project_name` field is unchanged and continues to work.

The SDK already forwards `langsmith_tracing` directly as `langsmith_tracer`, so this PR is a schema/documentation + test coverage change for the Python SDK pass-through behavior and is fully backward compatible.

Note: this SDK change depends on the corresponding server-side `langgraph-api` change to normalize/dedupe `project_name` and `project_names` and fan out traces to multiple projects. That server-side change, as well as JS LangSmith tracing support, lives outside this public repo.