### PR TITLE
fix(cli): add timeout for template downloads

### DIFF
--- a/libs/cli/langgraph_cli/templates.py
+++ b/libs/cli/langgraph_cli/templates.py
@@ -7,6 +7,8 @@ from zipfile import ZipFile
 
 import click
 
+TEMPLATE_DOWNLOAD_TIMEOUT_SECONDS = 30
+
 TEMPLATES: dict[str, dict[str, str]] = {
     "Deep Agent": {
         "description": "An opinionated deployment template for a Deep Agent.",
@@ -101,7 +103,9 @@ def _download_repo_with_requests(repo_url: str, path: str) -> None:
     click.secho("📥 Attempting to download repository as a ZIP archive...", fg="yellow")
     click.secho(f"URL: {repo_url}", fg="yellow")
     try:
-        with request.urlopen(repo_url) as response:
+        with request.urlopen(
+            repo_url, timeout=TEMPLATE_DOWNLOAD_TIMEOUT_SECONDS
+        ) as response:
             if response.status == 200:
                 with ZipFile(BytesIO(response.read())) as zip_file:
                     zip_file.extractall(path)
@@ -115,14 +119,8 @@ def _download_repo_with_requests(repo_url: str, path: str) -> None:
                 click.secho(
                     f"✅ Downloaded and extracted repository to {path}", fg="green"
                 )
-    except error.HTTPError as e:
-        click.secho(
-            f"❌ Error: Failed to download repository.\nDetails: {e}\n",
-            fg="red",
-            bold=True,
-            err=True,
-        )
-        sys.exit(1)
+    except (TimeoutError, error.URLError) as e:
+        raise click.ClickException(f"Failed to download repository: {e}") from e
 
 
 def create_new(path: str | None, template: str | None) -> None:

--- a/libs/cli/tests/unit_tests/cli/test_templates.py
+++ b/libs/cli/tests/unit_tests/cli/test_templates.py
@@ -14,7 +14,10 @@ from zipfile import ZipFile
 from click.testing import CliRunner
 
 from langgraph_cli.cli import cli
-from langgraph_cli.templates import TEMPLATE_ID_TO_CONFIG
+from langgraph_cli.templates import (
+    TEMPLATE_DOWNLOAD_TIMEOUT_SECONDS,
+    TEMPLATE_ID_TO_CONFIG,
+)
 
 
 @patch.object(request, "urlopen")
@@ -38,7 +41,11 @@ def test_create_new_with_mocked_download(mock_urlopen: MagicMock) -> None:
         template = next(
             iter(TEMPLATE_ID_TO_CONFIG)
         )  # Select the first template for the test
-        result = runner.invoke(cli, ["new", temp_dir, "--template", template])
+        result = runner.invoke(
+            cli,
+            ["new", temp_dir, "--template", template],
+            env={"LANGGRAPH_CLI_NO_ANALYTICS": "1"},
+        )
 
         # Verify CLI command execution and success
         assert result.exit_code == 0, result.output
@@ -54,13 +61,38 @@ def test_create_new_with_mocked_download(mock_urlopen: MagicMock) -> None:
         assert "test-file.txt" in extracted_files, (
             "Expected 'test-file.txt' in the extracted content."
         )
+        _, _, template_url = TEMPLATE_ID_TO_CONFIG[template]
+        mock_urlopen.assert_called_once_with(
+            template_url, timeout=TEMPLATE_DOWNLOAD_TIMEOUT_SECONDS
+        )
+
+
+@patch.object(request, "urlopen")
+def test_create_new_with_download_timeout(mock_urlopen: MagicMock) -> None:
+    """Test that stalled template downloads fail with an actionable CLI error."""
+    mock_urlopen.side_effect = TimeoutError("timed out")
+
+    with TemporaryDirectory() as temp_dir:
+        runner = CliRunner()
+        template = next(iter(TEMPLATE_ID_TO_CONFIG))
+        result = runner.invoke(
+            cli,
+            ["new", temp_dir, "--template", template],
+            env={"LANGGRAPH_CLI_NO_ANALYTICS": "1"},
+        )
+
+        assert result.exit_code != 0
+        assert "Failed to download repository" in result.output
+        assert "timed out" in result.output
 
 
 def test_invalid_template_id() -> None:
     """Test that an invalid template ID passed via CLI results in a graceful error."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["new", "dummy_path", "--template", "invalid-template-id"]
+        cli,
+        ["new", "dummy_path", "--template", "invalid-template-id"],
+        env={"LANGGRAPH_CLI_NO_ANALYTICS": "1"},
     )
 
     # Verify the command failed and proper message is displayed


### PR DESCRIPTION
﻿## Summary

- Adds an explicit timeout to `langgraph new` template ZIP downloads.
- Converts URL and timeout failures into a `click.ClickException` so the CLI exits with an actionable error instead of hanging.
- Adds regression coverage for the timeout path and verifies the download call uses the bounded timeout.

Fixes #8075.

## Duplicate check

- Checked open PRs for `8075 OR template downloads timeout OR _download_repo_with_requests timeout`: no matching open PR found.
- Checked open PRs for `request.urlopen templates.py ClickException timeout`: no matching open PR found.

## Validation

- `python -m uv run pytest tests/unit_tests/cli/test_templates.py -q`
- `python -m uv run ruff check langgraph_cli/templates.py tests/unit_tests/cli/test_templates.py`
- `python -m uv run ruff format --check langgraph_cli/templates.py tests/unit_tests/cli/test_templates.py`
- `git diff --check`

`make` is unavailable in this local Windows shell, so I ran the equivalent targeted `uv run` commands from `libs/cli`.

## Disclosure

This change was prepared with AI assistance and manually reviewed before submission.
