### PR TITLE
fix(checkpoint-postgres): pass serde to PostgresSaver constructor in from_conn_string

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -62,13 +62,15 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls, conn_string: str, *, pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde (SerializerProtocol): Serializer for encoding/decoding checkpoints.
 
         Returns:
             PostgresSaver: A new PostgresSaver instance.
@@ -78,9 +80,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
Fixes #8116

This PR adds a `serde` parameter to the `PostgresSaver.from_conn_string` classmethod, allowing users to pass a custom serializer (e.g., `JsonPlusSerializer`) directly during initialization. This aligns the method's functionality with the `PostgresSaver` constructor and resolves the current limitation where custom serializers cannot be easily set when using the connection string context manager.

- **Scope**: `checkpoint-postgres`
- **Type**: `feat`

### Details
- Modified `from_conn_string` to accept an optional `serde: SerializerProtocol | None = None` parameter.
- Passes the `serde` argument to the `cls(conn, pipe, serde=serde)` or `cls(conn, serde=serde)` instantiation.
- Updated the method's docstring to include the new parameter.

### How verified
- [ ] Ran `make format`, `make lint`, and `make test` from the `libs/checkpoint-postgres` root.
- [ ] Manually tested by creating a `PostgresSaver` instance with a custom `JsonPlusSerializer` using the updated `from_conn_string` method and verified checkpoints were serialized as expected.