### PR TITLE
Preserve v3 usage metadata details

### DIFF
--- a/libs/langgraph/langgraph/pregel/_messages.py
+++ b/libs/langgraph/langgraph/pregel/_messages.py
@@ -33,6 +33,7 @@ except ImportError:
 
 T = TypeVar("T")
 Meta = tuple[tuple[str, ...], dict[str, Any]]
+_USAGE_DETAIL_KEYS = ("input_token_details", "output_token_details")
 
 
 def _state_values(obj: Any) -> Sequence[Any]:
@@ -44,6 +45,33 @@ def _state_values(obj: Any) -> Sequence[Any]:
     elif is_dataclass(obj) and not isinstance(obj, type):
         return [getattr(obj, f.name) for f in fields(obj)]
     return ()
+
+
+def _usage_detail_fields(usage: Any) -> dict[str, dict[str, Any]]:
+    """Return usage detail dictionaries that are lost by older protocol bridges."""
+    if not isinstance(usage, dict):
+        return {}
+    return {
+        key: dict(value)
+        for key in _USAGE_DETAIL_KEYS
+        if isinstance((value := usage.get(key)), dict)
+    }
+
+
+def _merge_usage_details(
+    usage: Any, details: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    if not details:
+        return cast(dict[str, Any] | None, usage if isinstance(usage, dict) else None)
+
+    merged: dict[str, Any] = dict(usage) if isinstance(usage, dict) else {}
+    for key, value in details.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict):
+            merged[key] = {**existing, **value}
+        else:
+            merged[key] = dict(value)
+    return merged
 
 
 class StreamMessagesHandler(BaseCallbackHandler, _StreamingCallbackHandler):
@@ -272,28 +300,6 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
     AIMessageChunk shape.
     """
 
-    def on_llm_new_token(
-        self,
-        token: str,
-        *,
-        chunk: ChatGenerationChunk | None = None,
-        run_id: UUID,
-        parent_run_id: UUID | None = None,
-        tags: list[str] | None = None,
-        **kwargs: Any,
-    ) -> Any:
-        """Intentional no-op — v1 chunks are not used on v2-flagged runs.
-
-        The v2 marker already steers `invoke` to the event generator, so
-        `on_llm_new_token` should not fire under normal routing. This
-        override stays a pass-through (no call to `super()`) to make
-        the intent explicit and to guard against any caller (e.g. a
-        node that calls `model.stream()` directly, which still fires
-        the v1 callback) leaking AIMessageChunks onto a v2-flagged
-        messages stream.
-        """
-        # Intentionally empty: v2 handler does not forward v1 chunks.
-
     def __init__(
         self,
         stream: Callable[[StreamChunk], None],
@@ -303,6 +309,29 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
     ) -> None:
         super().__init__(stream, subgraphs, parent_ns=parent_ns)
         self._streamed_run_ids: set[UUID] = set()
+        self._usage_details_by_run: dict[UUID, dict[str, dict[str, Any]]] = {}
+
+    def _capture_usage_details(
+        self, run_id: UUID, usage: Any
+    ) -> dict[str, dict[str, Any]]:
+        details = _usage_detail_fields(usage)
+        if not details:
+            return {}
+        stored = self._usage_details_by_run.setdefault(run_id, {})
+        for key, value in details.items():
+            if key in stored:
+                stored[key].update(value)
+            else:
+                stored[key] = dict(value)
+        return stored
+
+    def _patch_usage_details(
+        self, run_id: UUID, usage: Any
+    ) -> dict[str, Any] | None:
+        details = self._usage_details_by_run.get(run_id)
+        if not details:
+            return cast(dict[str, Any] | None, usage if isinstance(usage, dict) else None)
+        return _merge_usage_details(usage, details)
 
     def _find_and_emit_messages(self, meta: Meta, response: Any) -> None:
         """Like the v1 handler, but skip ToolMessage from node outputs.
@@ -333,6 +362,26 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
                         ):
                             self._emit(meta, item, dedupe=True)
 
+    def on_llm_new_token(
+        self,
+        token: str,
+        *,
+        chunk: ChatGenerationChunk | None = None,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Capture v1 chunk usage details without emitting v1 chunks.
+
+        The langchain-core compat bridge converts chunks to v3 protocol events,
+        but older versions narrowed `usage_metadata` before the final
+        `message-finish` event. Keep the detail dictionaries so the finalized
+        message exposed through `on_llm_end` remains faithful to v2.
+        """
+        if isinstance(chunk, ChatGenerationChunk):
+            self._capture_usage_details(run_id, chunk.message.usage_metadata)
+
     def on_llm_end(
         self,
         response: LLMResult,
@@ -341,10 +390,15 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
         parent_run_id: UUID | None = None,
         **kwargs: Any,
     ) -> Any:
-        if meta := self.metadata.get(run_id):
-            if response.generations and response.generations[0]:
-                gen = response.generations[0][0]
-                if isinstance(gen, ChatGeneration):
+        if response.generations and response.generations[0]:
+            gen = response.generations[0][0]
+            if isinstance(gen, ChatGeneration):
+                patched_usage = self._patch_usage_details(
+                    run_id, gen.message.usage_metadata
+                )
+                if patched_usage is not None:
+                    gen.message.usage_metadata = patched_usage
+                if meta := self.metadata.get(run_id):
                     if run_id in self._streamed_run_ids:
                         if gen.message.id is None:
                             gen.message.id = str(uuid4())
@@ -352,6 +406,7 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
                     else:
                         self._emit(meta, gen.message, dedupe=True)
         self._streamed_run_ids.discard(run_id)
+        self._usage_details_by_run.pop(run_id, None)
         self.metadata.pop(run_id, None)
 
     def on_llm_error(
@@ -363,6 +418,7 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
         **kwargs: Any,
     ) -> Any:
         self._streamed_run_ids.discard(run_id)
+        self._usage_details_by_run.pop(run_id, None)
         super().on_llm_error(
             error,
             run_id=run_id,
@@ -404,6 +460,10 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
                 msg_id = event.get("message_id")
                 if msg_id:
                     self.seen.add(msg_id)
+            elif event.get("event") == "message-finish":
+                patched_usage = self._patch_usage_details(run_id, event.get("usage"))
+                if patched_usage is not None:
+                    event["usage"] = patched_usage
             v2_meta = {**meta[1], "run_id": str(run_id)}
             self.stream((meta[0], "messages", (event, v2_meta)))
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2833,13 +2833,15 @@ class Pregel(
                     if use_stream_messages_v2
                     else StreamMessagesHandler
                 )
-                run_manager.inheritable_handlers.append(
-                    messages_handler_cls(
-                        stream.put,
-                        subgraphs,
-                        parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
-                    )
+                messages_handler = messages_handler_cls(
+                    stream.put,
+                    subgraphs,
+                    parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
                 )
+                if use_stream_messages_v2:
+                    run_manager.inheritable_handlers.insert(0, messages_handler)
+                else:
+                    run_manager.inheritable_handlers.append(messages_handler)
 
             # set up tools stream mode
             if "tools" in stream_modes:
@@ -3261,13 +3263,15 @@ class Pregel(
                     if use_stream_messages_v2
                     else StreamMessagesHandler
                 )
-                run_manager.inheritable_handlers.append(
-                    messages_handler_cls(
-                        stream_put,
-                        subgraphs,
-                        parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
-                    )
+                messages_handler = messages_handler_cls(
+                    stream_put,
+                    subgraphs,
+                    parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
                 )
+                if use_stream_messages_v2:
+                    run_manager.inheritable_handlers.insert(0, messages_handler)
+                else:
+                    run_manager.inheritable_handlers.append(messages_handler)
 
             # set up tools stream mode
             if "tools" in stream_modes:

--- a/libs/langgraph/tests/test_stream_messages_transformer.py
+++ b/libs/langgraph/tests/test_stream_messages_transformer.py
@@ -7,12 +7,14 @@ import time
 from typing import Any
 
 import pytest
+from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.language_models import GenericFakeChatModel
 from langchain_core.language_models.chat_model_stream import (
     AsyncChatModelStream,
     ChatModelStream,
 )
 from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
+from langchain_core.outputs import LLMResult
 from langchain_core.runnables import RunnableConfig
 from typing_extensions import TypedDict
 
@@ -22,6 +24,7 @@ from langgraph.stream._mux import StreamMux
 from langgraph.stream.run_stream import GraphRunStream
 from langgraph.stream.stream_channel import StreamChannel
 from langgraph.stream.transformers import MessagesTransformer, ValuesTransformer
+from tests.fake_chat import FakeChatModel
 
 TS = int(time.time() * 1000)
 
@@ -767,6 +770,53 @@ class TestEndToEndV2Invoke:
         assert len(streams) == 1
         assert isinstance(streams[0], AsyncChatModelStream)
         assert (await streams[0].output).text == "async invoke"
+
+    @pytest.mark.anyio
+    async def test_astream_events_v3_preserves_usage_metadata_details_in_callbacks(
+        self,
+    ) -> None:
+        usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "total_tokens": 12,
+            "input_token_details": {"cache_creation": 1, "cache_read": 7},
+            "output_token_details": {"reasoning": 2},
+        }
+        model = FakeChatModel(
+            messages=[AIMessage(content="", usage_metadata=usage_metadata)]
+        )
+        captured: list[dict[str, Any]] = []
+
+        class CaptureUsage(AsyncCallbackHandler):
+            async def on_llm_end(
+                self, response: LLMResult, **kwargs: Any
+            ) -> None:
+                for generations in response.generations or []:
+                    for generation in generations:
+                        message = getattr(generation, "message", None)
+                        usage = getattr(message, "usage_metadata", None)
+                        if usage is not None:
+                            captured.append(dict(usage))
+
+        async def call_model(state: MessagesState) -> dict[str, Any]:
+            return {"messages": await model.ainvoke(state["messages"])}
+
+        graph = (
+            StateGraph(MessagesState)
+            .add_node("call_model", call_model)
+            .add_edge(START, "call_model")
+            .add_edge("call_model", END)
+            .compile()
+        )
+
+        run = await graph.astream_events(
+            {"messages": "hi"}, {"callbacks": [CaptureUsage()]}, version="v3"
+        )
+        streams = [stream async for stream in run.messages]
+
+        assert captured == [usage_metadata]
+        assert len(streams) == 1
+        assert (await streams[0].output).usage_metadata == usage_metadata
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #8094.

`astream_events(version="v3")` was dropping `usage_metadata.input_token_details` and `usage_metadata.output_token_details` before user `on_llm_end` callbacks observed the final AI message. The v3 message handler now retains usage detail dictionaries from streamed chunks and merges them back into the final `message-finish` usage payload and the shared `LLMResult` before callbacks run.

## Why

Cost tracking and cache-hit instrumentation rely on these detail fields. Without them, cached prompt tokens and reasoning-token breakdowns disappear under v3 even when providers return them correctly.

## Tests

- `python -m ruff check libs/langgraph/langgraph/pregel/_messages.py libs/langgraph/langgraph/pregel/main.py libs/langgraph/tests/test_stream_messages_transformer.py`
- `python -m pytest libs/langgraph/tests/test_stream_messages_transformer.py -q`
- `python -m pytest libs/langgraph/tests/test_pregel_stream_events_v3.py libs/langgraph/tests/test_stream_events_v3_e2e.py -q`