### PR TITLE
Fix binop reducer equality for unnamed callables

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -43,7 +43,9 @@ def _operators_equal(a: Callable, b: Callable) -> bool:
     Lambdas all share the name '<lambda>' so identity comparison is
     unreliable; treat any pairing that includes a lambda as equal.
     """
-    if a.__name__ == "<lambda>" or b.__name__ == "<lambda>":
+    if getattr(a, "__name__", None) == "<lambda>" or getattr(
+        b, "__name__", None
+    ) == "<lambda>":
         return True
     return a is b
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,5 +1,6 @@
 import operator
 from collections.abc import Sequence
+from functools import partial
 from typing import Annotated
 
 import pytest
@@ -103,6 +104,31 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_eq_handles_reducers_without_name() -> None:
+    def add_with_offset(offset: int, left: int, right: int) -> int:
+        return left + right + offset
+
+    class Add:
+        def __call__(self, left: int, right: int) -> int:
+            return left + right
+
+    partial_reducer = partial(add_with_offset, 0)
+    callable_reducer = Add()
+
+    assert BinaryOperatorAggregate(int, partial_reducer) == BinaryOperatorAggregate(
+        int, partial_reducer
+    )
+    assert BinaryOperatorAggregate(int, partial_reducer) != BinaryOperatorAggregate(
+        int, partial(add_with_offset, 0)
+    )
+    assert BinaryOperatorAggregate(int, callable_reducer) == BinaryOperatorAggregate(
+        int, callable_reducer
+    )
+    assert BinaryOperatorAggregate(int, callable_reducer) != BinaryOperatorAggregate(
+        int, Add()
+    )
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
Fixes #

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangGraph! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

    - feat(langgraph): add multi-tenant support
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langgraph/blob/main/.github/workflows/pr_lint.yml#L19-L43

2. PR description:

  - Write 1-2 sentences summarizing the change.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
