### PR TITLE
fix(prebuilt): include full state in ToolRuntime when using Send API

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1306,10 +1306,11 @@ class ToolNode(RunnableCallable):
                 return {}
             # Pregel installs CONFIG_KEY_READ as
             # `functools.partial(local_read, scratchpad, channels, managed, task)`.
-            # Match the previous inlined-state contract by reading channels only;
-            # managed values have their own injection path (`ToolRuntime.context`).
-            channels = read.args[1]
-            return cast("dict[str, Any]", read(list(channels), True))
+            # Read ALL channels to ensure custom state fields are included,
+            # not just the messages field. Managed values have their own
+            # injection path (`ToolRuntime.context`).
+            # Pass None to select parameter to read all available channels
+            return cast("dict[str, Any]", read(None, True))
         return input
 
     def _inject_tool_args(


### PR DESCRIPTION
The `ToolRuntime.state` was only receiving the `messages` field instead of the complete graph state when tools were dispatched using the Send API with bare ToolCall dicts. This prevented tools from accessing custom state fields through `runtime.state` or `InjectedState`.

The issue occurred in `_extract_state` at line 1312 of `tool_node.py`. When hydrating state from channels for the new Send payload format, the code was reading from a filtered channel list that might not include all custom state fields. The fix changes the channel reading logic to pass `None` as the select parameter, which reads all available channels instead of a potentially incomplete subset.

Custom state fields like `should_count` in the issue example will now be accessible via `runtime.state` when tools are executed through the Send API.

Fixes #8059
