### PR TITLE
fix(postgres-store): use numeric comparison for range filters

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -624,13 +624,25 @@ class BasePostgresStore(Generic[C]):
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
         elif op == "$gt":
-            return "value->>%s > %s", [key, str(value)]
-        elif op == "$gte":
-            return "value->>%s >= %s", [key, str(value)]
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric > %s::numeric", [key, value]
+            else:
+                return "value->>%s > %s", [key, str(value)]
         elif op == "$lt":
-            return "value->>%s < %s", [key, str(value)]
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric < %s::numeric", [key, value]
+            else:
+                return "value->>%s < %s", [key, str(value)]
         elif op == "$lte":
-            return "value->>%s <= %s", [key, str(value)]
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric <= %s::numeric", [key, value]
+            else:
+                return "value->>%s <= %s", [key, str(value)]
+        elif op == "$gte":
+            if isinstance(value, (int, float)):
+                return "(value->>%s)::numeric >= %s::numeric", [key, value]
+            else:
+                return "value->>%s >= %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]
         else:

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -573,6 +573,26 @@ async def test_vector_search_with_filters(vector_store: AsyncPostgresStore) -> N
     assert len(results) == 1
     assert results[0].key == "doc3"
 
+async def test_numeric_filter_regression(
+    vector_store: AsyncPostgresStore,
+) -> None:
+    docs = [
+        ("doc1", {"score": 9}),
+        ("doc2", {"score": 10}),
+        ("doc3", {"score": 11}),
+    ]
+
+    for key, value in docs:
+        await vector_store.aput(("test",), key, value)
+
+    results = await vector_store.asearch(
+        ("test",),
+        filter={"score": {"$gte": 10}},
+    )
+
+    keys = {r.key for r in results}
+
+    assert keys == {"doc2", "doc3"}
 
 async def test_vector_search_pagination(vector_store: AsyncPostgresStore) -> None:
     """Test pagination with vector search."""


### PR DESCRIPTION
Fixes #7684

Numeric range filters (`$gt`, `$gte`, `$lt`, `$lte`) in `PostgresStore` were using text comparison via `->>`, which could produce incorrect results (e.g. `9` matching `{"score": {"$gte": 10}}`). This change casts numeric filter values to `numeric` for proper numeric comparison and adds a regression test covering the issue.

Verified by:

* Reproducing the bug with a regression test (fails on the original implementation).
* Running the regression test after the fix (passes).
* Running the async Postgres store test suite successfully.

