### PR TITLE
fix: correct typos 'Whats' -> 'What's' in test files

### DIFF
--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5856,7 +5856,7 @@ def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(ask(q).result())
 
         return {"answers": answers}
@@ -5867,13 +5867,13 @@ def test_task_before_interrupt_resume(
     result = workflow.invoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = workflow.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = workflow.invoke(Command(resume="answer2"), config=config)
@@ -5982,7 +5982,7 @@ def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -6002,13 +6002,13 @@ def test_node_before_interrupt_resume_graph_api(
     result = graph.invoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = graph.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = graph.invoke(Command(resume="answer2"), config=config)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8073,7 +8073,7 @@ async def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(await ask(q))
 
         return {"answers": answers}
@@ -8084,13 +8084,13 @@ async def test_task_before_interrupt_resume(
     result = await workflow.ainvoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await workflow.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = await workflow.ainvoke(Command(resume="answer2"), config=config)
@@ -8202,7 +8202,7 @@ async def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -8222,13 +8222,13 @@ async def test_node_before_interrupt_resume_graph_api(
     result = await graph.ainvoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await graph.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = await graph.ainvoke(Command(resume="answer2"), config=config)


### PR DESCRIPTION
## Summary
Fixed spelling typos found via codespell in test files.

## Changes
- `Whats` → `What's` in `test_pregel.py` (6 occurrences)
- `Whats` → `What's` in `test_pregel_async.py` (6 occurrences)

## Related Issue
Closes #5021