### PR TITLE
fix(checkpoint-postgres): compare numeric store filters numerically, not as text

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -623,14 +623,15 @@ class BasePostgresStore(Generic[C]):
         """Helper to generate filter conditions."""
         if op == "$eq":
             return "value->%s = %s::jsonb", [key, json.dumps(value)]
-        elif op == "$gt":
-            return "value->>%s > %s", [key, str(value)]
-        elif op == "$gte":
-            return "value->>%s >= %s", [key, str(value)]
-        elif op == "$lt":
-            return "value->>%s < %s", [key, str(value)]
-        elif op == "$lte":
-            return "value->>%s <= %s", [key, str(value)]
+        elif op in ("$gt", "$gte", "$lt", "$lte"):
+            sql_op = {"$gt": ">", "$gte": ">=", "$lt": "<", "$lte": "<="}[op]
+            # `->>` extracts JSON values as text, so comparisons are lexicographic by
+            # default (e.g. "9" > "10" is true). Cast to numeric for real numbers so
+            # that, for example, {"score": {"$gte": 10}} compares numerically (see #7684).
+            # Mirrors SqliteStore, which casts numeric comparisons with CAST(... AS REAL).
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return f"(value->>%s)::numeric {sql_op} %s", [key, value]
+            return f"value->>%s {sql_op} %s", [key, str(value)]
         elif op == "$ne":
             return "value->%s != %s::jsonb", [key, json.dumps(value)]
         else:

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -375,6 +375,45 @@ def test_search(store) -> None:
         store.delete(namespace, key)
 
 
+def test_numeric_comparison_filters(store) -> None:
+    # Regression test for #7684: `value->>key` extracts JSON as text, so the
+    # comparison operators compared lexicographically ("9" >= "10" is true).
+    # They must compare numerically for int/float values.
+    namespace = ("test", "scores")
+    for key, score in [("a", 2), ("b", 9), ("c", 10), ("d", 11)]:
+        store.put(namespace, key, {"score": score})
+
+    def scores(filter: dict) -> list:
+        return sorted(
+            item.value["score"] for item in store.search(namespace, filter=filter)
+        )
+
+    assert scores({"score": {"$gte": 10}}) == [10, 11]  # not [9, 10, 11]
+    assert scores({"score": {"$gt": 9}}) == [10, 11]
+    assert scores({"score": {"$lt": 10}}) == [2, 9]
+    assert scores({"score": {"$lte": 9}}) == [2, 9]
+
+    # Floats compare numerically too.
+    store.put(namespace, "e", {"score": 9.5})
+    assert scores({"score": {"$gt": 9}}) == [9.5, 10, 11]
+
+    # String comparisons remain lexicographic (unchanged behavior).
+    str_namespace = ("test", "names")
+    for key, name in [("a", "apple"), ("b", "banana")]:
+        store.put(str_namespace, key, {"name": name})
+    names = sorted(
+        item.value["name"]
+        for item in store.search(str_namespace, filter={"name": {"$gt": "apple"}})
+    )
+    assert names == ["banana"]
+
+    # Cleanup
+    for key in ["a", "b", "c", "d", "e"]:
+        store.delete(namespace, key)
+    for key in ["a", "b"]:
+        store.delete(str_namespace, key)
+
+
 @contextmanager
 def _create_vector_store(
     vector_type: str,


### PR DESCRIPTION
Fixes #7684

`PostgresStore` built `value->>key <op> %s` with `str(value)` for `$gt`/`$gte`/`$lt`/`$lte`. Postgres `->>` extracts JSON values as text, so numeric filters compared lexicographically: `"9" >= "10"` is true, so `filter={"score": {"$gte": 10}}` wrongly matched items with score 2..9.

For those operators, when the operand is a real number (`int`/`float`, not `bool`), this casts the extracted value to numeric (`(value->>key)::numeric <op> %s`) and passes the number, mirroring `SqliteStore`, which already casts numeric comparisons with `CAST(... AS REAL)`. String operands keep text comparison, and `$eq`/`$ne` are unchanged. The shared `_get_filter_condition` covers both the sync and async stores.

Added a regression test (`test_numeric_comparison_filters`) covering int/float numeric comparisons and confirming string comparisons stay lexicographic.
