### PR TITLE
release(langgraph): 1.2.6

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.6"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.6"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.6"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Releases `langgraph` 1.2.6.

Bumps the package version `1.2.5` → `1.2.6` and propagates it into the `langgraph`, `prebuilt`, and `sdk-py` lockfiles. No dependency floor or source changes.