### PR TITLE
fix: disable autocommit when using pipeline in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, autocommit=not pipeline, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
`AsyncPostgresSaver.from_conn_string` with `pipeline=True` consistently fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This occurs because the connection is created with `autocommit=True`, which is incompatible with pipelining in psycopg. When autocommit is enabled, each statement is sent immediately, breaking the pipeline batching and causing unexpected connection closures.

## Fix
Set `autocommit=False` when `pipeline=True` in the `from_conn_string` method. This ensures that the connection operates in manual commit mode, which is required for proper pipeline functionality.

Closes #5675