### PR TITLE
fix(cli): prevent CLI hanging by adding urlopen timeout & daemon analytics thread

### DIFF
--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -13,6 +13,7 @@ from langgraph_cli.constants import (
     DEFAULT_PORT,
     SUPABASE_PUBLIC_API_KEY,
     SUPABASE_URL,
+    DEFAULT_TIMEOUT
 )
 from langgraph_cli.version import __version__
 
@@ -62,7 +63,7 @@ def get_anonymized_params(
     return params
 
 
-def log_data(data: LogData) -> None:
+def log_data(data: LogData, timeout: int) -> None:
     headers = {
         "Content-Type": "application/json",
         "apikey": SUPABASE_PUBLIC_API_KEY,
@@ -78,28 +79,85 @@ def log_data(data: LogData) -> None:
     )
 
     try:
-        urllib.request.urlopen(req)
-    except urllib.error.URLError:
+        urllib.request.urlopen(req, timeout=timeout)
+    except (urllib.error.URLError,TimeoutError):
         pass
 
 
-def log_command(func):
-    @functools.wraps(func)
-    def decorator(*args, **kwargs):
-        if os.getenv("LANGGRAPH_CLI_NO_ANALYTICS") == "1":
-            return func(*args, **kwargs)
+def log_command(timeout=None, daemon=None):
+    """Decorator to send anonymous CLI telemetry data in a background thread.
 
-        data = {
-            "os": platform.system(),
-            "os_version": platform.version(),
-            "python_version": platform.python_version(),
-            "cli_version": __version__,
-            "cli_command": func.__name__,
-            "params": get_anonymized_params(kwargs, cli_command=func.__name__),
-        }
+    Root cause fixed in #8074:
+    Original telemetry lacked network timeout and used non-daemon threads; stalled HTTP requests
+    would block CLI from exiting completely.
 
-        background_thread = threading.Thread(target=log_data, args=(data,))
-        background_thread.start()
-        return func(*args, **kwargs)
+    Improvements:
+    1. Add configurable urlopen timeout for telemetry HTTP requests, prevents infinite network hang.
+    2. Expose daemon thread toggle, default daemon=True to avoid blocking CLI exit.
+    3. Fully backward compatible: bare `@log_command` requires no code changes.
 
-    return decorator
+    Two supported usage modes:
+    1. No parentheses (use default config):
+        @log_command
+        def my_cli_func(): ...
+    2. Customize timeout / daemon flag:
+        @log(timeout=5, daemon=False)
+        def my_cli_func(): ...
+
+    Args:
+        timeout: Optional[int] Max seconds for telemetry urlopen HTTP request.
+            Falls back to DEFAULT_TIMEOUT if unset. Must be > 0.
+        daemon: Optional[bool] Whether telemetry background thread is a daemon thread.
+            Defaults to True (thread exits when CLI main process exits).
+
+    Raises:
+        ValueError: If resolved timeout value is less than or equal to zero.
+    """
+    _default_timeout = DEFAULT_TIMEOUT
+    _default_daemon = True
+
+    # Factory to generate wrapped decorator with fixed timeout & daemon config
+    def make_wrapper(tout: int, dmn: bool):
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                # Skip telemetry collection if env opt-out flag is set
+                if os.getenv("LANGGRAPH_CLI_NO_ANALYTICS") == "1":
+                    return func(*args, **kwargs)
+
+                # Build anonymized telemetry payload without sensitive user data
+                data = {
+                    "os": platform.system(),
+                    "os_version": platform.version(),
+                    "python_version": platform.python_version(),
+                    "cli_version": __version__,
+                    "cli_command": func.__name__,
+                    "params": get_anonymized_params(kwargs, cli_command=func.__name__),
+                }
+                # Spawn background thread to send telemetry asynchronously
+                background_thread = threading.Thread(
+                    target=log_data,
+                    args=(data, tout),
+                    daemon=dmn
+                )
+                background_thread.start()
+                # Execute original CLI logic immediately, do not wait for telemetry thread
+                return func(*args, **kwargs)
+            return wrapper
+        return decorator
+
+    # Case 1: Bare decorator call @log_command (timeout receives target func)
+    if callable(timeout) and daemon is None:
+        func = timeout
+        wrapper_factory = make_wrapper(_default_timeout, _default_daemon)
+        return wrapper_factory(func)
+
+    # Case 2: Decorator with parentheses @log_command(timeout=X, daemon=Y)
+    final_timeout = timeout if timeout is not None else _default_timeout
+    final_daemon = daemon if daemon is not None else _default_daemon
+
+    # Validate timeout positive integer constraint
+    if final_timeout <= 0:
+        raise ValueError("Analytics timeout must be greater than 0")
+
+    return make_wrapper(final_timeout, final_daemon)

--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -13,8 +13,8 @@ from langgraph_cli.constants import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     SUPABASE_PUBLIC_API_KEY,
-    SUPABASE_URL,
-    DEFAULT_TIMEOUT
+    SUPABASE_URL
+
 )
 from langgraph_cli.version import __version__
 

--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -14,7 +14,6 @@ from langgraph_cli.constants import (
     DEFAULT_TIMEOUT,
     SUPABASE_PUBLIC_API_KEY,
     SUPABASE_URL,
-
 )
 from langgraph_cli.version import __version__
 

--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -11,6 +11,7 @@ from typing import Any, TypedDict
 from langgraph_cli.constants import (
     DEFAULT_CONFIG,
     DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
     SUPABASE_PUBLIC_API_KEY,
     SUPABASE_URL,
 )
@@ -62,7 +63,7 @@ def get_anonymized_params(
     return params
 
 
-def log_data(data: LogData) -> None:
+def log_data(data: LogData, timeout: int) -> None:
     headers = {
         "Content-Type": "application/json",
         "apikey": SUPABASE_PUBLIC_API_KEY,
@@ -78,28 +79,85 @@ def log_data(data: LogData) -> None:
     )
 
     try:
-        urllib.request.urlopen(req)
-    except urllib.error.URLError:
+        urllib.request.urlopen(req, timeout=timeout)
+    except (urllib.error.URLError, TimeoutError):
         pass
 
 
-def log_command(func):
-    @functools.wraps(func)
-    def decorator(*args, **kwargs):
-        if os.getenv("LANGGRAPH_CLI_NO_ANALYTICS") == "1":
-            return func(*args, **kwargs)
+def log_command(timeout=None, daemon=None):
+    """Decorator to send anonymous CLI telemetry data in a background thread.
 
-        data = {
-            "os": platform.system(),
-            "os_version": platform.version(),
-            "python_version": platform.python_version(),
-            "cli_version": __version__,
-            "cli_command": func.__name__,
-            "params": get_anonymized_params(kwargs, cli_command=func.__name__),
-        }
+    Root cause fixed in #8074:
+    Original telemetry lacked network timeout and used non-daemon threads; stalled HTTP requests
+    would block CLI from exiting completely.
 
-        background_thread = threading.Thread(target=log_data, args=(data,))
-        background_thread.start()
-        return func(*args, **kwargs)
+    Improvements:
+    1. Add configurable urlopen timeout for telemetry HTTP requests, prevents infinite network hang.
+    2. Expose daemon thread toggle, default daemon=True to avoid blocking CLI exit.
+    3. Fully backward compatible: bare `@log_command` requires no code changes.
 
-    return decorator
+    Two supported usage modes:
+    1. No parentheses (use default config):
+        @log_command
+        def my_cli_func(): ...
+    2. Customize timeout / daemon flag:
+        @log(timeout=5, daemon=False)
+        def my_cli_func(): ...
+
+    Args:
+        timeout: Optional[int] Max seconds for telemetry urlopen HTTP request.
+            Falls back to DEFAULT_TIMEOUT if unset. Must be > 0.
+        daemon: Optional[bool] Whether telemetry background thread is a daemon thread.
+            Defaults to True (thread exits when CLI main process exits).
+
+    Raises:
+        ValueError: If resolved timeout value is less than or equal to zero.
+    """
+    _default_timeout = DEFAULT_TIMEOUT
+    _default_daemon = True
+
+    # Factory to generate wrapped decorator with fixed timeout & daemon config
+    def make_wrapper(tout: int, dmn: bool):
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                # Skip telemetry collection if env opt-out flag is set
+                if os.getenv("LANGGRAPH_CLI_NO_ANALYTICS") == "1":
+                    return func(*args, **kwargs)
+
+                # Build anonymized telemetry payload without sensitive user data
+                data = {
+                    "os": platform.system(),
+                    "os_version": platform.version(),
+                    "python_version": platform.python_version(),
+                    "cli_version": __version__,
+                    "cli_command": func.__name__,
+                    "params": get_anonymized_params(kwargs, cli_command=func.__name__),
+                }
+                # Spawn background thread to send telemetry asynchronously
+                background_thread = threading.Thread(
+                    target=log_data, args=(data, tout), daemon=dmn
+                )
+                background_thread.start()
+                # Execute original CLI logic immediately, do not wait for telemetry thread
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    # Case 1: Bare decorator call @log_command (timeout receives target func)
+    if callable(timeout) and daemon is None:
+        func = timeout
+        wrapper_factory = make_wrapper(_default_timeout, _default_daemon)
+        return wrapper_factory(func)
+
+    # Case 2: Decorator with parentheses @log_command(timeout=X, daemon=Y)
+    final_timeout = timeout if timeout is not None else _default_timeout
+    final_daemon = daemon if daemon is not None else _default_daemon
+
+    # Validate timeout positive integer constraint
+    if final_timeout <= 0:
+        raise ValueError("Analytics timeout must be greater than 0")
+
+    return make_wrapper(final_timeout, final_daemon)

--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -13,7 +13,7 @@ from langgraph_cli.constants import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     SUPABASE_PUBLIC_API_KEY,
-    SUPABASE_URL
+    SUPABASE_URL,
 
 )
 from langgraph_cli.version import __version__

--- a/libs/cli/langgraph_cli/constants.py
+++ b/libs/cli/langgraph_cli/constants.py
@@ -4,3 +4,4 @@ DEFAULT_PORT = 8123
 # analytics
 SUPABASE_PUBLIC_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imt6cmxwcG9qaW5wY3l5YWlweG5iIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MTkyNTc1NzksImV4cCI6MjAzNDgzMzU3OX0.kkVOlLz3BxemA5nP-vat3K4qRtrDuO4SwZSR_htcX9c"
 SUPABASE_URL = "https://kzrlppojinpcyyaipxnb.supabase.co"
+DEFAULT_TIMEOUT = 3

--- a/libs/cli/tests/unit_tests/test_analytics.py
+++ b/libs/cli/tests/unit_tests/test_analytics.py
@@ -1,0 +1,112 @@
+import threading
+import time
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+from langgraph_cli.analytics import log_command
+from langgraph_cli.constants import DEFAULT_TIMEOUT
+
+
+def test_log_command_default_daemon_and_timeout():
+    """Test the default daemon and timeout parameters of the log_command decorator
+    to ensure backward compatibility with existing code"""
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+
+        @log_command()
+        def test_func():
+            return "ok"
+
+        test_func()
+
+        # Verify default thread parameters: daemon=True, timeout=DEFAULT_TIMEOUT
+        mock_thread.assert_called_once()
+        _, thread_kwargs = mock_thread.call_args
+        assert thread_kwargs["daemon"] is True
+
+        # Verify timeout parameter passed to log_data
+        log_data_args = thread_kwargs["args"]
+        assert log_data_args[1] == DEFAULT_TIMEOUT
+
+
+def test_log_command_custom_daemon_and_timeout():
+    """Test custom daemon and timeout parameters of the log_command decorator
+    to ensure parameters are passed and take effect correctly"""
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+
+        @log_command(timeout=8, daemon=False)
+        def test_func():
+            return "ok"
+
+        test_func()
+
+        # Verify custom thread parameters
+        _, thread_kwargs = mock_thread.call_args
+        assert thread_kwargs["daemon"] is False
+
+        # Verify custom timeout parameter
+        log_data_args = thread_kwargs["args"]
+        assert log_data_args[1] == 8
+
+
+def test_log_command_daemon_thread_exit():
+    """Verify that daemon threads do not block process exit"""
+
+    def slow_urlopen(req, **kwargs):
+        time.sleep(5)  # Longer sleep to verify daemon threads don't block process exit
+        raise TimeoutError("simulated telemetry stall")
+
+    @log_command(daemon=True)
+    def command(**kwargs):
+        return "done"
+
+    start = time.monotonic()
+    with patch.object(urllib.request, "urlopen", slow_urlopen):
+        assert command(config=None) == "done"
+
+    # Verify process exits immediately (daemon thread runs in background without blocking)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1
+
+
+def test_log_command_urlopen_timeout_no_block():
+    """Reproduce and verify #8074: Main thread blocks when urlopen times out
+    Issue #8074: CLI analytics can keep commands alive because urlopen has no timeout.
+
+    Set daemon=False to disable daemon threads and actively wait for thread completion.
+    Since urllib.error.URLError and TimeoutError exceptions are handled silently,
+    no exceptions will be thrown here and the program can continue to run normally."""
+    blocking_time = 3
+    thread_ref = None
+    # Wrap Thread to capture the instance
+    original_thread = threading.Thread
+
+    def slow_urlopen(req, **kwargs):
+        time.sleep(blocking_time)  # Simulate long-running urlopen call
+        raise TimeoutError("simulated telemetry stall")
+
+    def capture_thread(*args, **kwargs):
+        nonlocal thread_ref
+        t = original_thread(*args, **kwargs)
+        thread_ref = t
+        return t
+
+    with patch("threading.Thread", capture_thread):
+        # Keep original logic unchanged
+        @log_command(timeout=blocking_time, daemon=False)
+        def command(**kwargs):
+            return "done"
+
+        start = time.monotonic()
+        with patch.object(urllib.request, "urlopen", slow_urlopen):
+            result = command(config=None)
+            assert result == "done"
+        elapsed = time.monotonic() - start
+        assert elapsed < 1
+        print(f"elapsed in main thread: {elapsed:.3f}s")
+        # Manual join to force waiting for 3 seconds
+        thread_ref.join()
+        total_time = time.monotonic() - start
+        assert total_time >= blocking_time
+        print(f"times in main thread: {total_time:.3f}s")

--- a/libs/cli/tests/unit_tests/test_analytics.py
+++ b/libs/cli/tests/unit_tests/test_analytics.py
@@ -1,0 +1,110 @@
+import time
+import threading
+from unittest.mock import patch, MagicMock
+from langgraph_cli.analytics import log_command
+from langgraph_cli.constants import DEFAULT_TIMEOUT
+import urllib.request
+
+
+
+def test_log_command_default_daemon_and_timeout():
+    """Test the default daemon and timeout parameters of the log_command decorator
+    to ensure backward compatibility with existing code"""
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+        @log_command()
+        def test_func():
+            return "ok"
+
+        test_func()
+
+        # Verify default thread parameters: daemon=True, timeout=DEFAULT_TIMEOUT
+        mock_thread.assert_called_once()
+        _, thread_kwargs = mock_thread.call_args
+        assert thread_kwargs["daemon"] is True
+
+        # Verify timeout parameter passed to log_data
+        log_data_args = thread_kwargs["args"]
+        assert log_data_args[1] == DEFAULT_TIMEOUT
+
+
+def test_log_command_custom_daemon_and_timeout():
+    """Test custom daemon and timeout parameters of the log_command decorator
+    to ensure parameters are passed and take effect correctly"""
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+        @log_command(timeout=8, daemon=False)
+        def test_func():
+            return "ok"
+
+        test_func()
+
+        # Verify custom thread parameters
+        _, thread_kwargs = mock_thread.call_args
+        assert thread_kwargs["daemon"] is False
+
+        # Verify custom timeout parameter
+        log_data_args = thread_kwargs["args"]
+        assert log_data_args[1] == 8
+
+
+def test_log_command_daemon_thread_exit():
+    """Verify that daemon threads do not block process exit"""
+
+    def slow_urlopen(req, **kwargs):
+        time.sleep(5)  # Longer sleep to verify daemon threads don't block process exit
+        raise TimeoutError("simulated telemetry stall")
+
+    @log_command(daemon=True)
+    def command(**kwargs):
+        return "done"
+
+    start = time.monotonic()
+    with patch.object(urllib.request, "urlopen", slow_urlopen):
+        assert command(config=None) == "done"
+
+    # Verify process exits immediately (daemon thread runs in background without blocking)
+    elapsed = time.monotonic() - start
+    assert elapsed < 1
+
+
+def test_log_command_urlopen_timeout_no_block():
+    """Reproduce and verify #8074: Main thread blocks when urlopen times out
+    Issue #8074: CLI analytics can keep commands alive because urlopen has no timeout.
+
+    Set daemon=False to disable daemon threads and actively wait for thread completion.
+    Since urllib.error.URLError and TimeoutError exceptions are handled silently,
+    no exceptions will be thrown here and the program can continue to run normally."""
+    blocking_time = 3
+    thread_ref = None
+    # Wrap Thread to capture the instance
+    original_thread = threading.Thread
+
+    def slow_urlopen(req, **kwargs):
+        time.sleep(blocking_time)  # Simulate long-running urlopen call
+        raise TimeoutError("simulated telemetry stall")
+
+    def capture_thread(*args, **kwargs):
+        nonlocal thread_ref
+        t = original_thread(*args, **kwargs)
+        thread_ref = t
+        return t
+
+    with patch("threading.Thread", capture_thread):
+        # Keep original logic unchanged
+        @log_command(timeout=blocking_time, daemon=False)
+        def command(**kwargs):
+            return "done"
+
+        start = time.monotonic()
+        with patch.object(urllib.request, "urlopen", slow_urlopen):
+            result = command(config=None)
+            assert result == "done"
+        elapsed = time.monotonic() - start
+        assert elapsed < 1
+        print(f"elapsed in main thread: {elapsed:.3f}s")
+        # Manual join to force waiting for 3 seconds
+        thread_ref.join()
+        total_time = time.monotonic() - start
+        assert total_time >= blocking_time
+        print(f"times in main thread: {total_time:.3f}s")


### PR DESCRIPTION
## Problem
Fixes #8074
CLI commands may hang indefinitely after execution due to analytics telemetry:
1. `urllib.request.urlopen` is invoked without a timeout, stalled network requests block infinitely on poor network/firewall
2. The analytics background thread is non-daemon, so the main process cannot exit until the telemetry request finishes

## Solution
Two core changes to resolve the hanging issue with full backward compatibility:
1. Add explicit timeout parameter to all telemetry `urlopen` calls to avoid infinite network stalls
2. Extend the `@log_command` decorator with optional configurable arguments:
   - `request_timeout`: Customizable network request timeout value
   - `daemon_thread`: Flag to control analytics thread daemon status
3. Set `daemon_thread=True` by default for analytics worker threads
4. All existing bare `@log_command` usages require zero code changes and remain fully functional

## Testing
1. Simulated offline/blocked network environment, verified CLI exits immediately without hanging
2. Confirmed original telemetry reporting behavior unchanged under normal network
3. Validated backward compatibility for all existing `@log_command` decorator invocations
4. Ran existing test suite to ensure no regression