### PR TITLE
fix: add serde parameter to sync PostgresSaver.from_conn_string()

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -62,13 +62,18 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: Serializer to use for checkpoint serialization.
 
         Returns:
             PostgresSaver: A new PostgresSaver instance.
@@ -78,9 +83,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -209,13 +209,18 @@ class ShallowPostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator["ShallowPostgresSaver"]:
         """Create a new ShallowPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: Serializer to use for checkpoint serialization.
 
         Returns:
             ShallowPostgresSaver: A new ShallowPostgresSaver instance.
@@ -225,9 +230,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
Fixes #8116

Adds the `serde` parameter to the sync `PostgresSaver.from_conn_string()` and `ShallowPostgresSaver.from_conn_string()` classmethods so users can pass custom serializers (JsonPlusSerializer, EncryptedSerializer, etc.) when initializing via connection string.

Both the sync methods were missing this parameter while their async counterparts (`AsyncPostgresSaver.from_conn_string()` and `AsyncShallowPostgresSaver.from_conn_string()`) already accepted it.