### PR TITLE
fix(tool_node): handle MCP tool content block lists in _normalize_tool_response

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1442,6 +1442,15 @@ class ToolNode(RunnableCallable):
             response.content = cast("str | list", msg_content_output(response.content))
             return response
         if isinstance(response, list):
+            if all(
+                isinstance(r, dict) and r.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for r in response
+            ):
+                return ToolMessage(
+                    content=response,
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                )
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
             msg = (


### PR DESCRIPTION
## Summary
Fixes #7985: `ToolNode._normalize_tool_response` raises `TypeError` for MCP tools returning content block lists.

## Root Cause
MCP (Model Context Protocol) tools can return a `list[dict]` of content blocks, which is a valid LangChain Core message content format. However, `_normalize_tool_response` only handled `Command`, `ToolMessage`, or `list[Command|ToolMessage]` — not raw content block dicts. This caused a `TypeError` when MCP tools returned content block formatted responses.

## Fix
Added a new condition to detect when the response is a list of content block dictionaries (checking for recognized `type` keys like `"text"`, `"image_url"`, etc.), and wraps them in a `ToolMessage` with the appropriate `name` and `tool_call_id`.

## Testing
- MCP tools returning content block lists now produce valid `ToolMessage` objects
- Existing tool response normalization paths are unaffected
