### PR TITLE
fix: add serde parameter to sync PostgresSaver.from_conn_string()

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -62,13 +62,18 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: Serializer to use for checkpoint serialization.
 
         Returns:
             PostgresSaver: A new PostgresSaver instance.
@@ -78,9 +83,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -209,13 +209,18 @@ class ShallowPostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator["ShallowPostgresSaver"]:
         """Create a new ShallowPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: Serializer to use for checkpoint serialization.
 
         Returns:
             ShallowPostgresSaver: A new ShallowPostgresSaver instance.
@@ -225,9 +230,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -22,6 +22,7 @@ from langgraph.checkpoint.postgres.aio import (
     AsyncPostgresSaver,
     AsyncShallowPostgresSaver,
 )
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from tests.conftest import DEFAULT_POSTGRES_URI
 
 
@@ -415,3 +416,95 @@ async def test_delta_channel_chain_reconstruction(saver_name: str) -> None:
         assert msgs[1].content == "reply-1"
         assert msgs[2].content == "there"
         assert msgs[3].content == "reply-3"
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+async def test_async_from_conn_string_serde_default(pipeline_flag: bool) -> None:
+    """Verify omitting serde on AsyncPostgresSaver keeps default."""
+    database = f"test_{uuid4().hex[:16]}"
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with AsyncPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+        ) as saver:
+            await saver.setup()
+            assert saver.serde is None
+    finally:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+async def test_async_from_conn_string_serde_custom(pipeline_flag: bool) -> None:
+    """Verify custom serde is propagated through AsyncPostgresSaver.from_conn_string."""
+    database = f"test_{uuid4().hex[:16]}"
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        custom_serde = JsonPlusSerializer()
+        async with AsyncPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+            serde=custom_serde,
+        ) as saver:
+            await saver.setup()
+            assert saver.serde is custom_serde
+    finally:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+async def test_async_shallow_from_conn_string_serde_custom(pipeline_flag: bool) -> None:
+    """Verify custom serde on AsyncShallowPostgresSaver.from_conn_string."""
+    database = f"test_{uuid4().hex[:16]}"
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        custom_serde = JsonPlusSerializer()
+        async with AsyncShallowPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+            serde=custom_serde,
+        ) as saver:
+            await saver.setup()
+            assert saver.serde is custom_serde
+    finally:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+async def test_async_shallow_from_conn_string_serde_default(pipeline_flag: bool) -> None:
+    """Verify omitting serde on AsyncShallowPostgresSaver keeps default."""
+    database = f"test_{uuid4().hex[:16]}"
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI, autocommit=True
+    ) as conn:
+        await conn.execute(f"CREATE DATABASE {database}")
+    try:
+        async with AsyncShallowPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+        ) as saver:
+            await saver.setup()
+            assert saver.serde is None
+    finally:
+        async with await AsyncConnection.connect(
+            DEFAULT_POSTGRES_URI, autocommit=True
+        ) as conn:
+            await conn.execute(f"DROP DATABASE {database}")

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -20,6 +20,7 @@ from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 
 from langgraph.checkpoint.postgres import PostgresSaver, ShallowPostgresSaver
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from tests.conftest import DEFAULT_POSTGRES_URI
 
 
@@ -358,3 +359,79 @@ def test_get_checkpoint_no_channel_values(
 
         checkpoint = saver.get_tuple(config)
         assert checkpoint.checkpoint["channel_values"] == {}
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+def test_from_conn_string_serde_default(pipeline_flag: bool) -> None:
+    """Verify omitting serde keeps default (no regression)."""
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+    try:
+        with PostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+        ) as saver:
+            saver.setup()
+            assert saver.serde is None
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+def test_from_conn_string_serde_custom(pipeline_flag: bool) -> None:
+    """Verify custom serde is passed through from_conn_string in both pipeline and non-pipeline paths."""
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+    try:
+        custom_serde = JsonPlusSerializer()
+        with PostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+            serde=custom_serde,
+        ) as saver:
+            saver.setup()
+            assert saver.serde is custom_serde
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+def test_shallow_from_conn_string_serde_custom(pipeline_flag: bool) -> None:
+    """Verify custom serde is passed through ShallowPostgresSaver.from_conn_string."""
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+    try:
+        custom_serde = JsonPlusSerializer()
+        with ShallowPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+            serde=custom_serde,
+        ) as saver:
+            saver.setup()
+            assert saver.serde is custom_serde
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")
+
+
+@pytest.mark.parametrize("pipeline_flag", [False, True])
+def test_shallow_from_conn_string_serde_default(pipeline_flag: bool) -> None:
+    """Verify omitting serde on ShallowPostgresSaver keeps default."""
+    database = f"test_{uuid4().hex[:16]}"
+    with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {database}")
+    try:
+        with ShallowPostgresSaver.from_conn_string(
+            DEFAULT_POSTGRES_URI + database,
+            pipeline=pipeline_flag,
+        ) as saver:
+            saver.setup()
+            assert saver.serde is None
+    finally:
+        with Connection.connect(DEFAULT_POSTGRES_URI, autocommit=True) as conn:
+            conn.execute(f"DROP DATABASE {database}")


### PR DESCRIPTION
Fixes #8116

Adds the `serde` parameter to the sync `PostgresSaver.from_conn_string()` and `ShallowPostgresSaver.from_conn_string()` classmethods so users can pass custom serializers (JsonPlusSerializer, EncryptedSerializer, etc.) when initializing via connection string.

Both the sync methods were missing this parameter while their async counterparts (`AsyncPostgresSaver.from_conn_string()` and `AsyncShallowPostgresSaver.from_conn_string()`) already accepted it.

### Tests added
8 new test cases covering all constructor branches:
* `PostgresSaver.from_conn_string` — pipeline + non-pipeline, with and without `serde=`
* `ShallowPostgresSaver.from_conn_string` — pipeline + non-pipeline, with and without `serde=`
* `AsyncPostgresSaver.from_conn_string` — pipeline + non-pipeline, with and without `serde=`
* `AsyncShallowPostgresSaver.from_conn_string` — pipeline + non-pipeline, with and without `serde=

Each custom-serde test asserts the exact object reference is preserved (`saver.serde is custom_serde`).
Each default test asserts `saver.serde is None` (no regression).