### PR TITLE
fix: disable autocommit when using psycopg pipeline in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
When `AsyncPostgresSaver.from_conn_string()` is called with `pipeline=True`, the connection is created with `autocommit=True`. However, psycopg's `AsyncPipeline` mode is incompatible with autocommit mode. Pipeline mode requires the connection to manage transaction boundaries manually; autocommit causes each statement to be sent immediately, which conflicts with the pipeline's batching mechanism. This results in `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`.

## Fix
Remove `autocommit=True` from the `AsyncConnection.connect()` call. The default is `False`, which allows pipeline mode to function correctly. When pipeline is not used, the connection will also work correctly (it will still benefit from the previous default behavior of explicit transaction management in the saver's methods).

Closes #5675