### PR TITLE
fix(checkpoint): preserve deque maxlen on JsonPlusSerializer round-trip

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -378,11 +378,22 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
             ),
         )
-    elif isinstance(obj, (set, frozenset, deque)):
+    elif isinstance(obj, (set, frozenset)):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, tuple(obj)),
+            ),
+        )
+    elif isinstance(obj, deque):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (tuple(obj), obj.maxlen),
+                ),
             ),
         )
     elif isinstance(obj, (IPv4Address, IPv4Interface, IPv4Network)):
@@ -660,8 +671,12 @@ def _create_msgpack_ext_hook(
                     return tup[2]
                 if tup[0] == "langgraph.types" and tup[1] == "Send":
                     return _send_from_args(tup[2])
+                cls = getattr(importlib.import_module(tup[0]), tup[1])
+                if isclass(cls) and issubclass(cls, deque):
+                    # elements, maxlen
+                    return cls(tup[2][0], maxlen=tup[2][1])
                 # module, name, args
-                return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
+                return cls(*tup[2])
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
@@ -774,6 +789,9 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             )
             if tup[0] == "langgraph.types" and tup[1] == "Send":
                 return _send_from_args(tup[2])
+            if tup[0] == "collections" and tup[1] == "deque":
+                # elements, maxlen
+                return tup[2][0]
             # module, name, args
             return tup[2]
         except Exception:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -30,6 +30,7 @@ from langgraph.checkpoint.serde.event_hooks import (
     register_serde_event_listener,
 )
 from langgraph.checkpoint.serde.jsonplus import (
+    EXT_CONSTRUCTOR_SINGLE_ARG,
     EXT_METHOD_SINGLE_ARG,
     InvalidModuleError,
     JsonPlusSerializer,
@@ -331,6 +332,40 @@ def test_serde_jsonplus_bytes() -> None:
 
     assert dumped == ("bytes", some_bytes)
     assert serde.loads_typed(dumped) == some_bytes
+
+
+def test_serde_jsonplus_deque_maxlen() -> None:
+    serde = JsonPlusSerializer()
+
+    # bounded deque keeps its maxlen and eviction behavior across a round-trip
+    bounded = deque([1, 2, 3], maxlen=3)
+    restored = serde.loads_typed(serde.dumps_typed(bounded))
+    assert isinstance(restored, deque)
+    assert list(restored) == [1, 2, 3]
+    assert restored.maxlen == 3
+    restored.append(99)
+    restored.append(100)
+    assert list(restored) == [3, 99, 100]
+
+    # unbounded deque round-trips with maxlen still None
+    unbounded = deque([1, 2, 3])
+    restored = serde.loads_typed(serde.dumps_typed(unbounded))
+    assert isinstance(restored, deque)
+    assert list(restored) == [1, 2, 3]
+    assert restored.maxlen is None
+
+    # legacy single-arg payloads (written before maxlen support) still load
+    legacy = ormsgpack.packb(
+        ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(("collections", "deque", (1, 2, 3))),
+        ),
+        option=ormsgpack.OPT_NON_STR_KEYS,
+    )
+    restored = serde.loads_typed(("msgpack", legacy))
+    assert isinstance(restored, deque)
+    assert list(restored) == [1, 2, 3]
+    assert restored.maxlen is None
 
 
 def test_lc2_json_safe_type_revives_without_allowlist() -> None:


### PR DESCRIPTION
Fixes #8157

`JsonPlusSerializer` was dropping a `deque`'s `maxlen` on a msgpack round-trip, so a bounded deque came back unbounded. `deque` was sharing the `(set, frozenset, deque)` single-argument constructor branch added in #1311, which only serialized the elements.

This splits `deque` into its own extension that carries `(elements, maxlen)` and reconstructs `deque(elements, maxlen=...)` on decode. `set` and `frozenset` encoding is unchanged, and older single-argument deque payloads still load (their `maxlen` reads back as `None`). Only the `checkpoint` package is touched.

How I verified: I added `test_serde_jsonplus_deque_maxlen` in `libs/checkpoint/tests/test_jsonplus.py`, covering a bounded deque (maxlen and eviction order preserved), an unbounded deque (maxlen stays `None`), and a legacy single-argument payload. The checkpoint package test suite passes locally.
