### PR TITLE
ci: add codespell linting

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -51,6 +51,11 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: uv sync --frozen --group lint
 
+      - name: Check spelling
+        if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'
+        working-directory: ${{ inputs.working-directory }}
+        run: uv run codespell --toml pyproject.toml
+
       - name: Analysing package code with our lint
         if: steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch'
         working-directory: ${{ inputs.working-directory }}

--- a/libs/checkpoint-conformance/pyproject.toml
+++ b/libs/checkpoint-conformance/pyproject.toml
@@ -23,6 +23,7 @@ test = [
   "pytest-asyncio",
 ]
 lint = [
+  "codespell",
   "ruff",
   "ty",
 ]

--- a/libs/checkpoint-conformance/uv.lock
+++ b/libs/checkpoint-conformance/uv.lock
@@ -149,6 +149,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9d/1d0903dff693160f893ca6abcabad545088e7a2ee0a6deae7c24e958be69/codespell-2.4.2.tar.gz", hash = "sha256:3c33be9ae34543807f088aeb4832dfad8cb2dae38da61cac0a7045dd376cfdf3", size = 352058, upload-time = "2026-03-05T18:10:42.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a1/52fa05533e95fe45bcc09bcf8a503874b1c08f221a4e35608017e0938f55/codespell-2.4.2-py3-none-any.whl", hash = "sha256:97e0c1060cf46bd1d5db89a936c98db8c2b804e1fdd4b5c645e82a1ec6b1f886", size = 353715, upload-time = "2026-03-05T18:10:41.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -335,12 +344,14 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codespell" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -354,12 +365,14 @@ requires-dist = [{ name = "langgraph-checkpoint", editable = "../checkpoint" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
 ]

--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -70,6 +70,7 @@ test = [
 ]
 lint = [
     "ruff",
+    "codespell",
     "ty",
     "types-requests",
 ]

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5856,7 +5856,7 @@ def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(ask(q).result())
 
         return {"answers": answers}
@@ -5867,13 +5867,13 @@ def test_task_before_interrupt_resume(
     result = workflow.invoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = workflow.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = workflow.invoke(Command(resume="answer2"), config=config)
@@ -5953,9 +5953,9 @@ def test_no_redundant_put_writes_for_cached_task(
         return orig(self, task_id, writes)
 
     with patch.object(PregelLoop, "put_writes", spy):
-        result = workflow.invoke(Command(resume="ans"), config=config)
+        result = workflow.invoke(Command(resume="answer"), config=config)
 
-    assert result == {"answer": "ans"}
+    assert result == {"answer": "answer"}
     # Count unique non-null task IDs that got put_writes.
     # Should be exactly 2: the ask task and the entrypoint task.
     # If 3, the cached setup task is being redundantly re-committed.
@@ -5982,7 +5982,7 @@ def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -6002,13 +6002,13 @@ def test_node_before_interrupt_resume_graph_api(
     result = graph.invoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = graph.invoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = graph.invoke(Command(resume="answer2"), config=config)

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8073,7 +8073,7 @@ async def test_task_before_interrupt_resume(
 
         answers = []
         for i in range(n):
-            q = f"Whats the answer for topic {i + 1}?"
+            q = f"What's the answer for topic {i + 1}?"
             answers.append(await ask(q))
 
         return {"answers": answers}
@@ -8084,13 +8084,13 @@ async def test_task_before_interrupt_resume(
     result = await workflow.ainvoke(2, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await workflow.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should get final result
     result = await workflow.ainvoke(Command(resume="answer2"), config=config)
@@ -8172,9 +8172,9 @@ async def test_no_redundant_put_writes_for_cached_task(
         return orig(self, task_id, writes)
 
     with patch.object(PregelLoop, "put_writes", spy):
-        result = await workflow.ainvoke(Command(resume="ans"), config=config)
+        result = await workflow.ainvoke(Command(resume="answer"), config=config)
 
-    assert result == {"answer": "ans"}
+    assert result == {"answer": "answer"}
     # Count unique non-null task IDs that got put_writes.
     # Should be exactly 2: the ask task and the entrypoint task.
     # If 3, the cached setup task is being redundantly re-committed.
@@ -8202,7 +8202,7 @@ async def test_node_before_interrupt_resume_graph_api(
     def ask(state: State) -> dict:
         answers = []
         for topic in state["topics"]:
-            answer = interrupt(f"Whats the answer for {topic}?")
+            answer = interrupt(f"What's the answer for {topic}?")
             answers.append(answer)
         return {"answers": answers}
 
@@ -8222,13 +8222,13 @@ async def test_node_before_interrupt_resume_graph_api(
     result = await graph.ainvoke({"topics": ["a", "b"], "answers": []}, config=config)
     assert "__interrupt__" in result
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 1?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 1?"
 
     # Resume with answer for topic 1 - should get second interrupt
     result = await graph.ainvoke(Command(resume="answer1"), config=config)
     assert "__interrupt__" in result, f"Expected interrupt for topic 2, got: {result}"
     assert len(result["__interrupt__"]) == 1
-    assert result["__interrupt__"][0].value == "Whats the answer for topic 2?"
+    assert result["__interrupt__"][0].value == "What's the answer for topic 2?"
 
     # Resume with answer for topic 2 - should complete
     result = await graph.ainvoke(Command(resume="answer2"), config=config)

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -402,6 +402,15 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9d/1d0903dff693160f893ca6abcabad545088e7a2ee0a6deae7c24e958be69/codespell-2.4.2.tar.gz", hash = "sha256:3c33be9ae34543807f088aeb4832dfad8cb2dae38da61cac0a7045dd376cfdf3", size = 352058, upload-time = "2026-03-05T18:10:42.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a1/52fa05533e95fe45bcc09bcf8a503874b1c08f221a4e35608017e0938f55/codespell-2.4.2-py3-none-any.whl", hash = "sha256:97e0c1060cf46bd1d5db89a936c98db8c2b804e1fdd4b5c645e82a1ec6b1f886", size = 353715, upload-time = "2026-03-05T18:10:41.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1451,6 +1460,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codespell" },
     { name = "httpx" },
     { name = "jupyter" },
     { name = "langchain-core" },
@@ -1479,6 +1489,7 @@ dev = [
     { name = "uvloop" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-requests" },
@@ -1520,6 +1531,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell" },
     { name = "httpx" },
     { name = "jupyter" },
     { name = "langchain-core", specifier = ">=1.0.0" },
@@ -1549,6 +1561,7 @@ dev = [
     { name = "uvloop", specifier = "==0.22.1" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-requests" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -308,6 +308,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell" },
     { name = "httpx" },
     { name = "jupyter" },
     { name = "langchain-core", specifier = ">=1.0.0" },
@@ -337,6 +338,7 @@ dev = [
     { name = "uvloop", specifier = "==0.22.1" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-requests" },

--- a/libs/sdk-py/pyproject.toml
+++ b/libs/sdk-py/pyproject.toml
@@ -64,6 +64,9 @@ default-groups = ['dev']
 [tool.uv.sources]
 langgraph = { path = "../langgraph", editable = true }
 
+[tool.codespell]
+ignore-words-list = "hel"
+
 [tool.ruff]
 exclude = ["venv", ".venv", "build", "dist"]
 [tool.ruff.lint]

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -321,6 +321,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell" },
     { name = "httpx" },
     { name = "jupyter" },
     { name = "langchain-core", specifier = ">=1.0.0" },
@@ -350,6 +351,7 @@ dev = [
     { name = "uvloop", specifier = "==0.22.1" },
 ]
 lint = [
+    { name = "codespell" },
     { name = "ruff" },
     { name = "ty" },
     { name = "types-requests" },


### PR DESCRIPTION
Fixes #5021.

## Summary
- Add `codespell` to the shared lint workflow so spelling regressions are caught in CI.
- Add `codespell` to the affected package lint dependency groups and refresh locks.
- Fix the existing spelling failures that would block the new lint step.

## Evidence
- `uv run --no-default-groups --group lint codespell --toml pyproject.toml` passed in all shared lint workflow packages: `libs/langgraph`, `libs/sdk-py`, `libs/checkpoint`, `libs/checkpoint-sqlite`, `libs/checkpoint-postgres`, `libs/checkpoint-conformance`, `libs/cli`, and `libs/prebuilt`.
- `NO_DOCKER=true uv run --no-sync ... pytest tests/test_pregel.py -q -k "test_task_before_interrupt_resume or test_multiple_tasks_before_interrupt_resume or test_node_before_interrupt_resume_graph_api or test_multiple_nodes_before_interrupt_resume_graph_api or test_no_redundant_put_writes_for_cached_task"` passed: `15 passed, 442 deselected`.
- `NO_DOCKER=true uv run --no-sync ... pytest tests/test_pregel_async.py -q -k "test_task_before_interrupt_resume or test_multiple_tasks_before_interrupt_resume or test_node_before_interrupt_resume_graph_api or test_multiple_nodes_before_interrupt_resume_graph_api or test_no_redundant_put_writes_for_cached_task"` passed: `10 passed, 300 deselected`.
- `git diff --check` passed.