### PR TITLE
fix(langgraph): copy mutable container in channel from_checkpoint

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -50,7 +50,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            empty.seen = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -128,7 +128,7 @@ class NamedBarrierValueAfterFinish(
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            empty.seen, empty.finished = checkpoint[0].copy(), checkpoint[1]
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -69,9 +69,9 @@ class Topic(
         if checkpoint is not MISSING:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
-                empty.values = checkpoint[1]
+                empty.values = checkpoint[1].copy()
             else:
-                empty.values = checkpoint
+                empty.values = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value | list[Value]]) -> bool:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -12,6 +12,10 @@ from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
+from langgraph.channels.named_barrier_value import (
+    NamedBarrierValue,
+    NamedBarrierValueAfterFinish,
+)
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
@@ -87,6 +91,57 @@ def test_topic_accumulate() -> None:
     assert channel.get() == ["a", "b", "b", "c", "d", "d"]
     assert channel.update(["e"])
     assert channel.get() == ["a", "b", "b", "c", "d", "d", "e"]
+
+
+def test_topic_from_checkpoint_does_not_alias_checkpoint() -> None:
+    """from_checkpoint must copy the values list, not alias it.
+
+    Two accumulate topics restored from the same checkpoint must be
+    independent, and updating one must not mutate the other or the
+    checkpoint container (regression for reusing a loaded checkpoint across
+    restores, e.g. replay / forking a thread).
+    """
+    source = Topic(str, accumulate=True)
+    source.update(["a", "b"])
+    checkpoint = source.checkpoint()
+
+    one = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    two = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    one.update(["c"])
+
+    assert one.get() == ["a", "b", "c"]
+    assert two.get() == ["a", "b"]
+    assert checkpoint == ["a", "b"]
+
+
+def test_named_barrier_value_from_checkpoint_does_not_alias_checkpoint() -> None:
+    """from_checkpoint must copy the seen set, not alias it."""
+    source = NamedBarrierValue(str, {"a", "b"})
+    source.update(["a"])
+    checkpoint = source.checkpoint()
+
+    one = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(checkpoint)
+    two = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(checkpoint)
+    one.update(["b"])
+
+    assert one.seen == {"a", "b"}
+    assert two.seen == {"a"}
+    assert checkpoint == {"a"}
+
+
+def test_named_barrier_value_after_finish_from_checkpoint_does_not_alias() -> None:
+    """from_checkpoint must copy the seen set, not alias it."""
+    source = NamedBarrierValueAfterFinish(str, {"a", "b"})
+    source.update(["a"])
+    checkpoint = source.checkpoint()
+
+    one = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(checkpoint)
+    two = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(checkpoint)
+    one.update(["b"])
+
+    assert one.seen == {"a", "b"}
+    assert two.seen == {"a"}
+    assert checkpoint[0] == {"a"}
 
 
 def test_binop() -> None:


### PR DESCRIPTION
## Summary

`Topic`, `NamedBarrierValue`, and `NamedBarrierValueAfterFinish` assign the checkpoint container straight onto the restored channel in `from_checkpoint` instead of copying it. Two channels restored from the same checkpoint object therefore share one list/set, so an in-place update to one mutates the checkpoint and the sibling — reusing a single loaded checkpoint across restores (replay / forking a thread) can silently corrupt the persisted snapshot.

## Why this is safe

Each channel's own `copy()` already copies the container (`self.values.copy()` / `self.seen.copy()`), and `BaseChannel.from_checkpoint` documents that "if the checkpoint contains complex data structures, they should be copied". This change only makes `from_checkpoint` consistent with both. Copying is strictly safer than aliasing, and pre-fix checkpoints — including the legacy tuple format `Topic` still accepts — load unchanged.

## What changed

- `channels/topic.py`: copy the values list in `from_checkpoint` (current and legacy-tuple branches)
- `channels/named_barrier_value.py`: copy the `seen` set in `from_checkpoint` for both barrier channels
- `tests/test_channels.py`: three regression tests — restore two channels from one checkpoint, mutate one, assert the other channel and the checkpoint are unchanged

## Test plan

- [x] New tests fail before the change, pass after (mutation-checked)
- [x] `make format`, `make lint`, `make type` pass
- [x] `NO_DOCKER=true make test` — 1964 passed, 4 skipped
- [x] Strict-msgpack pregel suite (`LANGGRAPH_STRICT_MSGPACK=true make test TEST="tests/test_pregel.py tests/test_pregel_async.py"`) — 767 passed

Fixes #7992
