### PR TITLE
fix(langgraph): guard __name__ access in BinaryOperatorAggregate equality

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -43,7 +43,10 @@ def _operators_equal(a: Callable, b: Callable) -> bool:
     Lambdas all share the name '<lambda>' so identity comparison is
     unreliable; treat any pairing that includes a lambda as equal.
     """
-    if a.__name__ == "<lambda>" or b.__name__ == "<lambda>":
+    if (
+        getattr(a, "__name__", None) == "<lambda>"
+        or getattr(b, "__name__", None) == "<lambda>"
+    ):
         return True
     return a is b
 

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,3 +1,4 @@
+import functools
 import operator
 from collections.abc import Sequence
 from typing import Annotated
@@ -103,6 +104,40 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_eq_reducer_without_name() -> None:
+    """Equality must not crash for reducers that lack `__name__`.
+
+    `functools.partial` objects and callable class instances are valid 2-arg
+    reducers but have no `__name__`. `_operators_equal` read `.__name__`
+    directly (before the identity check), so building a graph whose reducer
+    field is shared across schemas raised AttributeError. Regression for #8082.
+    """
+    reducer = functools.partial(operator.add)
+
+    # Same partial reducer on two channels: equal, no AttributeError.
+    assert BinaryOperatorAggregate(int, reducer) == BinaryOperatorAggregate(
+        int, reducer
+    )
+
+    class Add:
+        def __call__(self, a: int, b: int) -> int:
+            return a + b
+
+    add = Add()
+    assert BinaryOperatorAggregate(int, add) == BinaryOperatorAggregate(int, add)
+
+    # End-to-end repro from the issue: a partial reducer shared across the
+    # state and input schemas must build instead of raising.
+    class InputState(TypedDict):
+        items: Annotated[list, reducer]
+
+    class OverallState(TypedDict):
+        items: Annotated[list, reducer]
+        extra: str
+
+    StateGraph(OverallState, input_schema=InputState)
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
Fixes #8082

`_operators_equal` read `.__name__` directly to detect lambdas, but `functools.partial` objects and callable class instances are valid two-argument reducers that have no `__name__`. Since that check ran before the `a is b` fast-path, comparing two `BinaryOperatorAggregate` channels with such a reducer raised `AttributeError` — for example when a reducer field is shared across schemas (state + input) while building a `StateGraph`. This guards both lookups with `getattr(..., "__name__", None)`, matching every other `__name__` access in `libs/langgraph`.

Added a regression test covering a `functools.partial` reducer, a callable instance, and the original shared-across-schemas `StateGraph` repro; it fails before the change and passes after.
