### PR TITLE
fix(checkpoint): preserve deque maxlen during serialization

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -378,11 +378,22 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
             ),
         )
-    elif isinstance(obj, (set, frozenset, deque)):
+    elif isinstance(obj, (set, frozenset)):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, tuple(obj)),
+            ),
+        )
+    elif isinstance(obj, deque):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (tuple(obj), obj.maxlen),
+                ),
             ),
         )
     elif isinstance(obj, (IPv4Address, IPv4Interface, IPv4Network)):
@@ -774,6 +785,8 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             )
             if tup[0] == "langgraph.types" and tup[1] == "Send":
                 return _send_from_args(tup[2])
+            if tup[0] == "collections" and tup[1] == "deque":
+                return list(tup[2][0])
             # module, name, args
             return tup[2]
         except Exception:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -323,6 +323,27 @@ def test_serde_jsonplus_json_mode() -> None:
     assert result == expected_result
 
 
+def test_deque_maxlen_serialization() -> None:
+    serde = JsonPlusSerializer()
+
+    # maxlen must survive the round-trip
+    original = deque([1, 2, 3], maxlen=3)
+    restored = serde.loads_typed(serde.dumps_typed(original))
+    assert isinstance(restored, deque)
+    assert restored.maxlen == 3
+    assert list(restored) == [1, 2, 3]
+
+    # eviction still works after deserialization
+    restored.append(4)
+    assert list(restored) == [2, 3, 4]
+
+    # unbounded deque still round-trips correctly
+    unbounded = deque([1, 2, 3])
+    restored_unbounded = serde.loads_typed(serde.dumps_typed(unbounded))
+    assert restored_unbounded.maxlen is None
+    assert list(restored_unbounded) == [1, 2, 3]
+
+
 def test_serde_jsonplus_bytes() -> None:
     serde = JsonPlusSerializer()
 


### PR DESCRIPTION
Fixes #8157

This pull request updates `JsonPlusSerializer` to serialize `collections.deque` objects using positional arguments, encoding both the elements and the `maxlen`. This ensures that a `deque`'s maximum length safely survives the serialization round-trip while remaining fully backwards compatible with previously saved checkpoints.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

Thank you for contributing to LangGraph! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION
   - ✅ Formatted properly (fix(checkpoint))

2. PR description:
  - ✅ 1-2 sentence summary provided.
  - ✅ `Fixes #8157` line included at the top.
  - ✅ No breaking changes introduced.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
  - ✅ Code has been formatted, linted, and tests pass.

4. How did you verify your code works?
  - ✅ Added unit tests specifically verifying that a `deque` with a `maxlen` retains its `maxlen` upon serialization and deserialization. Manually verified backwards compatibility with `EXT_CONSTRUCTOR_SINGLE_ARG`.

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/