### PR TITLE
fix(langgraph): guard reducer equality for partial callables

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -43,9 +43,12 @@ def _operators_equal(a: Callable, b: Callable) -> bool:
     Lambdas all share the name '<lambda>' so identity comparison is
     unreliable; treat any pairing that includes a lambda as equal.
     """
-    if a.__name__ == "<lambda>" or b.__name__ == "<lambda>":
+    if a is b:
         return True
-    return a is b
+    return (
+        getattr(a, "__name__", None) == "<lambda>"
+        or getattr(b, "__name__", None) == "<lambda>"
+    )
 
 
 class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -1,3 +1,4 @@
+import functools
 import operator
 from collections.abc import Sequence
 from typing import Annotated
@@ -103,6 +104,30 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_eq_partial_reducer() -> None:
+    reducer = functools.partial(operator.add)
+    a = BinaryOperatorAggregate(list, reducer)
+    b = BinaryOperatorAggregate(list, reducer)
+    assert a == b
+
+
+def test_stategraph_shared_partial_reducer_across_schemas() -> None:
+    reducer = functools.partial(operator.add)
+
+    class InputState(TypedDict):
+        items: Annotated[list, reducer]
+
+    class OverallState(TypedDict):
+        items: Annotated[list, reducer]
+        extra: str
+
+    builder = StateGraph(OverallState, input_schema=InputState)
+    builder.add_node("n", lambda x: x)
+    builder.add_edge(START, "n")
+    graph = builder.compile()
+    assert isinstance(graph.channels["items"], BinaryOperatorAggregate)
 
 
 def test_untracked_value() -> None:


### PR DESCRIPTION
## Summary
- Fixes `BinaryOperatorAggregate.__eq__` raising `AttributeError` when a shared reducer is `functools.partial` or another callable without `__name__`.
- `_operators_equal` now checks identity first, then uses `getattr(..., "__name__", None)` for lambda detection (consistent with other `libs/langgraph` call sites).

Fixes #8082

## Test plan
- [x] `TEST="tests/test_channels.py::test_binop_eq_partial_reducer tests/test_channels.py::test_stategraph_shared_partial_reducer_across_schemas" make test`
- [x] `make format`
- [x] `make lint`