### PR TITLE
fix(langgraph): emit subgraph values on Command.PARENT stream exit

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1448,8 +1448,6 @@ class CompiledStateGraph(
             elif isinstance(input, dict):
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
-                if input.graph == Command.PARENT:
-                    return None
                 return [
                     (k, v) for k, v in input._update_as_tuples() if k in output_keys
                 ]
@@ -1461,8 +1459,6 @@ class CompiledStateGraph(
                 updates: list[tuple[str, Any]] = []
                 for i in input:
                     if isinstance(i, Command):
-                        if i.graph == Command.PARENT:
-                            continue
                         updates.extend(
                             (k, v) for k, v in i._update_as_tuples() if k in output_keys
                         )
@@ -1777,8 +1773,6 @@ def _control_static(
 
 def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
     if isinstance(input, Command):
-        if input.graph == Command.PARENT:
-            return ()
         return input._update_as_tuples()
     elif (
         isinstance(input, (list, tuple))
@@ -1788,8 +1782,6 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
         updates: list[tuple[str, Any]] = []
         for i in input:
             if isinstance(i, Command):
-                if i.graph == Command.PARENT:
-                    continue
                 updates.extend(i._update_as_tuples())
             else:
                 updates.append(("__root__", i))

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -714,6 +714,32 @@ class PregelLoop:
         # unset resuming flag
         self.config[CONF].pop(CONFIG_KEY_RESUMING, None)
 
+    def emit_values_for_task_writes(self, task: PregelExecutableTask) -> None:
+        """Apply a single task's writes and emit values before ParentCommand bubbles."""
+        if self.stream is None or "values" not in self.stream.modes:
+            return
+        if not task.writes or task.writes[0][0] in (ERROR, INTERRUPT):
+            return
+        updated = apply_writes(
+            self.checkpoint,
+            self.channels,
+            [task],
+            self.checkpointer_get_next_version,
+            self.trigger_to_nodes,
+        )
+        if not updated.isdisjoint(
+            (self.output_keys,)
+            if isinstance(self.output_keys, str)
+            else self.output_keys
+        ):
+            self._emit(
+                "values",
+                map_output_values,
+                self.output_keys,
+                list(task.writes),
+                self.channels,
+            )
+
     def match_cached_writes(self) -> Sequence[PregelExecutableTask]:
         raise NotImplementedError
 

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -41,7 +41,7 @@ from langgraph._internal._future import chain_future, run_coroutine_threadsafe
 from langgraph._internal._scratchpad import PregelScratchpad
 from langgraph._internal._typing import MISSING
 from langgraph.constants import TAG_HIDDEN
-from langgraph.errors import GraphBubbleUp, GraphInterrupt
+from langgraph.errors import GraphBubbleUp, GraphInterrupt, ParentCommand
 from langgraph.pregel._algo import Call
 from langgraph.pregel._executor import Submit
 from langgraph.pregel._retry import arun_with_retry, run_with_retry
@@ -589,6 +589,13 @@ class PregelRunner:
                     if resumes := [w for w in task.writes if w[0] == RESUME]:
                         writes.extend(resumes)
                     self.put_writes()(task.id, writes)  # type: ignore[misc]
+            elif isinstance(exception, ParentCommand):
+                if task.writes:
+                    put_writes = self.put_writes()
+                    put_writes(task.id, task.writes)  # type: ignore[misc]
+                    loop = getattr(put_writes, "__self__", None)
+                    if loop is not None:
+                        loop.emit_values_for_task_writes(task)
             elif isinstance(exception, GraphBubbleUp):
                 # exception will be raised in _panic_or_proceed
                 pass

--- a/libs/langgraph/langgraph/pregel/_write.py
+++ b/libs/langgraph/langgraph/pregel/_write.py
@@ -13,7 +13,7 @@ from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph._internal._constants import CONF, CONFIG_KEY_SEND, TASKS
 from langgraph._internal._runnable import RunnableCallable
 from langgraph._internal._typing import MISSING
-from langgraph.errors import InvalidUpdateError
+from langgraph.errors import InvalidUpdateError, ParentCommand
 from langgraph.types import Send
 
 TYPE_SEND = Callable[[Sequence[tuple[str, Any]]], None]
@@ -120,10 +120,13 @@ class ChannelWrite(RunnableCallable):
             if isinstance(w, ChannelWriteTupleEntry):
                 if w.value is PASSTHROUGH and not allow_passthrough:
                     raise InvalidUpdateError("PASSTHROUGH value must be replaced")
-        # if we want to persist writes found before hitting a ParentCommand
-        # can move this to a finally block
         write: TYPE_SEND = config[CONF][CONFIG_KEY_SEND]
-        write(_assemble_writes(writes))
+        try:
+            tuples = _assemble_writes(writes, on_partial=write)
+        except ParentCommand:
+            raise
+        if tuples:
+            write(tuples)
 
     @staticmethod
     def is_writer(runnable: Runnable) -> bool:
@@ -171,22 +174,29 @@ class ChannelWrite(RunnableCallable):
 
 def _assemble_writes(
     writes: Sequence[ChannelWriteEntry | ChannelWriteTupleEntry | Send],
+    *,
+    on_partial: TYPE_SEND | None = None,
 ) -> list[tuple[str, Any]]:
     """Assembles the writes into a list of tuples."""
     tuples: list[tuple[str, Any]] = []
     for w in writes:
-        if isinstance(w, Send):
-            tuples.append((TASKS, w))
-        elif isinstance(w, ChannelWriteTupleEntry):
-            if ww := w.mapper(w.value):
-                tuples.extend(ww)
-        elif isinstance(w, ChannelWriteEntry):
-            value = w.mapper(w.value) if w.mapper is not None else w.value
-            if value is SKIP_WRITE:
-                continue
-            if w.skip_none and value is None:
-                continue
-            tuples.append((w.channel, value))
-        else:
-            raise ValueError(f"Invalid write entry: {w}")
+        try:
+            if isinstance(w, Send):
+                tuples.append((TASKS, w))
+            elif isinstance(w, ChannelWriteTupleEntry):
+                if ww := w.mapper(w.value):
+                    tuples.extend(ww)
+            elif isinstance(w, ChannelWriteEntry):
+                value = w.mapper(w.value) if w.mapper is not None else w.value
+                if value is SKIP_WRITE:
+                    continue
+                if w.skip_none and value is None:
+                    continue
+                tuples.append((w.channel, value))
+            else:
+                raise ValueError(f"Invalid write entry: {w}")
+        except ParentCommand:
+            if on_partial and tuples:
+                on_partial(tuples)
+            raise
     return tuples

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -3461,6 +3461,68 @@ def test_stream_subgraphs_during_execution(
     ]
 
 
+def test_stream_subgraphs_command_parent_namespace() -> None:
+    """Command.PARENT exit should still emit final subgraph node under subgraph ns."""
+
+    def my_reducer(a: str, b: str | None) -> str:
+        if b is not None:
+            return b
+        return a
+
+    class State(TypedDict):
+        node_name: Annotated[str, my_reducer]
+        foo: str
+
+    def subgraph_node_1(state: State) -> Command[Literal["subgraph_node_2"]]:
+        return Command(
+            goto="subgraph_node_2",
+            update={
+                "node_name": "subgraph_node_1",
+                "foo": "Update at subgraph_node_1!",
+            },
+        )
+
+    def subgraph_node_2(state: State) -> Command:
+        return Command(
+            goto="node_3",
+            update={"node_name": "subgraph_node_2"},
+            graph=Command.PARENT,
+        )
+
+    subgraph_builder = StateGraph(State)
+    subgraph_builder.add_node(subgraph_node_1)
+    subgraph_builder.add_node(subgraph_node_2)
+    subgraph_builder.set_entry_point("subgraph_node_1")
+    subgraph = subgraph_builder.compile()
+
+    def node_1(state: State) -> Command[Literal["node_2"]]:
+        return Command(goto="node_2", update={"node_name": "node_1"})
+
+    def node_3(state: State) -> Command[Literal["__end__"]]:
+        return Command(goto=END, update={"node_name": "node_3"})
+
+    main_builder = StateGraph(State)
+    main_builder.add_node("node_1", node_1)
+    main_builder.add_node("node_2", subgraph)
+    main_builder.add_node("node_3", node_3)
+    main_builder.set_entry_point("node_1")
+    main_graph = main_builder.compile()
+
+    chunks = list(
+        main_graph.stream(
+            {"node_name": "__start__"}, stream_mode="values", subgraphs=True
+        )
+    )
+
+    subgraph_node_2_chunks = [
+        c for c in chunks if c[1].get("node_name") == "subgraph_node_2" and c[0]
+    ]
+    assert subgraph_node_2_chunks, (
+        "subgraph_node_2 should be emitted under subgraph namespace"
+    )
+    assert all(ns[0].startswith("node_2:") for ns, _ in subgraph_node_2_chunks)
+
+
 def test_stream_buffering_single_node(sync_checkpointer: BaseCheckpointSaver) -> None:
     class State(TypedDict):
         my_key: Annotated[str, operator.add]


### PR DESCRIPTION
## Summary
- When a subgraph node returns `Command(graph=Command.PARENT, ...)`, apply its state update in the subgraph before the command bubbles to the parent.
- Flush partial writes raised by `ParentCommand` during channel assembly so updates are not dropped.
- Emit `stream_mode="values"` chunks under the subgraph namespace before the parent-level bubble (fixes missing final-node output in `stream(..., subgraphs=True)`).

Fixes #3362

## Test plan
- [x] `TEST=tests/test_pregel.py::test_stream_subgraphs_command_parent_namespace make test`
- [x] `tests/test_pregel.py::test_parent_command` and `test_parent_command_goto`
- [x] `make format` and `make lint` in `libs/langgraph`
