### PR TITLE
fix(langgraph): restore invoke metadata on StateSnapshot.config

### DIFF
--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -459,6 +459,44 @@ _PROPAGATE_TO_METADATA = frozenset(
     )
 )
 
+_CHECKPOINT_METADATA_KEYS = frozenset(
+    {
+        "source",
+        "step",
+        "parents",
+        "run_id",
+        "counters_since_delta_snapshot",
+        "writes",
+    }
+)
+
+
+def split_state_snapshot_metadata(
+    config: RunnableConfig,
+    metadata: Mapping[str, Any] | None,
+) -> tuple[RunnableConfig, dict[str, Any] | None]:
+    """Split merged checkpoint metadata back into config metadata and checkpoint fields.
+
+    Invoke-time ``config.metadata`` is persisted inside checkpoint metadata by
+    checkpointers. When building a ``StateSnapshot``, restore user keys to
+    ``config['metadata']`` and keep structural checkpoint fields in ``metadata``.
+    """
+    if not metadata:
+        return config, None
+    checkpoint_metadata = {
+        k: v for k, v in metadata.items() if k in _CHECKPOINT_METADATA_KEYS
+    }
+    user_metadata = {
+        k: v for k, v in metadata.items() if k not in _CHECKPOINT_METADATA_KEYS
+    }
+    snapshot_config = dict(config)
+    if user_metadata:
+        snapshot_config["metadata"] = {
+            **user_metadata,
+            **(snapshot_config.get("metadata") or {}),
+        }
+    return snapshot_config, checkpoint_metadata or None
+
 
 def filter_to_user_tags(tags: Sequence[str] | None) -> list[str] | None:
     """Drop langgraph's internal `seq:step:*` bookkeeping tags.

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -61,6 +61,7 @@ from langgraph._internal._config import (
     patch_config,
     patch_configurable,
     recast_checkpoint_ns,
+    split_state_snapshot_metadata,
 )
 from langgraph._internal._constants import (
     CACHE_NS_WRITES,
@@ -1253,11 +1254,15 @@ class Pregel(
             self.stream_channels_asis,
         )
         # assemble the state snapshot
+        snapshot_config, snapshot_metadata = split_state_snapshot_metadata(
+            patch_checkpoint_map(saved.config, saved.metadata),
+            saved.metadata,
+        )
         return StateSnapshot(
             read_channels(channels, self.stream_channels_asis),
             tuple(t.name for t in next_tasks.values() if not t.writes),
-            patch_checkpoint_map(saved.config, saved.metadata),
-            saved.metadata,
+            snapshot_config,
+            snapshot_metadata,
             saved.checkpoint["ts"],
             patch_checkpoint_map(saved.parent_config, saved.metadata),
             tasks_with_writes,
@@ -1377,11 +1382,15 @@ class Pregel(
             self.stream_channels_asis,
         )
         # assemble the state snapshot
+        snapshot_config, snapshot_metadata = split_state_snapshot_metadata(
+            patch_checkpoint_map(saved.config, saved.metadata),
+            saved.metadata,
+        )
         return StateSnapshot(
             read_channels(channels, self.stream_channels_asis),
             tuple(t.name for t in next_tasks.values() if not t.writes),
-            patch_checkpoint_map(saved.config, saved.metadata),
-            saved.metadata,
+            snapshot_config,
+            snapshot_metadata,
             saved.checkpoint["ts"],
             patch_checkpoint_map(saved.parent_config, saved.metadata),
             tasks_with_writes,

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5346,6 +5346,40 @@ def test_multiple_interrupt_state_persistence(
     assert state.values["steps"] == ["step1", "step2"]
 
 
+@pytest.mark.anyio
+async def test_state_snapshot_invoke_metadata_in_config(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Invoke-time config metadata is exposed on StateSnapshot.config, not metadata."""
+
+    class State(TypedDict):
+        messages: Annotated[list[str], add_messages]
+
+    async def node1(state: State) -> State:
+        return {"messages": ["node1"]}
+
+    builder = StateGraph(State)
+    builder.add_node("node1", node1)
+    builder.add_edge(START, "node1")
+    builder.add_edge("node1", END)
+
+    app = builder.compile(checkpointer=async_checkpointer)
+    thread_id = "6460-metadata"
+    config = {
+        "metadata": {"foo": "bar"},
+        "configurable": {"thread_id": thread_id},
+    }
+    await app.ainvoke({"messages": []}, config=config)
+
+    history_config = {"configurable": {"thread_id": thread_id}}
+    async for snapshot in app.aget_state_history(config=history_config):
+        assert snapshot.config.get("metadata", {}).get("foo") == "bar"
+        assert "foo" not in (snapshot.metadata or {})
+        assert snapshot.metadata is not None
+        assert "source" in snapshot.metadata
+        assert "step" in snapshot.metadata
+
+
 def test_concurrent_execution_thread_safety():
     """Test thread safety during concurrent execution."""
 


### PR DESCRIPTION
Fixes #6460. Splits merged checkpoint metadata when building StateSnapshot so invoke-time config metadata appears in snapshot.config while structural checkpoint fields remain in snapshot.metadata.