### PR TITLE
fix(langgraph): prevent duplicate messages on nested agent fork

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -845,6 +845,9 @@ class PregelLoop:
         #   - None input: resume after interrupt (invoke(None, config))
         #   - Command input: any Command operates on existing state
         #   - Same run_id: re-entry into an ongoing run (e.g. stream reconnect)
+        # Capture before fork/input checkpoints are written below — subgraphs
+        # need the replay bound from the loaded checkpoint, not the new one.
+        loaded_checkpoint_id = self.checkpoint["id"]
         configurable = self.config.get(CONF, {})
         input_is_command = isinstance(self.input, Command)
         is_resuming = bool(self.checkpoint["channel_versions"]) and bool(
@@ -1036,7 +1039,7 @@ class PregelLoop:
             # current parent step.
             replay_state: ReplayState | None = None
             if is_time_traveling:
-                replay_checkpoint_id = self.checkpoint["id"]
+                replay_checkpoint_id = loaded_checkpoint_id
                 if (
                     self.checkpoint_metadata.get("source")
                     in (

--- a/libs/langgraph/tests/test_time_travel.py
+++ b/libs/langgraph/tests/test_time_travel.py
@@ -19,11 +19,12 @@ Key concepts:
 import operator
 from typing import Annotated
 
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict
 
-from langgraph.graph import START, StateGraph
+from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import Command, interrupt
 
 
@@ -2905,6 +2906,52 @@ def test_stateful_subgraph_retains_state_on_parent_fork(
     assert "__interrupt__" in fork_result
     # Fork sees 1st invocation's final state, NOT 2nd invocation's
     assert observed[0] == ("step_a", {"value": ["a:a1", "b:b1"]})
+
+
+def test_stateful_subgraph_invoke_fork_no_duplicate_messages(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Fork via invoke at a pre-input checkpoint with new input must not
+    merge stale subgraph message state from the original branch.
+
+    Regression for https://github.com/langchain-ai/langgraph/issues/7593
+    """
+    subgraph_inputs: list[list[str]] = []
+
+    def sub_node(state: MessagesState) -> MessagesState:
+        subgraph_inputs.append([m.content for m in state["messages"]])
+        return {"messages": [AIMessage(content="sub")]}
+
+    agent = (
+        StateGraph(MessagesState)
+        .add_node("n", sub_node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=True)
+    )
+
+    graph = (
+        StateGraph(MessagesState)
+        .add_node("agent", agent)
+        .add_edge(START, "agent")
+        .add_edge("agent", END)
+        .compile(checkpointer=sync_checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "7593"}}
+    graph.invoke({"messages": [HumanMessage(content="hi")]}, config)
+
+    history = list(graph.get_state_history(config))
+    pre_human = history[-1]
+    assert pre_human.metadata.get("step") == -1
+
+    graph.invoke({"messages": [HumanMessage(content="hi2")]}, pre_human.config)
+
+    assert subgraph_inputs[-1] == ["hi2"]
+    messages = graph.get_state(config).values["messages"]
+    humans = [m.content for m in messages if isinstance(m, HumanMessage)]
+    assert humans == ["hi2"]
+    assert [m.content for m in messages if isinstance(m, AIMessage)] == ["sub"]
 
 
 def test_stateful_subgraph_loads_state_across_ticks(


### PR DESCRIPTION
Fixes #7593. ReplayState now binds to the loaded checkpoint id before fork/input writes so nested checkpointer subgraphs do not restore stale messages when time-traveling with fresh input.