### PR TITLE
fix(checkpoint): serialize Fraction and complex in JsonPlusSerializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -30,6 +30,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("uuid", "UUID"),
         # numeric
         ("decimal", "Decimal"),
+        ("fractions", "Fraction"),
+        ("builtins", "complex"),
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import decimal
+import fractions
 import importlib
 import json
 import logging
@@ -376,6 +377,28 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
+    elif isinstance(obj, fractions.Fraction):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.numerator, obj.denominator),
+                ),
+            ),
+        )
+    elif isinstance(obj, complex):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.real, obj.imag),
+                ),
             ),
         )
     elif isinstance(obj, (set, frozenset, deque)):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -8,6 +8,7 @@ import uuid
 from collections import deque
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
+from fractions import Fraction
 from enum import Enum
 from ipaddress import IPv4Address
 from zoneinfo import ZoneInfo
@@ -803,6 +804,8 @@ def test_msgpack_safe_types_no_warning(caplog: pytest.LogCaptureFixture) -> None
         timezone.utc,
         uuid.uuid4(),
         Decimal("123.45"),
+        Fraction(1, 3),
+        complex(1, 2),
         {1, 2, 3},
         frozenset([1, 2, 3]),
         deque([1, 2, 3]),
@@ -1190,6 +1193,8 @@ def test_msgpack_safe_types_value_equality(caplog: pytest.LogCaptureFixture) -> 
         time(14, 30, 0),
         uuid.UUID("12345678-1234-5678-1234-567812345678"),
         Decimal("123.456789"),
+        Fraction(22, 7),
+        complex(3.5, -2.0),
         {1, 2, 3, 4, 5},
         frozenset(["a", "b", "c"]),
         deque([1, 2, 3]),
@@ -1210,6 +1215,14 @@ def test_msgpack_safe_types_value_equality(caplog: pytest.LogCaptureFixture) -> 
             assert result.flags == obj.flags
         else:
             assert result == obj, f"Value mismatch for {type(obj)}: {result} != {obj}"
+
+
+def test_msgpack_fraction_and_complex_roundtrip() -> None:
+    """Fraction and complex should serialize like Decimal (issue #8185)."""
+    serde = JsonPlusSerializer()
+
+    for obj in [Decimal("1.5"), Fraction(1, 3), complex(1, 2)]:
+        assert serde.loads_typed(serde.dumps_typed(obj)) == obj
 
 
 def test_msgpack_nested_pydantic_serializes_as_dict(


### PR DESCRIPTION
## Summary

Add msgpack serialization support for `fractions.Fraction` and builtin `complex` in `JsonPlusSerializer`, mirroring the existing `Decimal` handler.

## Motivation

Fixes #8185. Checkpoint state containing exact rationals or complex numbers currently raises `TypeError: Type is not msgpack serializable`, while `Decimal` already round-trips. This blocks graphs that use `Fraction` for exact arithmetic or `complex` in scientific workloads.

## Changes

- `jsonplus.py`: encode `Fraction` via `(numerator, denominator)` and `complex` via `(real, imag)` using `EXT_CONSTRUCTOR_POS_ARGS`
- `_msgpack.py`: add both types to `SAFE_MSGPACK_TYPES` for strict-mode deserialization
- `test_jsonplus.py`: round-trip regression test alongside existing safe-type coverage

## Tests

```bash
pytest tests/test_jsonplus.py::test_msgpack_fraction_and_complex_roundtrip -q
```

Passed locally.

## Notes

- Scope is limited to `Fraction` and `complex` only (not `range`/`PurePath` mentioned in the issue thread).
- Requested issue assignment in #8185 per external contributor policy; PR may auto-close until assigned.