### PR TITLE
fix(langgraph): bind Command goto+resume to target interrupted node

### DIFF
--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -71,6 +71,8 @@ CONFIG_KEY_RUNTIME = sys.intern("__pregel_runtime")
 # holds a `Runtime` instance with context, store, stream writer, etc.
 CONFIG_KEY_RESUME_MAP = sys.intern("__pregel_resume_map")
 # holds a mapping of task ns -> resume value for resuming tasks
+CONFIG_KEY_COMMAND_GOTO = sys.intern("__pregel_command_goto")
+# when set to a node name, the next tick runs only that node (Command goto+resume)
 CONFIG_KEY_STREAM_MESSAGES_V2 = sys.intern("__pregel_stream_messages_v2")
 # when True, attach StreamMessagesHandlerV2 so content-block (v2) events
 # flow through stream_mode="messages"; set by StreamingHandler only.

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -912,7 +912,10 @@ class PregelLoop:
             if task.name == target:
                 target_task_id = task.id
         if target_task_id is None:
-            return
+            raise RuntimeError(
+                f"Command resume cannot be routed to goto target {target!r}: "
+                "no matching pending or scheduled task found."
+            )
         self.put_writes(target_task_id, [(RESUME, cmd.resume)])
         self.config[CONF][CONFIG_KEY_COMMAND_GOTO] = target
 

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_COMMAND_GOTO,
     CONFIG_KEY_REPLAY_STATE,
     CONFIG_KEY_RESUME_MAP,
     CONFIG_KEY_RESUMING,
@@ -621,6 +622,12 @@ class PregelLoop:
             retry_policy=self.retry_policy,
             cache_policy=self.cache_policy,
         )
+        if goto_target := self.config[CONF].pop(CONFIG_KEY_COMMAND_GOTO, None):
+            self.tasks = {
+                tid: task
+                for tid, task in self.tasks.items()
+                if task.name == goto_target
+            }
 
         # produce debug output
         if self._checkpointer_put_after_previous is not None:
@@ -834,6 +841,81 @@ class PregelLoop:
 
         return hanging_interrupts
 
+    def _route_command_resume_to_goto(
+        self,
+        cmd: Command,
+        updated_channels: set[str] | None,
+    ) -> None:
+        """When Command specifies both goto and resume, bind resume to that node."""
+        target = cmd.goto
+        assert isinstance(target, str)
+        self.checkpoint_pending_writes = [
+            w
+            for w in self.checkpoint_pending_writes
+            if not (w[0] == NULL_TASK_ID and w[1] == RESUME)
+        ]
+        interrupt_task_ids = {
+            tid
+            for tid, wtype, _ in self.checkpoint_pending_writes
+            if wtype == INTERRUPT
+        }
+        if interrupt_task_ids:
+            preview = prepare_next_tasks(
+                self.checkpoint,
+                self.checkpoint_pending_writes,
+                self.nodes,
+                self.channels,
+                self.managed,
+                self.config,
+                self.step,
+                self.stop,
+                for_execution=False,
+                store=self.store,
+                checkpointer=self.checkpointer,
+                manager=self.manager,
+                trigger_to_nodes=self.trigger_to_nodes,
+                updated_channels=updated_channels,
+                retry_policy=self.retry_policy,
+                cache_policy=self.cache_policy,
+            )
+            non_target_interrupt_ids = {
+                task.id
+                for task in preview.values()
+                if task.name != target and task.id in interrupt_task_ids
+            }
+            if non_target_interrupt_ids:
+                self.checkpoint_pending_writes = [
+                    w
+                    for w in self.checkpoint_pending_writes
+                    if not (w[1] == INTERRUPT and w[0] in non_target_interrupt_ids)
+                ]
+        next_tasks = prepare_next_tasks(
+            self.checkpoint,
+            self.checkpoint_pending_writes,
+            self.nodes,
+            self.channels,
+            self.managed,
+            self.config,
+            self.step,
+            self.stop,
+            for_execution=True,
+            store=self.store,
+            checkpointer=self.checkpointer,
+            manager=self.manager,
+            trigger_to_nodes=self.trigger_to_nodes,
+            updated_channels=updated_channels,
+            retry_policy=self.retry_policy,
+            cache_policy=self.cache_policy,
+        )
+        target_task_id: str | None = None
+        for task in next_tasks.values():
+            if task.name == target:
+                target_task_id = task.id
+        if target_task_id is None:
+            return
+        self.put_writes(target_task_id, [(RESUME, cmd.resume)])
+        self.config[CONF][CONFIG_KEY_COMMAND_GOTO] = target
+
     def _first(
         self, *, input_keys: str | Sequence[str], updated_channels: set[str] | None
     ) -> set[str] | None:
@@ -889,8 +971,10 @@ class PregelLoop:
             ]
 
         # map command to writes
+        resume_is_map = False
         if input_is_command:
-            if (resume := cast(Command, self.input).resume) is not None:
+            cmd = cast(Command, self.input)
+            if (resume := cmd.resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(
                         "Cannot use Command(resume=...) without checkpointer"
@@ -901,16 +985,17 @@ class PregelLoop:
                     and all(is_xxh3_128_hexdigest(k) for k in resume)
                 ):
                     self.config[CONF][CONFIG_KEY_RESUME_MAP] = resume
-                else:
-                    if len(self._pending_interrupts()) > 1:
-                        raise RuntimeError(
-                            "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
-                        )
+                elif len(self._pending_interrupts()) > 1 and not isinstance(
+                    cmd.goto, str
+                ):
+                    raise RuntimeError(
+                        "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
+                        "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                    )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)
             # group writes by task ID
-            for tid, c, v in map_command(cmd=cast(Command, self.input)):
+            for tid, c, v in map_command(cmd=cmd):
                 if not (c == RESUME and resume_is_map):
                     writes[tid].append((c, v))
             if not writes and not resume_is_map:
@@ -931,6 +1016,14 @@ class PregelLoop:
             )
             if updated_channels is not None:
                 updated_channels.update(null_updated_channels)
+        if input_is_command:
+            cmd = cast(Command, self.input)
+            if (
+                cmd.resume is not None
+                and isinstance(cmd.goto, str)
+                and not resume_is_map
+            ):
+                self._route_command_resume_to_goto(cmd, updated_channels)
         # proceed past previous checkpoint
         if is_resuming:
             self.checkpoint["versions_seen"].setdefault(INTERRUPT, {})

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5346,6 +5346,81 @@ def test_multiple_interrupt_state_persistence(
     assert state.values["steps"] == ["step1", "step2"]
 
 
+def test_interrupt_command_goto_with_pending_interrupt(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Command(goto=..., resume=...) must target the named node when another interrupt is pending."""
+
+    class State(MessagesState):
+        interrupt: int
+        chat: int
+
+    delivery_ran = False
+
+    def payment_interrupt_node(state: State):
+        payload = interrupt("Payment Link...")
+        data = payload.get("data") if isinstance(payload, dict) else None
+        message = payload.get("message") if isinstance(payload, dict) else None
+        if data:
+            return Command(
+                goto="delivery",
+                update={
+                    "interrupt": state.get("interrupt", 0) + 1,
+                    "messages": [{"role": "ai", "content": data}],
+                },
+            )
+        if message:
+            if message == "normal conversation":
+                return {
+                    "chat": state.get("chat", 0) + 1,
+                    "messages": [{"role": "ai", "content": "reply"}],
+                }
+            return Command(
+                goto="another_interrupt_node",
+                update={
+                    "chat": state.get("chat", 0) + 1,
+                    "messages": [{"role": "ai", "content": "some interrupt"}],
+                },
+            )
+        return {"messages": [{"role": "ai", "content": "Error"}]}
+
+    def delivery(_state: State):
+        nonlocal delivery_ran
+        delivery_ran = True
+        return {"messages": [{"role": "ai", "content": "Delivery message."}]}
+
+    def another_interrupt_node(_state: State):
+        payload = interrupt("Another interrupt")
+        return {"messages": [{"role": "human", "content": str(payload)}]}
+
+    builder = StateGraph(State)
+    builder.add_node("payment_interrupt_node", payment_interrupt_node)
+    builder.add_node("delivery", delivery)
+    builder.add_node("another_interrupt_node", another_interrupt_node)
+    builder.add_edge(START, "payment_interrupt_node")
+    builder.add_edge("another_interrupt_node", END)
+    builder.add_edge("delivery", END)
+
+    app = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "6534"}}
+
+    app.invoke({"messages": [{"role": "user", "content": "buy"}]}, config)
+    app.invoke(Command(resume={"message": "ask some information"}), config)
+    app.invoke(
+        Command(goto="payment_interrupt_node", resume={"data": "30$"}),
+        config,
+    )
+
+    assert delivery_ran
+    state = app.get_state(config)
+    assert state.next == ()
+    assert any(
+        getattr(m, "content", None) == "Delivery message."
+        or (isinstance(m, dict) and m.get("content") == "Delivery message.")
+        for m in state.values["messages"]
+    )
+
+
 def test_concurrent_execution_thread_safety():
     """Test thread safety during concurrent execution."""
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5349,18 +5349,22 @@ def test_multiple_interrupt_state_persistence(
 def test_interrupt_command_goto_with_pending_interrupt(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:
-    """Command(goto=..., resume=...) must target the named node when another interrupt is pending."""
+    """Command(goto=..., resume=...) binds resume to the named node when another interrupt is pending."""
 
     class State(MessagesState):
         interrupt: int
         chat: int
 
+    payment_payloads: list[dict] = []
+    chat_payloads: list[object] = []
     delivery_ran = False
 
     def payment_interrupt_node(state: State):
         payload = interrupt("Payment Link...")
-        data = payload.get("data") if isinstance(payload, dict) else None
-        message = payload.get("message") if isinstance(payload, dict) else None
+        assert isinstance(payload, dict)
+        payment_payloads.append(payload)
+        data = payload.get("data")
+        message = payload.get("message")
         if data:
             return Command(
                 goto="delivery",
@@ -5391,6 +5395,7 @@ def test_interrupt_command_goto_with_pending_interrupt(
 
     def another_interrupt_node(_state: State):
         payload = interrupt("Another interrupt")
+        chat_payloads.append(payload)
         return {"messages": [{"role": "human", "content": str(payload)}]}
 
     builder = StateGraph(State)
@@ -5406,19 +5411,98 @@ def test_interrupt_command_goto_with_pending_interrupt(
 
     app.invoke({"messages": [{"role": "user", "content": "buy"}]}, config)
     app.invoke(Command(resume={"message": "ask some information"}), config)
-    app.invoke(
+
+    chat_pending = app.get_state(config)
+    assert chat_pending.next == ("another_interrupt_node",)
+    assert len(chat_pending.tasks) == 1
+    assert chat_pending.tasks[0].name == "another_interrupt_node"
+    assert chat_pending.tasks[0].interrupts[0].value == "Another interrupt"
+
+    checkpoint_events: list[dict] = []
+    for mode, chunk in app.stream(
         Command(goto="payment_interrupt_node", resume={"data": "30$"}),
         config,
-    )
+        stream_mode=["checkpoints", "updates"],
+    ):
+        if mode == "checkpoints":
+            checkpoint_events.append(chunk)
+        elif mode == "updates" and "__interrupt__" in chunk:
+            pytest.fail("payment resume should not surface as ambient interrupt update")
 
     assert delivery_ran
+    assert payment_payloads == [
+        {"message": "ask some information"},
+        {"data": "30$"},
+    ]
+    assert chat_payloads == []
+
     state = app.get_state(config)
     assert state.next == ()
+    assert state.values["interrupt"] == 1
+    assert state.values["chat"] == 1
     assert any(
         getattr(m, "content", None) == "Delivery message."
         or (isinstance(m, dict) and m.get("content") == "Delivery message.")
         for m in state.values["messages"]
     )
+
+    if checkpoint_events:
+        streamed = checkpoint_events[-1]
+        history = app.get_state(config)
+        assert streamed["next"] == list(history.next)
+        assert len(streamed["tasks"]) == len(history.tasks)
+        for stream_task, history_task in zip(streamed["tasks"], history.tasks):
+            assert stream_task["name"] == history_task.name
+            assert stream_task["interrupts"] == history_task.interrupts
+
+
+def test_interrupt_command_goto_mismatched_target_fails(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Stale goto targets fail closed instead of delivering resume to another interrupt."""
+
+    class State(MessagesState):
+        chat: int
+
+    chat_payloads: list[object] = []
+
+    def payment_interrupt_node(state: State):
+        payload = interrupt("Payment Link...")
+        message = payload.get("message") if isinstance(payload, dict) else None
+        if message:
+            return Command(
+                goto="another_interrupt_node",
+                update={"chat": state.get("chat", 0) + 1},
+            )
+        return {}
+
+    def another_interrupt_node(_state: State):
+        payload = interrupt("Another interrupt")
+        chat_payloads.append(payload)
+        return {"messages": [{"role": "human", "content": str(payload)}]}
+
+    builder = StateGraph(State)
+    builder.add_node("payment_interrupt_node", payment_interrupt_node)
+    builder.add_node("another_interrupt_node", another_interrupt_node)
+    builder.add_edge(START, "payment_interrupt_node")
+    builder.add_edge("another_interrupt_node", END)
+
+    app = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "6534-mismatch"}}
+
+    app.invoke({"messages": []}, config)
+    app.invoke(Command(resume={"message": "chat"}), config)
+
+    with pytest.raises(RuntimeError, match="goto target 'nonexistent_node'"):
+        app.invoke(
+            Command(goto="nonexistent_node", resume={"data": "30$"}),
+            config,
+        )
+
+    assert chat_payloads == []
+    pending = app.get_state(config)
+    assert pending.next == ("another_interrupt_node",)
+    assert pending.tasks[0].interrupts[0].value == "Another interrupt"
 
 
 def test_concurrent_execution_thread_safety():


### PR DESCRIPTION
Fixes #6534. Binds resume to goto target when another interrupt is pending, adds fail-closed behavior for stale targets, and expands regression tests.