### PR TITLE
fix: ensure AsyncPipeline is properly flushed before closing connection (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,14 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
+                # Enter pipeline mode; ensure we flush/sync before any exit
                 async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                    saver = cls(conn=conn, pipe=pipe, serde=serde)
+                    try:
+                        yield saver
+                    finally:
+                        # Flush any pending operations to avoid SSL errors on close
+                        await pipe.sync()
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the `from_conn_string` method does not ensure that the pipeline is fully flushed before the connection is closed. This can cause a `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` because the pipeline may still have pending operations when the connection context manager exits.

## Fix
Wrap the `yield` in a try-finally block inside the pipeline context manager, calling `await pipe.sync()` to flush all pending operations before the connection is closed. This ensures that the pipeline is properly synchronized, preventing the SSL connection from being terminated unexpectedly.

Closes #5675