### PR TITLE
checkpoint: add fractions.Fraction and complex support to JsonPlusSerializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -30,6 +30,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("uuid", "UUID"),
         # numeric
         ("decimal", "Decimal"),
+        ("fractions", "Fraction"),
+        ("builtins", "complex"),
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import decimal
+import fractions
 import importlib
 import json
 import logging
@@ -372,6 +373,20 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             ),
         )
     elif isinstance(obj, decimal.Decimal):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
+    elif isinstance(obj, fractions.Fraction):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
+    elif isinstance(obj, complex):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1,4 +1,5 @@
 import dataclasses
+import fractions
 import json
 import logging
 import pathlib
@@ -114,6 +115,8 @@ def test_serde_jsonplus() -> None:
         "path": pathlib.Path("foo", "bar"),
         "re": re.compile(r"foo", re.DOTALL),
         "decimal": Decimal("1.10101"),
+        "fraction": fractions.Fraction(1, 3),
+        "complex": complex(1.5, -2.5),
         "set": {1, 2, frozenset({1, 2})},
         "frozen_set": frozenset({1, 2, 3}),
         "ip4": ip4,
@@ -1235,3 +1238,51 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def test_serde_fraction_roundtrip() -> None:
+    serde = JsonPlusSerializer()
+    values = [
+        fractions.Fraction(1, 3),
+        fractions.Fraction(22, 7),
+        fractions.Fraction(-1, 4),
+        fractions.Fraction(0),
+        fractions.Fraction(5),
+    ]
+    for frac in values:
+        dumped = serde.dumps_typed(frac)
+        result = serde.loads_typed(dumped)
+        assert result == frac, f"Fraction roundtrip failed: {frac!r} -> {result!r}"
+        assert type(result) is fractions.Fraction
+
+
+def test_serde_complex_roundtrip() -> None:
+    serde = JsonPlusSerializer()
+    values = [
+        complex(1.5, -2.5),
+        complex(0, 1),
+        complex(-3.14, 0),
+        complex(0, 0),
+        1 + 2j,
+    ]
+    for num in values:
+        dumped = serde.dumps_typed(num)
+        result = serde.loads_typed(dumped)
+        assert result == num, f"complex roundtrip failed: {num!r} -> {result!r}"
+        assert type(result) is complex
+
+
+def test_serde_fraction_strict_mode() -> None:
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+    frac = fractions.Fraction(1, 3)
+    dumped = serde.dumps_typed(frac)
+    result = serde.loads_typed(dumped)
+    assert result == frac
+
+
+def test_serde_complex_strict_mode() -> None:
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+    num = complex(1.5, -2.5)
+    dumped = serde.dumps_typed(num)
+    result = serde.loads_typed(dumped)
+    assert result == num


### PR DESCRIPTION
## Problem

`JsonPlusSerializer` raises `TypeError: Object of type Fraction is not serializable` and `TypeError: Object of type complex is not serializable` when these types appear in checkpoint state.

This is inconsistent: `decimal.Decimal` is already handled, and both `fractions.Fraction` and `complex` follow the exact same single-arg-constructor pattern (i.e. `Fraction("1/3")` and `complex("(1+2j)")` both work from a string).

Closes #8185

## Changes

`libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py`: add `isinstance` checks for `fractions.Fraction` and `complex` in `_msgpack_default()`, using `EXT_CONSTRUCTOR_SINGLE_ARG` with `str(obj)` as the payload. The existing ext hook reconstructs them via `cls(str_arg)`, which works for both types.

`libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py`: add `("fractions", "Fraction")` and `("builtins", "complex")` to `SAFE_MSGPACK_TYPES` so both types are whitelisted in strict mode (`LANGGRAPH_STRICT_MSGPACK=true`).

`libs/checkpoint/tests/test_jsonplus.py`: extend the existing `test_serde_jsonplus` round-trip test with `Fraction` and `complex` entries; add four focused regression tests covering roundtrip and strict-mode deserialization.

## Verification

```python
from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
import fractions

serde = JsonPlusSerializer()

frac = fractions.Fraction(1, 3)
assert serde.loads_typed(serde.dumps_typed(frac)) == frac
# -> 1/3

num = complex(1.5, -2.5)
assert serde.loads_typed(serde.dumps_typed(num)) == num
# -> (1.5-2.5j)
```
