### PR TITLE
fix(prebuilt): allow return_direct tools when remaining_steps is 1

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -434,9 +434,10 @@ def create_react_agent(
             !!! Note
                 `remaining_steps` is used to limit the number of steps the react agent can take.
                 Calculated roughly as `recursion_limit` - `total_steps_taken`.
-                If `remaining_steps` is less than 2 and tool calls are present in the response,
-                the react agent will return a final AI Message with
-                the content "Sorry, need more steps to process this request.".
+                If `remaining_steps` is less than 2 and tool calls are present in the
+                response (and not all requested tools are `return_direct`), the react
+                agent will return a final AI Message with the content
+                "Sorry, need more steps to process this request.".
                 No `GraphRecusionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
@@ -628,7 +629,9 @@ def create_react_agent(
         if remaining_steps is not None:
             if remaining_steps < 1 and all_tools_return_direct:
                 return True
-            elif remaining_steps < 2 and has_tool_calls:
+            elif (
+                remaining_steps < 2 and has_tool_calls and not all_tools_return_direct
+            ):
                 return True
 
         return False

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1084,6 +1084,45 @@ async def test_return_direct(version: str) -> None:
     ]
 
 
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+def test_return_direct_with_remaining_steps_one(version: str) -> None:
+    @dec_tool(return_direct=True)
+    def tool_return_direct(input: str) -> str:
+        """A tool that returns directly."""
+        return f"Direct result: {input}"
+
+    tool_call = [
+        ToolCall(
+            name="tool_return_direct",
+            args={"input": "Test direct"},
+            id="1",
+        ),
+    ]
+    model = FakeToolCallingModel(tool_calls=[tool_call, []])
+    agent = create_react_agent(
+        model,
+        [tool_return_direct],
+        version=version,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage(content="Test direct", id="hum0")],
+            "remaining_steps": 1,
+        }
+    )
+    assert result["messages"] == [
+        HumanMessage(content="Test direct", id="hum0"),
+        AIMessage(content="Test direct", id="0", tool_calls=tool_call),
+        ToolMessage(
+            content="Direct result: Test direct",
+            name="tool_return_direct",
+            tool_call_id="1",
+            id=result["messages"][2].id,
+        ),
+    ]
+
+
 def test_inspect_react() -> None:
     model = FakeToolCallingModel(tool_calls=[])
     agent = create_react_agent(model, [])


### PR DESCRIPTION
## Summary
- Fix `_are_more_steps_needed` so `return_direct=True` tool calls are allowed when `remaining_steps == 1` (they do not require a second LLM step)
- Add regression test covering v1 and v2 react agent graph versions

Fixes #8204

## Test plan
- [x] `uv run pytest tests/test_react_agent.py::test_return_direct_with_remaining_steps_one -q` (2 passed: v1 + v2)


Made with [Cursor](https://cursor.com)