### PR TITLE
fix(prebuilt): allow return_direct tools with one remaining step

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -434,9 +434,9 @@ def create_react_agent(
             !!! Note
                 `remaining_steps` is used to limit the number of steps the react agent can take.
                 Calculated roughly as `recursion_limit` - `total_steps_taken`.
-                If `remaining_steps` is less than 2 and tool calls are present in the response,
-                the react agent will return a final AI Message with
-                the content "Sorry, need more steps to process this request.".
+                If `remaining_steps` is less than 2 and the model returns tool calls
+                that are not all `return_direct`, the react agent will return a final
+                AI Message with the content "Sorry, need more steps to process this request.".
                 No `GraphRecusionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
@@ -618,17 +618,17 @@ def create_react_agent(
             return static_model
 
     def _are_more_steps_needed(state: StateSchema, response: BaseMessage) -> bool:
-        has_tool_calls = isinstance(response, AIMessage) and response.tool_calls
+        has_tool_calls = isinstance(response, AIMessage) and bool(response.tool_calls)
         all_tools_return_direct = (
             all(call["name"] in should_return_direct for call in response.tool_calls)
-            if isinstance(response, AIMessage)
+            if has_tool_calls
             else False
         )
         remaining_steps = _get_state_value(state, "remaining_steps", None)
         if remaining_steps is not None:
             if remaining_steps < 1 and all_tools_return_direct:
                 return True
-            elif remaining_steps < 2 and has_tool_calls:
+            elif remaining_steps < 2 and has_tool_calls and not all_tools_return_direct:
                 return True
 
         return False

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -1023,6 +1023,35 @@ async def test_return_direct(version: str) -> None:
             id=result["messages"][2].id,
         ),
     ]
+
+    model = FakeToolCallingModel(tool_calls=[first_tool_call, []])
+
+    class State(TypedDict):
+        messages: Annotated[list[AnyMessage], add_messages]
+        remaining_steps: int
+
+    agent = create_react_agent(
+        model,
+        [tool_return_direct, tool_normal],
+        state_schema=State,
+        version=version,
+    )
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage(content="Test direct", id="hum0")],
+            "remaining_steps": 1,
+        },
+    )
+    assert result["messages"] == [
+        HumanMessage(content="Test direct", id="hum0"),
+        expected_ai,
+        _AnyIdToolMessage(
+            content="Direct result: Test direct",
+            name="tool_return_direct",
+            tool_call_id="1",
+        ),
+    ]
+
     second_tool_call = [
         ToolCall(
             name="tool_normal",
@@ -1047,6 +1076,24 @@ async def test_return_direct(version: str) -> None:
             id=result["messages"][2].id,
         ),
         AIMessage(content="Test normal-Test normal-Normal result: Test normal", id="1"),
+    ]
+
+    model = FakeToolCallingModel(tool_calls=[second_tool_call, []])
+    agent = create_react_agent(
+        model,
+        [tool_return_direct, tool_normal],
+        state_schema=State,
+        version=version,
+    )
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage(content="Test normal", id="hum1")],
+            "remaining_steps": 1,
+        },
+    )
+    assert result["messages"] == [
+        HumanMessage(content="Test normal", id="hum1"),
+        AIMessage(content="Sorry, need more steps to process this request.", id="0"),
     ]
 
     both_tool_calls = [


### PR DESCRIPTION
Fixes #8204.

## Summary

`create_react_agent` could return the "need more steps" fallback before executing tools when `remaining_steps == 1`, even if every requested tool was marked `return_direct=True`.

This updates the remaining-step guard so return-direct-only tool calls can still run, while preserving the existing fallback for regular tool calls.

## Test plan

- `uv run ruff check .`
- `uv run ty check langgraph`
- `LANGGRAPH_TEST_FAST=1 uv run pytest tests/test_react_agent.py -q`