### PR TITLE
chore: align type-checker wording with ty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ENV/
 env.bak/
 venv.bak/
 
-# mypy
+# Python type checker caches
 .mypy_cache/
 .dmypy.json
 dmypy.json

--- a/libs/langgraph/tests/test_stream_events_v3.py
+++ b/libs/langgraph/tests/test_stream_events_v3.py
@@ -1150,7 +1150,7 @@ class TestV2ValidationErrors:
 
 
 # --- type narrowing compile-time checks ---
-# These assert_type calls verify that mypy narrows the union correctly.
+# These assert_type calls verify that the type checker narrows the union correctly.
 
 
 _OutputT = TypeVar("_OutputT")


### PR DESCRIPTION
### Description
The Python libraries already run `ty` through their lint/type Makefile targets. This cleans up stale mypy-specific wording so the remaining mypy references are local cache ignores rather than active type-check configuration.

### Test Plan
- [x] `NO_COLOR=1 make -C libs/langgraph format`
- [x] `NO_COLOR=1 make -C libs/langgraph lint`
- [x] `NO_COLOR=1 make -C libs/langgraph TEST=tests/test_stream_events_v3.py NO_DOCKER=true test`

Made by [Open SWE](https://openswe.vercel.app/agents/4dbe439d-f548-df4a-4082-e555fa16b699)