### PR TITLE
fix: disable autocommit for pipeline mode to prevent SSL connection closure (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, autocommit=False, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the connection is created with `autocommit=True`. In psycopg's pipeline mode, autocommit must be disabled because the pipeline batches operations and flushes them as a group. With autocommit enabled, operations are sent individually, which can cause the pipeline to become confused and lead to the error: `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`.

## Fix
Changed `autocommit=True` to `autocommit=False` in the `from_conn_string` method. This ensures that when using pipeline mode, operations are properly batched and committed at the end of the pipeline block, preventing the SSL connection from being closed prematurely.

Closes #5675