### PR TITLE
GitContribute issue #8136

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/__init__.py
@@ -139,6 +139,7 @@ class SqliteSaver(BaseCheckpointSaver[str]):
         self.conn.executescript(
             """
             PRAGMA journal_mode=WAL;
+            PRAGMA busy_timeout=5000;
             CREATE TABLE IF NOT EXISTS checkpoints (
                 thread_id TEXT NOT NULL,
                 checkpoint_ns TEXT NOT NULL DEFAULT '',

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -316,6 +316,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             async with self.conn.executescript(
                 """
                 PRAGMA journal_mode=WAL;
+                PRAGMA busy_timeout=5000;
                 CREATE TABLE IF NOT EXISTS checkpoints (
                     thread_id TEXT NOT NULL,
                     checkpoint_ns TEXT NOT NULL DEFAULT '',

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,5 +1,8 @@
+import asyncio
+import sqlite3
 from typing import Any
 
+import aiosqlite
 import pytest
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
@@ -72,6 +75,30 @@ class TestAsyncSqliteSaver:
                 **self.metadata_2,
                 "run_id": "my_run_id",
             }
+
+    async def test_aput_waits_for_contended_writer(self, tmp_path) -> None:
+        db_path = tmp_path / "checkpoints.sqlite"
+        async with aiosqlite.connect(db_path, timeout=0) as conn:
+            saver = AsyncSqliteSaver(conn)
+            await saver.setup()
+
+            async with conn.execute("PRAGMA busy_timeout") as cur:
+                assert await cur.fetchone() == (5000,)
+
+            blocker = sqlite3.connect(db_path, timeout=0, isolation_level=None)
+            try:
+                blocker.execute("BEGIN IMMEDIATE")
+                put_task = asyncio.create_task(
+                    saver.aput(self.config_1, self.chkpnt_1, self.metadata_1, {})
+                )
+
+                await asyncio.sleep(0.1)
+                assert not put_task.done()
+
+                blocker.commit()
+                await put_task
+            finally:
+                blocker.close()
 
     async def test_asearch(self) -> None:
         async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:


### PR DESCRIPTION
# Set SQLite busy timeout for checkpoint savers

## Summary

- Set `PRAGMA busy_timeout=5000` during sync and async SQLite checkpoint saver setup.
- Add an async regression test for a contended writer using a saver connection opened with `timeout=0`, proving setup applies the busy timeout and `aput` waits for a separate write lock to release.

## Test evidence

- `git diff --check` passed.
- `python -m py_compile langgraph/checkpoint/sqlite/__init__.py langgraph/checkpoint/sqlite/aio.py tests/test_aiosqlite.py` passed.
- Targeted pytest and Makefile commands could not run in this environment because `uv`, `pytest`, `ruff`, and `aiosqlite` are not installed.

## Risks or notes for maintainers

- Please run `make format`, `make lint`, and the checkpoint-sqlite test suite in the standard project environment.
- `busy_timeout` helps contended SQLite writes wait instead of failing immediately, but SQLite remains a lightweight/local checkpointing backend rather than a high-throughput production database.

Related issue: #8136
