### PR TITLE
fix: add pipeline sync in setup() to prevent SSL disconnection (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -96,6 +96,8 @@ class AsyncPostgresSaver(BasePostgresSaver):
         """
         async with self._cursor() as cur:
             await cur.execute(self.MIGRATIONS[0])
+            if self.pipe:
+                await cur.connection.pipeline.sync()  # flush pipeline before query results
             results = await cur.execute(
                 "SELECT v FROM checkpoint_migrations ORDER BY v DESC LIMIT 1"
             )
@@ -113,6 +115,8 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
+                if self.pipe:
+                    await cur.connection.pipeline.sync()  # ensure pipeline consistency
         if self.pipe:
             await self.pipe.sync()
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with pipeline enabled (`pipeline=True`), calling `setup()` causes an `SSL connection has been closed unexpectedly` error. This happens because the setup method executes multiple SQL statements without properly synchronizing the pipeline between result-consuming operations.

## Fix
Added `await cur.connection.pipeline.sync()` right after the initial migration DDL execution and after each migration step in the loop. This ensures that the pipeline is flushed before we attempt to fetch results or proceed with further queries, preventing pipeline desynchronization.

Closes #5675