### PR TITLE
ci(checkpoint): add Windows runner for libs/checkpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,44 @@ jobs:
     uses: ./.github/workflows/_test_langgraph.yml
     secrets: inherit
 
+  # Incremental Windows support: starts with libs/checkpoint (pure Python, minimal native deps).
+  # Future PRs can extend to other libs once this lands. See issue #5029.
+  test-windows:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.deps == 'true'
+    name: "cd libs/checkpoint (windows-latest) #${{ matrix.python-version }}"
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: libs/checkpoint
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.13"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: ./.github/actions/uv_setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-suffix: test-libs-checkpoint-windows
+          working-directory: libs/checkpoint
+      - name: Install dependencies
+        run: uv sync --frozen --group test --no-dev
+      - name: Run tests
+        run: uv run pytest .
+      - name: Ensure the tests did not create any additional files
+        run: |
+          set -eu
+
+          STATUS="$(git status)"
+          echo "$STATUS"
+
+          echo "$STATUS" | grep 'nothing to commit, working tree clean'
+
   check-sdk-methods:
     needs: changes
     if: needs.changes.outputs.python == 'true'
@@ -163,6 +201,7 @@ jobs:
         lint,
         test,
         test-langgraph,
+        test-windows,
         check-sdk-methods,
         check-schema,
         integration-test,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,9 @@ jobs:
     uses: ./.github/workflows/_test_langgraph.yml
     secrets: inherit
 
-  # Incremental Windows support: starts with libs/checkpoint (pure Python, minimal native deps).
-  # Future PRs can extend to other libs once this lands. See issue #5029.
+  # Windows CI for libs/checkpoint: smallest native-dep surface in the monorepo
+  # (no Postgres/Docker), so the lowest-risk lib to validate the windows-latest
+  # runner. Extend to other libs in follow-ups. See #5029.
   test-windows:
     needs: changes
     if: needs.changes.outputs.python == 'true' || needs.changes.outputs.deps == 'true'
@@ -122,7 +123,7 @@ jobs:
         uses: ./.github/actions/uv_setup
         with:
           python-version: ${{ matrix.python-version }}
-          cache-suffix: test-libs-checkpoint-windows
+          cache-suffix: test-libs-checkpoint-windows-${{ matrix.python-version }}
           working-directory: libs/checkpoint
       - name: Install dependencies
         run: uv sync --frozen --group test --no-dev
@@ -135,6 +136,8 @@ jobs:
           STATUS="$(git status)"
           echo "$STATUS"
 
+          # grep will exit non-zero if the target message isn't found,
+          # and `set -e` above will cause the step to fail.
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
 
   check-sdk-methods:


### PR DESCRIPTION
Fixes #5029

Adds a `test-windows` job running the `libs/checkpoint` suite on `windows-latest` (Python 3.11 and 3.13). It calls `uv run pytest` directly instead of `make`, so the runner doesn't need GNU make; no test code changes, and the Redis cache test skips cleanly when Redis isn't present.

Verified on my fork CI: both windows-latest jobs pass the full `libs/checkpoint` suite. I picked up this issue on #5029 (comment on 2026-05-18) with this same branch and am opening the PR so the change is reviewable.
