### PR TITLE
fix(langgraph): do not report GraphBubbleUp as a tool-error on the tools stream

### DIFF
--- a/libs/langgraph/langgraph/pregel/_tools.py
+++ b/libs/langgraph/langgraph/pregel/_tools.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 
 from langgraph._internal._constants import NS_SEP
 from langgraph.constants import TAG_NOSTREAM
+from langgraph.errors import GraphBubbleUp
 from langgraph.pregel.protocol import StreamChunk
 
 try:
@@ -188,6 +189,15 @@ class StreamToolCallHandler(BaseCallbackHandler, _StreamingCallbackHandler):
             return
         ns, tool_call_id, token = info
         self._reset_writer(token)
+        # A `GraphBubbleUp` (e.g. the `GraphInterrupt` raised by `interrupt()`)
+        # is control flow, not a tool failure: the run pauses and the signal is
+        # surfaced via the `__interrupt__` channel / graph state. Reporting it as
+        # a `tool-error` would misclassify a pause as a failure and, since the
+        # event only carries `str(error)`, discard the structured payload (e.g.
+        # the `Interrupt` objects). Let it bubble untouched, mirroring how the
+        # runner, executor, and retry logic already special-case `GraphBubbleUp`.
+        if isinstance(error, GraphBubbleUp):
+            return
         self.stream(
             (
                 ns,

--- a/libs/langgraph/tests/test_tool_stream_handler.py
+++ b/libs/langgraph/tests/test_tool_stream_handler.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.prebuilt import ToolNode, ToolRuntime
 from typing_extensions import TypedDict
 
@@ -20,6 +21,7 @@ from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.pregel._tools import _tool_call_writer
+from langgraph.types import interrupt
 
 
 class _State(TypedDict):
@@ -195,6 +197,79 @@ class TestAsyncGraphAsyncTool:
         kinds = [p["event"] for _, p in events]
         assert kinds == ["tool-started", "tool-output-delta", "tool-finished"]
         assert events[1][1]["delta"] == "hi"
+
+
+class TestToolInterrupt:
+    """A tool calling `interrupt()` raises `GraphInterrupt`, a `GraphBubbleUp`.
+
+    That is control flow (the run pauses and resumes), not a tool failure, and
+    it is surfaced via the `__interrupt__` channel / graph state. It must not be
+    reported on the `tools` channel as a `tool-error`: doing so misreports a
+    pause as a failure and, because the event only carries `str(error)`, loses
+    the structured `Interrupt` objects entirely.
+    """
+
+    def test_interrupt_not_reported_as_tool_error_sync(self) -> None:
+        @tool
+        def ask_human(question: str) -> str:
+            """Pause for human input."""
+            return interrupt(question)
+
+        sg = StateGraph(_State)
+        sg.add_node("caller", _caller_sync("ask_human", {"question": "ok?"}))
+        sg.add_node("tools", ToolNode([ask_human]))
+        sg.add_edge(START, "caller")
+        sg.add_edge("caller", "tools")
+        sg.add_edge("tools", END)
+        graph = sg.compile(checkpointer=InMemorySaver())
+
+        config = {"configurable": {"thread_id": "t1"}}
+        events = _tool_events(
+            graph.stream(
+                {"messages": []},
+                config=config,
+                stream_mode=["tools"],
+                subgraphs=True,
+            )
+        )
+
+        kinds = [p["event"] for _, p in events]
+        # The pause must not surface as a failure on the tools channel.
+        assert "tool-error" not in kinds
+        assert kinds == ["tool-started"]
+        # The run did pause: the interrupt is recorded on graph state.
+        assert graph.get_state(config).interrupts
+
+    @pytest.mark.anyio
+    async def test_interrupt_not_reported_as_tool_error_async(self) -> None:
+        @tool
+        async def ask_human(question: str) -> str:
+            """Pause for human input."""
+            return interrupt(question)
+
+        sg = StateGraph(_State)
+        sg.add_node("caller", _caller_async("ask_human", {"question": "ok?"}))
+        sg.add_node("tools", ToolNode([ask_human]))
+        sg.add_edge(START, "caller")
+        sg.add_edge("caller", "tools")
+        sg.add_edge("tools", END)
+        graph = sg.compile(checkpointer=InMemorySaver())
+
+        config = {"configurable": {"thread_id": "t1"}}
+        events: list[tuple[tuple[str, ...], dict]] = []
+        async for ns, mode, payload in graph.astream(
+            {"messages": []},
+            config=config,
+            stream_mode=["tools"],
+            subgraphs=True,
+        ):
+            if mode == "tools":
+                events.append((tuple(ns), payload))
+
+        kinds = [p["event"] for _, p in events]
+        assert "tool-error" not in kinds
+        assert kinds == ["tool-started"]
+        assert (await graph.aget_state(config)).interrupts
 
 
 class TestConcurrentToolCalls:


### PR DESCRIPTION
Fixes #8218.

### Problem

When a tool calls `interrupt()`, the resulting `GraphInterrupt` (a `GraphBubbleUp`) is reported on the `tools` stream channel as a `tool-error` event with `message=str(error)`. This misclassifies a control-flow pause as a tool failure, and flattens the structured `Interrupt` objects to a string like `"(Interrupt(value='ok?', id='...'),)"` - so consumers (e.g. the prebuilt `ToolCallStream`, whose `error` is typed `str | None`) can't tell a pause apart from a real failure or recover the interrupt `id`/`value`.

### Fix

`StreamToolCallHandler._error` now skips emitting `tool-error` for `GraphBubbleUp` (after the existing writer/cleanup), letting control-flow signals bubble untouched. The interrupt continues to surface via the `__interrupt__` channel / graph state, as everywhere else. This mirrors the existing `GraphBubbleUp` special-casing in `_runner.py`, `_executor.py`, and `_retry.py`.

Genuine tool exceptions (e.g. `ValueError`) are unchanged - they still produce a `tool-error` event.

### Behavior

A tool that calls `interrupt()`, streamed with `stream_mode=["tools"]`:

Before:
```
{'event': 'tool-started', ...}
{'event': 'tool-error', 'message': "(Interrupt(value='ok?', id='...'),)"}
```

After:
```
{'event': 'tool-started', ...}
```
(the pause is read from `graph.get_state(config).interrupts`, as usual)

### Tests

Added `TestToolInterrupt` (sync + async) to `tests/test_tool_stream_handler.py`, asserting an interrupting tool emits no `tool-error` and the run pauses (interrupt present on state). Both tests fail on `main` and pass with this change.

- `tests/test_tool_stream_handler.py` - 10 passed (8 existing + 2 new); the existing `test_tool_error_event` (real `ValueError`) still passes.
- Regression sweep over `test_pregel_stream_events_v3.py`, `test_stream_events_v3.py`, `test_stream_events_v3_e2e.py`, `test_interruption.py`, `test_stream_data_transformers.py`, `test_stream_lifecycle_transformer.py` - 285 passed.
- `ruff check` / `ruff format` / `ty check langgraph` all clean.
