### PR TITLE
fix(checkpoint): clear stale vectors on InMemoryStore index=False update

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -211,11 +211,13 @@ class InMemoryStore(BaseStore):
             queryinmem_store = self._embed_search_queries(search_ops)
             self._batch_search(search_ops, queryinmem_store, results)
 
+        # Apply puts before (re)inserting vectors so stale vectors from an
+        # updated key are cleared before the new embeddings are written.
+        self._apply_put_ops(put_ops)
         to_embed = self._extract_texts(put_ops)
         if to_embed and self.index_config and self.embeddings:
             embeddings = self.embeddings.embed_documents(list(to_embed))
             self._insertinmem_store(to_embed, embeddings)
-        self._apply_put_ops(put_ops)
         return results
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
@@ -226,11 +228,13 @@ class InMemoryStore(BaseStore):
             queryinmem_store = await self._aembed_search_queries(search_ops)
             self._batch_search(search_ops, queryinmem_store, results)
 
+        # Apply puts before (re)inserting vectors so stale vectors from an
+        # updated key are cleared before the new embeddings are written.
+        self._apply_put_ops(put_ops)
         to_embed = self._extract_texts(put_ops)
         if to_embed and self.index_config and self.embeddings:
             embeddings = await self.embeddings.aembed_documents(list(to_embed))
             self._insertinmem_store(to_embed, embeddings)
-        self._apply_put_ops(put_ops)
         return results
 
     # Helpers
@@ -414,6 +418,11 @@ class InMemoryStore(BaseStore):
                     created_at=datetime.now(timezone.utc),
                     updated_at=datetime.now(timezone.utc),
                 )
+                # Clear any existing vectors for this key. Embeddings for the new
+                # value are recomputed and re-inserted afterwards (when indexed),
+                # so stale vectors from the previous value must not linger. This
+                # also handles `index=False` updates, where nothing is re-embedded.
+                self._vectors[namespace].pop(key, None)
 
     def _extract_texts(
         self, put_ops: dict[tuple[tuple[str, ...], str], PutOp]

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -716,6 +716,47 @@ async def test_async_vector_update_with_embedding(
     assert not any(r.key == "doc4" for r in results_new)
 
 
+def test_vector_update_index_false_clears_stale_vectors(
+    fake_embeddings: CharacterEmbeddings,
+) -> None:
+    """Updating an indexed key with index=False must drop its old embeddings."""
+    store = InMemoryStore(
+        index={"dims": fake_embeddings.dims, "embed": fake_embeddings}
+    )
+    store.put(("test",), "doc1", {"text": "zany zebra Xerxes"})
+
+    results_initial = store.search(("test",), query="Zany Xerxes")
+    assert any(r.key == "doc1" and r.score is not None for r in results_initial)
+
+    # Re-put the same key without indexing; the stale vector must not survive.
+    store.put(("test",), "doc1", {"text": "new text about dogs"}, index=False)
+
+    results_after = store.search(("test",), query="Zany Xerxes")
+    doc1 = next((r for r in results_after if r.key == "doc1"), None)
+    # doc1 either drops out of the scored results or comes back scoreless,
+    # but it must never retain the old embedding's similarity score.
+    assert doc1 is None or doc1.score is None
+
+
+async def test_async_vector_update_index_false_clears_stale_vectors(
+    fake_embeddings: CharacterEmbeddings,
+) -> None:
+    """Async: updating an indexed key with index=False must drop its old embeddings."""
+    store = InMemoryStore(
+        index={"dims": fake_embeddings.dims, "embed": fake_embeddings}
+    )
+    await store.aput(("test",), "doc1", {"text": "zany zebra Xerxes"})
+
+    results_initial = await store.asearch(("test",), query="Zany Xerxes")
+    assert any(r.key == "doc1" and r.score is not None for r in results_initial)
+
+    await store.aput(("test",), "doc1", {"text": "new text about dogs"}, index=False)
+
+    results_after = await store.asearch(("test",), query="Zany Xerxes")
+    doc1 = next((r for r in results_after if r.key == "doc1"), None)
+    assert doc1 is None or doc1.score is None
+
+
 def test_vector_search_with_filters(fake_embeddings: CharacterEmbeddings) -> None:
     """Test combining vector search with filters."""
     inmem_store = InMemoryStore(


### PR DESCRIPTION
Updating an existing key with index=False left the previous embedding in _vectors, so search returned stale similarity scores. Clear a key's vectors in _apply_put_ops and apply puts before re-inserting embeddings.

Fixes #8214
