### PR TITLE
fix(prebuilt): re-raise GraphInterrupt through wrap_tool_call middleware (#8217)

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1053,6 +1053,8 @@ class ToolNode(RunnableCallable):
         # Call wrapper with request and execute callable
         try:
             return self._wrap_tool_call(tool_request, execute)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1208,6 +1210,8 @@ class ToolNode(RunnableCallable):
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
             return self._wrap_tool_call(tool_request, _sync_execute)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -623,6 +623,59 @@ def test_tool_node_node_interrupt() -> None:
             assert exc_info.value == "foo"
 
 
+def _tool_interrupt_input() -> dict[str, list[AIMessage]]:
+    return {
+        "messages": [
+            AIMessage(
+                "hi?",
+                tool_calls=[
+                    {
+                        "name": "tool_interrupt",
+                        "args": {"some_val": 0},
+                        "id": "some 0",
+                    }
+                ],
+            )
+        ]
+    }
+
+
+@pytest.mark.parametrize("use_async_wrapper", [False, True])
+async def test_tool_node_interrupt_with_wrap_tool_call(
+    use_async_wrapper: bool,
+) -> None:
+    """GraphBubbleUp must propagate through wrap/awrap_tool_call middleware."""
+
+    def tool_interrupt(some_val: int) -> None:
+        """Tool docstring."""
+        raise GraphBubbleUp("foo")
+
+    def wrap_tool_call(request, execute):
+        return execute(request)
+
+    async def awrap_tool_call(request, execute):
+        return await execute(request)
+
+    node_kwargs: dict[str, Any] = {
+        "handle_tool_errors": lambda e: f"Tool call failed ({type(e).__name__}): {e}",
+    }
+    if use_async_wrapper:
+        node_kwargs["awrap_tool_call"] = awrap_tool_call
+    else:
+        node_kwargs["wrap_tool_call"] = wrap_tool_call
+
+    node = ToolNode([tool_interrupt], **node_kwargs)
+    config = _create_config_with_runtime()
+
+    with pytest.raises(GraphBubbleUp) as exc_info:
+        if use_async_wrapper:
+            await node.ainvoke(_tool_interrupt_input(), config=config)
+        else:
+            node.invoke(_tool_interrupt_input(), config=config)
+
+    assert exc_info.value.args[0] == "foo"
+
+
 @pytest.mark.parametrize("input_type", ["dict", "tool_calls"])
 async def test_tool_node_command(input_type: str) -> None:
     from langchain_core.tools.base import InjectedToolCallId


### PR DESCRIPTION
### Problem
When `ToolNode` uses `wrap_tool_call` or `awrap_tool_call`, tools calling `interrupt()` raise `GraphInterrupt`, but the wrapper path catches it as a generic exception and converts it to a tool error. The graph never suspends.

### Root cause
`_run_one` and `_arun_one` use `except Exception` without first re-raising `GraphBubbleUp`, unlike the direct execution paths.

### Fix
Add `except GraphBubbleUp: raise` before the generic handler in both wrapper code paths.

### Test plan
- [x] `test_tool_node_interrupt_with_wrap_tool_call` (sync + async)
- [x] Full `tests/test_tool_node.py` (45 passed)

Closes #8217