### PR TITLE
fix(prebuilt): correct `GraphRecursionError` typo and mermaid grammar

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -437,7 +437,7 @@ def create_react_agent(
                 If `remaining_steps` is less than 2 and tool calls are present in the response,
                 the react agent will return a final AI Message with
                 the content "Sorry, need more steps to process this request.".
-                No `GraphRecusionError` will be raised in this case.
+                No `GraphRecursionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
         checkpointer: An optional checkpoint saver object. This is used for persisting
@@ -491,7 +491,7 @@ def create_react_agent(
             Note over A: Prompt + LLM
             loop while tool_calls present
                 A->>T: Execute tools
-                T-->>A: ToolMessage for each tool_calls
+                T-->>A: ToolMessage for each tool_call
             end
             A->>U: Return final state
     ```


### PR DESCRIPTION
Fixes #8130
Fixes #8226

---

Two trivial documentation fixes in `create_react_agent`:

- **Typo**: `GraphRecusionError` → `GraphRecursionError` (line 440)
- **Grammar**: `ToolMessage for each tool_calls` → `ToolMessage for each tool_call` in the mermaid diagram (line 494)

Both are purely cosmetic — no behavior change, no test impact.

This contribution was prepared with AI assistance.