### PR TITLE
fix(sdk-py): apply `_quote_path_param` to path identifiers in stream f-strings

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -24,6 +24,7 @@ from langchain_core.language_models.chat_model_stream import AsyncChatModelStrea
 from langchain_protocol import Event, SubscribeParams
 
 from langgraph_sdk._async.http import HttpClient
+from langgraph_sdk._shared.utilities import _quote_path_param
 from langgraph_sdk.schema import QueryParamTypes
 from langgraph_sdk.stream.controller import _SeenEventIds
 from langgraph_sdk.stream.decoders import (
@@ -151,7 +152,7 @@ class _AgentModule:
             query_params.update(dict(params))
         request_headers = {**self._owner._headers, **dict(headers or {})}
         return await self._owner._http.get(
-            f"/assistants/{self._owner.assistant_id}/graph",
+            f"/assistants/{_quote_path_param(self._owner.assistant_id)}/graph",
             params=query_params,
             headers=request_headers or None,
         )
@@ -1899,7 +1900,7 @@ class AsyncThreadStream:
     async def _fetch_state(self) -> dict[str, Any]:
         """Fetch the current thread state from the REST endpoint."""
         return await self._http.get(
-            f"/threads/{self.thread_id}/state",
+            f"/threads/{_quote_path_param(self.thread_id)}/state",
             headers=self._headers or None,
         )
 

--- a/libs/sdk-py/langgraph_sdk/_sync/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/stream.py
@@ -22,6 +22,7 @@ from typing import Any, Literal, TypedDict, cast
 from langchain_core.language_models.chat_model_stream import ChatModelStream
 from langchain_protocol import Event, SubscribeParams
 
+from langgraph_sdk._shared.utilities import _quote_path_param
 from langgraph_sdk._sync.http import SyncHttpClient
 from langgraph_sdk.schema import QueryParamTypes
 from langgraph_sdk.stream.decoders import (
@@ -194,7 +195,7 @@ class _SyncAgentModule:
             query_params.update(dict(params))
         request_headers = {**self._owner._headers, **dict(headers or {})}
         return self._owner._http.get(
-            f"/assistants/{self._owner.assistant_id}/graph",
+            f"/assistants/{_quote_path_param(self._owner.assistant_id)}/graph",
             params=query_params,
             headers=request_headers or None,
         )
@@ -1549,7 +1550,7 @@ class SyncThreadStream:
     def _fetch_state(self) -> dict[str, Any]:
         """Fetch the current thread state from the REST endpoint."""
         return self._http.get(
-            f"/threads/{self.thread_id}/state",
+            f"/threads/{_quote_path_param(self.thread_id)}/state",
             headers=self._headers or None,
         )
 


### PR DESCRIPTION
Fixes #8222

---

Four f-string sites in the SDK stream transports embed user-controlled
identifiers (`assistant_id`, `thread_id`) directly into URL path
segments without percent-encoding. This is the same class of issue as
GHSA-w39p-vh2g-g8g5 / CVE-2026-48776, which was partially addressed
in #7953/#7954.

This applies `_quote_path_param` to the four remaining sites:

- `_async/stream.py:154` → `/assistants/.../graph`
- `_sync/stream.py:197` → same path, sync transport
- `_async/stream.py:1902` → `/threads/.../state`
- `_sync/stream.py:1552` → same path, sync transport

The helper is already imported and used extensively in `assistants.py`
for the same identifiers.

This contribution was prepared with AI assistance.