### PR TITLE
feat(serde): add native msgpack serialization for pandas DataFrame/Series

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -20,6 +20,9 @@ _SENTINEL = cast(None, object())
 
 SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
     {
+        # pandas
+        ("pandas.core.frame", "DataFrame"),
+        ("pandas.core.series", "Series"),
         # datetime types
         ("datetime", "datetime"),
         ("datetime", "date"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -262,6 +262,14 @@ class JsonPlusSerializer(SerializerProtocol):
             return "bytes", obj
         elif isinstance(obj, bytearray):
             return "bytearray", obj
+        elif (pd_mod := sys.modules.get("pandas")) is not None and isinstance(
+            obj, pd_mod.DataFrame
+        ):
+            return "msgpack", _msgpack_enc_pandas_dataframe(obj)
+        elif (pd_mod := sys.modules.get("pandas")) is not None and isinstance(
+            obj, pd_mod.Series
+        ):
+            return "msgpack", _msgpack_enc_pandas_series(obj)
         else:
             try:
                 return "msgpack", _msgpack_enc(obj)
@@ -300,6 +308,55 @@ EXT_PYDANTIC_V1 = 4
 EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 EXT_DELTA_SNAPSHOT = 7
+EXT_PANDAS_DATAFRAME = 8
+EXT_PANDAS_SERIES = 9
+
+
+def _msgpack_enc_pandas_dataframe(obj: Any) -> bytes:
+    import io
+    import pyarrow as pa
+
+    try:
+        table = pa.Table.from_pandas(obj)
+        buf = io.BytesIO()
+        writer = pa.ipc.new_file(buf, table.schema)
+        writer.write_table(table)
+        writer.close()
+        return ormsgpack.packb(
+            ormsgpack.Ext(EXT_PANDAS_DATAFRAME, b"A" + buf.getvalue()),
+            option=_option,
+        )
+    except Exception:
+        pass
+    tight = obj.to_dict(orient="tight")
+    return ormsgpack.packb(
+        ormsgpack.Ext(EXT_PANDAS_DATAFRAME, b"D" + _msgpack_enc(tight)),
+        option=_option,
+    )
+
+
+def _msgpack_enc_pandas_series(obj: Any) -> bytes:
+    import io
+    import pyarrow as pa
+
+    try:
+        table = pa.Table.from_pandas(obj.to_frame())
+        buf = io.BytesIO()
+        writer = pa.ipc.new_file(buf, table.schema)
+        writer.write_table(table)
+        writer.close()
+        return ormsgpack.packb(
+            ormsgpack.Ext(EXT_PANDAS_SERIES, b"A" + buf.getvalue()),
+            option=_option,
+        )
+    except Exception:
+        pass
+    name = obj.name
+    tight = obj.to_frame().to_dict(orient="tight")
+    return ormsgpack.packb(
+        ormsgpack.Ext(EXT_PANDAS_SERIES, b"D" + _msgpack_enc((name, tight))),
+        option=_option,
+    )
 
 
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
@@ -739,6 +796,48 @@ def _create_msgpack_ext_hook(
                 return arr.reshape(shape, order=order)
             except Exception:
                 return None
+        elif code == EXT_PANDAS_DATAFRAME:
+            try:
+                import pandas as _pd
+                import pyarrow as _pa
+
+                if data[:1] == b"A":
+                    reader = _pa.ipc.open_file(data[1:])
+                    table = reader.read_all()
+                    return table.to_pandas()
+                else:
+                    tight = ormsgpack.unpackb(
+                        data[1:],
+                        ext_hook=ext_hook,
+                        option=ormsgpack.OPT_NON_STR_KEYS,
+                    )
+                    return _pd.DataFrame.from_dict(tight, orient="tight")
+            except Exception:
+                return None
+        elif code == EXT_PANDAS_SERIES:
+            try:
+                import pandas as _pd
+                import pyarrow as _pa
+
+                if data[:1] == b"A":
+                    reader = _pa.ipc.open_file(data[1:])
+                    table = reader.read_all()
+                    df = table.to_pandas()
+                    series = df.iloc[:, 0]
+                    series.name = df.columns[0]
+                    return series
+                else:
+                    name, tight = ormsgpack.unpackb(
+                        data[1:],
+                        ext_hook=ext_hook,
+                        option=ormsgpack.OPT_NON_STR_KEYS,
+                    )
+                    df = _pd.DataFrame.from_dict(tight, orient="tight")
+                    series = df.iloc[:, 0]
+                    series.name = name
+                    return series
+            except Exception:
+                return None
         return None
 
     return ext_hook
@@ -835,6 +934,47 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             )
             arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
             return arr.reshape(shape, order=order).tolist()
+        except Exception:
+            return
+    elif code == EXT_PANDAS_DATAFRAME:
+        try:
+            import pandas as _pd
+
+            if data[:1] == b"A":
+                import pyarrow as _pa
+
+                reader = _pa.ipc.open_file(data[1:])
+                table = reader.read_all()
+                return table.to_pandas().to_dict(orient="tight")
+            else:
+                tight = ormsgpack.unpackb(
+                    data[1:],
+                    ext_hook=_msgpack_ext_hook_to_json,
+                    option=ormsgpack.OPT_NON_STR_KEYS,
+                )
+                return tight
+        except Exception:
+            return
+    elif code == EXT_PANDAS_SERIES:
+        try:
+            import pandas as _pd
+
+            if data[:1] == b"A":
+                import pyarrow as _pa
+
+                reader = _pa.ipc.open_file(data[1:])
+                table = reader.read_all()
+                df = table.to_pandas()
+                series = df.iloc[:, 0]
+                series.name = df.columns[0]
+                return series.to_dict(orient="tight")
+            else:
+                name, tight = ormsgpack.unpackb(
+                    data[1:],
+                    ext_hook=_msgpack_ext_hook_to_json,
+                    option=ormsgpack.OPT_NON_STR_KEYS,
+                )
+                return tight
         except Exception:
             return
 

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -729,10 +729,10 @@ def test_serde_jsonplus_numpy_array_json_hook(arr: np.ndarray) -> None:
     ],
 )
 def test_serde_jsonplus_pandas_dataframe(df: pd.DataFrame) -> None:
-    serde = JsonPlusSerializer(pickle_fallback=True)
+    serde = JsonPlusSerializer()
 
     dumped = serde.dumps_typed(df)
-    assert dumped[0] == "pickle"
+    assert dumped[0] == "msgpack"
     result = serde.loads_typed(dumped)
     assert result.equals(df)
 
@@ -783,10 +783,10 @@ def test_serde_jsonplus_pandas_dataframe(df: pd.DataFrame) -> None:
     ],
 )
 def test_serde_jsonplus_pandas_series(series: pd.Series) -> None:
-    serde = JsonPlusSerializer(pickle_fallback=True)
+    serde = JsonPlusSerializer()
     dumped = serde.dumps_typed(series)
 
-    assert dumped[0] == "pickle"
+    assert dumped[0] == "msgpack"
     result = serde.loads_typed(dumped)
     assert result.equals(series)
 


### PR DESCRIPTION
## Summary

Replace pickle-fallback-only pandas serialization with a native msgpack serializer using pyarrow IPC format, with a dict-based fallback for mixed-type columns.

Closes #5077

## Changes

### `jsonplus.py`
- Added `EXT_PANDAS_DATAFRAME (8)` and `EXT_PANDAS_SERIES (9)` ext codes
- Added `dumps_typed` intercept for DataFrame/Series (bypasses ormsgpack's mapping handling)
- **Arrow path** (preferred): Uses `pyarrow` IPC file format — efficient, dtype-preserving
- **Dict fallback**: Uses `to_dict('tight')` for mixed-type columns pyarrow can't handle
- Format distinguished by prefix byte: `b"A"` (Arrow) / `b"D"` (dict)
- Added deserialization in ext_hook for both formats
- Added JSON conversion in `_msgpack_ext_hook_to_json`

### `_msgpack.py`
- Added `("pandas.core.frame", "DataFrame")` and `("pandas.core.series", "Series")` to `SAFE_MSGPACK_TYPES`

### `test_jsonplus.py`
- Changed DataFrame/Series tests from `pickle_fallback=True` → native `msgpack` assertion
- All 99 tests passing

## Test plan
- [x] `pytest libs/checkpoint/tests/test_jsonplus.py -k pandas -v` — 57 passed
- [x] `pytest libs/checkpoint/tests/test_jsonplus.py -v` — 99 passed (all tests)