### PR TITLE
fix(langgraph): add missing stacklevel to warnings.warn() calls

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -383,7 +383,7 @@ def _format_messages(messages: Sequence[BaseMessage]) -> list[BaseMessage]:
             "version or remove the 'format' flag. Returning un-formatted "
             "messages."
         )
-        warnings.warn(msg)
+        warnings.warn(msg, stacklevel=2)
         return list(messages)
     else:
         return convert_to_messages(convert_to_openai_messages(messages))

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -116,7 +116,8 @@ def _warn_invalid_state_schema(schema: type[Any] | Any) -> None:
     warnings.warn(
         f"Invalid state_schema: {schema}. Expected a type or Annotated[type, reducer]. "
         "Please provide a valid schema to ensure correct updates.\n"
-        " See: https://langchain-ai.github.io/langgraph/reference/graphs/#stategraph"
+        " See: https://langchain-ai.github.io/langgraph/reference/graphs/#stategraph",
+        stacklevel=2,
     )
 
 
@@ -752,6 +753,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             warnings.warn(
                 "`retry` is deprecated and will be removed. Please use `retry_policy` instead.",
                 category=LangGraphDeprecatedSinceV05,
+                stacklevel=2,
             )
             if retry_policy is None:
                 retry_policy = retry  # type: ignore[assignment]
@@ -760,6 +762,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             warnings.warn(
                 "`input` is deprecated and will be removed. Please use `input_schema` instead.",
                 category=LangGraphDeprecatedSinceV05,
+                stacklevel=2,
             )
             if input_schema is None:
                 input_schema = cast(type[NodeInputT] | None, input_)

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2817,6 +2817,7 @@ class Pregel(
             if checkpointer is None and durability is not None:
                 warnings.warn(
                     "`durability` has no effect when no checkpointer is present.",
+                    stacklevel=2,
                 )
             # set up subgraph checkpointing
             if self.checkpointer is True:
@@ -3244,6 +3245,7 @@ class Pregel(
             if checkpointer is None and durability is not None:
                 warnings.warn(
                     "`durability` has no effect when no checkpointer is present.",
+                    stacklevel=2,
                 )
             # set up subgraph checkpointing
             if self.checkpointer is True:


### PR DESCRIPTION
## Summary

Add `stacklevel=2` to 6 `warnings.warn()` calls so the warning source location points to user code instead of framework internals.

## Changes

| File | Line | Warning |
|------|------|---------|
| `graph/state.py` | 116 | Invalid `state_schema` |
| `graph/state.py` | 752 | Deprecated `retry` param |
| `graph/state.py` | 760 | Deprecated `input` param |
| `graph/message.py` | 386 | Unsupported format flag |
| `pregel/main.py` | 2818 | `durability` without checkpointer (sync) |
| `pregel/main.py` | 3245 | `durability` without checkpointer (async) |

Fixes #7776