### PR TITLE
fix(checkpoint-postgres): add serde passthrough to from_conn_string

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -62,13 +62,18 @@ class PostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: The serializer to use. If None, the default serializer is used.
 
         Returns:
             PostgresSaver: A new PostgresSaver instance.
@@ -78,9 +83,9 @@ class PostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -209,13 +209,18 @@ class ShallowPostgresSaver(BasePostgresSaver):
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        serde: SerializerProtocol | None = None,
     ) -> Iterator["ShallowPostgresSaver"]:
         """Create a new ShallowPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
             pipeline: whether to use Pipeline
+            serde: The serializer to use. If None, the default serializer is used.
 
         Returns:
             ShallowPostgresSaver: A new ShallowPostgresSaver instance.
@@ -225,9 +230,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                    yield cls(conn, pipe, serde=serde)
             else:
-                yield cls(conn)
+                yield cls(conn, serde=serde)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## Summary

`PostgresSaver.from_conn_string` now accepts an optional `serde` parameter and forwards it to the constructor, matching the existing behavior of `AsyncPostgresSaver.from_conn_string`.

Also fixes `ShallowPostgresSaver.from_conn_string` for consistency.

## Changes

- `libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py`: Added `serde` param to `PostgresSaver.from_conn_string`
- `libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py`: Added `serde` param to `ShallowPostgresSaver.from_conn_string`

Fixes #8116