### PR TITLE
fix(langgraph): raise async guard error on Python < 3.11

### DIFF
--- a/libs/langgraph/langgraph/config.py
+++ b/libs/langgraph/langgraph/config.py
@@ -17,12 +17,13 @@ def _no_op_stream_writer(c: Any) -> None:
 def get_config() -> RunnableConfig:
     if sys.version_info < (3, 11):
         try:
-            if asyncio.current_task():
-                raise RuntimeError(
-                    "Python 3.11 or later required to use this in an async context"
-                )
+            in_async = asyncio.current_task() is not None
         except RuntimeError:
-            pass
+            in_async = False
+        if in_async:
+            raise RuntimeError(
+                "Python 3.11 or later required to use this in an async context"
+            )
     if var_config := var_child_runnable_config.get():
         return var_config
     else:

--- a/libs/langgraph/tests/test_config_async.py
+++ b/libs/langgraph/tests/test_config_async.py
@@ -1,10 +1,25 @@
+import sys
+
 import pytest
 from langchain_core.callbacks import AsyncCallbackManager, BaseCallbackHandler
 
 from langgraph._internal._config import get_async_callback_manager_for_config
+from langgraph.config import get_config
 from langgraph.graph import StateGraph
 
 pytestmark = pytest.mark.anyio
+
+
+def test_get_config_raises_on_async_use_py310(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "version_info", (3, 10, 0, "final", 0))
+
+    async def call_in_async() -> None:
+        get_config()
+
+    with pytest.raises(RuntimeError, match="Python 3.11 or later"):
+        import asyncio
+
+        asyncio.run(call_in_async())
 
 
 def test_new_async_manager_includes_tags() -> None:


### PR DESCRIPTION
## Summary

Fixes a bug where `get_config()`'s Python 3.11 async guard was silently swallowed on Python 3.10. The `except RuntimeError: pass` block wrapped the intentional version-gate `raise`, so async callers never saw the intended error message.

## Motivation

On Python < 3.11, calling `get_config()` (or `get_store()` / `get_stream_writer()`) from inside an async task should raise:

> Python 3.11 or later required to use this in an async context

Instead, the guard was caught and discarded, and callers got the misleading fallback:

> Called get_config outside of a runnable context

## Changes

- **`libs/langgraph/langgraph/config.py`**: Split the guard so only `asyncio.current_task()` is protected; raise the version error outside the `try/except`.
- **`libs/langgraph/tests/test_config_async.py`**: Add `test_get_config_raises_on_async_use_py310` that monkeypatches `sys.version_info` to 3.10 and asserts the correct `RuntimeError` in an async context.

## Tests

```bash
cd libs/langgraph
uv run pytest tests/test_config_async.py::test_get_config_raises_on_async_use_py310 -q
# 1 passed

uv run pytest tests/test_config_async.py -q
# 7 passed

uv run ruff check langgraph/config.py tests/test_config_async.py
# All checks passed
```

## Notes

- Non-breaking, runtime behavior change only for Python < 3.11 async misuse (now surfaces the intended error).
- Reviewed with composer-2.5 subagent: **APPROVE**.

Fixes #8203