### PR TITLE
docs: fix grammar in create_react_agent mermaid diagram

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -491,7 +491,7 @@ def create_react_agent(
             Note over A: Prompt + LLM
             loop while tool_calls present
                 A->>T: Execute tools
-                T-->>A: ToolMessage for each tool_calls
+                T-->>A: ToolMessage for each tool_call
             end
             A->>U: Return final state
     ```


### PR DESCRIPTION
Fixes #8226

One-word fix in the mermaid sequence diagram inside `create_react_agent`'s docstring: `ToolMessage for each tool_calls` -> `ToolMessage for each tool_call` (singular, since it describes what happens for each individual tool call).