### PR TITLE
fix: properly manage AsyncPipeline lifecycle in from_conn_string (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
+                pipe = conn.pipeline()
+                await pipe.__aenter__()
+                try:
                     yield cls(conn=conn, pipe=pipe, serde=serde)
+                finally:
+                    await pipe.__aexit__(None, None, None)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the SSL connection can be closed unexpectedly (`psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`). This occurs because the nested `async with conn.pipeline()` context manager does not properly synchronize with the outer connection context manager, causing the pipeline to be left in an inconsistent state when errors occur or during cleanup.

## Fix
Instead of using the nested `async with` context manager for the pipeline, this fix manually enters the pipeline context using `__aenter__()` and ensures it is properly exited in a `finally` block, maintaining proper lifecycle management. This ensures the pipeline is always closed before the database connection exits.

Additionally ensures that the pipeline is closed properly even if an exception occurs during checkpoint operations.

Closes #5675