### PR TITLE
fix(langgraph): raise get_config async guard on Python < 3.11

### DIFF
--- a/libs/langgraph/langgraph/config.py
+++ b/libs/langgraph/langgraph/config.py
@@ -17,12 +17,14 @@ def _no_op_stream_writer(c: Any) -> None:
 def get_config() -> RunnableConfig:
     if sys.version_info < (3, 11):
         try:
-            if asyncio.current_task():
-                raise RuntimeError(
-                    "Python 3.11 or later required to use this in an async context"
-                )
+            in_async_context = asyncio.current_task() is not None
         except RuntimeError:
-            pass
+            # No running event loop -> not in an async context.
+            in_async_context = False
+        if in_async_context:
+            raise RuntimeError(
+                "Python 3.11 or later required to use this in an async context"
+            )
     if var_config := var_child_runnable_config.get():
         return var_config
     else:

--- a/libs/langgraph/tests/test_config_async.py
+++ b/libs/langgraph/tests/test_config_async.py
@@ -1,3 +1,6 @@
+import asyncio
+import sys
+
 import pytest
 from langchain_core.callbacks import AsyncCallbackManager, BaseCallbackHandler
 
@@ -114,3 +117,31 @@ async def test_with_config_tags_preserved_on_invoke() -> None:
     await graph.ainvoke({}, {"tags": ["invoke"]})
     assert "bound" in captured, "bound tag was dropped by ensure_config overwrite"
     assert "invoke" in captured, "invoke-time tag not present"
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="the async-context guard in get_config() only applies on Python < 3.11",
+)
+def test_get_config_raises_in_async_context_on_py310() -> None:
+    """On Python < 3.11, get_config() must raise inside an async context.
+
+    Regression test for the guard being swallowed by its own
+    ``except RuntimeError: pass`` (see #8203).
+    """
+    from langchain_core.runnables.config import var_child_runnable_config
+
+    from langgraph.config import get_config
+
+    async def main() -> None:
+        # Seed a config so the fall-through path would otherwise succeed;
+        # this isolates the async guard from the "outside a runnable context"
+        # error.
+        token = var_child_runnable_config.set({"tags": [], "metadata": {}})
+        try:
+            with pytest.raises(RuntimeError, match="3.11 or later"):
+                get_config()
+        finally:
+            var_child_runnable_config.reset(token)
+
+    asyncio.run(main())


### PR DESCRIPTION
On Python < 3.11 the async-context guard in `get_config()` raised `RuntimeError` inside a `try` whose `except RuntimeError: pass` immediately swallowed it, so the guard never fired in an async context and callers fell through to the contextvar lookup instead.

Only the `asyncio.current_task()` call (which legitimately raises `RuntimeError` when there is no running event loop) needs to be guarded by the try; raise the "3.11 or later required" error outside it so it propagates. Add a regression test that runs the check inside an asyncio task and is skipped on Python >= 3.11.

Fixes #8203