### PR TITLE
fix(checkpoint): raise minimum langchain-core version

### DIFF
--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ['LICENSE']
 dependencies = [
-    "langchain-core>=0.2.38",
+    "langchain-core>=1.2.5",
     "ormsgpack>=1.12.0",
 ]
 

--- a/libs/checkpoint/uv.lock
+++ b/libs/checkpoint/uv.lock
@@ -344,7 +344,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", specifier = ">=0.2.38" },
+    { name = "langchain-core", specifier = ">=1.2.5" },
     { name = "ormsgpack", specifier = ">=1.12.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Raise `langgraph-checkpoint`'s minimum `langchain-core` dependency from `>=0.2.38` to `>=1.2.5`.
- Update the checkpoint `uv.lock` package metadata to match.

## Root cause

`dc0d992b` changed checkpoint serde to instantiate `Reviver(allowed_objects="core")`, but the package metadata still allowed `langchain-core==0.2.38`. Under a lowest-direct install, that old version is selected and importing `langgraph.checkpoint.serde.jsonplus` fails during test collection with:

```text
TypeError: Reviver.__init__() got an unexpected keyword argument 'allowed_objects'
```

I probed the `Reviver` signature across released `langchain-core` versions: `1.2.4` does not expose `allowed_objects`; `1.2.5` is the first version I found that does.

This is a small follow-up that makes the declared lower bound match the current runtime API use, and it gives #5026 a concrete min-dependency failure/fix case for `libs/checkpoint`.

## Validation

Before the fix:

- `uv pip install --resolution lowest-direct --reinstall -e .` selected `langchain-core==0.2.38` and `ormsgpack==1.12.0`
- `.venv/bin/pytest -q .` failed during collection with `Reviver.__init__() got an unexpected keyword argument 'allowed_objects'`

After the fix:

- `uv pip install --resolution lowest-direct --reinstall -e .` selects `langchain-core==1.2.5` and `ormsgpack==1.12.0`
- `.venv/bin/pytest -q .` -> `172 passed, 1 skipped, 2 warnings`
- `uv sync --frozen --group test --no-dev && make test` -> `172 passed, 1 skipped, 2 warnings`
- `uv lock --check`
- `git diff --check`
