### PR TITLE
fix(langgraph): correct type annotations for NamedBarrierValue channels

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -21,7 +21,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
     def __init__(self, typ: type[Value], names: set[Value]) -> None:
         super().__init__(typ)
         self.names = names
-        self.seen: set[str] = set()
+        self.seen: set[Value] = set()
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, NamedBarrierValue) and value.names == self.names
@@ -90,11 +90,12 @@ class NamedBarrierValueAfterFinish(
 
     names: set[Value]
     seen: set[Value]
+    finished: bool
 
     def __init__(self, typ: type[Value], names: set[Value]) -> None:
         super().__init__(typ)
         self.names = names
-        self.seen: set[str] = set()
+        self.seen: set[Value] = set()
         self.finished = False
 
     def __eq__(self, value: object) -> bool:


### PR DESCRIPTION
Fixes #8209

Corrects type annotation inconsistencies in NamedBarrierValue channels: (1) Fixes `self.seen: set[str]` → `self.seen: set[Value]` in both classes to match the class-level generic type parameter; (2) Adds missing `finished: bool` class-level annotation to `NamedBarrierValueAfterFinish`. All changes are confined to `libs/langgraph` and are non-breaking.The changes are minimal.

Verified with `ruff check .`, `ty check langgraph`, and `ruff format .`, all passing  