### PR TITLE
fix: keep connection alive in AsyncPostgresSaver.from_conn_string (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -61,14 +61,13 @@ class AsyncPostgresSaver(BasePostgresSaver):
         self.supports_pipeline = Capabilities().has_pipeline()
 
     @classmethod
-    @asynccontextmanager
     async def from_conn_string(
         cls,
         conn_string: str,
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
-    ) -> AsyncIterator[AsyncPostgresSaver]:
+    ) -> AsyncPostgresSaver:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
         Args:
@@ -78,14 +77,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
+        conn = await AsyncConnection.connect(
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
-            else:
-                yield cls(conn=conn, serde=serde)
+        )
+        if pipeline:
+            pipe = conn.pipeline()
+            await pipe.__aenter__()
+            return cls(conn=conn, pipe=pipe, serde=serde)
+        else:
+            return cls(conn=conn, serde=serde)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## What
AsynchronousPostgresSaver.from_conn_string used async context managers for the database connection and pipeline, which closed the connection when the context exited. This caused the saver to fail with 'SSL connection has been closed unexpectedly' when any method tried to use the connection after creation.

## Fix
Changed from_conn_string to a regular async method that returns the saver with an open connection, rather than yielding within a context manager. The connection and pipeline lifecycle is now managed directly, ensuring the connection remains open for the saver's operations. Users should call await saver.setup() after creation.

Closes #5675