### PR TITLE
[pregel] perf: avoid O(T^2) re-scan in FuturesDict.on_done

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -128,7 +128,11 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
                 self.counter -= 1
                 # Wake waiter when all tracked futures are done, or when runner-level
                 # stop condition is met (for example, a non-handled fatal exception).
-                if self.counter == 0 or self.should_stop(self.done):
+                # Only the just-completed future can newly satisfy the stop condition,
+                # since futures already in `self.done` are terminal — their
+                # `cancelled()`/`exception()` state is immutable, so re-scanning the
+                # whole set on every callback would be O(T^2) for T parallel tasks.
+                if self.counter == 0 or self.should_stop({fut}):
                     self.event.set()
 
 


### PR DESCRIPTION
## Summary

`FuturesDict.on_done` re-scans the entire `self.done` set on every
task completion to evaluate the runner-level stop condition. Because
the set grows by one on each callback and the futures it contains are
terminal, this turns a fan-out superstep of T parallel tasks into
T(T+1)/2 future method calls — each of which acquires the future's
internal lock. On a 400-task fan-out this shows up as ~80,000
`future.exception()` calls per `invoke`.

Only the just-completed future can newly satisfy the stop condition,
so we narrow the check to a single-element set, reducing the per-
superstep work to O(T).

Fixes #8240

## Problem

`FuturesDict.on_done` is registered via `add_done_callback` in
`__setitem__` for every non-waiter future. Each invocation:

  1. Adds `fut` to `self.done`.
  2. Calls `self.should_stop(self.done)`.

`should_stop` is `_should_stop_others`, which iterates the entire
set calling `fut.cancelled()` and `fut.exception()` on every future
(acquiring the future's internal lock each time). Because
`self.done` grows by one on each callback, a superstep with T
parallel tasks does `1 + 2 + ... + T = O(T^2)` lock-guarded future
calls.

The `FuturesDict` is built and torn down once per superstep, so this
is the dominant internal hot frame on fan-out workloads (parallel
tool calls, multi-agent, `Send`-based map) after the per-channel
costs.

## Fix

Pass the just-completed future alone to `should_stop`:

```python
if self.counter == 0 or self.should_stop({fut}):
    self.event.set()
```

This is `O(T)` total per superstep. A future already in `self.done`
is terminal — its `cancelled()` / `exception()` state is immutable —
so re-checking it on every later callback is pure waste.

## Why the fix is safe

The `on_done` callback is only an early-wake path used to unblock
`futures.event.wait()`. The authoritative stop / panic decision is
made elsewhere:

  - `PregelRunner.tick` (line 330) / `PregelRunner.atick` (line 539)
    call `_should_stop_others(done_for_stop, ...)` after each batch
    from `concurrent.futures.wait` and may break the wait loop.
  - `_panic_or_proceed` (line 650) is the final authoritative
    decision: it iterates all `done` and `inflight` futures and
    raises / cancels as appropriate.

Narrowing the `on_done` check does not affect either of those.

In addition:

  - **No false negatives.** A future already in `self.done` cannot
    transition from non-fatal to fatal: `cancelled()` is monotonic,
    `exception()` is set once, `_handled_exception_ids` only grows,
    and `SKIP_RERAISE_SET` only grows (entries are pinned by live
    futures throughout the superstep). So if `should_stop({fut})`
    is `False` when the failing future's `on_done` runs, no later
    callback could re-introduce that fatal state.
  - **No semantic change for handled exceptions.** `commit(task,
    _exception(fut))` runs *inside* `on_done` *before* `should_stop`
    is evaluated. By the time we check `self.should_stop({fut})`,
    the just-completed future's exception id has already been added
    to `_handled_exception_ids` if it was routed to the error
    handler — so `should_stop({fut})` correctly returns `False` for
    handled exceptions even though `self.should_stop(self.done)`
    would also have returned `False` in that case.
  - **No effect on the waiter path.** `__setitem__` only registers
    `on_done` when `value is not None`, so waiter futures do not
    participate in this loop and are unaffected by the change.
  - **Sync and async covered.** Both `tick` and `atick` inject
    `_should_stop_others` as `should_stop`, so a single one-line
    change in `on_done` covers both paths.

## Reproduction

Profiling a fan-out graph of T = 400 parallel tasks on the in-memory
backend, `future.exception()` is called ~80,000 times per `invoke` —
exactly `T^2 / 2`. `fut.cancelled()` shows the same count, and the
future-lock acquire / release counts track them. After the fix, the
counts drop to T (one per `on_done`).

## Testing

  - `make format` — clean.
  - `make lint` — clean.
  - Local fan-out benchmarking shows roughly a 2x wall-clock
    improvement at a few hundred parallel tasks (box is noisy; the
    deterministic `T^2 -> T` call-count reduction is the reliable
    signal).
  - Full sync + async pregel suite passes on the in-memory backend
    (375 cases, including the cancellation / interrupt /
    `max_concurrency` / retry tests that exercise this path).

## Files changed

  - `libs/langgraph/langgraph/pregel/_runner.py` — one-line change
    in `FuturesDict.on_done` plus an explanatory comment.