### PR TITLE
fix: add pipeline sync in setup() to prevent SSL connection closure (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -95,7 +95,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
         the first time checkpointer is used.
         """
         async with self._cursor() as cur:
+            # When using pipeline mode, we must ensure we sync after each statement
+            if self.pipe:
+                await self.pipe.sync()  # Ensure pipeline is ready
             await cur.execute(self.MIGRATIONS[0])
+            if self.pipe:
+                await self.pipe.sync()
             results = await cur.execute(
                 "SELECT v FROM checkpoint_migrations ORDER BY v DESC LIMIT 1"
             )
@@ -110,10 +115,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 strict=False,
             ):
                 await cur.execute(migration)
+                if self.pipe:
+                    await self.pipe.sync()
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
+                if self.pipe:
+                    await self.pipe.sync()
         if self.pipe:
+            await self.pipe.sync()  # Final sync to ensure all operations completed
             await self.pipe.sync()
 
     async def alist(


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with pipeline mode (`pipeline=True`), calling `setup()` can fail with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This happens because the pipeline sends multiple statements without waiting for responses, and if the connection is interrupted (e.g., due to network issues or Supabase idle timeout), the pipeline gets into an inconsistent state.

## Fix
Added explicit `await self.pipe.sync()` calls after each cursor execution in `setup()`. This ensures that the pipeline processes each statement's response before sending the next one, preventing buffering issues and allowing proper error detection. This matches the pattern used in the synchronous `PostgresSaver` implementation and resolves the SSL/connection closure errors reported in pipeline mode.

Closes #5675