### PR TITLE
fix(cli): honor [tool.uv.workspace].exclude when discovering workspace members

### DIFF
--- a/libs/cli/langgraph_cli/uv_lock.py
+++ b/libs/cli/langgraph_cli/uv_lock.py
@@ -358,13 +358,28 @@ def _discover_uv_lock_workspace_packages(
     if isinstance(root_project, dict) and isinstance(root_project.get("name"), str):
         candidate_roots.append(project_root)
 
-    workspace_members = (
-        root_data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
-    )
+    workspace_table = root_data.get("tool", {}).get("uv", {}).get("workspace", {})
+    workspace_members = workspace_table.get("members", [])
     if workspace_members and not isinstance(workspace_members, list):
         raise click.UsageError(
             "source.kind 'uv' requires [tool.uv.workspace].members to be a list."
         )
+    workspace_excludes = workspace_table.get("exclude", [])
+    if workspace_excludes and not isinstance(workspace_excludes, list):
+        raise click.UsageError(
+            "source.kind 'uv' requires [tool.uv.workspace].exclude to be a list."
+        )
+
+    excluded_roots: set[pathlib.Path] = set()
+    for pattern in workspace_excludes:
+        if not isinstance(pattern, str):
+            raise click.UsageError(
+                "source.kind 'uv' requires every [tool.uv.workspace].exclude "
+                "entry to be a string."
+            )
+        for match in project_root.glob(pattern):
+            excluded_root = match if match.is_dir() else match.parent
+            excluded_roots.add(excluded_root.resolve())
 
     for pattern in workspace_members:
         if not isinstance(pattern, str):
@@ -375,6 +390,8 @@ def _discover_uv_lock_workspace_packages(
         for match in sorted(project_root.glob(pattern)):
             package_root = match if match.is_dir() else match.parent
             package_root = package_root.resolve()
+            if package_root in excluded_roots:
+                continue
             if (package_root / "pyproject.toml").is_file():
                 candidate_roots.append(package_root)
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -39,6 +39,7 @@ def _write_uv_lock_workspace(
     agent_sources: str = "",
     shared_uv_config: str = "",
     agent_dependencies: list[str] | None = None,
+    workspace_exclude: str = "",
 ) -> tuple[pathlib.Path, pathlib.Path]:
     project_root = tmpdir_path / "workspace"
     config_dir = project_root / config_relative_dir
@@ -61,6 +62,7 @@ def _write_uv_lock_workspace(
 
             [tool.uv.workspace]
             members = ["apps/*", "libs/*"]
+            {workspace_exclude}
 
             {root_sources}
 
@@ -1447,6 +1449,63 @@ def test_config_to_docker_uv_lock():
             '"agent": "/deps/workspace/apps/agent/src/agent/graph.py:graph"' in docker
         )
         assert "rm /usr/bin/uv /usr/bin/uvx" in docker
+
+
+@pytest.mark.parametrize(
+    "excluded_pyproject",
+    [
+        pytest.param(
+            "[tool.ruff]\nline-length = 100\n",
+            id="tool-only-pyproject-without-project-name",
+        ),
+        pytest.param(
+            '[project]\nname = "shared"\nversion = "0.0.0"\n',
+            id="name-colliding-with-real-member",
+        ),
+    ],
+)
+def test_config_to_docker_uv_lock_honors_workspace_exclude(excluded_pyproject):
+    """Dirs matched by [tool.uv.workspace].exclude are not workspace members.
+
+    uv only requires directories included by the `members` globs *and not
+    excluded by the `exclude` globs* to be valid packages, so `uv lock`
+    accepts workspaces whose excluded dirs have tool-only pyprojects or
+    duplicate package names. Discovery must skip them the same way.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = pathlib.Path(tmpdir)
+        project_root, config_path = _write_uv_lock_workspace(
+            tmpdir_path,
+            agent_sources="[tool.uv.sources]\nshared = { workspace = true }",
+            workspace_exclude='exclude = ["libs/scratch"]',
+        )
+        scratch_dir = project_root / "libs" / "scratch"
+        scratch_dir.mkdir(parents=True)
+        (scratch_dir / "pyproject.toml").write_text(excluded_pyproject)
+
+        config = validate_config(
+            {
+                "python_version": "3.11",
+                "graphs": {
+                    "agent": "../../apps/agent/src/agent/graph.py:graph",
+                },
+                "source": {"kind": "uv", "root": "../..", "package": "agent"},
+            }
+        )
+        docker, _ = config_to_docker(
+            config_path, config, base_image="langchain/langgraph-api:0.2.47"
+        )
+
+        assert "# -- Adding workspace package libs/scratch --" not in docker
+        assert "libs/scratch /deps/workspace/libs/scratch" not in docker
+        assert (
+            "COPY --from=uv-workspace-root apps/agent /deps/workspace/apps/agent"
+            in docker
+        )
+        assert (
+            "COPY --from=uv-workspace-root libs/shared /deps/workspace/libs/shared"
+            in docker
+        )
 
 
 def test_config_to_docker_uv_lock_honors_root_workspace_sources():


### PR DESCRIPTION
Fixes #8275

Workspace discovery for `source.kind: "uv"` read the `members` globs but ignored `exclude`, so `langgraph dockerfile` / `langgraph build` failed on workspaces that `uv lock` accepts (excluded dirs with tool-only pyprojects or duplicate package names). Discovery now skips roots matched by the `exclude` globs, matching uv's documented workspace semantics. Added parametrized regression tests for both failure modes.

Verified with `make format lint test` in `libs/cli` (338 passed).