### PR TITLE
fix: check SKIP_RERAISE_SET in BackgroundExecutor.__exit__ to suppres…

### DIFF
--- a/libs/langgraph/langgraph/pregel/_constants.py
+++ b/libs/langgraph/langgraph/pregel/_constants.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import weakref
+
+SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
+    weakref.WeakSet()
+)

--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -19,6 +19,7 @@ from typing_extensions import ParamSpec
 
 from langgraph._internal._future import CONTEXT_NOT_SUPPORTED, run_coroutine_threadsafe
 from langgraph.errors import GraphBubbleUp
+from langgraph.pregel._constants import SKIP_RERAISE_SET
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -113,6 +114,8 @@ class BackgroundExecutor(AbstractContextManager):
             for task, (_, reraise) in tasks.items():
                 if not reraise:
                     continue
+                if task in SKIP_RERAISE_SET:
+                    continue
                 try:
                     task.result()
                 except concurrent.futures.CancelledError:
@@ -203,6 +206,8 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
                 if not reraise:
+                    continue
+                if task in SKIP_RERAISE_SET:
                     continue
                 try:
                     if exc := task.exception():

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -67,9 +67,7 @@ EXCLUDED_FRAME_FNAMES = (
     "concurrent/futures/_base.py",
 )
 
-SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
-    weakref.WeakSet()
-)
+from langgraph.pregel._constants import SKIP_RERAISE_SET
 
 
 class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):


### PR DESCRIPTION
## What this fixes
Closes #8277

When a node with an `error_handler` fails while running in parallel with 
other tasks in the same superstep, the handler fired and its state update 
was applied correctly — but the original exception was still re-raised to 
the caller at loop exit.

## Root cause
`BackgroundExecutor.__exit__` (and its async counterpart) called 
`task.result()` on every failed future with `reraise=True`, without 
consulting `SKIP_RERAISE_SET` — the set that `_runner.py` uses to mark 
exceptions as already handled by an error handler.

The single-task fast path in `tick` runs inline (no future is created), 
so `SKIP_RERAISE_SET` was never hit and single-node examples worked fine. 
This masked the bug.

## Fix
- Moved `SKIP_RERAISE_SET` from `_runner.py` to a new shared module 
  `pregel/_constants.py` to avoid a circular import 
  (`_runner` → `_executor` → `_runner`)
- Both `BackgroundExecutor.__exit__` (sync) and 
  `AsyncBackgroundExecutor.__aexit__` (async) now skip re-raising if the 
  future is in `SKIP_RERAISE_SET`

## Reproduction
```python
# Before fix: raises RuntimeError: boom
# After fix: {'xs': ['degraded', 'ok']}
parallel.invoke({})
```