### PR TITLE
fix: properly sync AsyncPipeline before connection close to prevent SSL errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -84,6 +84,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             if pipeline:
                 async with conn.pipeline() as pipe:
                     yield cls(conn=conn, pipe=pipe, serde=serde)
+                    await pipe.sync()  # Ensure all pending pipeline results are processed before closing
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the psycopg `AsyncPipeline` batches multiple queries but does not automatically flush before the connection is closed. This results in `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` because the pipeline's buffered commands are not fully processed when the connection shuts down.

## Fix
Added an explicit `await pipe.sync()` call inside the pipeline context manager in `from_conn_string()` to ensure all pending pipeline results are processed before the connection closes. This is a minimal, safe change that preserves the pipeline feature while fixing the race condition.

Closes #5675