### PR TITLE
fix(prebuilt): declare langgraph runtime dependency

### DIFF
--- a/libs/prebuilt/pyproject.toml
+++ b/libs/prebuilt/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "langgraph-checkpoint>=2.1.0,<5.0.0",
+    "langgraph>=1.2.0,<2.0.0",
     "langchain-core>=1.3.1",
 ]
 

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -511,6 +511,7 @@ version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "langgraph-checkpoint" },
 ]
 
@@ -553,6 +554,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", specifier = ">=1.3.1" },
+    { name = "langgraph", editable = "../langgraph" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
 ]
 


### PR DESCRIPTION
Fixes #7908.

## Summary
- Add langgraph>=1.2.0,<2.0.0 to langgraph-prebuilt runtime dependencies.
- Update libs/prebuilt/uv.lock so the locked metadata includes the new runtime dependency.

## Why
langgraph-prebuilt imports langgraph.stream._types at import time through _tool_call_transformer.py, so installing langgraph-prebuilt alone can fail with ModuleNotFoundError: No module named 'langgraph.stream'. The package metadata should declare langgraph as a runtime dependency because the import graph requires it.

## Validation
- uv lock --check
- git diff --check
- Built langgraph-prebuilt wheel and verified metadata includes Requires-Dist: langgraph<2.0.0,>=1.2.0
