### PR TITLE
fix(langgraph): skip tool-error emit for GraphBubbleUp in tools stream

### DIFF
--- a/libs/langgraph/langgraph/pregel/_tools.py
+++ b/libs/langgraph/langgraph/pregel/_tools.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 
 from langgraph._internal._constants import NS_SEP
 from langgraph.constants import TAG_NOSTREAM
+from langgraph.errors import GraphBubbleUp
 from langgraph.pregel.protocol import StreamChunk
 
 try:
@@ -188,6 +189,8 @@ class StreamToolCallHandler(BaseCallbackHandler, _StreamingCallbackHandler):
             return
         ns, tool_call_id, token = info
         self._reset_writer(token)
+        if isinstance(error, GraphBubbleUp):
+            return
         self.stream(
             (
                 ns,

--- a/libs/langgraph/tests/test_tool_stream_handler.py
+++ b/libs/langgraph/tests/test_tool_stream_handler.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.prebuilt import ToolNode, ToolRuntime
 from typing_extensions import TypedDict
 
@@ -20,6 +21,7 @@ from langgraph.constants import END, START
 from langgraph.graph import StateGraph
 from langgraph.graph.message import add_messages
 from langgraph.pregel._tools import _tool_call_writer
+from langgraph.types import interrupt
 
 
 class _State(TypedDict):
@@ -195,6 +197,68 @@ class TestAsyncGraphAsyncTool:
         kinds = [p["event"] for _, p in events]
         assert kinds == ["tool-started", "tool-output-delta", "tool-finished"]
         assert events[1][1]["delta"] == "hi"
+
+
+class TestToolInterrupt:
+    def test_interrupt_not_reported_as_tool_error_sync(self) -> None:
+        @tool
+        def ask_human(question: str) -> str:
+            """Pause for human input."""
+            return interrupt(question)
+
+        sg = StateGraph(_State)
+        sg.add_node("caller", _caller_sync("ask_human", {"question": "ok?"}))
+        sg.add_node("tools", ToolNode([ask_human]))
+        sg.add_edge(START, "caller")
+        sg.add_edge("caller", "tools")
+        sg.add_edge("tools", END)
+        graph = sg.compile(checkpointer=InMemorySaver())
+
+        config = {"configurable": {"thread_id": "t1"}}
+        events = _tool_events(
+            graph.stream(
+                {"messages": []},
+                config=config,
+                stream_mode=["tools"],
+                subgraphs=True,
+            )
+        )
+
+        kinds = [p["event"] for _, p in events]
+        assert "tool-error" not in kinds
+        assert kinds == ["tool-started"]
+        assert graph.get_state(config).interrupts
+
+    @pytest.mark.anyio
+    async def test_interrupt_not_reported_as_tool_error_async(self) -> None:
+        @tool
+        async def ask_human(question: str) -> str:
+            """Pause for human input."""
+            return interrupt(question)
+
+        sg = StateGraph(_State)
+        sg.add_node("caller", _caller_async("ask_human", {"question": "ok?"}))
+        sg.add_node("tools", ToolNode([ask_human]))
+        sg.add_edge(START, "caller")
+        sg.add_edge("caller", "tools")
+        sg.add_edge("tools", END)
+        graph = sg.compile(checkpointer=InMemorySaver())
+
+        config = {"configurable": {"thread_id": "t1"}}
+        events: list[tuple[tuple[str, ...], dict]] = []
+        async for ns, mode, payload in graph.astream(
+            {"messages": []},
+            config=config,
+            stream_mode=["tools"],
+            subgraphs=True,
+        ):
+            if mode == "tools":
+                events.append((tuple(ns), payload))
+
+        kinds = [p["event"] for _, p in events]
+        assert "tool-error" not in kinds
+        assert kinds == ["tool-started"]
+        assert (await graph.aget_state(config)).interrupts
 
 
 class TestConcurrentToolCalls:


### PR DESCRIPTION
Fixes #8218

When a tool calls `interrupt()`, `StreamToolCallHandler._error` was emitting a `tool-error` event with `message=str(error)`, misclassifying a resumable pause as a failure and flattening the structured interrupt payload. This change skips the `tool-error` emit for `GraphBubbleUp`, consistent with `_runner`, `_executor`, and `_retry`.

Verified with `make format`, `make lint`, and `TEST=tests/test_tool_stream_handler.py make test` in `libs/langgraph`.