### PR TITLE
fix: flush AsyncPipeline before connection close to prevent SSL errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -84,6 +84,8 @@ class AsyncPostgresSaver(BasePostgresSaver):
             if pipeline:
                 async with conn.pipeline() as pipe:
                     yield cls(conn=conn, pipe=pipe, serde=serde)
+                # Ensure all pending operations are flushed before connection closes
+                await pipe.sync()
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the connection could be closed while pipeline operations are still pending, causing "consuming input failed: SSL connection has been closed unexpectedly". This happens because the `conn.pipeline()` context manager exits and closes the connection without ensuring all batched queries are completed.

## Fix
Call `pipe.sync()` explicitly after the pipeline context manager yields the saver instance. This flushes any pending operations and waits for the server to process them before the connection is closed.

Closes #5675