### PR TITLE
fix(sdk-py): encode stream scoped path params

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -24,6 +24,7 @@ from langchain_core.language_models.chat_model_stream import AsyncChatModelStrea
 from langchain_protocol import Event, SubscribeParams
 
 from langgraph_sdk._async.http import HttpClient
+from langgraph_sdk._shared.utilities import _quote_path_param
 from langgraph_sdk.schema import QueryParamTypes
 from langgraph_sdk.stream.controller import _SeenEventIds
 from langgraph_sdk.stream.decoders import (
@@ -151,7 +152,7 @@ class _AgentModule:
             query_params.update(dict(params))
         request_headers = {**self._owner._headers, **dict(headers or {})}
         return await self._owner._http.get(
-            f"/assistants/{self._owner.assistant_id}/graph",
+            f"/assistants/{_quote_path_param(self._owner.assistant_id)}/graph",
             params=query_params,
             headers=request_headers or None,
         )
@@ -1899,7 +1900,7 @@ class AsyncThreadStream:
     async def _fetch_state(self) -> dict[str, Any]:
         """Fetch the current thread state from the REST endpoint."""
         return await self._http.get(
-            f"/threads/{self.thread_id}/state",
+            f"/threads/{_quote_path_param(self.thread_id)}/state",
             headers=self._headers or None,
         )
 

--- a/libs/sdk-py/langgraph_sdk/_sync/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/stream.py
@@ -22,6 +22,7 @@ from typing import Any, Literal, TypedDict, cast
 from langchain_core.language_models.chat_model_stream import ChatModelStream
 from langchain_protocol import Event, SubscribeParams
 
+from langgraph_sdk._shared.utilities import _quote_path_param
 from langgraph_sdk._sync.http import SyncHttpClient
 from langgraph_sdk.schema import QueryParamTypes
 from langgraph_sdk.stream.decoders import (
@@ -194,7 +195,7 @@ class _SyncAgentModule:
             query_params.update(dict(params))
         request_headers = {**self._owner._headers, **dict(headers or {})}
         return self._owner._http.get(
-            f"/assistants/{self._owner.assistant_id}/graph",
+            f"/assistants/{_quote_path_param(self._owner.assistant_id)}/graph",
             params=query_params,
             headers=request_headers or None,
         )
@@ -1549,7 +1550,7 @@ class SyncThreadStream:
     def _fetch_state(self) -> dict[str, Any]:
         """Fetch the current thread state from the REST endpoint."""
         return self._http.get(
-            f"/threads/{self.thread_id}/state",
+            f"/threads/{_quote_path_param(self.thread_id)}/state",
             headers=self._headers or None,
         )
 

--- a/libs/sdk-py/tests/test_path_encoding.py
+++ b/libs/sdk-py/tests/test_path_encoding.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from langgraph_sdk._async.stream import AsyncThreadStream
 from langgraph_sdk._shared.utilities import _quote_path_param
+from langgraph_sdk._sync.stream import SyncThreadStream
 from langgraph_sdk.client import (
     AssistantsClient,
     CronClient,
@@ -339,6 +341,46 @@ class TestAsyncPathEncoding:
 
         assert captured == ["/threads/550e8400-e29b-41d4-a716-446655440000"]
 
+    async def test_thread_stream_agent_get_tree_encodes_assistant_id(self) -> None:
+        captured: list[str] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(_wire_path(request))
+            return httpx.Response(200, json={"nodes": [], "edges": []})
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="https://example.com"
+        ) as client:
+            stream = AsyncThreadStream(
+                http=HttpClient(client),
+                thread_id="thread-1",
+                assistant_id="../threads/pivot",
+            )
+            await stream.agent.get_tree()
+
+        assert captured == ["/assistants/..%2Fthreads%2Fpivot/graph"]
+
+    async def test_thread_stream_fetch_state_encodes_thread_id(self) -> None:
+        captured: list[str] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(_wire_path(request))
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="https://example.com"
+        ) as client:
+            stream = AsyncThreadStream(
+                http=HttpClient(client),
+                thread_id="../assistants/pivot",
+                assistant_id="assistant-1",
+            )
+            await stream._fetch_state()
+
+        assert captured == ["/threads/..%2Fassistants%2Fpivot/state"]
+
 
 class TestSyncPathEncoding:
     """Sync-client tests that mirror the async coverage on a representative subset."""
@@ -446,3 +488,43 @@ class TestSyncPathEncoding:
             threads_client.get("550e8400-e29b-41d4-a716-446655440000")
 
         assert captured == ["/threads/550e8400-e29b-41d4-a716-446655440000"]
+
+    def test_thread_stream_agent_get_tree_encodes_assistant_id(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(_wire_path(request))
+            return httpx.Response(200, json={"nodes": [], "edges": []})
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(
+            transport=transport, base_url="https://example.com"
+        ) as client:
+            stream = SyncThreadStream(
+                http=SyncHttpClient(client),
+                thread_id="thread-1",
+                assistant_id="../threads/pivot",
+            )
+            stream.agent.get_tree()
+
+        assert captured == ["/assistants/..%2Fthreads%2Fpivot/graph"]
+
+    def test_thread_stream_fetch_state_encodes_thread_id(self) -> None:
+        captured: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(_wire_path(request))
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(
+            transport=transport, base_url="https://example.com"
+        ) as client:
+            stream = SyncThreadStream(
+                http=SyncHttpClient(client),
+                thread_id="../assistants/pivot",
+                assistant_id="assistant-1",
+            )
+            stream._fetch_state()
+
+        assert captured == ["/threads/..%2Fassistants%2Fpivot/state"]


### PR DESCRIPTION
Fixes #8222

Encode thread-stream scoped `assistant_id` and `thread_id` path segments in async and sync stream helper REST calls, reusing `_quote_path_param` like the sibling SDK clients. Adds regression coverage for agent graph and thread state paths with traversal-like IDs.

Verification:
- `uv run pytest tests/test_path_encoding.py`
- `uv run ruff check tests/test_path_encoding.py langgraph_sdk/_async/stream.py langgraph_sdk/_sync/stream.py`