### PR TITLE
fix(prebuilt): allow return_direct tools when remaining_steps < 2

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -626,9 +626,9 @@ def create_react_agent(
         )
         remaining_steps = _get_state_value(state, "remaining_steps", None)
         if remaining_steps is not None:
-            if remaining_steps < 1 and all_tools_return_direct:
+            if remaining_steps < 1:
                 return True
-            elif remaining_steps < 2 and has_tool_calls:
+            elif remaining_steps < 2 and has_tool_calls and not all_tools_return_direct:
                 return True
 
         return False


### PR DESCRIPTION
## Summary

Fixes #8204: `create_react_agent` with `return_direct=True` tools incorrectly requires at least 2 `remaining_steps`, even though return_direct tools exit the agent immediately without a second LLM call — they only need 1 step.

## Changes

In `_are_more_steps_needed()` (`libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py:628-632`):

- Moved the `all_tools_return_direct` guard from the `remaining_steps < 1` branch to the `remaining_steps < 2` branch
- Simplified `remaining_steps < 1` to a hard abort (no steps left is always fatal)
- Added `and not all_tools_return_direct` to the `remaining_steps < 2` condition so return_direct tools are allowed when exactly 1 step remains

**Before:**
```python
if remaining_steps < 1 and all_tools_return_direct:
    return True
elif remaining_steps < 2 and has_tool_calls:
    return True
```

**After:**
```python
if remaining_steps < 1:
    return True
elif remaining_steps < 2 and has_tool_calls and not all_tools_return_direct:
    return True
```

## Why

A `return_direct=True` tool consumes exactly 1 step: the tool executes and its result is returned directly to the caller without another LLM round-trip. The old logic grouped the `all_tools_return_direct` check on the wrong branch, effectively requiring 2 steps for any tool call regardless of whether it needed the follow-up LLM call.

## Validation

- Existing test suite covers `_are_more_steps_needed` indirectly through `create_react_agent` integration tests
- The fix is a 2-line logic change — no new imports, no API changes, no migration needed