### PR TITLE
prebuilt: add composable tool middleware utilities and deduplication support

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/__init__.py
+++ b/libs/prebuilt/langgraph/prebuilt/__init__.py
@@ -2,6 +2,13 @@
 
 from langgraph.prebuilt._tool_call_transformer import ToolCallTransformer
 from langgraph.prebuilt.chat_agent_executor import create_react_agent
+from langgraph.prebuilt.tool_middleware import (
+    build_tool_call_key,
+    chain_async_tool_wrappers,
+    chain_tool_wrappers,
+    deduplicate_tool_calls,
+    deduplicate_tool_calls_in_state,
+)
 from langgraph.prebuilt.tool_node import (
     InjectedState,
     InjectedStore,
@@ -20,4 +27,9 @@ __all__ = [
     "InjectedState",
     "InjectedStore",
     "ToolRuntime",
+    "build_tool_call_key",
+    "chain_async_tool_wrappers",
+    "chain_tool_wrappers",
+    "deduplicate_tool_calls",
+    "deduplicate_tool_calls_in_state",
 ]

--- a/libs/prebuilt/langgraph/prebuilt/tool_middleware.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_middleware.py
@@ -1,0 +1,411 @@
+"""Composable ``ToolNode`` middleware utilities.
+
+Provides message-level tool-call deduplication and ``wrap_tool_call`` chaining
+for applications using :class:`~langgraph.prebuilt.tool_node.ToolNode`.
+
+Key components:
+
+- :func:`build_tool_call_key`: Build a stable deduplication key from tool name
+  and arguments.
+- :func:`deduplicate_tool_calls`: Remove duplicate tool calls from the trailing
+  ``AIMessage`` before tool execution.
+- :func:`deduplicate_tool_calls_in_state`: Apply :func:`deduplicate_tool_calls`
+  to a graph state mapping.
+- :func:`chain_tool_wrappers`: Compose synchronous ``wrap_tool_call`` handlers.
+- :func:`chain_async_tool_wrappers`: Compose async ``awrap_tool_call`` handlers.
+
+Example:
+
+    from langgraph.prebuilt import (
+        ToolNode,
+        chain_tool_wrappers,
+        deduplicate_tool_calls_in_state,
+    )
+
+    def log_tool(request, execute):
+        return execute(request)
+
+    tool_node = ToolNode(tools, wrap_tool_call=chain_tool_wrappers(log_tool))
+    state = deduplicate_tool_calls_in_state(state)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, TypeAlias
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+from langgraph.types import Command
+from typing_extensions import TypeIs
+
+from langgraph.prebuilt.tool_node import (
+    AsyncToolCallWrapper,
+    ToolCallRequest,
+    ToolCallWrapper,
+)
+
+__all__ = [
+    "build_tool_call_key",
+    "chain_async_tool_wrappers",
+    "chain_tool_wrappers",
+    "deduplicate_tool_calls",
+    "deduplicate_tool_calls_in_state",
+]
+
+ToolCallMapping: TypeAlias = Mapping[str, Any]
+ToolCallKeyFn: TypeAlias = Callable[[ToolCallMapping], Any]
+
+ExecuteSync: TypeAlias = Callable[[ToolCallRequest], ToolMessage | Command]
+ExecuteAsync: TypeAlias = Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]]
+
+AnyToolCallWrapper: TypeAlias = ToolCallWrapper | AsyncToolCallWrapper
+
+
+def build_tool_call_key(
+    tool_call: ToolCallMapping,
+    *,
+    key: ToolCallKeyFn | None = None,
+) -> Any:
+    """Build a stable deduplication key for a tool call.
+
+    This helper canonicalizes tool name and arguments so equivalent calls with
+    different argument ordering compare equal. Custom key functions can override
+    the default strategy when domain-specific identity is required.
+
+    Args:
+        tool_call: Tool call mapping with ``name`` and ``args`` keys.
+        key: Optional custom key function. When omitted, uses
+            ``(name, canonical_json(args))``.
+
+    Returns:
+        Hashable key identifying the tool invocation.
+    """
+    if key is not None:
+        return key(tool_call)
+
+    name = str(tool_call.get("name", ""))
+    args = tool_call.get("args") or {}
+    if not isinstance(args, Mapping):
+        args = {"value": args}
+    args_digest = json.dumps(args, sort_keys=True, default=str, separators=(",", ":"))
+    return (name, args_digest)
+
+
+def deduplicate_tool_calls(
+    messages: Sequence[BaseMessage],
+    *,
+    key: ToolCallKeyFn | None = None,
+) -> list[BaseMessage]:
+    """Remove duplicate tool calls from the final ``AIMessage``.
+
+    Language models sometimes emit multiple identical tool calls in parallel.
+    This utility keeps the first occurrence of each unique call and drops later
+    duplicates from the trailing ``AIMessage`` only. Earlier messages are left
+    unchanged.
+
+    Args:
+        messages: Conversation messages, typically from graph state.
+        key: Optional custom key function passed to :func:`build_tool_call_key`.
+
+    Returns:
+        A new message list with duplicates removed from the trailing AI message.
+        When no deduplication is required, returns a shallow copy of ``messages``.
+    """
+    if not messages:
+        return list(messages)
+
+    last = messages[-1]
+    if not isinstance(last, AIMessage) or not last.tool_calls:
+        return list(messages)
+
+    seen: set[Any] = set()
+    unique_calls: list[dict[str, Any]] = []
+    for tool_call in last.tool_calls:
+        call_dict = _coerce_tool_call_mapping(tool_call)
+        call_key = build_tool_call_key(call_dict, key=key)
+        if call_key in seen:
+            continue
+        seen.add(call_key)
+        unique_calls.append(dict(call_dict))
+
+    if len(unique_calls) == len(last.tool_calls):
+        return list(messages)
+
+    deduplicated = last.model_copy(update={"tool_calls": unique_calls})
+    return [*messages[:-1], deduplicated]
+
+
+def deduplicate_tool_calls_in_state(
+    state: Mapping[str, Any],
+    *,
+    messages_key: str = "messages",
+    key: ToolCallKeyFn | None = None,
+) -> dict[str, Any]:
+    """Return state with duplicate tool calls removed from the last AI message.
+
+    This is a convenience wrapper around :func:`deduplicate_tool_calls` for
+    graph state mappings. Call it immediately before invoking a ``ToolNode`` when
+    duplicate parallel tool calls should not be executed.
+
+    Args:
+        state: LangGraph state mapping.
+        messages_key: State key holding the conversation messages.
+        key: Optional custom deduplication key function.
+
+    Returns:
+        A shallow copy of ``state``. When the trailing AI message changes, the
+        returned mapping contains an updated ``messages`` list; otherwise the
+        message objects are unchanged.
+    """
+    messages = list(state.get(messages_key) or [])
+    updated_messages = deduplicate_tool_calls(messages, key=key)
+    if _have_same_trailing_tool_calls(messages, updated_messages):
+        return dict(state)
+    return {**state, messages_key: updated_messages}
+
+
+def chain_tool_wrappers(*wrappers: ToolCallWrapper) -> ToolCallWrapper:
+    """Compose synchronous ``wrap_tool_call`` handlers.
+
+    This utility combines multiple tool interceptors into a single handler
+    suitable for ``ToolNode(wrap_tool_call=...)``. Wrappers are applied in
+    declaration order: the first wrapper is outermost and sees the request
+    first; the last wrapper sits closest to tool execution.
+
+    Args:
+        *wrappers: One or more sync tool interceptors.
+
+    Returns:
+        Combined interceptor that runs each wrapper in order before executing
+        the tool.
+
+    Raises:
+        ValueError: If no wrappers are provided.
+    """
+    if not wrappers:
+        msg = "chain_tool_wrappers requires at least one wrapper"
+        raise ValueError(msg)
+
+    if len(wrappers) == 1:
+        return wrappers[0]
+
+    def chained(
+        request: ToolCallRequest, execute: ExecuteSync
+    ) -> ToolMessage | Command:
+        return _invoke_wrapper_chain(0, request, execute, wrappers)
+
+    return chained
+
+
+def chain_async_tool_wrappers(
+    *wrappers: AnyToolCallWrapper,
+) -> AsyncToolCallWrapper:
+    """Compose async-compatible ``awrap_tool_call`` handlers.
+
+    This utility combines multiple tool interceptors into a single async handler
+    suitable for ``ToolNode(awrap_tool_call=...)``. Sync wrappers are supported
+    via a thread-pool bridge so they do not block the event loop when calling
+    async tool execution.
+
+    Args:
+        *wrappers: One or more sync or async tool interceptors.
+
+    Returns:
+        Combined async interceptor that runs each wrapper in order before
+        executing the tool.
+
+    Raises:
+        ValueError: If no wrappers are provided.
+    """
+    if not wrappers:
+        msg = "chain_async_tool_wrappers requires at least one wrapper"
+        raise ValueError(msg)
+
+    if len(wrappers) == 1:
+        wrapper = wrappers[0]
+        if _is_async_tool_wrapper(wrapper):
+            return wrapper
+        return _adapt_sync_wrapper_to_async(wrapper)
+
+    async def chained(
+        request: ToolCallRequest, execute: ExecuteAsync
+    ) -> ToolMessage | Command:
+        return await _invoke_async_wrapper_chain(0, request, execute, wrappers)
+
+    return chained
+
+
+def _is_async_tool_wrapper(wrapper: AnyToolCallWrapper) -> TypeIs[AsyncToolCallWrapper]:
+    """Return whether ``wrapper`` is an async tool interceptor."""
+    return inspect.iscoroutinefunction(wrapper)
+
+
+def _have_same_trailing_tool_calls(
+    before: Sequence[BaseMessage],
+    after: Sequence[BaseMessage],
+) -> bool:
+    """Return whether two message lists have identical trailing tool calls.
+
+    Args:
+        before: Message list before deduplication.
+        after: Message list after deduplication.
+
+    Returns:
+        ``True`` when both lists have the same length and the trailing AI
+        message contains the same tool calls.
+    """
+    if len(before) != len(after):
+        return False
+    if not before:
+        return True
+    last_before = before[-1]
+    last_after = after[-1]
+    if not isinstance(last_before, AIMessage) or not isinstance(last_after, AIMessage):
+        return last_before == last_after
+    return last_before.tool_calls == last_after.tool_calls
+
+
+def _coerce_tool_call_mapping(tool_call: Any) -> dict[str, Any]:
+    """Normalize a tool call object to a plain dict.
+
+    Args:
+        tool_call: Tool call dict, ``ToolCall`` model, or compatible object.
+
+    Returns:
+        Tool call mapping with ``name``, ``args``, ``id``, and ``type`` keys.
+    """
+    if isinstance(tool_call, Mapping):
+        return {
+            "name": tool_call.get("name", ""),
+            "args": dict(tool_call.get("args") or {}),
+            "id": tool_call.get("id", ""),
+            "type": tool_call.get("type", "tool_call"),
+        }
+    if hasattr(tool_call, "model_dump"):
+        dumped = tool_call.model_dump()
+        return {
+            "name": dumped.get("name", ""),
+            "args": dict(dumped.get("args") or {}),
+            "id": dumped.get("id", ""),
+            "type": dumped.get("type", "tool_call"),
+        }
+    return {
+        "name": getattr(tool_call, "name", ""),
+        "args": dict(getattr(tool_call, "args", {}) or {}),
+        "id": getattr(tool_call, "id", ""),
+        "type": getattr(tool_call, "type", "tool_call"),
+    }
+
+
+def _invoke_wrapper_chain(
+    index: int,
+    request: ToolCallRequest,
+    execute: ExecuteSync,
+    wrappers: Sequence[ToolCallWrapper],
+) -> ToolMessage | Command:
+    """Invoke a sync wrapper chain recursively.
+
+    Args:
+        index: Current wrapper index in ``wrappers``.
+        request: Tool execution request.
+        execute: Final sync execute callable passed to the innermost wrapper.
+        wrappers: Ordered sync wrappers to apply.
+
+    Returns:
+        Tool execution result from the composed wrapper chain.
+    """
+    if index >= len(wrappers):
+        return execute(request)
+
+    wrapper = wrappers[index]
+
+    def next_execute(next_request: ToolCallRequest) -> ToolMessage | Command:
+        return _invoke_wrapper_chain(index + 1, next_request, execute, wrappers)
+
+    return wrapper(request, next_execute)
+
+
+async def _invoke_async_wrapper_chain(
+    index: int,
+    request: ToolCallRequest,
+    execute: ExecuteAsync,
+    wrappers: Sequence[AnyToolCallWrapper],
+) -> ToolMessage | Command:
+    """Invoke an async wrapper chain recursively.
+
+    Args:
+        index: Current wrapper index in ``wrappers``.
+        request: Tool execution request.
+        execute: Final async execute callable passed to the innermost wrapper.
+        wrappers: Ordered sync or async wrappers to apply.
+
+    Returns:
+        Tool execution result from the composed wrapper chain.
+    """
+    if index >= len(wrappers):
+        return await execute(request)
+
+    wrapper = wrappers[index]
+
+    async def next_execute(next_request: ToolCallRequest) -> ToolMessage | Command:
+        return await _invoke_async_wrapper_chain(
+            index + 1, next_request, execute, wrappers
+        )
+
+    if _is_async_tool_wrapper(wrapper):
+        return await wrapper(request, next_execute)
+
+    loop = asyncio.get_running_loop()
+    return await asyncio.to_thread(
+        wrapper,
+        request,
+        _make_sync_execute_bridge(next_execute, loop),
+    )
+
+
+def _make_sync_execute_bridge(
+    async_execute: ExecuteAsync,
+    loop: asyncio.AbstractEventLoop,
+) -> ExecuteSync:
+    """Bridge async tool execution into a sync callable.
+
+    Args:
+        async_execute: Async execute callable from the wrapper chain.
+        loop: Event loop used to schedule ``async_execute``.
+
+    Returns:
+        Sync callable that blocks until ``async_execute`` completes.
+    """
+
+    def sync_execute(request: ToolCallRequest) -> ToolMessage | Command:
+        future = asyncio.run_coroutine_threadsafe(async_execute(request), loop)
+        return future.result()
+
+    return sync_execute
+
+
+def _adapt_sync_wrapper_to_async(wrapper: ToolCallWrapper) -> AsyncToolCallWrapper:
+    """Adapt a sync wrapper for ``ToolNode(awrap_tool_call=...)``.
+
+    Args:
+        wrapper: Sync tool interceptor.
+
+    Returns:
+        Async wrapper that runs ``wrapper`` in a worker thread.
+    """
+
+    async def async_wrapper(
+        request: ToolCallRequest,
+        execute: ExecuteAsync,
+    ) -> ToolMessage | Command:
+        loop = asyncio.get_running_loop()
+        return await asyncio.to_thread(
+            wrapper,
+            request,
+            _make_sync_execute_bridge(execute, loop),
+        )
+
+    return async_wrapper

--- a/libs/prebuilt/tests/test_tool_middleware.py
+++ b/libs/prebuilt/tests/test_tool_middleware.py
@@ -1,0 +1,325 @@
+"""Unit tests for composable ToolNode middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langgraph.store.base import BaseStore
+
+from langgraph.prebuilt import (
+    ToolNode,
+    build_tool_call_key,
+    chain_async_tool_wrappers,
+    chain_tool_wrappers,
+    deduplicate_tool_calls,
+    deduplicate_tool_calls_in_state,
+)
+from langgraph.prebuilt.tool_node import ToolCallRequest
+
+pytestmark = pytest.mark.anyio
+
+
+def _create_mock_runtime(store: BaseStore | None = None) -> Mock:
+    mock_runtime = Mock()
+    mock_runtime.store = store
+    mock_runtime.context = None
+    mock_runtime.stream_writer = lambda _: None
+    return mock_runtime
+
+
+def _create_config_with_runtime(store: BaseStore | None = None) -> RunnableConfig:
+    return {"configurable": {"__pregel_runtime": _create_mock_runtime(store)}}
+
+
+@tool
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def test_build_tool_call_key_is_stable_for_equivalent_args() -> None:
+    first = {"name": "search", "args": {"term": "milk", "banner": "loblaw"}}
+    second = {"name": "search", "args": {"banner": "loblaw", "term": "milk"}}
+
+    assert build_tool_call_key(first) == build_tool_call_key(second)
+
+
+def test_deduplicate_tool_calls_removes_exact_duplicates() -> None:
+    messages = [
+        HumanMessage(content="find milk"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "search", "id": "call_1", "args": {"term": "milk"}},
+                {"name": "search", "id": "call_2", "args": {"term": "milk"}},
+                {"name": "read_cart", "id": "call_3", "args": {}},
+            ],
+        ),
+    ]
+
+    deduplicated = deduplicate_tool_calls(messages)
+
+    tool_calls = deduplicated[-1].tool_calls
+    assert len(tool_calls) == 2
+    assert [call["name"] for call in tool_calls] == ["search", "read_cart"]
+    assert [call["id"] for call in tool_calls] == ["call_1", "call_3"]
+
+
+def test_deduplicate_tool_calls_treats_reordered_args_as_duplicates() -> None:
+    messages = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "search",
+                    "id": "call_1",
+                    "args": {"term": "milk", "banner": "loblaw"},
+                },
+                {
+                    "name": "search",
+                    "id": "call_2",
+                    "args": {"banner": "loblaw", "term": "milk"},
+                },
+            ],
+        )
+    ]
+
+    deduplicated = deduplicate_tool_calls(messages)
+
+    assert len(deduplicated[-1].tool_calls) == 1
+    assert deduplicated[-1].tool_calls[0]["id"] == "call_1"
+
+
+def test_deduplicate_tool_calls_returns_new_list_when_nothing_changes() -> None:
+    messages = [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+    ]
+
+    deduplicated = deduplicate_tool_calls(messages)
+
+    assert deduplicated == messages
+    assert deduplicated is not messages
+
+
+def test_deduplicate_tool_calls_in_state_updates_messages_key() -> None:
+    state = {
+        "messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"name": "search", "id": "call_1", "args": {"term": "milk"}},
+                    {"name": "search", "id": "call_2", "args": {"term": "milk"}},
+                ],
+            )
+        ],
+        "metadata": [],
+    }
+
+    updated = deduplicate_tool_calls_in_state(state)
+
+    assert len(updated["messages"][-1].tool_calls) == 1
+    assert updated["metadata"] == []
+    assert len(state["messages"][-1].tool_calls) == 2
+
+
+def test_chain_tool_wrappers_runs_outer_then_inner() -> None:
+    order: list[str] = []
+
+    def outer(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage],
+    ) -> ToolMessage:
+        order.append("outer")
+        result = execute(request)
+        order.append("outer_after")
+        return result
+
+    def inner(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage],
+    ) -> ToolMessage:
+        order.append("inner")
+        return execute(request)
+
+    tool_node = ToolNode([add], wrap_tool_call=chain_tool_wrappers(outer, inner))
+
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "add", "id": "call_1", "args": {"a": 1, "b": 2}}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    assert order == ["outer", "inner", "outer_after"]
+    assert result["messages"][-1].content == "3"
+
+
+def test_chain_tool_wrappers_requires_at_least_one_wrapper() -> None:
+    with pytest.raises(ValueError, match="requires at least one wrapper"):
+        chain_tool_wrappers()
+
+
+def test_chain_async_tool_wrappers_requires_at_least_one_wrapper() -> None:
+    with pytest.raises(ValueError, match="requires at least one wrapper"):
+        chain_async_tool_wrappers()
+
+
+async def test_chain_async_tool_wrappers_supports_sync_wrapper() -> None:
+    seen: list[str] = []
+
+    def sync_wrapper(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage],
+    ) -> ToolMessage:
+        seen.append("sync")
+        return execute(request)
+
+    tool_node = ToolNode([add], awrap_tool_call=chain_async_tool_wrappers(sync_wrapper))
+
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "add", "id": "call_1", "args": {"a": 3, "b": 5}}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    assert seen == ["sync"]
+    assert result["messages"][-1].content == "8"
+
+
+async def test_chain_async_tool_wrappers_runs_outer_then_inner() -> None:
+    order: list[str] = []
+
+    async def outer(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage:
+        order.append("outer")
+        result = await execute(request)
+        order.append("outer_after")
+        return result
+
+    def inner(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage],
+    ) -> ToolMessage:
+        order.append("inner")
+        return execute(request)
+
+    tool_node = ToolNode([add], awrap_tool_call=chain_async_tool_wrappers(outer, inner))
+
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "add", "id": "call_1", "args": {"a": 1, "b": 2}}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    assert order == ["outer", "inner", "outer_after"]
+    assert result["messages"][-1].content == "3"
+
+
+async def test_chain_async_tool_wrappers_supports_async_wrapper() -> None:
+    seen: list[str] = []
+
+    async def async_wrapper(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage:
+        seen.append("async")
+        return await execute(request)
+
+    tool_node = ToolNode(
+        [add], awrap_tool_call=chain_async_tool_wrappers(async_wrapper)
+    )
+
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "add", "id": "call_1", "args": {"a": 2, "b": 4}}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    assert seen == ["async"]
+    assert result["messages"][-1].content == "6"
+
+
+def test_tool_node_with_deduplicated_state_executes_each_unique_call_once() -> None:
+    execution_count = {"add": 0}
+
+    @tool
+    def counting_add(a: int, b: int) -> int:
+        """Add while counting invocations."""
+        execution_count["add"] += 1
+        return a + b
+
+    tool_node = ToolNode([counting_add])
+    state = deduplicate_tool_calls_in_state(
+        {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "counting_add",
+                            "id": "call_1",
+                            "args": {"a": 1, "b": 1},
+                        },
+                        {
+                            "name": "counting_add",
+                            "id": "call_2",
+                            "args": {"a": 1, "b": 1},
+                        },
+                        {
+                            "name": "counting_add",
+                            "id": "call_3",
+                            "args": {"a": 2, "b": 3},
+                        },
+                    ],
+                )
+            ]
+        }
+    )
+
+    result = tool_node.invoke(state, config=_create_config_with_runtime())
+
+    tool_messages = [
+        message for message in result["messages"] if isinstance(message, ToolMessage)
+    ]
+    assert len(tool_messages) == 2
+    assert execution_count["add"] == 2


### PR DESCRIPTION
## Summary

Add composable tool middleware utilities to `langgraph.prebuilt` and expose them as part of the public prebuilt API.

## What's Changed

* Added `tool_middleware.py` with the following utilities:

  * `build_tool_call_key`
  * `deduplicate_tool_calls`
  * `deduplicate_tool_calls_in_state`
  * `chain_tool_wrappers`
  * `chain_async_tool_wrappers`
* Exported the new middleware helpers from `__init__.py`.
* Added unit tests in `test_tool_middleware.py`.

## Why

This change provides a foundation for more robust and extensible tool execution by:

* Deduplicating repeated tool calls emitted by LLMs.
* Supporting composition of synchronous and asynchronous tool-call wrappers.
* Enabling reusable middleware patterns for `ToolNode` and other prebuilt agent components.

## Testing

Added and passed unit tests covering:

* Stable tool-call key generation.
* Duplicate tool-call elimination.
* State-based deduplication.
* Wrapper chaining semantics.
* Synchronous wrappers within asynchronous middleware chains.
* Single execution of deduplicated tool calls.

## Notes

The new middleware utilities are now part of the `langgraph.prebuilt` public API. They provide reusable building blocks for implementing safer, composable, and extensible tool middleware in downstream prebuilt agent implementations.
