### PR TITLE
fix: manage AsyncPipeline lifecycle in AsyncPostgresSaver.from_conn_string (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -81,9 +81,13 @@ class AsyncPostgresSaver(BasePostgresSaver):
         async with await AsyncConnection.connect(
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
+            if pipeline and Capabilities().has_pipeline():
+                pipe = conn.pipeline()
+                await pipe.__aenter__()
+                try:
                     yield cls(conn=conn, pipe=pipe, serde=serde)
+                finally:
+                    await pipe.__aexit__(None, None, None)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
The `AsyncPostgresSaver.from_conn_string` method used `async with conn.pipeline()` as a context manager, which meant the pipeline was entered and exited within the `from_conn_string` coroutine. However, the saver instance was yielded inside the pipeline context, causing the pipeline to be closed prematurely when the context manager exited. This left the saver with a stale `pipe` reference, leading to the observed `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` error when using the saver.

Additionally, the `supports_pipeline` property was set unconditionally without checking if the connection actually supports pipelines, which could cause issues on older PostgreSQL versions.

## Fix
- Changed `from_conn_string` to manually manage the AsyncPipeline lifecycle: entering the pipeline before yielding the saver and exiting it in a `finally` block to ensure proper cleanup.
- Added a check `Capabilities().has_pipeline()` before attempting to use the pipeline.

Closes #5675