### PR TITLE
fix(config): stop swallowing get_config() async guard on Python < 3.11 (#8203)

### DIFF
--- a/libs/langgraph/langgraph/config.py
+++ b/libs/langgraph/langgraph/config.py
@@ -17,12 +17,13 @@ def _no_op_stream_writer(c: Any) -> None:
 def get_config() -> RunnableConfig:
     if sys.version_info < (3, 11):
         try:
-            if asyncio.current_task():
-                raise RuntimeError(
-                    "Python 3.11 or later required to use this in an async context"
-                )
+            in_async_context = asyncio.current_task() is not None
         except RuntimeError:
-            pass
+            in_async_context = False
+        if in_async_context:
+            raise RuntimeError(
+                "Python 3.11 or later required to use this in an async context"
+            )
     if var_config := var_child_runnable_config.get():
         return var_config
     else:

--- a/libs/langgraph/tests/test_config.py
+++ b/libs/langgraph/tests/test_config.py
@@ -1,0 +1,23 @@
+import asyncio
+import sys
+
+import pytest
+
+from langgraph.config import get_config
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="Python < 3.11 guard only applies on older interpreters",
+)
+def test_get_config_raises_in_async_context_on_python_lt_311() -> None:
+    """Issue #8203: the async guard must not be swallowed on Python < 3.11."""
+
+    async def main() -> None:
+        with pytest.raises(
+            RuntimeError,
+            match="Python 3.11 or later required to use this in an async context",
+        ):
+            get_config()
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Fix `get_config()` on Python < 3.11 so the intentional `RuntimeError` for async usage is no longer caught and discarded by a broad `except RuntimeError: pass` block.
- Add a regression test that asserts the guard fires inside an async task on older Python versions.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have enabled "Allow edits from maintainers" for this pull request**

Fixes #8203

Made with [Cursor](https://cursor.com)