### PR TITLE
fix: stop checkpoints after failed delta writes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1538,13 +1538,13 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         if self._delta_write_futs:
             futs, self._delta_write_futs = self._delta_write_futs, []
             concurrent.futures.wait(futs)
-        try:
-            if prev is not None:
-                prev.result()
-        finally:
-            cast(BaseCheckpointSaver, self.checkpointer).put(
-                config, checkpoint, metadata, new_versions
-            )
+            for fut in futs:
+                fut.result()
+        if prev is not None:
+            prev.result()
+        return cast(BaseCheckpointSaver, self.checkpointer).put(
+            config, checkpoint, metadata, new_versions
+        )
 
     def match_cached_writes(self) -> Sequence[PregelExecutableTask]:
         if self.cache is None:
@@ -1793,13 +1793,11 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         if self._delta_write_futs:
             futs, self._delta_write_futs = self._delta_write_futs, []
             await asyncio.gather(*futs)
-        try:
-            if prev is not None:
-                await prev
-        finally:
-            await cast(BaseCheckpointSaver, self.checkpointer).aput(
-                config, checkpoint, metadata, new_versions
-            )
+        if prev is not None:
+            await prev
+        return await cast(BaseCheckpointSaver, self.checkpointer).aput(
+            config, checkpoint, metadata, new_versions
+        )
 
     async def amatch_cached_writes(self) -> Sequence[PregelExecutableTask]:
         if self.cache is None:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -234,6 +234,67 @@ def test_checkpoint_errors() -> None:
         )
 
 
+def test_sync_durability_failed_delta_writes_skip_checkpoint() -> None:
+    class FaultyDeltaWriteCheckpointer(InMemorySaver):
+        put_sources: list[str | None]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.put_sources = []
+
+        def put(
+            self,
+            config: RunnableConfig,
+            checkpoint: Checkpoint,
+            metadata: CheckpointMetadata,
+            new_versions: dict[str, str | int | float] | None = None,
+        ) -> RunnableConfig:
+            self.put_sources.append(metadata.get("source"))
+            return super().put(config, checkpoint, metadata, new_versions)
+
+        def put_writes(
+            self,
+            config: RunnableConfig,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> None:
+            if any(
+                channel == "messages"
+                and isinstance(value, list)
+                and any(
+                    isinstance(message, AIMessage) and message.content == "reply"
+                    for message in value
+                )
+                for channel, value in writes
+            ):
+                time.sleep(0.05)
+                raise ValueError("Faulty delta put_writes")
+            return super().put_writes(config, writes, task_id, task_path)
+
+    class State(TypedDict):
+        messages: Annotated[list, DeltaChannel(_messages_delta_reducer)]
+
+    def respond(state: State) -> dict:
+        return {"messages": [AIMessage(content="reply", id="ai1")]}
+
+    checkpointer = FaultyDeltaWriteCheckpointer()
+    builder = StateGraph(State)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    graph = builder.compile(checkpointer=checkpointer)
+
+    with pytest.raises(ValueError, match="Faulty delta put_writes"):
+        graph.invoke(
+            {"messages": [HumanMessage(content="hello", id="h1")]},
+            {"configurable": {"thread_id": "failed-delta-sync"}},
+            durability="sync",
+        )
+
+    assert "input" in checkpointer.put_sources
+    assert checkpointer.put_sources.count("loop") == 1
+
+
 def test_context_json_schema() -> None:
     """Test that config json schema is generated properly."""
     chain = NodeBuilder().subscribe_only("input").write_to("output")

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8,6 +8,7 @@ import random
 import sys
 import uuid
 from collections import Counter, deque
+from collections.abc import Sequence
 from dataclasses import replace
 from time import perf_counter
 from typing import (
@@ -21,7 +22,7 @@ from uuid import UUID
 
 import pytest
 from langchain_core.language_models import GenericFakeChatModel
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnablePassthrough
 from langchain_core.utils.aiter import aclosing
 from langchain_core.version import VERSION as LANGCHAIN_CORE_VERSION
@@ -45,6 +46,7 @@ from typing_extensions import NotRequired, TypedDict
 from langgraph._internal._constants import CONFIG_KEY_NODE_FINISHED, ERROR, PULL
 from langgraph._internal._queue import AsyncQueue
 from langgraph.channels.binop import BinaryOperatorAggregate
+from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.errors import (
@@ -55,7 +57,7 @@ from langgraph.errors import (
 )
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
-from langgraph.graph.message import MessagesState, add_messages
+from langgraph.graph.message import MessagesState, _messages_delta_reducer, add_messages
 from langgraph.pregel import NodeBuilder, Pregel
 from langgraph.pregel._loop import AsyncPregelLoop
 from langgraph.pregel._runner import PregelRunner
@@ -216,6 +218,67 @@ async def test_checkpoint_errors() -> None:
             "", {"configurable": {"thread_id": "thread-3"}}, version="v2"
         ):
             pass
+
+
+async def test_sync_durability_failed_delta_writes_skip_checkpoint_async() -> None:
+    class FaultyDeltaWriteCheckpointer(InMemorySaver):
+        put_sources: list[str | None]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.put_sources = []
+
+        async def aput(
+            self,
+            config: RunnableConfig,
+            checkpoint: Checkpoint,
+            metadata: CheckpointMetadata,
+            new_versions: ChannelVersions,
+        ) -> RunnableConfig:
+            self.put_sources.append(metadata.get("source"))
+            return await super().aput(config, checkpoint, metadata, new_versions)
+
+        async def aput_writes(
+            self,
+            config: RunnableConfig,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> None:
+            if any(
+                channel == "messages"
+                and isinstance(value, list)
+                and any(
+                    isinstance(message, AIMessage) and message.content == "reply"
+                    for message in value
+                )
+                for channel, value in writes
+            ):
+                await asyncio.sleep(0.05)
+                raise ValueError("Faulty delta put_writes")
+            return await super().aput_writes(config, writes, task_id, task_path)
+
+    class State(TypedDict):
+        messages: Annotated[list, DeltaChannel(_messages_delta_reducer)]
+
+    def respond(state: State) -> dict:
+        return {"messages": [AIMessage(content="reply", id="ai1")]}
+
+    checkpointer = FaultyDeltaWriteCheckpointer()
+    builder = StateGraph(State)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+    graph = builder.compile(checkpointer=checkpointer)
+
+    with pytest.raises(ValueError, match="Faulty delta put_writes"):
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content="hello", id="h1")]},
+            {"configurable": {"thread_id": "failed-delta-async"}},
+            durability="sync",
+        )
+
+    assert "input" in checkpointer.put_sources
+    assert checkpointer.put_sources.count("loop") == 1
 
 
 @NEEDS_CONTEXTVARS


### PR DESCRIPTION
## Summary

- propagate DeltaChannel `put_writes` future failures before persisting checkpoints in sync and async Pregel loops
- remove the `finally` path that allowed a checkpoint to persist after a failed write or previous checkpoint future
- add sync and async regression coverage for delayed DeltaChannel write failure under `durability="sync"`

Fixes #8234.

## Tests

- `git diff --check`
- `make format`
- `NO_DOCKER=true uv run pytest tests/test_pregel.py::test_checkpoint_errors tests/test_pregel.py::test_sync_durability_failed_delta_writes_skip_checkpoint tests/test_pregel.py::test_delta_channel_durability_exit_stores_snapshot tests/test_pregel.py::test_delta_channel_async_write_ordering tests/test_pregel_async.py::test_checkpoint_errors tests/test_pregel_async.py::test_sync_durability_failed_delta_writes_skip_checkpoint_async tests/test_pregel_async.py::test_delta_channel_durability_exit_stores_snapshot_async -q` (7 passed)
- `make lint`
- `NO_DOCKER=true make test TEST='tests/test_pregel.py tests/test_pregel_async.py'` (769 passed, 58 warnings)
- `NO_DOCKER=true make test` (1968 passed, 4 skipped, 155 warnings)