### PR TITLE
fix: avoid AsyncPipeline with SSL connections to prevent OperationalError (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,17 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                force_no_ssl = "sslmode=disable" not in conn_string.lower()
+                if force_no_ssl:
+                    import warnings
+                    warnings.warn(
+                        "AsyncPipeline is not compatible with SSL connections. "
+                        "Falling back to non-pipeline mode."
+                    )
+                    yield cls(conn=conn, serde=serde)
+                else:
+                    async with conn.pipeline() as pipe:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True` and an SSL-requiring PostgreSQL connection (common with cloud-hosted databases like Supabase), psycopg's `AsyncPipeline` fails because it does not support SSL. This causes a `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`.

## Fix
Detect if the connection string uses SSL (i.e., does not contain `sslmode=disable`). If SSL is active and `pipeline=True`, emit a warning and fall back to non-pipeline mode. This ensures that users get a working checkpointer without manually adjusting their connection string or disabling pipelines when they don't need SSL.

Closes #5675