### PR TITLE
fix(store): preserve created_at on upsert in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,11 +407,16 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=(
+                        existing.created_at
+                        if existing is not None
+                        else datetime.now(timezone.utc)
+                    ),
                     updated_at=datetime.now(timezone.utc),
                 )
 

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -1044,3 +1044,17 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_upsert_preserves_created_at() -> None:
+    store = InMemoryStore()
+    store.put(("ns",), "k", {"v": 1})
+    # Simulate an item that was originally created in the past.
+    original = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    store._data[("ns",)]["k"].created_at = original
+    # Upsert the same key with a new value.
+    store.put(("ns",), "k", {"v": 2})
+    item = store.get(("ns",), "k")
+    assert item is not None
+    assert item.created_at == original  # creation timestamp must be retained
+    assert item.updated_at > original  # update timestamp should advance


### PR DESCRIPTION
## Summary
- `InMemoryStore._apply_put_ops` rebuilt `Item` with `created_at=datetime.now()` on every `put`, including upserts, so the original creation timestamp was lost on update. The disk-load path already preserved `created_at`.
- Now `created_at` is only set for genuinely new keys; upserts keep the existing value while `updated_at` advances.

## Test plan
- Added `test_upsert_preserves_created_at` to `libs/checkpoint/tests/test_store.py`.
- Fail-before/pass-after verified locally; ruff clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>