### PR TITLE
feat(langgraph): add optional pub-sub mode for StateGraph nodes

### DIFF
--- a/docs/docs/how-tos/pubsub.md
+++ b/docs/docs/how-tos/pubsub.md
@@ -1,0 +1,407 @@
+# Pub-sub in LangGraph graphs
+
+LangGraph graphs support two complementary ways to connect nodes:
+
+| Mode | What it is | How a node is started |
+|------|------------|------------------------|
+| **Workflow** (default) | Direct control flow | Edges, `Command(goto=...)`, `Send` |
+| **Pub-sub** | Classical publish / subscribe | Messages on a **topic** |
+
+You can use either mode alone, or **both on the same node**. Pub-sub does **not** replace edges—it is an option next to them.
+
+```text
+WORKFLOW                         PUB-SUB
+────────                         ───────
+  A ──edge──► B                    publisher
+                                    │ Publish("events", msg)
+                                    ▼
+                                  topic "events"
+                                    │
+                          ┌─────────┴─────────┐
+                          ▼                   ▼
+                     subscriber_1        subscriber_2
+```
+
+- **Publishers** do not name subscribers.
+- **Subscribers** do not name publishers.
+- They only share a **topic** name.
+
+This guide is for people who have never used pub-sub. Every example is runnable with the Graph API (`StateGraph`).
+
+---
+
+## When to use which
+
+| Use **workflow** edges when… | Use **pub-sub** when… |
+|------------------------------|------------------------|
+| The next step is part of the main recipe | Side effects should not couple to the main path |
+| You need a strict order (A then B then C) | Several listeners should react to the same event |
+| Routing depends on a condition / `Command` | Producers should not know who is listening |
+| Map-reduce with a known target node (`Send`) | You want fan-out by **topic**, not by node name |
+
+**Combine them** when you have a clear workflow spine (ingest → process → respond) and optional side paths (audit log, metrics, cache warmers) that should not clutter the edge list.
+
+---
+
+## Concepts
+
+### Topics
+
+A **topic** is a named channel that collects published messages for one superstep (or longer if `accumulate=True`).
+
+Declare a topic in either of two ways:
+
+1. **As a state key** (payload visible in normal state):
+
+   ```python
+   from typing import Annotated, Sequence, TypedDict
+   from langgraph.channels import Topic
+
+   class State(TypedDict):
+       events: Annotated[Sequence[str], Topic(str)]
+   ```
+
+2. **With `add_topic`** (side channel; not required on the TypedDict):
+
+   ```python
+   builder.add_topic("events", typ=str)
+   ```
+
+If the same name is both a `Topic` state key and passed to `add_topic`, LangGraph reuses the channel (they must agree on `accumulate`).
+
+### Publish
+
+From a node, return a `Publish` (alone or with a state update):
+
+```python
+from langgraph.types import Publish
+
+return Publish("events", "user-created")
+return {"count": 1}, Publish("events", "tick")
+return [Command(update={"count": 1}), Publish("events", "tick")]
+```
+
+If the topic is a state key, writing that key also publishes:
+
+```python
+return {"events": "user-created"}  # wakes subscribers of "events"
+```
+
+### Subscribe and modes
+
+```python
+builder.add_node(
+    "audit",
+    audit_fn,
+    mode="pubsub",              # only woken by topics
+    subscribes=["events"],
+)
+
+builder.add_node(
+    "hybrid",
+    hybrid_fn,
+    mode="both",               # edges AND topics
+    subscribes=["events"],
+)
+```
+
+| `mode` | Activated by |
+|--------|----------------|
+| `"workflow"` (default) | Edges / `Command` / `Send` |
+| `"pubsub"` | Subscribed topics only |
+| `"both"` or `("workflow", "pubsub")` | Either |
+
+**Rules of thumb:**
+
+- `subscribes=...` requires `pubsub` in the mode (if you omit `mode`, pubsub is added automatically and workflow is kept).
+- `mode="workflow"` **plus** `subscribes=...` is a conflict → error.
+- **Edges must not target pubsub-only nodes** (they would never run). Use `mode="both"` if the node should accept edges *and* topics.
+- Publishing (`publishes=...` / `Publish`) does **not** change mode; any node may publish.
+
+Declare `publishes=[...]` (or `builder.publish(node, topic)`) so the **diagram** can draw topic edges. Runtime still works if you only return `Publish`, but static visualization uses the declaration.
+
+---
+
+## Minimal example
+
+```python
+from typing import Annotated, Sequence, TypedDict
+import operator
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.channels import Topic
+from langgraph.types import Publish
+
+
+class State(TypedDict):
+    items: Annotated[list[str], operator.add]
+    logs: Annotated[Sequence[str], Topic(str)]
+
+
+def produce(state: State):
+    item = f"item-{len(state['items'])}"
+    return {"items": [item]}, Publish("logs", f"produced {item}")
+
+
+def audit(state: State):
+    # Runs because it subscribes to "logs" — no edge from produce
+    print("audit saw", state["logs"])
+    return {}
+
+
+builder = StateGraph(State)
+builder.add_node("produce", produce, publishes=["logs"])
+builder.add_node("audit", audit, mode="pubsub", subscribes=["logs"])
+builder.add_edge(START, "produce")
+builder.add_edge("produce", END)
+graph = builder.compile()
+
+graph.invoke({"items": []})
+# produce runs, publishes to logs, audit runs, graph finishes
+```
+
+---
+
+## Fan-out (one publisher → many subscribers)
+
+```python
+from typing import Annotated, Sequence, TypedDict
+import operator
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.channels import Topic
+from langgraph.types import Publish
+
+
+class State(TypedDict):
+    bus: Annotated[Sequence[str], Topic(str)]
+    a: Annotated[list[str], operator.add]
+    b: Annotated[list[str], operator.add]
+
+
+def publish(state: State):
+    return Publish("bus", "hello")
+
+
+def listener_a(state: State):
+    return {"a": [f"A saw {list(state['bus'])}"]}
+
+
+def listener_b(state: State):
+    return {"b": [f"B saw {list(state['bus'])}"]}
+
+
+builder = StateGraph(State)
+builder.add_node("publish", publish, publishes=["bus"])
+builder.add_node("a", listener_a, mode="pubsub", subscribes=["bus"])
+builder.add_node("b", listener_b, mode="pubsub", subscribes=["bus"])
+builder.add_edge(START, "publish")
+builder.add_edge("publish", END)
+graph = builder.compile()
+
+print(graph.invoke({"a": [], "b": []}))
+# Both a and b receive the same topic batch
+```
+
+---
+
+## Fan-in (many publishers → one subscriber)
+
+When several nodes publish in the **same** superstep, the subscriber sees **all** values as a sequence:
+
+```python
+def left(state):
+    return Publish("bus", "L")
+
+def right(state):
+    return Publish("bus", "R")
+
+def join(state):
+    return {"sink": [f"got {sorted(state['bus'])}"]}
+
+builder = StateGraph(State)  # State has bus: Topic and sink: list reducer
+builder.add_node("left", left, publishes=["bus"])
+builder.add_node("right", right, publishes=["bus"])
+builder.add_node("join", join, mode="pubsub", subscribes=["bus"])
+builder.add_edge(START, "left")
+builder.add_edge(START, "right")
+builder.add_edge("left", END)
+builder.add_edge("right", END)
+```
+
+---
+
+## Hybrid graph (workflow spine + side subscribers)
+
+```python
+from typing import Annotated, Sequence, TypedDict
+import operator
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.channels import Topic
+from langgraph.types import Publish
+
+
+class State(TypedDict):
+    steps: Annotated[list[str], operator.add]
+    events: Annotated[Sequence[str], Topic(str)]
+
+
+def ingest(state: State):
+    return {"steps": ["ingest"]}, Publish("events", "ingested")
+
+
+def process(state: State):
+    return {"steps": ["process"]}
+
+
+def audit(state: State):
+    return {"steps": [f"audit:{list(state['events'])}"]}
+
+
+builder = StateGraph(State)
+builder.add_node("ingest", ingest, publishes=["events"])
+builder.add_node("process", process)
+builder.add_node("audit", audit, mode="pubsub", subscribes=["events"])
+builder.add_edge(START, "ingest")
+builder.add_edge("ingest", "process")
+builder.add_edge("process", END)
+graph = builder.compile()
+
+print(graph.invoke({"steps": []}))
+# steps includes ingest, process, and an audit:* entry
+```
+
+The main path stays a simple chain. Audit is not an edge destination; it only listens.
+
+---
+
+## Side topics (not on the state schema)
+
+```python
+class State(TypedDict):
+    n: int
+    sink: Annotated[list[str], operator.add]
+
+
+def src(state: State):
+    return {"n": state["n"] + 1}, Publish("metrics", {"n": state["n"]})
+
+
+def metrics_sink(state: State):
+    # Subscribed topics are added to the node input even if not on State
+    return {"sink": [str(state.get("metrics"))]}  # type: ignore[typeddict-item]
+
+
+builder = StateGraph(State)
+builder.add_topic("metrics", typ=dict)
+builder.add_node("src", src, publishes=["metrics"])
+builder.add_node("metrics_sink", metrics_sink, mode="pubsub", subscribes=["metrics"])
+builder.add_edge(START, "src")
+builder.add_edge("src", END)
+```
+
+Prefer **state-key topics** when handlers should type the payload in the TypedDict. Use **side topics** for telemetry-style channels you do not want in the main schema.
+
+---
+
+## Fluent wiring
+
+Equivalent to kwargs on `add_node`:
+
+```python
+builder.add_node("src", src)
+builder.add_node("dst", dst)
+builder.publish("src", "events")
+builder.subscribe("dst", "events")  # adds pubsub mode if needed
+```
+
+---
+
+## Visualization
+
+```python
+print(graph.get_graph().draw_mermaid())
+```
+
+You should see:
+
+- Node metadata: `mode = workflow`, `mode = pubsub`, or `mode = pubsub+workflow`
+- Optional `publishes = ...` / `subscribes = ...`
+- Dashed edges labeled `topic:<name>` from publishers to subscribers
+
+Example shape:
+
+```text
+__start__ --> produce
+produce -. topic:logs .-> audit
+produce --> __end__
+```
+
+Declare `publishes=` so those topic edges appear without executing real node logic (static analysis).
+
+---
+
+## `Publish` vs `Send`
+
+| | `Publish(topic, value)` | `Send(node, arg)` |
+|--|-------------------------|-------------------|
+| Addressing | By **topic** (anonymous consumers) | By **node name** |
+| Consumer input | Graph state (+ topic batch) | Custom `arg` as node input |
+| Typical use | Events, audits, multi-listener | Map-reduce fan-out |
+| Coupling | Loose | Explicit target |
+
+Use `Send` when you know the worker node and want a custom per-task payload. Use `Publish` when any number of listeners should react without the producer listing them.
+
+---
+
+## Modes in one place
+
+```python
+# Workflow only (default) — edges / Command
+builder.add_node("a", fn_a)
+
+# Pub-sub only — topics; do not add edges TO this node
+builder.add_node("b", fn_b, mode="pubsub", subscribes=["t"])
+
+# Both — edges and topics
+builder.add_node("c", fn_c, mode="both", subscribes=["t"])
+# same as mode=("workflow", "pubsub")
+```
+
+---
+
+## Pitfalls
+
+1. **Nothing publishes → subscribers never run.** There must be a workflow path that eventually `Publish`es (or writes the Topic key).
+2. **Edge into `mode="pubsub"` only** → compile error. Use `mode="both"` if the node should also be an edge target.
+3. **Topic not in state** → payload is still injected under the topic name for subscribers, but it will not appear in typed `State` fields or default outputs unless you put it on the schema / output schema.
+4. **Self-sustaining loops** (`subscribe` + `publish` on the same topic) can run until the recursion limit. Prefer a workflow sink (`END`) or stop publishing when done.
+5. **Diagram missing topic edges** → add `publishes=["topic"]` on the publisher node.
+6. **`accumulate=False` (default)** clears the topic after each step once updates are applied; use `accumulate=True` only when you need history across steps.
+7. **Subgraphs** do not share topics with parents unless you pass state keys through shared schema design; there is no global process-wide bus.
+
+---
+
+## API checklist
+
+```python
+from langgraph.graph import StateGraph, START, END, Publish
+from langgraph.channels import Topic
+from langgraph.types import Publish  # same object
+
+builder.add_topic(name, typ=Any, accumulate=False)
+builder.add_node(
+    name,
+    fn,
+    mode="workflow" | "pubsub" | "both" | ("workflow", "pubsub"),
+    publishes=["topic", ...],
+    subscribes=["topic", ...],
+)
+builder.publish(node, *topics)
+builder.subscribe(node, *topics)
+# runtime
+return Publish("topic", value)
+```
+
+For low-level actor/channel graphs, the same idea exists as `Topic` + `NodeBuilder().subscribe_to(...).write_to(...)`. The Graph API above is the supported way to do classical pub-sub on `StateGraph`.

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -24,11 +24,21 @@ class Topic(
     Generic[Value],
     BaseChannel[Sequence[Value], Value | list[Value], list[Value]],
 ):
-    """A configurable PubSub Topic.
+    """A configurable pub-sub topic channel.
+
+    Multiple nodes can publish values in the same step; subscribers see the
+    collected sequence. Used as:
+
+    - A **state key**: `events: Annotated[Sequence[T], Topic(T)]`
+    - A **graph topic**: `builder.add_topic("events", typ=T)` (Graph API pub-sub)
+
+    With the Graph API, pair topics with `publishes` / `subscribes` on nodes and
+    [`Publish`][langgraph.types.Publish] return values. See the pub-sub how-to.
 
     Args:
         typ: The type of the value stored in the channel.
-        accumulate: Whether to accumulate values across steps. If `False`, the channel will be emptied after each step.
+        accumulate: Whether to accumulate values across steps. If `False`, the
+            channel will be emptied after each step.
     """
 
     __slots__ = ("values", "accumulate")

--- a/libs/langgraph/langgraph/graph/__init__.py
+++ b/libs/langgraph/langgraph/graph/__init__.py
@@ -1,11 +1,14 @@
 from langgraph.constants import END, START
 from langgraph.graph.message import MessageGraph, MessagesState, add_messages
 from langgraph.graph.state import StateGraph
+from langgraph.types import NodeMode, Publish
 
 __all__ = (
     "END",
     "START",
     "StateGraph",
+    "Publish",
+    "NodeMode",
     "add_messages",
     "MessagesState",
     "MessageGraph",

--- a/libs/langgraph/langgraph/graph/_node.py
+++ b/libs/langgraph/langgraph/graph/_node.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Generic, Protocol, TypeAlias
 
 from langchain_core.runnables import Runnable, RunnableConfig
@@ -9,7 +9,13 @@ from langgraph.store.base import BaseStore
 
 from langgraph._internal._typing import EMPTY_SEQ
 from langgraph.runtime import Runtime
-from langgraph.types import CachePolicy, RetryPolicy, StreamWriter, TimeoutPolicy
+from langgraph.types import (
+    CachePolicy,
+    NodeMode,
+    RetryPolicy,
+    StreamWriter,
+    TimeoutPolicy,
+)
 from langgraph.typing import ContextT, NodeInputT, NodeInputT_contra
 
 
@@ -93,3 +99,11 @@ class StateNodeSpec(Generic[NodeInputT, ContextT]):
     ends: tuple[str, ...] | dict[str, str] | None = EMPTY_SEQ
     defer: bool = False
     timeout: TimeoutPolicy | None = None
+    modes: frozenset[NodeMode] = field(
+        default_factory=lambda: frozenset({"workflow"})  # type: ignore[arg-type]
+    )
+    """Activation modes: `workflow` (edges/Command), `pubsub` (topics), or both."""
+    publishes: tuple[str, ...] = ()
+    """Topic names this node is declared to publish to (diagram + validation)."""
+    subscribes: tuple[str, ...] = ()
+    """Topic names that wake this node when `pubsub` is in `modes`."""

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -57,6 +57,7 @@ from langgraph.channels.named_barrier_value import (
     NamedBarrierValue,
     NamedBarrierValueAfterFinish,
 )
+from langgraph.channels.topic import Topic
 from langgraph.constants import END, START, TAG_HIDDEN
 from langgraph.errors import (
     ErrorCode,
@@ -82,6 +83,8 @@ from langgraph.types import (
     CachePolicy,
     Checkpointer,
     Command,
+    NodeMode,
+    Publish,
     RetryPolicy,
     Send,
     TimeoutPolicy,
@@ -135,6 +138,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     Each state key can optionally be annotated with a reducer function that
     will be used to aggregate the values of that key received from multiple nodes.
     The signature of a reducer function is `(Value, Value) -> Value`.
+
+    Nodes are activated by **workflow** control flow (edges, `Command`, `Send`)
+    and/or by **pub-sub** topics (`add_topic`, `Publish`, `subscribes`). See
+    `add_topic`, `publish`, `subscribe`, and [`Publish`][langgraph.types.Publish].
 
     !!! warning
 
@@ -205,6 +212,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     managed: dict[str, ManagedValueSpec]
     schemas: dict[type[Any], dict[str, BaseChannel | ManagedValueSpec]]
     waiting_edges: set[tuple[tuple[str, ...], str]]
+    topics: dict[str, Topic[Any]]
+    """Registered pub-sub topics (name → `Topic` channel)."""
 
     compiled: bool
     state_schema: type[StateT]
@@ -256,6 +265,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self.managed = {}
         self.compiled = False
         self.waiting_edges = set()
+        self.topics = {}
 
         self.state_schema = state_schema
         self.input_schema = cast(type[InputT], input_schema or state_schema)
@@ -267,6 +277,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         self._add_schema(self.state_schema)
         self._add_schema(self.input_schema, allow_managed=False)
         self._add_schema(self.output_schema, allow_managed=False)
+        # State keys that are already Topic channels are pub-sub topics.
+        for name, channel in self.channels.items():
+            if isinstance(channel, Topic):
+                self.topics[name] = channel
 
     def set_node_defaults(
         self,
@@ -333,6 +347,142 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             defaults.timeout = coerce_timeout_policy(timeout)
         return self
 
+    def add_topic(
+        self,
+        name: str,
+        *,
+        typ: type[Any] = Any,  # type: ignore[assignment]
+        accumulate: bool = False,
+    ) -> Self:
+        """Register a pub-sub topic.
+
+        Topics are named channels that publishers write to and subscribers
+        trigger on. A topic may also be declared as a state key with
+        `Annotated[Sequence[T], Topic(T)]`; calling `add_topic` with the same
+        name reuses that channel when compatible.
+
+        Args:
+            name: Topic name (also the channel key).
+            typ: Payload type stored on the topic (used when creating a new
+                channel). Ignored when reusing an existing compatible `Topic`.
+            accumulate: If `True`, messages accumulate across supersteps.
+                If `False` (default), the topic is emptied after each step.
+
+        Returns:
+            Self, for chaining.
+
+        Example:
+            ```python
+            builder.add_topic("events")
+            builder.add_node("src", src, publishes=["events"])
+            builder.add_node("dst", dst, mode="pubsub", subscribes=["events"])
+            ```
+        """
+        if self.compiled:
+            logger.warning(
+                "Adding a topic to a graph that has already been compiled. This will "
+                "not be reflected in the compiled graph."
+            )
+        if name in (START, END):
+            raise ValueError(f"Topic name `{name}` is reserved.")
+        existing = self.channels.get(name)
+        if existing is not None:
+            if not isinstance(existing, Topic):
+                raise ValueError(
+                    f"Channel `{name}` already exists and is not a Topic "
+                    f"({type(existing).__name__}). Choose a different topic name "
+                    "or declare the state key with Topic."
+                )
+            # Reuse existing Topic; accumulate/typ mismatches are errors if explicit
+            if existing.accumulate != accumulate:
+                raise ValueError(
+                    f"Topic `{name}` already exists with accumulate="
+                    f"{existing.accumulate}, cannot re-register with "
+                    f"accumulate={accumulate}."
+                )
+            self.topics[name] = existing
+            return self
+
+        topic: Topic[Any] = Topic(typ, accumulate=accumulate)
+        topic.key = name
+        self.channels[name] = topic
+        self.topics[name] = topic
+        return self
+
+    def publish(self, node: str, *topics: str) -> Self:
+        """Declare that `node` publishes to the given topics.
+
+        Used for diagram edges and validation. Runtime publishing is done by
+        returning [`Publish`][langgraph.types.Publish] (or writing a Topic state
+        key). Call after `add_node`.
+
+        Args:
+            node: Node name.
+            *topics: One or more registered topic names.
+
+        Returns:
+            Self, for chaining.
+        """
+        if not topics:
+            raise ValueError("publish() requires at least one topic name")
+        if node not in self.nodes:
+            raise ValueError(f"Need to add_node `{node}` first")
+        self._ensure_topics_registered(*topics)
+        spec = self.nodes[node]
+        merged = tuple(dict.fromkeys((*spec.publishes, *topics)))
+        self.nodes[node] = _replace_node_spec(spec, publishes=merged)
+        return self
+
+    def subscribe(self, node: str, *topics: str) -> Self:
+        """Subscribe `node` to the given topics (pub-sub activation).
+
+        Ensures the node has `pubsub` in its modes (added if missing). If the
+        node was explicitly `mode="workflow"` only, raises.
+
+        Args:
+            node: Node name.
+            *topics: One or more registered topic names.
+
+        Returns:
+            Self, for chaining.
+        """
+        if not topics:
+            raise ValueError("subscribe() requires at least one topic name")
+        if node not in self.nodes:
+            raise ValueError(f"Need to add_node `{node}` first")
+        self._ensure_topics_registered(*topics)
+        spec = self.nodes[node]
+        modes = set(spec.modes)
+        if "pubsub" not in modes:
+            if modes == {"workflow"}:
+                # Common case: subscribe() after add_node without mode= —
+                # enable pubsub while keeping workflow so hybrid still works.
+                modes.add("pubsub")
+            else:
+                raise ValueError(
+                    f"Node `{node}` cannot subscribe: modes={sorted(spec.modes)} "
+                    "do not include 'pubsub'."
+                )
+        merged = tuple(dict.fromkeys((*spec.subscribes, *topics)))
+        self.nodes[node] = _replace_node_spec(
+            spec, modes=frozenset(cast(set[NodeMode], modes)), subscribes=merged
+        )
+        return self
+
+    def _ensure_topics_registered(self, *topics: str) -> None:
+        for topic in topics:
+            if topic not in self.topics:
+                # Auto-register a default Topic for convenience if no channel yet
+                if topic in self.channels:
+                    channel = self.channels[topic]
+                    if isinstance(channel, Topic):
+                        self.topics[topic] = channel
+                        continue
+                    raise ValueError(
+                        f"Topic `{topic}` conflicts with existing non-Topic channel"
+                    )
+                self.add_topic(topic)
+
     @property
     def _all_edges(self) -> set[tuple[str, str]]:
         return self.edges | {
@@ -384,6 +534,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
+        mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None = None,
+        publishes: Sequence[str] | None = None,
+        subscribes: Sequence[str] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema.
@@ -453,6 +606,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
+        mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None = None,
+        publishes: Sequence[str] | None = None,
+        subscribes: Sequence[str] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph` where input schema is specified.
@@ -527,6 +683,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
+        mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None = None,
+        publishes: Sequence[str] | None = None,
+        subscribes: Sequence[str] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is inferred as the state schema.
@@ -596,6 +755,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
+        mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None = None,
+        publishes: Sequence[str] | None = None,
+        subscribes: Sequence[str] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`, input schema is specified.
@@ -672,6 +834,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         error_handler: StateNode[Any, ContextT] | None = None,
         destinations: dict[str, str] | tuple[str, ...] | None = None,
         timeout: float | timedelta | TimeoutPolicy | None = None,
+        mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None = None,
+        publishes: Sequence[str] | None = None,
+        subscribes: Sequence[str] | None = None,
         **kwargs: Unpack[DeprecatedKwargs],
     ) -> Self:
         """Add a new node to the `StateGraph`.
@@ -710,6 +875,13 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 and the retry policy (if any) decides whether to retry. Timeouts
                 are supported only for async nodes; sync nodes cannot be safely
                 cancelled in-process.
+            mode: Activation mode(s): `'workflow'` (default, edges/Command),
+                `'pubsub'` (topics), a sequence of both, or `'both'`.
+            publishes: Topic names this node may publish to (for diagrams and
+                validation). Publish at runtime with
+                [`Publish`][langgraph.types.Publish].
+            subscribes: Topic names that wake this node. Implies `pubsub` mode
+                unless `mode` is set explicitly to exclude it (which errors).
 
         Example:
             ```python
@@ -850,6 +1022,14 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         if destinations is not None:
             ends = destinations
 
+        publish_topics = tuple(publishes or ())
+        subscribe_topics = tuple(subscribes or ())
+        if publish_topics:
+            self._ensure_topics_registered(*publish_topics)
+        if subscribe_topics:
+            self._ensure_topics_registered(*subscribe_topics)
+        node_modes = _normalize_node_modes(mode, subscribes=subscribe_topics)
+
         resolved_input_schema: type[Any] = (
             input_schema or inferred_input_schema or self.state_schema
         )
@@ -880,6 +1060,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
+                modes=node_modes,
+                publishes=publish_topics,
+                subscribes=subscribe_topics,
             )
         elif inferred_input_schema is not None:
             self.nodes[node] = StateNodeSpec(
@@ -892,6 +1075,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
+                modes=node_modes,
+                publishes=publish_topics,
+                subscribes=subscribe_topics,
             )
         else:
             self.nodes[node] = StateNodeSpec[StateT, ContextT](
@@ -904,6 +1090,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 ends=ends,
                 defer=defer,
                 timeout=timeout,
+                modes=node_modes,
+                publishes=publish_topics,
+                subscribes=subscribe_topics,
             )
 
         input_schema = input_schema or inferred_input_schema
@@ -1153,6 +1342,70 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for target in all_targets:
             if target not in self.nodes and target != END:
                 raise ValueError(f"Found edge ending at unknown node `{target}`")
+        # validate pub-sub
+        for name, spec in self.nodes.items():
+            if not spec.modes:
+                raise ValueError(f"Node `{name}` has empty modes")
+            if spec.subscribes and "pubsub" not in spec.modes:
+                raise ValueError(
+                    f"Node `{name}` subscribes to topics but modes "
+                    f"{sorted(spec.modes)} do not include 'pubsub'"
+                )
+            if (
+                "pubsub" in spec.modes
+                and not spec.subscribes
+                and not spec.is_error_handler
+            ):
+                raise ValueError(
+                    f"Node `{name}` has mode 'pubsub' but no subscriptions. "
+                    "Pass subscribes=... or call subscribe()."
+                )
+            for topic in (*spec.publishes, *spec.subscribes):
+                if topic not in self.topics:
+                    raise ValueError(
+                        f"Node `{name}` references unknown topic `{topic}`. "
+                        "Call add_topic() or declare a Topic state key."
+                    )
+            # Same-topic subscribe+publish can recurse until the step limit
+            overlap = set(spec.publishes) & set(spec.subscribes)
+            if overlap and not spec.is_error_handler:
+                warnings.warn(
+                    f"Node `{name}` both subscribes to and publishes on "
+                    f"topic(s) {sorted(overlap)}. This can loop until the "
+                    "recursion limit unless the node stops publishing.",
+                    stacklevel=2,
+                )
+            # Node must have at least one activation path
+            if (
+                not spec.is_error_handler
+                and "workflow" not in spec.modes
+                and not spec.subscribes
+            ):
+                raise ValueError(
+                    f"Node `{name}` has no activation path "
+                    "(no workflow mode and no topic subscriptions)"
+                )
+        # Edges / Command destinations only activate workflow-mode nodes
+        workflow_targets = {end for _, end in self._all_edges if end != END}
+        for start, branches in self.branches.items():
+            for branch in branches.values():
+                if branch.ends is not None:
+                    workflow_targets.update(e for e in branch.ends.values() if e != END)
+        for name, spec in self.nodes.items():
+            if spec.ends:
+                if isinstance(spec.ends, dict):
+                    workflow_targets.update(e for e in spec.ends if e != END)
+                else:
+                    workflow_targets.update(e for e in spec.ends if e != END)
+        for target in workflow_targets:
+            if target in self.nodes and "workflow" not in self.nodes[target].modes:
+                raise ValueError(
+                    f"Edge or destination targets node `{target}` which has "
+                    f"modes={sorted(self.nodes[target].modes)} without 'workflow'. "
+                    "Pub-sub-only nodes are activated by topics, not edges. "
+                    "Use mode='both' (or include 'workflow') if this node should "
+                    "also accept edges."
+                )
         # validate interrupts
         if interrupt:
             for node in interrupt:
@@ -1447,6 +1700,13 @@ class CompiledStateGraph(
                 return None
             elif isinstance(input, dict):
                 return [(k, v) for k, v in input.items() if k in output_keys]
+            elif isinstance(input, Publish):
+                if input.topic not in output_keys:
+                    raise InvalidUpdateError(
+                        f"Unknown topic `{input.topic}`. "
+                        "Register it with add_topic() or a Topic state key."
+                    )
+                return [(input.topic, input.value)]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:
                     return None
@@ -1456,7 +1716,7 @@ class CompiledStateGraph(
             elif (
                 isinstance(input, (list, tuple))
                 and input
-                and any(isinstance(i, Command) for i in input)
+                and any(isinstance(i, (Command, Publish)) for i in input)
             ):
                 updates: list[tuple[str, Any]] = []
                 for i in input:
@@ -1478,10 +1738,17 @@ class CompiledStateGraph(
                 )
                 raise InvalidUpdateError(msg)
 
+        publish_static = (
+            _publish_static(node.publishes)
+            if node is not None and node.publishes
+            else None
+        )
+
         # state updaters
         write_entries: tuple[ChannelWriteEntry | ChannelWriteTupleEntry, ...] = (
             ChannelWriteTupleEntry(
-                mapper=_get_root if output_keys == ["__root__"] else _get_updates
+                mapper=_get_root if output_keys == ["__root__"] else _get_updates,
+                static=publish_static,
             ),
             ChannelWriteTupleEntry(
                 mapper=_control_branch,
@@ -1502,12 +1769,25 @@ class CompiledStateGraph(
         elif node is not None:
             input_schema = node.input_schema if node else self.builder.state_schema
             input_channels = list(self.builder.schemas[input_schema])
-            is_single_input = len(input_channels) == 1 and "__root__" in input_channels
+            # Subscribers also read their topics so payloads appear in input.
+            extra_topic_channels = [
+                t for t in node.subscribes if t not in input_channels
+            ]
+            read_channels = (
+                input_channels
+                if not extra_topic_channels
+                else [*input_channels, *extra_topic_channels]
+            )
+            is_single_input = len(read_channels) == 1 and "__root__" in read_channels
             if input_schema in self.schema_to_mapper:
                 mapper = self.schema_to_mapper[input_schema]
             else:
                 mapper = _pick_mapper(input_channels, input_schema)
                 self.schema_to_mapper[input_schema] = mapper
+            if mapper is not None and extra_topic_channels:
+                mapper = partial(
+                    _coerce_state_with_topics, mapper, tuple(extra_topic_channels)
+                )
 
             branch_channel = _CHANNEL_BRANCH_TO.format(key)
             self.channels[branch_channel] = (
@@ -1515,15 +1795,38 @@ class CompiledStateGraph(
                 if node.defer
                 else EphemeralValue(Any, guard=False)
             )
+
+            triggers: list[str] = []
+            if "workflow" in node.modes:
+                triggers.append(branch_channel)
+            if "pubsub" in node.modes:
+                triggers.extend(node.subscribes)
+            # Error handlers / legacy specs: always keep a control-flow trigger
+            if not triggers:
+                triggers.append(branch_channel)
+
+            # Only annotate diagrams when pub-sub is in play (avoid noise on
+            # pure workflow graphs and snapshot churn).
+            meta = dict(node.metadata or {})
+            uses_pubsub = bool(
+                node.publishes or node.subscribes or "pubsub" in node.modes
+            )
+            if uses_pubsub:
+                meta["mode"] = "+".join(sorted(node.modes))
+                if node.publishes:
+                    meta["publishes"] = ",".join(node.publishes)
+                if node.subscribes:
+                    meta["subscribes"] = ",".join(node.subscribes)
+
             self.nodes[key] = PregelNode(
-                triggers=[branch_channel],
-                # read state keys and managed values
-                channels=("__root__" if is_single_input else input_channels),
+                triggers=triggers,
+                # read state keys and managed values (+ subscribed topics)
+                channels=("__root__" if is_single_input else read_channels),
                 # coerce state dict to schema class (eg. pydantic model)
                 mapper=mapper,
                 # publish to state keys
                 writers=[ChannelWrite(write_entries)],
-                metadata=node.metadata,
+                metadata=meta or None,
                 retry_policy=node.retry_policy,
                 cache_policy=node.cache_policy,
                 is_error_handler=node.is_error_handler,
@@ -1732,6 +2035,88 @@ def _coerce_state(schema: type[_S], input: dict[str, Any]) -> _S:
     return schema(**input)
 
 
+def _coerce_state_with_topics(
+    base_mapper: Callable[[dict[str, Any]], Any],
+    extra_topics: tuple[str, ...],
+    input: dict[str, Any],
+) -> Any:
+    """Coerce the schema portion of input; keep side-topic keys as a dict.
+
+    When a subscriber reads topics that are not fields of a pydantic/dataclass
+    schema, we cannot attach arbitrary attributes to the model safely. In that
+    case the node receives a plain `dict` with both schema fields and topic
+    payloads. Prefer declaring topics on the state schema when you need typed
+    models.
+    """
+    extras = {k: input[k] for k in extra_topics if k in input}
+    core = {k: v for k, v in input.items() if k not in extra_topics}
+    coerced = base_mapper(core)
+    if not extras:
+        return coerced
+    if isinstance(coerced, dict):
+        return {**coerced, **extras}
+    if hasattr(coerced, "model_dump"):
+        return {**coerced.model_dump(), **extras}
+    if is_dataclass(coerced) and not isinstance(coerced, type):
+        from dataclasses import asdict
+
+        return {**asdict(coerced), **extras}
+    raise TypeError(
+        "Subscribed side topics require a dict-like node input when the input "
+        "schema is not a TypedDict/dict. Declare the topic on the state schema "
+        f"or use a TypedDict. Extra topics: {sorted(extras)}"
+    )
+
+
+def _normalize_node_modes(
+    mode: NodeMode | Sequence[NodeMode] | Literal["both"] | None,
+    *,
+    subscribes: Sequence[str],
+) -> frozenset[NodeMode]:
+    """Normalize `mode` / `subscribes` into a frozenset of node modes."""
+    explicit = mode is not None
+    if mode is None:
+        modes: set[str] = {"workflow"}
+    elif mode == "both":
+        modes = {"workflow", "pubsub"}
+    elif isinstance(mode, str):
+        if mode not in ("workflow", "pubsub"):
+            raise ValueError(
+                f"Invalid mode {mode!r}. Expected 'workflow', 'pubsub', 'both', "
+                "or a sequence of those."
+            )
+        modes = {mode}
+    else:
+        modes = set(mode)
+        invalid = modes - {"workflow", "pubsub"}
+        if invalid:
+            raise ValueError(
+                f"Invalid mode values {sorted(invalid)}. "
+                "Expected 'workflow' and/or 'pubsub'."
+            )
+        if not modes:
+            raise ValueError("mode sequence must be non-empty")
+
+    if subscribes:
+        if explicit and "pubsub" not in modes:
+            raise ValueError(
+                "subscribes=... requires mode to include 'pubsub' "
+                f"(got mode={sorted(modes)}). Pass mode='pubsub', mode='both', "
+                "or omit mode to auto-enable pubsub."
+            )
+        modes.add("pubsub")
+
+    return frozenset(cast(set[NodeMode], modes))
+
+
+def _replace_node_spec(
+    spec: StateNodeSpec[Any, Any], **changes: Any
+) -> StateNodeSpec[Any, Any]:
+    from dataclasses import replace
+
+    return replace(spec, **changes)
+
+
 def _control_branch(value: Any) -> Sequence[tuple[str, Any]]:
     if isinstance(value, Send):
         return ((TASKS, value),)
@@ -1775,7 +2160,16 @@ def _control_static(
         ]
 
 
+def _publish_static(
+    topics: Sequence[str],
+) -> Sequence[tuple[str, Any, str | None]]:
+    """Declared topic writes for static graph visualization."""
+    return [(topic, None, f"topic:{topic}") for topic in topics]
+
+
 def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
+    if isinstance(input, Publish):
+        return [(input.topic, input.value)]
     if isinstance(input, Command):
         if input.graph == Command.PARENT:
             return ()
@@ -1783,7 +2177,7 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
     elif (
         isinstance(input, (list, tuple))
         and input
-        and any(isinstance(i, Command) for i in input)
+        and any(isinstance(i, (Command, Publish)) for i in input)
     ):
         updates: list[tuple[str, Any]] = []
         for i in input:
@@ -1791,6 +2185,8 @@ def _get_root(input: Any) -> Sequence[tuple[str, Any]] | None:
                 if i.graph == Command.PARENT:
                     continue
                 updates.extend(i._update_as_tuples())
+            elif isinstance(i, Publish):
+                updates.append((i.topic, i.value))
             else:
                 updates.append(("__root__", i))
         return updates

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -77,6 +77,8 @@ __all__ = (
     "StateSnapshot",
     "Send",
     "Command",
+    "Publish",
+    "NodeMode",
     "Durability",
     "interrupt",
     "Overwrite",
@@ -753,6 +755,49 @@ class Send:
 
 
 N = TypeVar("N", bound=Hashable)
+
+NodeMode = Literal["workflow", "pubsub"]
+"""How a graph node is activated.
+
+- `'workflow'`: woken by edges / `Command(goto=...)` / `Send` (control-flow channels).
+- `'pubsub'`: woken by subscribed topics.
+
+A node may use either mode or both (pass a sequence, or the string `'both'`).
+Publishing with [`Publish`][langgraph.types.Publish] is independent of mode:
+any node may publish; mode only controls **how the node is started**.
+"""
+
+
+@dataclass(slots=True)
+class Publish:
+    """Publish a value to a named topic (classical pub-sub).
+
+    Use from a node return value to send a message to every node that
+    `subscribe`s to the same topic. Publishers do not name subscribers;
+    subscribers do not name publishers.
+
+    Can be returned alone, or combined with a state update / `Command`:
+
+    ```python
+    return Publish("events", {"kind": "created"})
+    return {"count": 1}, Publish("events", "tick")
+    return [Command(update={"count": 1}), Publish("events", "tick")]
+    ```
+
+    Topics are registered with `StateGraph.add_topic` or as state keys
+    annotated with [`Topic`][langgraph.channels.Topic].
+
+    See the pub-sub how-to for full examples.
+    """
+
+    topic: str
+    """Topic name to publish to (must be a registered topic / channel)."""
+    value: Any
+    """Payload delivered to the topic channel (and to subscribers' state if the
+    topic is a state key or is included in the subscriber's read channels)."""
+
+    def __repr__(self) -> str:
+        return f"Publish(topic={self.topic!r}, value={self.value!r})"
 
 
 @dataclass(**_DC_KWARGS)

--- a/libs/langgraph/tests/test_pubsub.py
+++ b/libs/langgraph/tests/test_pubsub.py
@@ -1,0 +1,416 @@
+"""Tests for Graph API pub-sub (topics, Publish, node modes)."""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Sequence
+from typing import Annotated
+
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.channels import Topic
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, Publish
+
+
+class BusState(TypedDict):
+    n: int
+    bus: Annotated[Sequence[str], Topic(str)]
+    sink: Annotated[list[str], operator.add]
+
+
+class DualSinkState(TypedDict):
+    n: int
+    bus: Annotated[Sequence[str], Topic(str)]
+    a: Annotated[list[str], operator.add]
+    b: Annotated[list[str], operator.add]
+
+
+def test_fan_out_one_publisher_two_subscribers() -> None:
+    def pub(state: DualSinkState):
+        return {"n": state["n"] + 1}, Publish("bus", "hello")
+
+    def sub_a(state: DualSinkState):
+        return {"a": [f"A:{list(state['bus'])}"]}
+
+    def sub_b(state: DualSinkState):
+        return {"b": [f"B:{list(state['bus'])}"]}
+
+    builder = StateGraph(DualSinkState)
+    builder.add_node("pub", pub, publishes=["bus"])
+    builder.add_node("a", sub_a, mode="pubsub", subscribes=["bus"])
+    builder.add_node("b", sub_b, mode="pubsub", subscribes=["bus"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+
+    result = graph.invoke({"n": 0, "a": [], "b": []})
+    assert result["n"] == 1
+    assert result["a"] == ["A:['hello']"]
+    assert result["b"] == ["B:['hello']"]
+
+
+def test_fan_in_two_publishers_one_subscriber() -> None:
+    def pub1(state: BusState):
+        return Publish("bus", "from-1")
+
+    def pub2(state: BusState):
+        return Publish("bus", "from-2")
+
+    def sub(state: BusState):
+        return {"sink": [f"got:{sorted(state['bus'])}"]}
+
+    builder = StateGraph(BusState)
+    builder.add_node("pub1", pub1, publishes=["bus"])
+    builder.add_node("pub2", pub2, publishes=["bus"])
+    builder.add_node("sub", sub, mode="pubsub", subscribes=["bus"])
+    builder.add_edge(START, "pub1")
+    builder.add_edge(START, "pub2")
+    builder.add_edge("pub1", END)
+    builder.add_edge("pub2", END)
+    graph = builder.compile()
+
+    result = graph.invoke({"n": 0, "sink": []})
+    assert result["sink"] == ["got:['from-1', 'from-2']"]
+
+
+def test_workflow_and_pubsub_coexist() -> None:
+    """Workflow spine continues while a side subscriber audits."""
+
+    class State(TypedDict):
+        steps: Annotated[list[str], operator.add]
+        events: Annotated[Sequence[str], Topic(str)]
+
+    def step_a(state: State):
+        return {"steps": ["a"]}, Publish("events", "after-a")
+
+    def step_b(state: State):
+        return {"steps": ["b"]}
+
+    def audit(state: State):
+        return {"steps": [f"audit:{list(state['events'])}"]}
+
+    builder = StateGraph(State)
+    builder.add_node("a", step_a, publishes=["events"])
+    builder.add_node("b", step_b)
+    builder.add_node("audit", audit, mode="pubsub", subscribes=["events"])
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", END)
+    graph = builder.compile()
+
+    result = graph.invoke({"steps": []})
+    assert "a" in result["steps"]
+    assert "b" in result["steps"]
+    assert any(s.startswith("audit:") for s in result["steps"])
+
+
+def test_mode_pubsub_not_activated_by_edge() -> None:
+    class State(TypedDict):
+        t: Annotated[Sequence[int], Topic(int)]
+        hits: Annotated[list[str], operator.add]
+
+    def entry(state: State):
+        return Publish("t", 1)
+
+    def listener(state: State):
+        return {"hits": ["listener"]}
+
+    # Edge to pubsub-only node is illegal at compile time
+    builder = StateGraph(State)
+    builder.add_node("entry", entry, publishes=["t"])
+    builder.add_node("listener", listener, mode="pubsub", subscribes=["t"])
+    builder.add_edge(START, "entry")
+    builder.add_edge("entry", "listener")
+    with pytest.raises(ValueError, match="without 'workflow'"):
+        builder.compile()
+
+    # Without an edge, the subscriber is only woken by the topic
+    builder2 = StateGraph(State)
+    builder2.add_node("entry", entry, publishes=["t"])
+    builder2.add_node("listener", listener, mode="pubsub", subscribes=["t"])
+    builder2.add_edge(START, "entry")
+    builder2.add_edge("entry", END)
+    graph = builder2.compile()
+    result = graph.invoke({"hits": []})
+    assert result["hits"] == ["listener"]
+
+
+def test_mode_workflow_not_activated_by_topic_alone() -> None:
+    class State(TypedDict):
+        t: Annotated[Sequence[int], Topic(int)]
+        hits: Annotated[list[str], operator.add]
+
+    calls: list[str] = []
+
+    def pub(state: State):
+        return Publish("t", 7)
+
+    def workflow_only(state: State):
+        calls.append("wf")
+        return {"hits": ["wf"]}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub, publishes=["t"])
+    builder.add_node("wf", workflow_only)  # no subscription
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+    result = graph.invoke({"hits": []})
+    assert calls == []
+    assert result.get("hits", []) == []
+
+
+def test_mode_both_accepts_edge_and_topic() -> None:
+    class State(TypedDict):
+        t: Annotated[Sequence[str], Topic(str)]
+        hits: Annotated[list[str], operator.add]
+
+    def pub(state: State):
+        return Publish("t", "ping")
+
+    def hybrid(state: State):
+        note = f"t={list(state.get('t') or [])}"
+        return {"hits": [note]}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub, publishes=["t"])
+    builder.add_node("hybrid", hybrid, mode="both", subscribes=["t"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", "hybrid")
+    builder.add_edge("hybrid", END)
+    graph = builder.compile()
+    result = graph.invoke({"hits": []})
+    assert result["hits"]
+    # Topic payload visible when woken (edge and/or topic in same step)
+    assert any("ping" in h for h in result["hits"])
+
+
+def test_publish_return_shapes() -> None:
+    class State(TypedDict):
+        n: int
+        bus: Annotated[Sequence[str], Topic(str)]
+        sink: Annotated[list[str], operator.add]
+
+    def alone(state: State):
+        return Publish("bus", "alone")
+
+    def with_dict(state: State):
+        return {"n": 1}, Publish("bus", "dict")
+
+    def with_list(state: State):
+        return [Command(update={"n": 2}), Publish("bus", "list")]
+
+    def sub(state: State):
+        return {"sink": list(state["bus"])}
+
+    for producer, expected_n, expected_msg in [
+        (alone, 0, "alone"),
+        (with_dict, 1, "dict"),
+        (with_list, 2, "list"),
+    ]:
+        builder = StateGraph(State)
+        builder.add_node("p", producer, publishes=["bus"])
+        builder.add_node("s", sub, mode="pubsub", subscribes=["bus"])
+        builder.add_edge(START, "p")
+        builder.add_edge("p", END)
+        graph = builder.compile()
+        result = graph.invoke({"n": 0, "sink": []})
+        assert result["n"] == expected_n
+        assert expected_msg in result["sink"]
+
+
+def test_state_key_topic_dict_write_triggers_subscriber() -> None:
+    """Writing the Topic state key (without Publish) still wakes subscribers."""
+
+    class State(TypedDict):
+        bus: Annotated[Sequence[str], Topic(str)]
+        sink: Annotated[list[str], operator.add]
+
+    def pub(state: State):
+        return {"bus": "via-dict"}
+
+    def sub(state: State):
+        return {"sink": list(state["bus"])}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub, publishes=["bus"])
+    builder.add_node("sub", sub, mode="pubsub", subscribes=["bus"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+    result = graph.invoke({"sink": []})
+    assert "via-dict" in result["sink"]
+
+
+def test_add_topic_side_channel() -> None:
+    """Topics need not be on the state schema; subscribers still read payloads."""
+
+    class State(TypedDict):
+        n: int
+        sink: Annotated[list[str], operator.add]
+
+    def pub(state: State):
+        return {"n": state["n"] + 1}, Publish("side", "ping")
+
+    def sub(state: State):
+        # side topic is injected into the input dict for subscribers
+        return {"sink": [str(state.get("side"))]}  # type: ignore[typeddict-item]
+
+    builder = StateGraph(State)
+    builder.add_topic("side", typ=str)
+    builder.add_node("pub", pub, publishes=["side"])
+    builder.add_node("sub", sub, mode="pubsub", subscribes=["side"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+    result = graph.invoke({"n": 0, "sink": []})
+    assert result["n"] == 1
+    assert result["sink"] == ["['ping']"]
+
+
+def test_validation_errors() -> None:
+    class State(TypedDict):
+        x: int
+
+    def noop(state: State):
+        return {}
+
+    # mode workflow + subscribes
+    b = StateGraph(State)
+    with pytest.raises(ValueError, match="requires mode to include 'pubsub'"):
+        b.add_node("n", noop, mode="workflow", subscribes=["missing"])
+
+    # pubsub without subscriptions
+    b2 = StateGraph(State)
+    b2.add_node("n", noop, mode="pubsub")
+    b2.add_edge(START, "n")
+    with pytest.raises(ValueError, match="no subscriptions"):
+        b2.compile()
+
+    # edge to pubsub-only
+    class S2(TypedDict):
+        t: Annotated[Sequence[int], Topic(int)]
+
+    def pub(state: S2):
+        return Publish("t", 1)
+
+    def sub(state: S2):
+        return {}
+
+    b3 = StateGraph(S2)
+    b3.add_node("pub", pub, publishes=["t"])
+    b3.add_node("sub", sub, mode="pubsub", subscribes=["t"])
+    b3.add_edge(START, "pub")
+    b3.add_edge("pub", "sub")
+    with pytest.raises(ValueError, match="without 'workflow'"):
+        b3.compile()
+
+
+def test_publish_and_subscribe_fluent_api() -> None:
+    class State(TypedDict):
+        bus: Annotated[Sequence[str], Topic(str)]
+        sink: Annotated[list[str], operator.add]
+
+    def pub(state: State):
+        return Publish("bus", "fluent")
+
+    def sub(state: State):
+        return {"sink": list(state["bus"])}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub)
+    builder.add_node("sub", sub)
+    builder.publish("pub", "bus")
+    builder.subscribe("sub", "bus")
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+    result = graph.invoke({"sink": []})
+    assert result["sink"] == ["fluent"]
+    assert "pubsub" in builder.nodes["sub"].modes
+
+
+def test_accumulate_topic() -> None:
+    class AccState(TypedDict):
+        bus: Annotated[Sequence[str], Topic(str, accumulate=True)]
+        rounds: int
+        sink: Annotated[list[str], operator.add]
+
+    def tick(state: AccState):
+        return (
+            {"rounds": state["rounds"] + 1},
+            Publish("bus", f"r{state['rounds']}"),
+        )
+
+    def collect(state: AccState):
+        return {"sink": [",".join(state["bus"])]}
+
+    builder = StateGraph(AccState)
+    builder.add_topic("bus", typ=str, accumulate=True)
+    builder.add_node("tick1", tick, publishes=["bus"])
+    builder.add_node("tick2", tick, publishes=["bus"])
+    builder.add_node("collect", collect, mode="both", subscribes=["bus"])
+    builder.add_edge(START, "tick1")
+    builder.add_edge("tick1", "tick2")
+    builder.add_edge("tick2", "collect")
+    builder.add_edge("collect", END)
+    graph = builder.compile()
+    result = graph.invoke({"rounds": 0, "sink": []})
+    # accumulate=True keeps messages across supersteps
+    assert "r0" in result["bus"] and "r1" in result["bus"]
+    assert result["rounds"] == 2
+
+
+def test_diagram_shows_mode_and_topic_edges() -> None:
+    class State(TypedDict):
+        bus: Annotated[Sequence[str], Topic(str)]
+
+    def pub(state: State):
+        return Publish("bus", "x")
+
+    def sub(state: State):
+        return {}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub, publishes=["bus"])
+    builder.add_node("sub", sub, mode="pubsub", subscribes=["bus"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+
+    drawable = graph.get_graph()
+    assert drawable.nodes["pub"].metadata is not None
+    assert drawable.nodes["pub"].metadata["mode"] == "workflow"
+    assert drawable.nodes["pub"].metadata["publishes"] == "bus"
+    assert drawable.nodes["sub"].metadata is not None
+    assert drawable.nodes["sub"].metadata["mode"] == "pubsub"
+    assert drawable.nodes["sub"].metadata["subscribes"] == "bus"
+
+    mermaid = drawable.draw_mermaid()
+    assert "mode = workflow" in mermaid
+    assert "mode = pubsub" in mermaid
+    assert "topic:bus" in mermaid
+
+
+@pytest.mark.anyio
+async def test_pubsub_async() -> None:
+    class State(TypedDict):
+        bus: Annotated[Sequence[str], Topic(str)]
+        sink: Annotated[list[str], operator.add]
+
+    async def pub(state: State):
+        return Publish("bus", "async")
+
+    async def sub(state: State):
+        return {"sink": list(state["bus"])}
+
+    builder = StateGraph(State)
+    builder.add_node("pub", pub, publishes=["bus"])
+    builder.add_node("sub", sub, mode="pubsub", subscribes=["bus"])
+    builder.add_edge(START, "pub")
+    builder.add_edge("pub", END)
+    graph = builder.compile()
+    result = await graph.ainvoke({"sink": []})
+    assert result["sink"] == ["async"]


### PR DESCRIPTION
# Expose existing Pregel topic channels on StateGraph (optional pub-sub alongside edges)


## TL;DR

This is not a second execution model. LangGraph’s runtime is already channel-based pub-sub (Topic, NodeBuilder.subscribe_to / write_to). That power is effectively hidden behind the low-level Pregel API. StateGraph only exposes workflow edges (branch:to:*).

This PR adds a thin, optional Graph API so users can do classical publish/subscribe without dropping out of StateGraph, and without changing default behavior.

No new dependencies. No Pregel loop changes. No breakage for existing graphs.

───

## Why this exists (the actual gap)

Today, if you want “when X finishes, notify whoever cares - without X knowing who”:

| Approach  | Problem    |
|---|---|
| Extra edges to every listener    | Couples producers to consumers; diagram becomes a hairball        |
| Send("audit", …)                 | Addressed delivery - producer must name nodes                       |
| Write a Topic state key only     | Does not wake StateGraph nodes (they only trigger on branch:to:*) |
| Drop to raw Pregel + NodeBuilder | Works - but we force advanced users off the supported Graph API     |
| Side effects outside the graph   | Lose checkpointing, streaming, Studio, interrupts                 |

So users already invent half-solutions, or leave StateGraph. The missing piece is one line of truth:

Allow a StateGraph node to trigger on a Topic channel update, the same way Pregel actors already do.

That is this PR.

───
## What we are not proposing

• ❌ Not Kafka / Redis / cross-thread buses
• ❌ Not a replacement for edges, Command, or Send
• ❌ Not a new scheduler, durability mode, or stream protocol
• ❌ Not required for any existing graph
• ❌ Not a dependency bump

Send stays for map-reduce (named node + custom arg).
Publish is for anonymous topic delivery. Different jobs; both stay.

───

## Design (deliberately small)

Built only on pieces that already ship:

1. Topic channel (already documented as a pub-sub topic)
2. Node triggers = channel versions (existing BSP)
3. Static writes for diagrams (same pattern as destinations / Command ends)
4. Publish  -  peer of Send/Command, not a framework inside a framework

Modes (activation only):

• workflow (default)  -  edges / Command / Send only → today’s behavior
• pubsub  -  subscribed topics only
• both  -  union

Publishing does not change mode; mode only answers how this node is woken.

Default path for every existing graph: unchanged. Mode metadata is only attached when pub-sub is actually used (no diagram snapshot noise).

───

## API surface (can fit on a card)

```python
builder.add_topic("events")  # or Annotated[..., Topic(...)] on state
builder.add_node("src", src, publishes=["events"])
builder.add_node("audit", audit, mode="pubsub", subscribes=["events"])
# runtime:
return Publish("events", payload)
# or write the Topic state key  -  still wakes subscribers
```

Fluent: publish() / subscribe().
Docs: docs/docs/how-tos/pubsub.md.
Tests: tests/test_pubsub.py (fan-out/in, hybrid, modes, validation, mermaid, async).

───

## Why this earns its keep in a “no new features” bar

1. It’s a façade, not a feature island  -  exposes capability the monorepo already implements and tests at the Pregel layer.
2. Zero default cost  -  opt-in per node/topic; no migration.
3. Reduces footguns  -  edges into pubsub-only nodes fail at compile; same-topic sub+pub warns; unknown topics error.
4. Keeps users on StateGraph  -  audits, metrics, multi-listener events without fake edges or out-of-band side effects.
5. Studio/diagram honest  -  mode, publishes/subscribes, dashed topic:… edges via existing static-write analysis.
6. Composes with the stack you care about  -  checkpoints, interrupts, stream modes, subgraphs still apply; topics are in-run channels, not a parallel world.

If the bar is “we only land things that make the product more coherent,” this closes a hole between the mental model of Pregel and the API we recommend.

───

## Compatibility

| Check                                 | Result                              |
|---|---|
| Existing StateGraph without topics    | Identical triggers (branch:to only) |
| Public deps                           | Unchanged                           |
| Pregel internals / prepare_next_tasks | Untouched                           |
| Breaking API                          | None                                |

───

## Test plan

• [x] tests/test_pubsub.py  -  fan-out, fan-in, hybrid workflow+pubsub, mode isolation, Publish shapes, dict write to Topic key, side topics, validation, accumulate, mermaid metadata, async
• [x] Related regression: test_state.py, test_channels.py
• [ ] CI on this branch

───

## Reviewer guide (where to be harsh)

Worth scrutinizing:

1. Mode rules  -  explicit mode="workflow" + subscribes= must error; edges into pure pubsub must error.
2. Payload visibility  -  state-key Topic vs add_topic side channels (side topics injected into subscriber input dict).
3. Diagram  -  relies on declared publishes= for static edges (same honesty tradeoff as destinations for Command).
4. Scope  -  intentionally not cross-graph global bus; say so if that was a fear.

Not in scope on purpose: external brokers, cross-thread pub-sub, replacing Send.

───

## Ask

Treat this as completing the Graph API for a runtime contract that already exists, with an opt-in surface and a hard compatibility line - not as greenfield product scope.

If you’d rather ship even thinner: the irreducible core is “subscriber triggers include topic channels + Publish → topic write.” Modes and diagram metadata are the safety/ergonomics shell around that one idea.

Happy to trim docs location, rename, or gate behind a clearer experimental label if that helps adoption - but the gap is real either way.