### PR TITLE
fix: cancel v3 streams from cancelled handlers

### DIFF
--- a/libs/langgraph/langgraph/stream/run_stream.py
+++ b/libs/langgraph/langgraph/stream/run_stream.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
+import sys
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from types import MappingProxyType, TracebackType
 from typing import TYPE_CHECKING, Any
@@ -360,6 +362,7 @@ class AsyncGraphRunStream:
         self._pumping = False
         self._anext_task: asyncio.Future[Any] | None = None
         self._aborting = False
+        self._abort_task: asyncio.Task[None] | None = None
         for key in mux.native_keys:
             setattr(self, key, mux.extensions[key])
         if wire_pump:
@@ -426,15 +429,16 @@ class AsyncGraphRunStream:
                 # is running ("asynchronous generator is already running").
                 self._anext_task = asyncio.ensure_future(self._graph_aiter.__anext__())
                 try:
-                    part = await self._anext_task
+                    part = await asyncio.shield(self._anext_task)
                 except asyncio.CancelledError:
                     if self._aborting:
                         # Abort-initiated cancel: stop gracefully.
                         self._exhausted = True
                         return False
-                    # Genuine external cancel of this task: also stop the
-                    # in-flight pull, then propagate.
-                    self._anext_task.cancel()
+                    # Genuine external cancel of this task: start the same
+                    # cleanup path as `abort()` before propagating, so callers
+                    # running inside a cancelled scope still stop the graph.
+                    self.abort()
                     raise
                 finally:
                     self._anext_task = None
@@ -455,29 +459,12 @@ class AsyncGraphRunStream:
                 self._pumping = False
                 self._pump_cond.notify_all()
 
-    async def abort(self) -> None:
-        """Stop the run early.
-
-        Marks the stream exhausted and wakes any pump-waiters. Cancels an
-        in-flight pull if one is running, then closes the underlying graph
-        iterator, so running nodes and nested subgraphs are cancelled
-        whether or not a pump is mid-pull. Closes the mux; any `apush`
-        blocked on backpressure wakes and returns without appending.
-        Idempotent.
-        """
-        async with self._pump_cond:
-            if self._exhausted:
-                return
-            self._exhausted = True
-            self._aborting = True
-            graph_aiter = self._graph_aiter
-            self._graph_aiter = None
-            anext_task = self._anext_task
-            self._pump_cond.notify_all()
-        # If a pump is mid-pull, cancel it so the cancellation propagates
-        # into running nodes and nested subgraphs. Once it settles the
-        # generator is no longer running, so the `aclose()` below is a safe
-        # final cleanup (and handles the no-in-flight-pull case directly).
+    async def _abort_cleanup(
+        self,
+        graph_aiter: AsyncIterator[Any] | None,
+        anext_task: asyncio.Future[Any] | None,
+    ) -> None:
+        """Finish abort cleanup outside the caller's cancellation scope."""
         if anext_task is not None and not anext_task.done():
             anext_task.cancel()
             try:
@@ -496,6 +483,57 @@ class AsyncGraphRunStream:
             await self._mux.aclose()
         except Exception:
             pass
+        async with self._pump_cond:
+            self._pump_cond.notify_all()
+
+    # Regular `def` is intentional: callers may invoke `await run.abort()`
+    # from an already-cancelled AnyIO scope, so cleanup must be scheduled
+    # before the await expression reaches its first cancellation checkpoint.
+    def abort(self) -> asyncio.Future[None]:
+        """Stop the run early.
+
+        Marks the stream exhausted and wakes any pump-waiters. Cancels an
+        in-flight pull if one is running, then closes the underlying graph
+        iterator, so running nodes and nested subgraphs are cancelled
+        whether or not a pump is mid-pull. Closes the mux; any `apush`
+        blocked on backpressure wakes and returns without appending.
+        Idempotent.
+        """
+        if self._abort_task is not None:
+            return asyncio.shield(self._abort_task)
+
+        loop = asyncio.get_running_loop()
+        if self._exhausted:
+            done = loop.create_future()
+            done.set_result(None)
+            return done
+
+        self._exhausted = True
+        self._aborting = True
+        graph_aiter = self._graph_aiter
+        self._graph_aiter = None
+        anext_task = self._anext_task
+        if anext_task is not None and not anext_task.done():
+            anext_task.cancel()
+        if sys.version_info >= (3, 11):
+            create_task: Any = asyncio.create_task
+            self._abort_task = create_task(
+                self._abort_cleanup(graph_aiter, anext_task),
+                context=contextvars.Context(),
+            )
+        else:
+            self._abort_task = contextvars.Context().run(
+                lambda: asyncio.create_task(
+                    self._abort_cleanup(graph_aiter, anext_task)
+                )
+            )
+
+        def clear_abort_task(task: asyncio.Task[None]) -> None:
+            if self._abort_task is task:
+                self._abort_task = None
+
+        self._abort_task.add_done_callback(clear_abort_task)
+        return asyncio.shield(self._abort_task)
 
     async def __aenter__(self) -> AsyncGraphRunStream:
         return self

--- a/libs/langgraph/langgraph/stream/stream_channel.py
+++ b/libs/langgraph/langgraph/stream/stream_channel.py
@@ -232,7 +232,7 @@ class StreamChannel(Generic[T]):
                     raise self._error
                 return
             elif self._arequest_more is not None:
-                if not await self._arequest_more():
+                if not await asyncio.shield(self._arequest_more()):
                     if not self._items and not self._closed:
                         return
             else:

--- a/libs/langgraph/tests/test_pregel_stream_events_v3.py
+++ b/libs/langgraph/tests/test_pregel_stream_events_v3.py
@@ -8,6 +8,7 @@ import sys
 import time
 from typing import Annotated, Any
 
+import anyio
 import pytest
 from langgraph.checkpoint.memory import InMemorySaver
 from typing_extensions import TypedDict
@@ -764,6 +765,71 @@ class TestStreamV2Async:
                 await consumer
             except asyncio.CancelledError:
                 pass
+
+    async def test_abort_cleans_up_from_cancelled_anyio_scope(self) -> None:
+        class CountState(TypedDict):
+            count: int
+
+        runs: list[int] = []
+        finally_seen = anyio.Event()
+        scope_holder: dict[str, anyio.CancelScope] = {}
+        run_holder: dict[str, AsyncGraphRunStream] = {}
+
+        async def sub_node(state: CountState) -> dict:
+            runs.append(state["count"] + 1)
+            await asyncio.sleep(0.05)
+            return {"count": state["count"] + 1}
+
+        sub_graph = (
+            StateGraph(CountState)
+            .add_node("sub_node", sub_node)
+            .set_entry_point("sub_node")
+            .add_conditional_edges(
+                "sub_node",
+                lambda s: END if s["count"] >= 10 else "sub_node",
+            )
+            .compile()
+        )
+
+        async def main_node(state: CountState) -> None:
+            await sub_graph.ainvoke({"count": 0})
+
+        main_graph = (
+            StateGraph(CountState)
+            .add_node("main_node", main_node)
+            .set_entry_point("main_node")
+            .compile()
+        )
+
+        async def handler() -> None:
+            with anyio.CancelScope() as scope:
+                scope_holder["scope"] = scope
+                run = await main_graph.astream_events({"count": 0}, version="v3")
+                run_holder["run"] = run
+                try:
+                    async for _e in run:
+                        pass
+                finally:
+                    finally_seen.set()
+                    await run.abort()
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(handler)
+            while len(runs) < 2 or "scope" not in scope_holder:
+                await anyio.sleep(0.01)
+            scope_holder["scope"].cancel()
+            await finally_seen.wait()
+            with anyio.fail_after(2):
+                while (abort_task := run_holder["run"]._abort_task) is not None:
+                    if abort_task.done():
+                        break
+                    await anyio.sleep(0.01)
+            tg.cancel_scope.cancel()
+
+        runs_at_abort = len(runs)
+        await anyio.sleep(0.3)
+        assert len(runs) == runs_at_abort
+        assert len(runs) < 10
 
     async def test_extensions_has_native_keys(self) -> None:
         run = await _build_simple_graph().astream_events(


### PR DESCRIPTION
Fixes #8302

## Summary

This changes v3 async stream cancellation so a handler cancelled by an AnyIO cancel scope can still stop the underlying graph run.

The patch:
- shields async cursor pump calls from consumer-task cancellation, so the graph iterator is not left half-cancelled before `abort()` runs
- schedules `AsyncGraphRunStream.abort()` cleanup before the first await checkpoint, which lets `await run.abort()` work from an already-cancelled AnyIO scope
- adds a regression test for the cancelled-handler case with a looping subgraph

## Validation

- `make format` passed
- `make lint` passed
- `NO_DOCKER=true TEST="tests/test_pregel_stream_events_v3.py -k abort --count=3" make test` passed: 24 passed
- `NO_DOCKER=true make test` passed: 1967 passed, 4 skipped

## Notes

The broader test suite passes with `StreamChannel` shielding async pump calls. That shield is what keeps external consumer cancellation from interrupting the pump before `AsyncGraphRunStream.abort()` can own graph cleanup.
