### PR TITLE
release(langgraph): 1.2.9

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.8"
+version = "1.2.9"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1438,7 +1438,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.8"
+version = "1.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.8"
+version = "1.2.9"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.8"
+version = "1.2.9"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## Summary

Releases `langgraph` 1.2.9.

Bumps the package version `1.2.8` -> `1.2.9` and propagates it into the `langgraph`, `prebuilt`, and `sdk-py` lockfiles. No dependency floor or source changes.

Includes #8315 (fix non-fresh `update_state` delta channel counters/snapshot metadata for Postgres replay).

## Changes

- Update `libs/langgraph/pyproject.toml` to version `1.2.9`.
- Update the editable `langgraph` package entries in `libs/langgraph/uv.lock`, `libs/prebuilt/uv.lock`, and `libs/sdk-py/uv.lock`.


Made with [Cursor](https://cursor.com)