### PR TITLE
docs(prebuilt): fix grammar in create_react_agent mermaid diagram

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -491,7 +491,7 @@ def create_react_agent(
             Note over A: Prompt + LLM
             loop while tool_calls present
                 A->>T: Execute tools
-                T-->>A: ToolMessage for each tool_calls
+                T-->>A: ToolMessage for each tool_call
             end
             A->>U: Return final state
     ```


### PR DESCRIPTION
Fixes #8226

The mermaid sequence diagram in the `create_react_agent` docstring (`libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py`) read "ToolMessage for each tool_calls" — plural `tool_calls` used where the sentence describes a single per-iteration event, so it should be singular `tool_call`.

Verified against the current source on `main`: the line is unchanged since the issue was filed (confirmed via `git clone` + grep at line 494). Two prior PRs referencing this issue (#8229, #8259) were closed without merging, so the fix has not landed. One-word change, no behavior impact.
