### PR TITLE
fix(graph): warn when node returns keys not declared in state schema

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1446,6 +1446,19 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
+                if key != START:
+                    undeclared = [k for k in input if k not in output_keys]
+                    if undeclared:
+                        warnings.warn(
+                            f"Node '{key}' returned "
+                            f"{'key' if len(undeclared) == 1 else 'keys'} "
+                            f"{undeclared!r} not declared in the state schema; "
+                            f"{'it' if len(undeclared) == 1 else 'they'} will be "
+                            f"ignored. Add {'it' if len(undeclared) == 1 else 'them'} "
+                            f"to your TypedDict to persist the value.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:


### PR DESCRIPTION
## Summary

Fixes #8320 — `StateGraph` silently dropped keys returned by a node that were not declared in the state `TypedDict`, giving no feedback to the developer.

- Added a `warnings.warn(UserWarning)` in `_get_updates` (the mapper that converts node return values into channel writes) when the returned dict contains keys that are not in `output_keys`.
- The warning names the node and the undeclared keys, and tells the user to add them to their `TypedDict`.
- The guard skips `START` nodes (where input and state schemas may intentionally differ).
- No behaviour change: undeclared keys are still dropped. The fix only adds the warning.

## Test plan

- [ ] Run the repro from the issue — `node` returns `{"x": 1, "undeclared_key": "..."}` — and confirm a `UserWarning` is emitted naming `'undeclared_key'` and the node `'n'`.
- [ ] Run with only declared keys — confirm no warning is emitted.
- [ ] Run existing unit tests: `cd libs/langgraph && python -m pytest tests/ -x -q`.