### PR TITLE
feat(prebuilt): carry tool_call_id on ActionRequest for HITL tool interrupts

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/interrupt.py
+++ b/libs/prebuilt/langgraph/prebuilt/interrupt.py
@@ -1,7 +1,8 @@
 from typing import Literal
 
+from typing_extensions import NotRequired, TypedDict, deprecated
+
 from langgraph.warnings import LangGraphDeprecatedSinceV10
-from typing_extensions import TypedDict, deprecated
 
 
 @deprecated(
@@ -38,10 +39,14 @@ class ActionRequest(TypedDict):
     Attributes:
         action: The type or name of action being requested (e.g., `"Approve XYZ action"`)
         args: Key-value pairs of arguments needed for the action
+        tool_call_id: Optional originating tool call ID when the interrupt is
+            produced by a tool call, allowing the consumer to correlate the
+            approval artifact back to the specific call in message history.
     """
 
     action: str
     args: dict
+    tool_call_id: NotRequired[str | None]
 
 
 @deprecated(

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -2154,3 +2154,75 @@ def test_create_react_agent_inject_vars_with_post_model_hook(
         AIMessage("hi-hi-6", id="1"),
     ]
     assert result["foo"] == 2
+
+
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+def test_action_request_carries_tool_call_id(
+    sync_checkpointer: BaseCheckpointSaver,
+    version: Literal["v1", "v2"],
+) -> None:
+    """ActionRequest should carry the originating tool_call_id so that
+    external HITL consumers can correlate the interrupt back to the
+    specific tool call in message history without out-of-band recovery."""
+
+    @dec_tool
+    def ask_human(question: str, tool_call_id: Annotated[str, InjectedToolCallId]):
+        """Ask a human a question."""
+        from langgraph.prebuilt.interrupt import HumanInterrupt
+
+        request: HumanInterrupt = {
+            "action_request": {
+                "action": "human_approval",
+                "args": {"question": question},
+                "tool_call_id": tool_call_id,
+            },
+            "config": {
+                "allow_ignore": True,
+                "allow_respond": True,
+                "allow_edit": False,
+                "allow_accept": True,
+            },
+            "description": question,
+        }
+        response = interrupt([request])[0]
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"Human responded: {response}",
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    tool_calls = [
+        [{"args": {"question": "Is this OK?"}, "id": "call_42", "name": "ask_human"}]
+    ]
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    agent = create_react_agent(
+        model,
+        [ask_human],
+        checkpointer=sync_checkpointer,
+        version=version,
+    )
+    config = {"configurable": {"thread_id": "test_tool_call_id"}}
+    # Run until interrupted
+    agent.invoke({"messages": [("user", "approve this")]}, config)
+
+    # Verify the interrupt payload carries the tool_call_id
+    state = agent.get_state(config)
+    task = state.tasks[0]
+    interrupts = task.interrupts
+    assert len(interrupts) == 1
+    payload = interrupts[0].value
+    assert isinstance(payload, list)
+    action_request = payload[0]["action_request"]
+    assert action_request["tool_call_id"] == "call_42"
+    assert action_request["action"] == "human_approval"
+
+    # Resume and verify the tool_call_id round-trips correctly
+    result = agent.invoke(Command(resume="yes"), config)
+    tool_message = result["messages"][-2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.tool_call_id == "call_42"


### PR DESCRIPTION
Fixes #8304

## Summary

Adds an optional `tool_call_id: str | None` field to `ActionRequest` so that external HITL consumers can correlate an interrupt artifact back to the originating tool call in message history without out-of-band recovery.

## Changes

- **`libs/prebuilt/langgraph/prebuilt/interrupt.py`** -- Added `tool_call_id: NotRequired[str | None]` to `ActionRequest` TypedDict with docstring.
- **`libs/prebuilt/tests/test_react_agent.py`** -- Added `test_action_request_carries_tool_call_id` regression test that verifies the field is populated on interrupt and round-trips correctly through resume.

## Backward Compatibility

The field is `NotRequired` (defaults to absent), so existing consumers that don't set it are unaffected.

## Test Results

```
tests/test_react_agent.py::test_action_request_carries_tool_call_id[memory-v1] PASSED
tests/test_react_agent.py::test_action_request_carries_tool_call_id[memory-v2] PASSED
```
