### PR TITLE
fix: disable autocommit when using AsyncPipeline to prevent SSL connection errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, autocommit=not pipeline, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the connection is created with `autocommit=True`, which conflicts with the pipeline mode. psycopg's pipeline mode requires explicit transaction handling; autocommit implicitly causes SSL connection drops due to invalid pipeline nesting.

## Fix
Set `autocommit=False` when pipeline mode is enabled. This ensures the pipeline operates correctly without conflicting with internal autocommit handling.

Closes #5675