### PR TITLE
feat(checkpoint-postgres): add pluggable Postgres driver adapters

### DIFF
--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -18,7 +18,13 @@ uv add langgraph-checkpoint-postgres
 
 This library provides a Postgres implementation of LangGraph's checkpoint saver. Use it when you want LangGraph state persistence backed by Postgres for durable, long-running workflows and agents.
 
-By default, `langgraph-checkpoint-postgres` installs `psycopg` (Psycopg 3) without any extras. You can choose a specific installation that best suits your needs in the [Psycopg installation docs](https://www.psycopg.org/psycopg3/docs/basic/install.html), for example `psycopg[binary]`.
+`langgraph-checkpoint-postgres` includes a built-in adapter for Psycopg 3. Install it with the `psycopg` extra:
+
+```bash
+uv add "langgraph-checkpoint-postgres[psycopg]"
+```
+
+You can choose a specific Psycopg installation in the [Psycopg installation docs](https://www.psycopg.org/psycopg3/docs/basic/install.html), for example `psycopg[binary]`. The core package does not require Psycopg at install time: provide a `SyncPostgresDriverAdapter` or `AsyncPostgresDriverAdapter` when using another Postgres driver. An adapter owns connection and cursor lifecycle, transactions/pipelines, JSONB parameters, and any SQL placeholder translation; cursors must return mapping-like rows.
 
 ## 📖 Documentation
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -19,12 +19,7 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import _DeltaSnapshot
-from psycopg import Capabilities, Connection, Cursor, Pipeline
-from psycopg.rows import DictRow, dict_row
-from psycopg.types.json import Jsonb
-from psycopg_pool import ConnectionPool
 
-from langgraph.checkpoint.postgres import _internal
 from langgraph.checkpoint.postgres.base import (
     _DELTA_PAGE_SIZE,
     BasePostgresSaver,
@@ -32,9 +27,15 @@ from langgraph.checkpoint.postgres.base import (
     _build_delta_stage2_sql,
     _DeltaStage2Row,
 )
+from langgraph.checkpoint.postgres.driver import (
+    PostgresDriverAdapter,
+    PsycopgDriverAdapter,
+    SyncCursor,
+    SyncPostgresDriverAdapter,
+)
 from langgraph.checkpoint.postgres.shallow import ShallowPostgresSaver
 
-Conn = _internal.Conn  # For backward compatibility
+Conn = Any  # For backward compatibility
 
 
 class PostgresSaver(BasePostgresSaver):
@@ -44,12 +45,15 @@ class PostgresSaver(BasePostgresSaver):
 
     def __init__(
         self,
-        conn: _internal.Conn,
-        pipe: Pipeline | None = None,
+        conn: Any,
+        pipe: Any | None = None,
         serde: SerializerProtocol | None = None,
+        *,
+        adapter: SyncPostgresDriverAdapter | None = None,
     ) -> None:
-        super().__init__(serde=serde)
-        if isinstance(conn, ConnectionPool) and pipe is not None:
+        self.adapter = adapter or PsycopgDriverAdapter()
+        super().__init__(serde=serde, jsonb=self.adapter.jsonb)
+        if self.adapter.is_pool(conn) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single Connection, not ConnectionPool."
             )
@@ -57,12 +61,16 @@ class PostgresSaver(BasePostgresSaver):
         self.conn = conn
         self.pipe = pipe
         self.lock = threading.Lock()
-        self.supports_pipeline = Capabilities().has_pipeline()
+        self.supports_pipeline = self.adapter.supports_pipeline()
 
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        adapter: SyncPostgresDriverAdapter | None = None,
     ) -> Iterator[PostgresSaver]:
         """Create a new PostgresSaver instance from a connection string.
 
@@ -73,14 +81,13 @@ class PostgresSaver(BasePostgresSaver):
         Returns:
             PostgresSaver: A new PostgresSaver instance.
         """
-        with Connection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
+        driver = adapter or PsycopgDriverAdapter()
+        with driver.connect(conn_string) as conn:
             if pipeline:
-                with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                with driver.pipeline(conn) as pipe:
+                    yield cls(conn, pipe, adapter=driver)
             else:
-                yield cls(conn)
+                yield cls(conn, adapter=driver)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -107,7 +114,7 @@ class PostgresSaver(BasePostgresSaver):
                 cur.execute(migration)
                 cur.execute("INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,))
         if self.pipe:
-            self.pipe.sync()
+            self.adapter.sync_pipeline(self.pipe)
 
     def list(
         self,
@@ -338,8 +345,10 @@ class PostgresSaver(BasePostgresSaver):
                     checkpoint_ns,
                     checkpoint["id"],
                     checkpoint_id,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                    self.adapter.jsonb(copy),
+                    self.adapter.jsonb(
+                        get_serializable_checkpoint_metadata(config, metadata)
+                    ),
                 ),
             )
         return next_config
@@ -402,7 +411,7 @@ class PostgresSaver(BasePostgresSaver):
             )
 
     @contextmanager
-    def _cursor(self, *, pipeline: bool = False) -> Iterator[Cursor[DictRow]]:
+    def _cursor(self, *, pipeline: bool = False) -> Iterator[SyncCursor]:
         """Create a database cursor as a context manager.
 
         Args:
@@ -410,35 +419,35 @@ class PostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the PostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
-        with self.lock, _internal.get_connection(self.conn) as conn:
+        with self.lock, self.adapter.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    with self.adapter.cursor(conn) as cur:
                         yield cur
                 finally:
                     if pipeline:
-                        self.pipe.sync()
+                        self.adapter.sync_pipeline(self.pipe)
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     with (
-                        conn.pipeline(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.pipeline(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     with (
-                        conn.transaction(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.transaction(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
             else:
-                with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                with self.adapter.cursor(conn) as cur:
                     yield cur
 
     def get_delta_channel_history(
@@ -549,7 +558,7 @@ class PostgresSaver(BasePostgresSaver):
             stage2_rows=cast("list[_DeltaStage2Row]", stage2_rows),
         )
 
-    def _load_checkpoint_tuple(self, value: DictRow) -> CheckpointTuple:
+    def _load_checkpoint_tuple(self, value: Mapping[str, Any]) -> CheckpointTuple:
         """
         Convert a database row into a CheckpointTuple object.
 
@@ -592,4 +601,12 @@ class PostgresSaver(BasePostgresSaver):
         )
 
 
-__all__ = ["PostgresSaver", "BasePostgresSaver", "ShallowPostgresSaver", "Conn"]
+__all__ = [
+    "Conn",
+    "BasePostgresSaver",
+    "PostgresSaver",
+    "PostgresDriverAdapter",
+    "PsycopgDriverAdapter",
+    "ShallowPostgresSaver",
+    "SyncPostgresDriverAdapter",
+]

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -19,12 +19,7 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import _DeltaSnapshot
-from psycopg import AsyncConnection, AsyncCursor, AsyncPipeline, Capabilities
-from psycopg.rows import DictRow, dict_row
-from psycopg.types.json import Jsonb
-from psycopg_pool import AsyncConnectionPool
 
-from langgraph.checkpoint.postgres import _ainternal
 from langgraph.checkpoint.postgres.base import (
     _DELTA_PAGE_SIZE,
     BasePostgresSaver,
@@ -32,9 +27,14 @@ from langgraph.checkpoint.postgres.base import (
     _build_delta_stage2_sql,
     _DeltaStage2Row,
 )
+from langgraph.checkpoint.postgres.driver import (
+    AsyncCursor,
+    AsyncPostgresDriverAdapter,
+    AsyncPsycopgDriverAdapter,
+)
 from langgraph.checkpoint.postgres.shallow import AsyncShallowPostgresSaver
 
-Conn = _ainternal.Conn  # For backward compatibility
+Conn = Any  # For backward compatibility
 
 
 class AsyncPostgresSaver(BasePostgresSaver):
@@ -44,12 +44,15 @@ class AsyncPostgresSaver(BasePostgresSaver):
 
     def __init__(
         self,
-        conn: _ainternal.Conn,
-        pipe: AsyncPipeline | None = None,
+        conn: Any,
+        pipe: Any | None = None,
         serde: SerializerProtocol | None = None,
+        *,
+        adapter: AsyncPostgresDriverAdapter | None = None,
     ) -> None:
-        super().__init__(serde=serde)
-        if isinstance(conn, AsyncConnectionPool) and pipe is not None:
+        self.adapter = adapter or AsyncPsycopgDriverAdapter()
+        super().__init__(serde=serde, jsonb=self.adapter.jsonb)
+        if self.adapter.is_pool(conn) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single AsyncConnection, not AsyncConnectionPool."
             )
@@ -58,7 +61,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         self.pipe = pipe
         self.lock = asyncio.Lock()
         self.loop = asyncio.get_running_loop()
-        self.supports_pipeline = Capabilities().has_pipeline()
+        self.supports_pipeline = self.adapter.supports_pipeline()
 
     @classmethod
     @asynccontextmanager
@@ -68,6 +71,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        adapter: AsyncPostgresDriverAdapter | None = None,
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
@@ -78,14 +82,13 @@ class AsyncPostgresSaver(BasePostgresSaver):
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
+        driver = adapter or AsyncPsycopgDriverAdapter()
+        async with driver.connect(conn_string) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                async with driver.pipeline(conn) as pipe:
+                    yield cls(conn=conn, pipe=pipe, serde=serde, adapter=driver)
             else:
-                yield cls(conn=conn, serde=serde)
+                yield cls(conn=conn, serde=serde, adapter=driver)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -114,7 +117,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
         if self.pipe:
-            await self.pipe.sync()
+            await self.adapter.sync_pipeline(self.pipe)
 
     async def alist(
         self,
@@ -298,8 +301,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     checkpoint_ns,
                     checkpoint["id"],
                     checkpoint_id,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                    self.adapter.jsonb(copy),
+                    self.adapter.jsonb(
+                        get_serializable_checkpoint_metadata(config, metadata)
+                    ),
                 ),
             )
         return next_config
@@ -361,9 +366,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             )
 
     @asynccontextmanager
-    async def _cursor(
-        self, *, pipeline: bool = False
-    ) -> AsyncIterator[AsyncCursor[DictRow]]:
+    async def _cursor(self, *, pipeline: bool = False) -> AsyncIterator[AsyncCursor]:
         """Create a database cursor as a context manager.
 
         Args:
@@ -371,35 +374,35 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the AsyncPostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
-        async with self.lock, _ainternal.get_connection(self.conn) as conn:
+        async with self.lock, self.adapter.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    async with self.adapter.cursor(conn) as cur:
                         yield cur
                 finally:
                     if pipeline:
-                        await self.pipe.sync()
+                        await self.adapter.sync_pipeline(self.pipe)
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     async with (
-                        conn.pipeline(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.pipeline(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     async with (
-                        conn.transaction(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.transaction(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
             else:
-                async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                async with self.adapter.cursor(conn) as cur:
                     yield cur
 
     async def aget_delta_channel_history(
@@ -493,7 +496,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             stage2_rows=cast("list[_DeltaStage2Row]", stage2_rows),
         )
 
-    async def _load_checkpoint_tuple(self, value: DictRow) -> CheckpointTuple:
+    async def _load_checkpoint_tuple(self, value: Mapping[str, Any]) -> CheckpointTuple:
         """
         Convert a database row into a CheckpointTuple object.
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import warnings
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from importlib.metadata import version as get_version
 from typing import Any, TypedDict, cast
 
@@ -15,8 +15,8 @@ from langgraph.checkpoint.base import (
     PendingWrite,
     get_checkpoint_id,
 )
+from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import TASKS
-from psycopg.types.json import Jsonb
 
 # Page size for stage-1 paged scan in `get_delta_channel_history`. Internal
 # constant — exposing this as a kwarg is left as a follow-up.
@@ -305,6 +305,15 @@ class BasePostgresSaver(BaseCheckpointSaver[str]):
 
     supports_pipeline: bool
 
+    def __init__(
+        self,
+        serde: SerializerProtocol | None = None,
+        *,
+        jsonb: Callable[[Any], Any] | None = None,
+    ) -> None:
+        super().__init__(serde=serde)
+        self._jsonb = jsonb or (lambda value: value)
+
     def _migrate_pending_sends(
         self,
         pending_sends: list[tuple[bytes, bytes]],
@@ -583,7 +592,7 @@ class BasePostgresSaver(BaseCheckpointSaver[str]):
         # construct predicate for metadata filter
         if filter:
             wheres.append("metadata @> %s ")
-            param_values.append(Jsonb(filter))
+            param_values.append(self._jsonb(filter))
 
         # construct predicate for `before`
         if before is not None:

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/driver.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/driver.py
@@ -1,0 +1,282 @@
+"""Driver adapters for PostgreSQL checkpoint savers.
+
+Adapters isolate database-driver details such as connection lifecycle, cursor
+creation, transactions, pipelines, and JSONB values. The saver SQL continues to
+use psycopg-style placeholders; an alternative adapter can translate them in its
+cursor implementation before delegating to another driver.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Iterator, Sequence
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SyncCursor(Protocol):
+    """Cursor operations required by synchronous checkpoint savers."""
+
+    def execute(
+        self,
+        query: str,
+        params: Sequence[Any] | None = None,
+        *,
+        binary: bool = False,
+    ) -> Any: ...
+
+    def executemany(self, query: str, params_seq: Sequence[Sequence[Any]]) -> Any: ...
+
+    def fetchone(self) -> Any: ...
+
+    def fetchall(self) -> list[Any]: ...
+
+    def __iter__(self) -> Iterator[Any]: ...
+
+
+@runtime_checkable
+class AsyncCursor(Protocol):
+    """Cursor operations required by asynchronous checkpoint savers."""
+
+    async def execute(
+        self,
+        query: str,
+        params: Sequence[Any] | None = None,
+        *,
+        binary: bool = False,
+    ) -> Any: ...
+
+    async def executemany(
+        self, query: str, params_seq: Sequence[Sequence[Any]]
+    ) -> Any: ...
+
+    async def fetchone(self) -> Any: ...
+
+    async def fetchall(self) -> list[Any]: ...
+
+    def __aiter__(self) -> AsyncIterator[Any]: ...
+
+
+class PostgresDriverAdapter(ABC):
+    """Common driver contract for PostgreSQL checkpoint savers.
+
+    Implement a sync or async subclass to use a driver other than psycopg. The
+    cursor returned by an adapter owns SQL execution and parameter adaptation.
+    It must return mapping-like rows because savers address result columns by name.
+    """
+
+    @abstractmethod
+    def is_pool(self, connection: Any) -> bool:
+        """Return whether ``connection`` checks out a connection per operation."""
+
+    def supports_pipeline(self) -> bool:
+        """Return whether this driver supports a pipeline context manager."""
+        return False
+
+    def jsonb(self, value: Any) -> Any:
+        """Convert a Python JSON-compatible value into a driver JSONB parameter."""
+        return value
+
+
+class SyncPostgresDriverAdapter(PostgresDriverAdapter, ABC):
+    """Driver contract for :class:`PostgresSaver` and its shallow variant."""
+
+    @abstractmethod
+    def connect(self, conn_string: str) -> Any:
+        """Return a context manager that opens and closes a connection."""
+
+    @abstractmethod
+    def get_connection(self, connection: Any) -> Any:
+        """Return a context manager yielding a concrete connection."""
+
+    @abstractmethod
+    def cursor(self, connection: Any) -> Any:
+        """Return a context manager yielding a :class:`SyncCursor`."""
+
+    @abstractmethod
+    def transaction(self, connection: Any) -> Any:
+        """Return a transaction context manager."""
+
+    @abstractmethod
+    def pipeline(self, connection: Any) -> Any:
+        """Return a pipeline context manager when pipelines are supported."""
+
+    @abstractmethod
+    def sync_pipeline(self, pipeline: Any) -> None:
+        """Flush work submitted to an active pipeline."""
+
+
+class AsyncPostgresDriverAdapter(PostgresDriverAdapter, ABC):
+    """Driver contract for :class:`AsyncPostgresSaver` and its shallow variant."""
+
+    @abstractmethod
+    def connect(self, conn_string: str) -> Any:
+        """Return an async context manager that opens and closes a connection."""
+
+    @abstractmethod
+    def get_connection(self, connection: Any) -> Any:
+        """Return an async context manager yielding a concrete connection."""
+
+    @abstractmethod
+    def cursor(self, connection: Any) -> Any:
+        """Return an async context manager yielding an :class:`AsyncCursor`."""
+
+    @abstractmethod
+    def transaction(self, connection: Any) -> Any:
+        """Return an async transaction context manager."""
+
+    @abstractmethod
+    def pipeline(self, connection: Any) -> Any:
+        """Return an async pipeline context manager when pipelines are supported."""
+
+    @abstractmethod
+    async def sync_pipeline(self, pipeline: Any) -> None:
+        """Flush work submitted to an active pipeline."""
+
+
+def _load_psycopg() -> tuple[Any, Any, Any, Any, Any, Any]:
+    try:
+        from psycopg import AsyncConnection, Capabilities, Connection
+        from psycopg.rows import dict_row
+        from psycopg.types.json import Jsonb
+        from psycopg_pool import AsyncConnectionPool, ConnectionPool
+    except ModuleNotFoundError as exc:
+        if exc.name in {"psycopg", "psycopg_pool"}:
+            raise ImportError(
+                "The default psycopg driver is not installed. Install it with "
+                '`pip install "langgraph-checkpoint-postgres[psycopg]"`, or '
+                "pass a custom Postgres driver adapter."
+            ) from exc
+        raise
+    return (
+        Connection,
+        AsyncConnection,
+        ConnectionPool,
+        AsyncConnectionPool,
+        Capabilities,
+        (dict_row, Jsonb),
+    )
+
+
+class PsycopgDriverAdapter(SyncPostgresDriverAdapter):
+    """Default synchronous adapter backed by psycopg 3."""
+
+    def is_pool(self, connection: Any) -> bool:
+        _, _, ConnectionPool, _, _, _ = _load_psycopg()
+        return isinstance(connection, ConnectionPool)
+
+    def supports_pipeline(self) -> bool:
+        _, _, _, _, Capabilities, _ = _load_psycopg()
+        return Capabilities().has_pipeline()
+
+    def jsonb(self, value: Any) -> Any:
+        *_, helpers = _load_psycopg()
+        _, Jsonb = helpers
+        return Jsonb(value)
+
+    @contextmanager
+    def connect(self, conn_string: str) -> Iterator[Any]:
+        Connection, _, _, _, _, helpers = _load_psycopg()
+        dict_row, _ = helpers
+        with Connection.connect(
+            conn_string,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as connection:
+            yield connection
+
+    @contextmanager
+    def get_connection(self, connection: Any) -> Iterator[Any]:
+        Connection, _, ConnectionPool, _, _, _ = _load_psycopg()
+        if isinstance(connection, Connection):
+            yield connection
+        elif isinstance(connection, ConnectionPool):
+            with connection.connection() as checked_out:
+                yield checked_out
+        else:
+            raise TypeError(f"Invalid connection type: {type(connection)}")
+
+    @contextmanager
+    def cursor(self, connection: Any) -> Iterator[SyncCursor]:
+        *_, helpers = _load_psycopg()
+        dict_row, _ = helpers
+        with connection.cursor(binary=True, row_factory=dict_row) as cursor:
+            yield cursor
+
+    def transaction(self, connection: Any) -> Any:
+        return connection.transaction()
+
+    def pipeline(self, connection: Any) -> Any:
+        return connection.pipeline()
+
+    def sync_pipeline(self, pipeline: Any) -> None:
+        pipeline.sync()
+
+
+class AsyncPsycopgDriverAdapter(AsyncPostgresDriverAdapter):
+    """Default asynchronous adapter backed by psycopg 3."""
+
+    def is_pool(self, connection: Any) -> bool:
+        _, _, _, AsyncConnectionPool, _, _ = _load_psycopg()
+        return isinstance(connection, AsyncConnectionPool)
+
+    def supports_pipeline(self) -> bool:
+        _, _, _, _, Capabilities, _ = _load_psycopg()
+        return Capabilities().has_pipeline()
+
+    def jsonb(self, value: Any) -> Any:
+        *_, helpers = _load_psycopg()
+        _, Jsonb = helpers
+        return Jsonb(value)
+
+    @asynccontextmanager
+    async def connect(self, conn_string: str) -> AsyncIterator[Any]:
+        _, AsyncConnection, _, _, _, helpers = _load_psycopg()
+        dict_row, _ = helpers
+        async with await AsyncConnection.connect(
+            conn_string,
+            autocommit=True,
+            prepare_threshold=0,
+            row_factory=dict_row,
+        ) as connection:
+            yield connection
+
+    @asynccontextmanager
+    async def get_connection(self, connection: Any) -> AsyncIterator[Any]:
+        _, AsyncConnection, _, AsyncConnectionPool, _, _ = _load_psycopg()
+        if isinstance(connection, AsyncConnection):
+            yield connection
+        elif isinstance(connection, AsyncConnectionPool):
+            async with connection.connection() as checked_out:
+                yield checked_out
+        else:
+            raise TypeError(f"Invalid connection type: {type(connection)}")
+
+    @asynccontextmanager
+    async def cursor(self, connection: Any) -> AsyncIterator[AsyncCursor]:
+        *_, helpers = _load_psycopg()
+        dict_row, _ = helpers
+        async with connection.cursor(binary=True, row_factory=dict_row) as cursor:
+            yield cursor
+
+    def transaction(self, connection: Any) -> Any:
+        return connection.transaction()
+
+    def pipeline(self, connection: Any) -> Any:
+        return connection.pipeline()
+
+    async def sync_pipeline(self, pipeline: Any) -> None:
+        await pipeline.sync()
+
+
+__all__ = [
+    "AsyncCursor",
+    "AsyncPostgresDriverAdapter",
+    "AsyncPsycopgDriverAdapter",
+    "PostgresDriverAdapter",
+    "PsycopgDriverAdapter",
+    "SyncCursor",
+    "SyncPostgresDriverAdapter",
+]

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -16,21 +16,16 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from langgraph.checkpoint.serde.types import TASKS
-from psycopg import (
-    AsyncConnection,
-    AsyncCursor,
-    AsyncPipeline,
-    Capabilities,
-    Connection,
-    Cursor,
-    Pipeline,
-)
-from psycopg.rows import DictRow, dict_row
-from psycopg.types.json import Jsonb
-from psycopg_pool import AsyncConnectionPool, ConnectionPool
 
-from langgraph.checkpoint.postgres import _ainternal, _internal
 from langgraph.checkpoint.postgres.base import BasePostgresSaver
+from langgraph.checkpoint.postgres.driver import (
+    AsyncCursor,
+    AsyncPostgresDriverAdapter,
+    AsyncPsycopgDriverAdapter,
+    PsycopgDriverAdapter,
+    SyncCursor,
+    SyncPostgresDriverAdapter,
+)
 
 """
 To add a new migration, add a new string to the MIGRATIONS list.
@@ -185,9 +180,11 @@ class ShallowPostgresSaver(BasePostgresSaver):
 
     def __init__(
         self,
-        conn: _internal.Conn,
-        pipe: Pipeline | None = None,
+        conn: Any,
+        pipe: Any | None = None,
         serde: SerializerProtocol | None = None,
+        *,
+        adapter: SyncPostgresDriverAdapter | None = None,
     ) -> None:
         warnings.warn(
             "ShallowPostgresSaver is deprecated as of version 2.0.20 and will be removed in 3.0.0. "
@@ -195,8 +192,9 @@ class ShallowPostgresSaver(BasePostgresSaver):
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(serde=serde)
-        if isinstance(conn, ConnectionPool) and pipe is not None:
+        self.adapter = adapter or PsycopgDriverAdapter()
+        super().__init__(serde=serde, jsonb=self.adapter.jsonb)
+        if self.adapter.is_pool(conn) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single Connection, not ConnectionPool."
             )
@@ -204,12 +202,16 @@ class ShallowPostgresSaver(BasePostgresSaver):
         self.conn = conn
         self.pipe = pipe
         self.lock = threading.Lock()
-        self.supports_pipeline = Capabilities().has_pipeline()
+        self.supports_pipeline = self.adapter.supports_pipeline()
 
     @classmethod
     @contextmanager
     def from_conn_string(
-        cls, conn_string: str, *, pipeline: bool = False
+        cls,
+        conn_string: str,
+        *,
+        pipeline: bool = False,
+        adapter: SyncPostgresDriverAdapter | None = None,
     ) -> Iterator["ShallowPostgresSaver"]:
         """Create a new ShallowPostgresSaver instance from a connection string.
 
@@ -220,14 +222,13 @@ class ShallowPostgresSaver(BasePostgresSaver):
         Returns:
             ShallowPostgresSaver: A new ShallowPostgresSaver instance.
         """
-        with Connection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
+        driver = adapter or PsycopgDriverAdapter()
+        with driver.connect(conn_string) as conn:
             if pipeline:
-                with conn.pipeline() as pipe:
-                    yield cls(conn, pipe)
+                with driver.pipeline(conn) as pipe:
+                    yield cls(conn, pipe, adapter=driver)
             else:
-                yield cls(conn)
+                yield cls(conn, adapter=driver)
 
     def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -254,7 +255,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
                 cur.execute(migration)
                 cur.execute("INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,))
         if self.pipe:
-            self.pipe.sync()
+            self.adapter.sync_pipeline(self.pipe)
 
     def list(
         self,
@@ -443,8 +444,10 @@ class ShallowPostgresSaver(BasePostgresSaver):
                 (
                     thread_id,
                     checkpoint_ns,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                    self.adapter.jsonb(copy),
+                    self.adapter.jsonb(
+                        get_serializable_checkpoint_metadata(config, metadata)
+                    ),
                 ),
             )
         return next_config
@@ -484,7 +487,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
             )
 
     @contextmanager
-    def _cursor(self, *, pipeline: bool = False) -> Iterator[Cursor[DictRow]]:
+    def _cursor(self, *, pipeline: bool = False) -> Iterator[SyncCursor]:
         """Create a database cursor as a context manager.
 
         Args:
@@ -492,37 +495,37 @@ class ShallowPostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the ShallowPostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
-        with _internal.get_connection(self.conn) as conn:
+        with self.adapter.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    with self.adapter.cursor(conn) as cur:
                         yield cur
                 finally:
                     if pipeline:
-                        self.pipe.sync()
+                        self.adapter.sync_pipeline(self.pipe)
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     with (
                         self.lock,
-                        conn.pipeline(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.pipeline(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     with (
                         self.lock,
-                        conn.transaction(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.transaction(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
             else:
-                with self.lock, conn.cursor(binary=True, row_factory=dict_row) as cur:
+                with self.lock, self.adapter.cursor(conn) as cur:
                     yield cur
 
 
@@ -544,9 +547,11 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
 
     def __init__(
         self,
-        conn: _ainternal.Conn,
-        pipe: AsyncPipeline | None = None,
+        conn: Any,
+        pipe: Any | None = None,
         serde: SerializerProtocol | None = None,
+        *,
+        adapter: AsyncPostgresDriverAdapter | None = None,
     ) -> None:
         warnings.warn(
             "AsyncShallowPostgresSaver is deprecated as of version 2.0.20 and will be removed in 3.0.0. "
@@ -554,8 +559,9 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
             DeprecationWarning,
             stacklevel=2,
         )
-        super().__init__(serde=serde)
-        if isinstance(conn, AsyncConnectionPool) and pipe is not None:
+        self.adapter = adapter or AsyncPsycopgDriverAdapter()
+        super().__init__(serde=serde, jsonb=self.adapter.jsonb)
+        if self.adapter.is_pool(conn) and pipe is not None:
             raise ValueError(
                 "Pipeline should be used only with a single AsyncConnection, not AsyncConnectionPool."
             )
@@ -564,7 +570,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         self.pipe = pipe
         self.lock = asyncio.Lock()
         self.loop = asyncio.get_running_loop()
-        self.supports_pipeline = Capabilities().has_pipeline()
+        self.supports_pipeline = self.adapter.supports_pipeline()
 
     @classmethod
     @asynccontextmanager
@@ -574,6 +580,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         *,
         pipeline: bool = False,
         serde: SerializerProtocol | None = None,
+        adapter: AsyncPostgresDriverAdapter | None = None,
     ) -> AsyncIterator["AsyncShallowPostgresSaver"]:
         """Create a new AsyncShallowPostgresSaver instance from a connection string.
 
@@ -584,14 +591,13 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         Returns:
             AsyncShallowPostgresSaver: A new AsyncShallowPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
+        driver = adapter or AsyncPsycopgDriverAdapter()
+        async with driver.connect(conn_string) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                async with driver.pipeline(conn) as pipe:
+                    yield cls(conn=conn, pipe=pipe, serde=serde, adapter=driver)
             else:
-                yield cls(conn=conn, serde=serde)
+                yield cls(conn=conn, serde=serde, adapter=driver)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.
@@ -620,7 +626,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
         if self.pipe:
-            await self.pipe.sync()
+            await self.adapter.sync_pipeline(self.pipe)
 
     async def alist(
         self,
@@ -781,8 +787,10 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 (
                     thread_id,
                     checkpoint_ns,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                    self.adapter.jsonb(copy),
+                    self.adapter.jsonb(
+                        get_serializable_checkpoint_metadata(config, metadata)
+                    ),
                 ),
             )
         return next_config
@@ -821,9 +829,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
             await cur.executemany(query, params)
 
     @asynccontextmanager
-    async def _cursor(
-        self, *, pipeline: bool = False
-    ) -> AsyncIterator[AsyncCursor[DictRow]]:
+    async def _cursor(self, *, pipeline: bool = False) -> AsyncIterator[AsyncCursor]:
         """Create a database cursor as a context manager.
 
         Args:
@@ -831,39 +837,39 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                 Will be applied regardless of whether the AsyncShallowPostgresSaver instance was initialized with a pipeline.
                 If pipeline mode is not supported, will fall back to using transaction context manager.
         """
-        async with _ainternal.get_connection(self.conn) as conn:
+        async with self.adapter.get_connection(self.conn) as conn:
             if self.pipe:
                 # a connection in pipeline mode can be used concurrently
                 # in multiple threads/coroutines, but only one cursor can be
                 # used at a time
                 try:
-                    async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                    async with self.adapter.cursor(conn) as cur:
                         yield cur
                 finally:
                     if pipeline:
-                        await self.pipe.sync()
+                        await self.adapter.sync_pipeline(self.pipe)
             elif pipeline:
                 # a connection not in pipeline mode can only be used by one
                 # thread/coroutine at a time, so we acquire a lock
                 if self.supports_pipeline:
                     async with (
                         self.lock,
-                        conn.pipeline(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.pipeline(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
                 else:
                     # Use connection's transaction context manager when pipeline mode not supported
                     async with (
                         self.lock,
-                        conn.transaction(),
-                        conn.cursor(binary=True, row_factory=dict_row) as cur,
+                        self.adapter.transaction(conn),
+                        self.adapter.cursor(conn) as cur,
                     ):
                         yield cur
             else:
                 async with (
                     self.lock,
-                    conn.cursor(binary=True, row_factory=dict_row) as cur,
+                    self.adapter.cursor(conn) as cur,
                 ):
                     yield cur
 

--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -14,6 +14,10 @@ license-files = ['LICENSE']
 dependencies = [
   "langgraph-checkpoint>=4.1.0,<5.0.0",
   "orjson>=3.11.5",
+]
+
+[project.optional-dependencies]
+psycopg = [
   "psycopg>=3.2.0",
   "psycopg-pool>=3.2.0",
 ]
@@ -31,6 +35,7 @@ test = [
   "pytest-asyncio",
   "pytest-mock",
   "psycopg[binary]",
+  "psycopg-pool>=3.2.0",
   "langgraph-checkpoint",
   "pytest-watcher",
 ]

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -22,11 +22,48 @@ from langgraph.checkpoint.postgres.aio import (
     AsyncPostgresSaver,
     AsyncShallowPostgresSaver,
 )
+from langgraph.checkpoint.postgres.driver import AsyncPsycopgDriverAdapter
 from tests.conftest import DEFAULT_POSTGRES_URI
 
 
 def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
+
+
+class _TracingAsyncCursor:
+    def __init__(self, cursor: Any, adapter: "_TracingAsyncPsycopgAdapter") -> None:
+        self.cursor = cursor
+        self.adapter = adapter
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        self.adapter.execute_calls += 1
+        return await self.cursor.execute(*args, **kwargs)
+
+    async def executemany(self, *args: Any, **kwargs: Any) -> Any:
+        self.adapter.executemany_calls += 1
+        return await self.cursor.executemany(*args, **kwargs)
+
+    def __aiter__(self):
+        return self.cursor.__aiter__()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.cursor, name)
+
+
+class _TracingAsyncPsycopgAdapter(AsyncPsycopgDriverAdapter):
+    def __init__(self) -> None:
+        self.execute_calls = 0
+        self.executemany_calls = 0
+        self.jsonb_values: list[Any] = []
+
+    @asynccontextmanager
+    async def cursor(self, conn: Any):
+        async with super().cursor(conn) as cursor:
+            yield _TracingAsyncCursor(cursor, self)
+
+    def jsonb(self, value: Any) -> Any:
+        self.jsonb_values.append(value)
+        return super().jsonb(value)
 
 
 @asynccontextmanager
@@ -226,6 +263,33 @@ async def test_combined_metadata(saver_name: str, test_data) -> None:
             **metadata,
             "run_id": "my_run_id",
         }
+
+
+async def test_custom_async_driver_adapter_handles_database_operations() -> None:
+    adapter = _TracingAsyncPsycopgAdapter()
+    async with await AsyncConnection.connect(
+        DEFAULT_POSTGRES_URI,
+        autocommit=True,
+        prepare_threshold=0,
+        row_factory=dict_row,
+    ) as conn:
+        saver = AsyncPostgresSaver(conn, adapter=adapter)
+        await saver.setup()
+        config = {"configurable": {"thread_id": "adapter", "checkpoint_ns": ""}}
+        checkpoint = create_checkpoint(empty_checkpoint(), {}, 1)
+        next_config = await saver.aput(
+            config, checkpoint, {"source": "input", "step": 0}, {}
+        )
+        await saver.aput_writes(next_config, [("custom", "value")], "task")
+
+        assert await saver.aget_tuple(next_config) is not None
+
+    assert adapter.execute_calls > 0
+    assert adapter.executemany_calls > 0
+    assert adapter.jsonb_values == [
+        checkpoint,
+        {"source": "input", "step": 0},
+    ]
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])

--- a/libs/checkpoint-postgres/tests/test_driver.py
+++ b/libs/checkpoint-postgres/tests/test_driver.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+from textwrap import dedent
+
+
+def test_checkpoint_savers_import_without_psycopg() -> None:
+    """Keep alternative drivers usable when the optional psycopg extra is absent."""
+    script = dedent(
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def block_psycopg(name, *args, **kwargs):
+            if name.split('.', 1)[0] in {'psycopg', 'psycopg_pool'}:
+                raise ModuleNotFoundError(name)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = block_psycopg
+
+        from langgraph.checkpoint.postgres import PostgresSaver
+        from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+        from langgraph.checkpoint.postgres.driver import (
+            AsyncPostgresDriverAdapter,
+            SyncPostgresDriverAdapter,
+        )
+
+        assert PostgresSaver
+        assert AsyncPostgresSaver
+        assert SyncPostgresDriverAdapter
+        assert AsyncPostgresDriverAdapter
+        """
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -20,11 +20,48 @@ from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 
 from langgraph.checkpoint.postgres import PostgresSaver, ShallowPostgresSaver
+from langgraph.checkpoint.postgres.driver import PsycopgDriverAdapter
 from tests.conftest import DEFAULT_POSTGRES_URI
 
 
 def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
+
+
+class _TracingCursor:
+    def __init__(self, cursor: Any, adapter: "_TracingPsycopgAdapter") -> None:
+        self.cursor = cursor
+        self.adapter = adapter
+
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        self.adapter.execute_calls += 1
+        return self.cursor.execute(*args, **kwargs)
+
+    def executemany(self, *args: Any, **kwargs: Any) -> Any:
+        self.adapter.executemany_calls += 1
+        return self.cursor.executemany(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self.cursor)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.cursor, name)
+
+
+class _TracingPsycopgAdapter(PsycopgDriverAdapter):
+    def __init__(self) -> None:
+        self.execute_calls = 0
+        self.executemany_calls = 0
+        self.jsonb_values: list[Any] = []
+
+    @contextmanager
+    def cursor(self, conn: Any):
+        with super().cursor(conn) as cursor:
+            yield _TracingCursor(cursor, self)
+
+    def jsonb(self, value: Any) -> Any:
+        self.jsonb_values.append(value)
+        return super().jsonb(value)
 
 
 @contextmanager
@@ -208,6 +245,31 @@ def test_combined_metadata(saver_name: str, test_data) -> None:
             **metadata,
             "run_id": "my_run_id",
         }
+
+
+def test_custom_driver_adapter_handles_database_operations() -> None:
+    adapter = _TracingPsycopgAdapter()
+    with Connection.connect(
+        DEFAULT_POSTGRES_URI,
+        autocommit=True,
+        prepare_threshold=0,
+        row_factory=dict_row,
+    ) as conn:
+        saver = PostgresSaver(conn, adapter=adapter)
+        saver.setup()
+        config = {"configurable": {"thread_id": "adapter", "checkpoint_ns": ""}}
+        checkpoint = create_checkpoint(empty_checkpoint(), {}, 1)
+        next_config = saver.put(config, checkpoint, {"source": "input", "step": 0}, {})
+        saver.put_writes(next_config, [("custom", "value")], "task")
+
+        assert saver.get_tuple(next_config) is not None
+
+    assert adapter.execute_calls > 0
+    assert adapter.executemany_calls > 0
+    assert adapter.jsonb_values == [
+        checkpoint,
+        {"source": "input", "step": 0},
+    ]
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -159,7 +159,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -329,6 +329,10 @@ source = { editable = "." }
 dependencies = [
     { name = "langgraph-checkpoint" },
     { name = "orjson" },
+]
+
+[package.optional-dependencies]
+psycopg = [
     { name = "psycopg" },
     { name = "psycopg-pool" },
 ]
@@ -339,6 +343,7 @@ dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -355,6 +360,7 @@ test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -365,9 +371,10 @@ test = [
 requires-dist = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "orjson", specifier = ">=3.11.5" },
-    { name = "psycopg", specifier = ">=3.2.0" },
-    { name = "psycopg-pool", specifier = ">=3.2.0" },
+    { name = "psycopg", marker = "extra == 'psycopg'", specifier = ">=3.2.0" },
+    { name = "psycopg-pool", marker = "extra == 'psycopg'", specifier = ">=3.2.0" },
 ]
+provides-extras = ["psycopg"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -375,6 +382,7 @@ dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "psycopg", extras = ["binary"] },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -391,6 +399,7 @@ test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
     { name = "psycopg", extras = ["binary"] },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },


### PR DESCRIPTION
Fixes #7692

Add a pluggable sync/async driver-adapter boundary to Postgres checkpoint savers, retaining Psycopg as the default while allowing alternative drivers. Psycopg is now an optional extra.

## How did you verify this?

From `libs/checkpoint-postgres` (Docker required for Postgres):

```bash
make format
make lint
make test
```

The full suite passed on PostgreSQL 15 and 16: 220 passed, 3 skipped on each version.