### PR TITLE
fix: type annotation inconsistencies in NamedBarrierValue channels

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -21,7 +21,7 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
     def __init__(self, typ: type[Value], names: set[Value]) -> None:
         super().__init__(typ)
         self.names = names
-        self.seen: set[str] = set()
+        self.seen: set[Value] = set()
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, NamedBarrierValue) and value.names == self.names
@@ -90,11 +90,12 @@ class NamedBarrierValueAfterFinish(
 
     names: set[Value]
     seen: set[Value]
+    finished: bool
 
     def __init__(self, typ: type[Value], names: set[Value]) -> None:
         super().__init__(typ)
         self.names = names
-        self.seen: set[str] = set()
+        self.seen: set[Value] = set()
         self.finished = False
 
     def __eq__(self, value: object) -> bool:

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -437,7 +437,7 @@ def create_react_agent(
                 If `remaining_steps` is less than 2 and tool calls are present in the response,
                 the react agent will return a final AI Message with
                 the content "Sorry, need more steps to process this request.".
-                No `GraphRecusionError` will be raised in this case.
+                No `GraphRecursionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
         checkpointer: An optional checkpoint saver object. This is used for persisting


### PR DESCRIPTION
Addresses #8209

Fixes two type annotation issues in `NamedBarrierValue` and `NamedBarrierValueAfterFinish`:

1. `self.seen: set[str] = set()` → `self.seen: set[Value] = set()` (was incorrectly narrowed to `str`)
2. Added missing `finished: bool` class-level annotation on `NamedBarrierValueAfterFinish`