### PR TITLE
fix: avoid holding pipeline across async yield in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                yield cls(conn=conn, pipe=None, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
The `from_conn_string` context manager creates an `AsyncPipeline` and yields the checkpointer, but the pipeline remains open across the yield. When the user's code (e.g., an LLM call) runs after the context manager yields, the pipeline blocks other queries or times out, causing an SSL connection closed error.

## Fix
Remove the `async with conn.pipeline() as pipe:` from `from_conn_string`. Instead, the pipeline will be created internally in checkpoint operations when needed, ensuring it is not held open across user code.

Closes #5675