### PR TITLE
add serde support for PurePath and range

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -33,6 +33,7 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),
+        ("builtins", "range"),
         ("collections", "deque"),
         # ip addresses
         ("ipaddress", "IPv4Address"),
@@ -45,10 +46,16 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("pathlib", "Path"),
         ("pathlib", "PosixPath"),
         ("pathlib", "WindowsPath"),
+        ("pathlib", "PurePath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "PureWindowsPath"),
         # pathlib in Python 3.13+
         ("pathlib._local", "Path"),
         ("pathlib._local", "PosixPath"),
         ("pathlib._local", "WindowsPath"),
+        ("pathlib._local", "PurePath"),
+        ("pathlib._local", "PurePosixPath"),
+        ("pathlib._local", "PureWindowsPath"),
         # zoneinfo
         ("zoneinfo", "ZoneInfo"),
         # regex

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,7 +350,7 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
@@ -383,6 +383,17 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, tuple(obj)),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.start, obj.stop, obj.step),
+                ),
             ),
         )
     elif isinstance(obj, (IPv4Address, IPv4Interface, IPv4Network)):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -112,6 +112,9 @@ def test_serde_jsonplus() -> None:
 
     to_serialize = {
         "path": pathlib.Path("foo", "bar"),
+        "pure_posix_path": pathlib.PurePosixPath("foo", "bar"),
+        "pure_windows_path": pathlib.PureWindowsPath("foo", "bar"),
+        "range": range(0, 10, 2),
         "re": re.compile(r"foo", re.DOTALL),
         "decimal": Decimal("1.10101"),
         "set": {1, 2, frozenset({1, 2})},
@@ -216,6 +219,9 @@ def test_serde_jsonplus_json_mode() -> None:
 
     to_serialize = {
         "path": pathlib.Path("foo", "bar"),
+        "pure_posix_path": pathlib.PurePosixPath("foo", "bar"),
+        "pure_windows_path": pathlib.PureWindowsPath("foo", "bar"),
+        "range": range(0, 10, 2),
         "re": re.compile(r"foo", re.DOTALL),
         "decimal": Decimal("1.10101"),
         "set": {1, 2, frozenset({1, 2})},
@@ -268,6 +274,9 @@ def test_serde_jsonplus_json_mode() -> None:
 
     expected_result = {
         "path": ["foo", "bar"],
+        "pure_posix_path": ["foo", "bar"],
+        "pure_windows_path": ["foo", "bar"],
+        "range": [0, 10, 2],
         "re": ["foo", 48],
         "decimal": "1.10101",
         "set": [1, 2, [1, 2]],
@@ -321,6 +330,34 @@ def test_serde_jsonplus_json_mode() -> None:
         expected_result["my_secret_str_v1"] = "meow"
 
     assert result == expected_result
+
+
+def test_serde_jsonplus_range_and_purepath_strict(monkeypatch) -> None:
+    """range and pathlib PurePath variants must round-trip under strict msgpack mode.
+
+    Regression test for: https://github.com/langchain-ai/langgraph/issues/8231
+    (same root cause as #8185): ``_msgpack_default`` did not special-case ``range``,
+    and its ``pathlib.Path`` check excluded ``PurePosixPath``/``PureWindowsPath``
+    because they are not ``Path`` subclasses. Both are now in SAFE_MSGPACK_TYPES so
+    they deserialize even when ``LANGGRAPH_STRICT_MSGPACK=true``.
+    """
+    monkeypatch.setenv("LANGGRAPH_STRICT_MSGPACK", "true")
+
+    serde = JsonPlusSerializer()
+
+    values = [
+        range(0, 10, 2),
+        range(1, 20, 3),
+        range(5),
+        pathlib.PurePosixPath("/a/b"),
+        pathlib.PureWindowsPath("C:/x/y"),
+        pathlib.Path("/foo/bar"),
+    ]
+
+    for value in values:
+        restored = serde.loads_typed(serde.dumps_typed(value))
+        assert restored == value
+        assert type(restored) is type(value)
 
 
 def test_serde_jsonplus_bytes() -> None:


### PR DESCRIPTION
Broaden the existing `pathlib.Path` serializer to `pathlib.PurePath` so `PurePosixPath` and `PureWindowsPath` are also supported, and add serialization support for `range`. Register both in `SAFE_MSGPACK_TYPES` to enable round-trip serialization in strict msgpack mode, and add corresponding round-trip tests.

Fixes #8326
