### PR TITLE
fix(langgraph): prevent state channel aliasing via copy-on-write at update

### DIFF
--- a/libs/langgraph/langgraph/channels/any_value.py
+++ b/libs/langgraph/langgraph/channels/any_value.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any, Generic
 
@@ -14,7 +15,14 @@ __all__ = ("AnyValue",)
 
 class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
     """Stores the last value received, assumes that if multiple values are
-    received, they are all equal."""
+    received, they are all equal.
+
+    Note:
+        This channel performs a shallow copy of updates at the write boundary
+        to prevent caller-owned mutable inputs from directly becoming channel
+        storage. However, `get()` still returns a direct reference to the
+        channel's stored value, so mutating it in-place remains unsafe.
+    """
 
     __slots__ = ("typ", "value")
 
@@ -57,10 +65,16 @@ class AnyValue(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = MISSING
                 return True
 
-        self.value = values[-1]
+        self.value = copy.copy(values[-1])
         return True
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING:
             raise EmptyChannelError()
         return self.value

--- a/libs/langgraph/langgraph/channels/base.py
+++ b/libs/langgraph/langgraph/channels/base.py
@@ -70,6 +70,10 @@ class BaseChannel(Generic[Value, Update, Checkpoint], ABC):
     def get(self) -> Value:
         """Return the current value of the channel.
 
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+
         Raises `EmptyChannelError` if the channel is empty (never updated yet)."""
 
     def is_available(self) -> bool:

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -1,4 +1,5 @@
 import collections.abc
+import copy
 from collections.abc import Callable, Sequence
 from typing import Any, Generic
 
@@ -65,6 +66,13 @@ def _operators_equal(a: Callable, b: Callable) -> bool:
 class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     """Stores the result of applying a binary operator to the current value and each new value.
 
+    Note:
+        This channel performs a shallow copy of updates (initial values and
+        overwrites) at the write boundary to prevent caller-owned mutable inputs
+        from directly becoming channel storage. However, `get()` still returns
+        a direct reference to the channel's stored value, so mutating it in-place
+        remains unsafe.
+
     ```python
     import operator
 
@@ -124,7 +132,7 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
         if not values:
             return False
         if self.value is MISSING:
-            self.value = values[0]
+            self.value = copy.copy(values[0])
             values = values[1:]
         seen_overwrite: bool = False
         for value in values:
@@ -136,7 +144,7 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                         error_code=ErrorCode.INVALID_CONCURRENT_GRAPH_UPDATE,
                     )
                     raise InvalidUpdateError(msg)
-                self.value = overwrite_value
+                self.value = copy.copy(overwrite_value)
                 seen_overwrite = True
                 continue
             if not seen_overwrite:
@@ -144,6 +152,12 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
         return True
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING:
             raise EmptyChannelError()
         return self.value

--- a/libs/langgraph/langgraph/channels/ephemeral_value.py
+++ b/libs/langgraph/langgraph/channels/ephemeral_value.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any, Generic
 
@@ -13,7 +14,14 @@ __all__ = ("EphemeralValue",)
 
 
 class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
-    """Stores the value received in the step immediately preceding, clears after."""
+    """Stores the value received in the step immediately preceding, clears after.
+
+    Note:
+        This channel performs a shallow copy of updates at the write boundary
+        to prevent caller-owned mutable inputs from directly becoming channel
+        storage. However, `get()` still returns a direct reference to the
+        channel's stored value, so mutating it in-place remains unsafe.
+    """
 
     __slots__ = ("value", "guard")
 
@@ -64,10 +72,16 @@ class EphemeralValue(Generic[Value], BaseChannel[Value, Value, Value]):
                 f"At key '{self.key}': EphemeralValue(guard=True) can receive only one value per step. Use guard=False if you want to store any one of multiple values."
             )
 
-        self.value = values[-1]
+        self.value = copy.copy(values[-1])
         return True
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING:
             raise EmptyChannelError()
         return self.value

--- a/libs/langgraph/langgraph/channels/last_value.py
+++ b/libs/langgraph/langgraph/channels/last_value.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any, Generic
 
@@ -18,7 +19,14 @@ __all__ = ("LastValue", "LastValueAfterFinish")
 
 
 class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
-    """Stores the last value received, can receive at most one value per step."""
+    """Stores the last value received, can receive at most one value per step.
+
+    Note:
+        This channel performs a shallow copy of updates at the write boundary
+        to prevent caller-owned mutable inputs from directly becoming channel
+        storage. However, `get()` still returns a direct reference to the
+        channel's stored value, so mutating it in-place remains unsafe.
+    """
 
     __slots__ = ("value",)
 
@@ -63,10 +71,16 @@ class LastValue(Generic[Value], BaseChannel[Value, Value, Value]):
             )
             raise InvalidUpdateError(msg)
 
-        self.value = values[-1]
+        self.value = copy.copy(values[-1])
         return True
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING:
             raise EmptyChannelError()
         return self.value
@@ -82,7 +96,14 @@ class LastValueAfterFinish(
     Generic[Value], BaseChannel[Value, Value, tuple[Value, bool]]
 ):
     """Stores the last value received, but only made available after finish().
-    Once made available, clears the value."""
+    Once made available, clears the value.
+
+    Note:
+        This channel performs a shallow copy of updates at the write boundary
+        to prevent caller-owned mutable inputs from directly becoming channel
+        storage. However, `get()` still returns a direct reference to the
+        channel's stored value, so mutating it in-place remains unsafe.
+    """
 
     __slots__ = ("value", "finished")
 
@@ -124,7 +145,7 @@ class LastValueAfterFinish(
             return False
 
         self.finished = False
-        self.value = values[-1]
+        self.value = copy.copy(values[-1])
         return True
 
     def consume(self) -> bool:
@@ -143,6 +164,12 @@ class LastValueAfterFinish(
             return False
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING or not self.finished:
             raise EmptyChannelError()
         return self.value

--- a/libs/langgraph/langgraph/channels/untracked_value.py
+++ b/libs/langgraph/langgraph/channels/untracked_value.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Sequence
 from typing import Any, Generic
 
@@ -13,7 +14,14 @@ __all__ = ("UntrackedValue",)
 
 
 class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
-    """Stores the last value received, never checkpointed."""
+    """Stores the last value received, never checkpointed.
+
+    Note:
+        This channel performs a shallow copy of updates at the write boundary
+        to prevent caller-owned mutable inputs from directly becoming channel
+        storage. However, `get()` still returns a direct reference to the
+        channel's stored value, so mutating it in-place remains unsafe.
+    """
 
     __slots__ = ("value", "guard")
 
@@ -61,10 +69,16 @@ class UntrackedValue(Generic[Value], BaseChannel[Value, Value, Value]):
                 f"At key '{self.key}': UntrackedValue(guard=True) can receive only one value per step. Use guard=False if you want to store any one of multiple values."
             )
 
-        self.value = values[-1]
+        self.value = copy.copy(values[-1])
         return True
 
     def get(self) -> Value:
+        """Return the current value of the channel.
+
+        Note:
+            This returns a reference to the stored value. Mutating the returned
+            value in-place is unsafe because it will mutate the channel's internal state.
+        """
         if self.value is MISSING:
             raise EmptyChannelError()
         return self.value

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -4,8 +4,6 @@ from typing import Annotated
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage
-from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from typing_extensions import NotRequired, TypedDict
 
 from langgraph._internal._typing import MISSING
@@ -14,6 +12,8 @@ from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
 from langgraph.graph import START, StateGraph
 from langgraph.graph.message import _messages_delta_reducer
@@ -801,3 +801,138 @@ def test_delta_channel_from_checkpoint_seed_none_is_distinct_from_sentinel() -> 
     ch = spec.from_checkpoint(None)
     ch.replay_writes([("t0", "x", "after")])
     assert ch.get() == "after"
+
+
+def test_channel_aliasing_last_value() -> None:
+    from langgraph.channels.last_value import LastValue
+
+    # LastValue
+    chan = LastValue(list).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    # Modify original
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_last_value_after_finish() -> None:
+    from langgraph.channels.last_value import LastValueAfterFinish
+
+    # LastValueAfterFinish
+    chan = LastValueAfterFinish(list).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    chan.finish()
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    # Modify original
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_binop() -> None:
+    from langgraph.channels.binop import BinaryOperatorAggregate
+
+    # BinaryOperatorAggregate
+    chan = BinaryOperatorAggregate(list, operator.add).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_any_value() -> None:
+    from langgraph.channels.any_value import AnyValue
+
+    chan = AnyValue(list).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_ephemeral_value() -> None:
+    from langgraph.channels.ephemeral_value import EphemeralValue
+
+    chan = EphemeralValue(list).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_untracked_value() -> None:
+    from langgraph.channels.untracked_value import UntrackedValue
+
+    chan = UntrackedValue(list).from_checkpoint(MISSING)
+    original = [1, 2]
+    chan.update([original])
+    assert chan.get() is not original
+    assert chan.get() == original
+
+    original.append(3)
+    assert chan.get() == [1, 2]
+
+
+def test_channel_aliasing_integration() -> None:
+    from langgraph.graph import END, START, StateGraph
+
+    class State(TypedDict):
+        items: list
+
+    def node_a(state: State) -> dict:
+        return {}
+
+    def router(state: State) -> str:
+        items = state["items"]
+        items.append("MUTATED_BY_ROUTER")
+        return "b"
+
+    def node_b(state: State) -> dict:
+        return {}
+
+    builder = StateGraph(State)
+    builder.add_node("a", node_a)
+    builder.add_node("b", node_b)
+    builder.add_edge(START, "a")
+    builder.add_conditional_edges("a", router, {"b": "b", "__end__": END})
+    builder.add_edge("b", END)
+    graph = builder.compile()
+
+    original = ["x", "y"]
+    result = graph.invoke({"items": original})
+
+    # Verify that the caller's input list was NOT mutated
+    assert original == ["x", "y"]
+    # The channel itself holds the mutated value because router mutated the returned view,
+    # which is expected since read-side in-place mutation remains unsafe (as documented).
+    assert result["items"] == ["x", "y", "MUTATED_BY_ROUTER"]
+
+    # Plain node mutation leak case
+    def mutating_node(state: State) -> dict:
+        state["items"].append("MUTATED_BY_NODE")
+        return {}
+
+    builder2 = StateGraph(State)
+    builder2.add_node("mutating", mutating_node)
+    builder2.add_edge(START, "mutating")
+    builder2.add_edge("mutating", END)
+    graph2 = builder2.compile()
+
+    original_2 = ["x", "y"]
+    result_2 = graph2.invoke({"items": original_2})
+    assert original_2 == ["x", "y"]
+    assert result_2["items"] == ["x", "y", "MUTATED_BY_NODE"]

--- a/libs/prebuilt/langgraph/prebuilt/interrupt.py
+++ b/libs/prebuilt/langgraph/prebuilt/interrupt.py
@@ -1,7 +1,8 @@
 from typing import Literal
 
+from typing_extensions import NotRequired, TypedDict, deprecated
+
 from langgraph.warnings import LangGraphDeprecatedSinceV10
-from typing_extensions import TypedDict, deprecated
 
 
 @deprecated(
@@ -38,10 +39,14 @@ class ActionRequest(TypedDict):
     Attributes:
         action: The type or name of action being requested (e.g., `"Approve XYZ action"`)
         args: Key-value pairs of arguments needed for the action
+        tool_call_id: Optional originating tool call ID when the interrupt is
+            produced by a tool call, allowing the consumer to correlate the
+            approval artifact back to the specific call in message history.
     """
 
     action: str
     args: dict
+    tool_call_id: NotRequired[str | None]
 
 
 @deprecated(

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -2154,3 +2154,75 @@ def test_create_react_agent_inject_vars_with_post_model_hook(
         AIMessage("hi-hi-6", id="1"),
     ]
     assert result["foo"] == 2
+
+
+@pytest.mark.parametrize("version", REACT_TOOL_CALL_VERSIONS)
+def test_action_request_carries_tool_call_id(
+    sync_checkpointer: BaseCheckpointSaver,
+    version: Literal["v1", "v2"],
+) -> None:
+    """ActionRequest should carry the originating tool_call_id so that
+    external HITL consumers can correlate the interrupt back to the
+    specific tool call in message history without out-of-band recovery."""
+
+    @dec_tool
+    def ask_human(question: str, tool_call_id: Annotated[str, InjectedToolCallId]):
+        """Ask a human a question."""
+        from langgraph.prebuilt.interrupt import HumanInterrupt
+
+        request: HumanInterrupt = {
+            "action_request": {
+                "action": "human_approval",
+                "args": {"question": question},
+                "tool_call_id": tool_call_id,
+            },
+            "config": {
+                "allow_ignore": True,
+                "allow_respond": True,
+                "allow_edit": False,
+                "allow_accept": True,
+            },
+            "description": question,
+        }
+        response = interrupt([request])[0]
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"Human responded: {response}",
+                        tool_call_id=tool_call_id,
+                    )
+                ],
+            }
+        )
+
+    tool_calls = [
+        [{"args": {"question": "Is this OK?"}, "id": "call_42", "name": "ask_human"}]
+    ]
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    agent = create_react_agent(
+        model,
+        [ask_human],
+        checkpointer=sync_checkpointer,
+        version=version,
+    )
+    config = {"configurable": {"thread_id": "test_tool_call_id"}}
+    # Run until interrupted
+    agent.invoke({"messages": [("user", "approve this")]}, config)
+
+    # Verify the interrupt payload carries the tool_call_id
+    state = agent.get_state(config)
+    task = state.tasks[0]
+    interrupts = task.interrupts
+    assert len(interrupts) == 1
+    payload = interrupts[0].value
+    assert isinstance(payload, list)
+    action_request = payload[0]["action_request"]
+    assert action_request["tool_call_id"] == "call_42"
+    assert action_request["action"] == "human_approval"
+
+    # Resume and verify the tool_call_id round-trips correctly
+    result = agent.invoke(Command(resume="yes"), config)
+    tool_message = result["messages"][-2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.tool_call_id == "call_42"


### PR DESCRIPTION
Establish write-side boundaries to ensure that caller-owned mutable inputs do not directly become channel storage (closing #8314).

Note: esult['items'] still reflects in-place mutations made by nodes/routers after reading — this is expected and documented as a separate, still-open read-side issue. This PR only closes the write-side aliasing (caller/cross-run object leakage).