### PR TITLE
fix: synchronize pipeline after setup migrations to prevent SSL errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -113,7 +113,9 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
-        if self.pipe:
+            # If using pipeline, synchronize after all migrations to avoid SSL issues
+            if self.pipe:
+                await self.pipe.sync()
             await self.pipe.sync()
 
     async def alist(


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, calling `setup()` causes a `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This happens because pipeline mode defers sending queued commands, and if the connection is reused after setup without explicit synchronization, the pipeline may try to send commands after the connection has been closed or interrupted.

## Fix
Add an explicit `await self.pipe.sync()` call at the end of the `setup()` method to ensure all queued migration commands are flushed and the pipeline state is synchronized before the cursor is closed. This prevents the SSL disconnection error by ensuring the pipeline is properly drained.

Closes #5675