### PR TITLE
fix(checkpoint): add range and PurePath serialization support

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -41,14 +41,22 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("ipaddress", "IPv6Address"),
         ("ipaddress", "IPv6Interface"),
         ("ipaddress", "IPv6Network"),
-        # pathlib
+        # pathlib (concrete + pure variants)
         ("pathlib", "Path"),
         ("pathlib", "PosixPath"),
         ("pathlib", "WindowsPath"),
+        ("pathlib", "PurePath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "PureWindowsPath"),
         # pathlib in Python 3.13+
         ("pathlib._local", "Path"),
         ("pathlib._local", "PosixPath"),
         ("pathlib._local", "WindowsPath"),
+        ("pathlib._local", "PurePath"),
+        ("pathlib._local", "PurePosixPath"),
+        ("pathlib._local", "PureWindowsPath"),
+        # builtins
+        ("builtins", "range"),
         # zoneinfo
         ("zoneinfo", "ZoneInfo"),
         # regex

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,7 +350,7 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
@@ -528,6 +528,13 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             meta = (obj.dtype.str, obj.shape, order, buf)
             return ormsgpack.Ext(EXT_NUMPY_ARRAY, _msgpack_enc(meta))
 
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "range", (obj.start, obj.stop, obj.step)),
+            ),
+        )
     elif isinstance(obj, BaseException):
         return repr(obj)
     else:


### PR DESCRIPTION
## Summary

Fixes #8326. Same root cause as #8185 (Fraction/complex missed types).

`JsonPlusSerializer` in `libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py`
does not handle two families of Python stdlib types:

1. **`range`** — no handler at all, raises `TypeError: Type is not msgpack serializable: range`.
2. **`PurePath` variants** — `PurePosixPath` / `PureWindowsPath` inherit from `pathlib.PurePath`
   but NOT from `pathlib.Path`, so the existing `isinstance(obj, pathlib.Path)` guard misses them.

These types are valid state values (e.g. `range(0, 10)` as a loop bound, `PurePosixPath`
as a portable file reference) and their presence in a checkpoint causes serialization to crash
instead of round-tripping cleanly.

## Fix

### `jsonplus.py`

1. Broaden the `pathlib.Path` check to `pathlib.PurePath`:
   ```python
   # Before:
   elif isinstance(obj, pathlib.Path):
   # After:
   elif isinstance(obj, pathlib.PurePath):
   ```
   This handles `PurePosixPath`, `PureWindowsPath`, `PurePath`, **and** all concrete
   subclasses — the existing encode/decode logic (`obj.parts` → `classname(*parts)`)
   works identically for all of them.

2. Add a `range` handler before the `BaseException` catch-all:
   ```python
   elif isinstance(obj, range):
       return ormsgpack.Ext(
           EXT_CONSTRUCTOR_POS_ARGS,
           _msgpack_enc(
               ("builtins", "range", (obj.start, obj.stop, obj.step)),
           ),
       )
   ```
   Deserializes as `builtins.range(start, stop, step)`, which faithfully reproduces
   `range(0, 10, 2)` → `range(0, 10, 2)`.

### `_msgpack.py`

Add the new types to `SAFE_MSGPACK_TYPES` so they round-trip correctly when
`LANGGRAPH_STRICT_MSGPACK=true` is set:
- `("pathlib", "PurePath")`, `("pathlib", "PurePosixPath")`, `("pathlib", "PureWindowsPath")`
- Same three entries for `pathlib._local` (Python 3.13+)
- `("builtins", "range")`

## Reproduction (from the issue)

```python
from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
import pathlib

s = JsonPlusSerializer()

# Previously: TypeError: Type is not msgpack serializable: range
assert s.loads_typed(s.dumps_typed(range(0, 10, 2))) == range(0, 10, 2)

# Previously: TypeError: Type is not msgpack serializable: PurePosixPath
p = pathlib.PurePosixPath("/a/b")
assert s.loads_typed(s.dumps_typed(p)) == p
```

Closes #8326.
