### PR TITLE
fix(langgraph): stop subgraph nodes from re-running reducers on untouched keys

### DIFF
--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -63,6 +63,12 @@ CONFIG_KEY_TIMED_ATTEMPT_OBSERVER = sys.intern("__pregel_timed_attempt_observer"
 # holds a callback to be called when an idle-timed node attempt starts or finishes
 CONFIG_KEY_SCRATCHPAD = sys.intern("__pregel_scratchpad")
 # holds a mutable dict for temporary storage scoped to the current task
+CONFIG_KEY_DELTA_CHANNELS = sys.intern("__pregel_delta_channels")
+# internal only: when present in a nested run's config, holds a `set[str]`
+# that the loop fills in with channels genuinely written during that run
+# (excluding the initial input-seed step). Used by subgraph-node invocation
+# to avoid echoing untouched, merely-seeded keys back to the parent as
+# writes, which would otherwise re-trigger their reducers on every call.
 CONFIG_KEY_RUNNER_SUBMIT = sys.intern("__pregel_runner_submit")
 # holds a function that receives tasks from runner, executes them and returns results
 CONFIG_KEY_DURABILITY = sys.intern("__pregel_durability")

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -33,7 +33,9 @@ from pydantic import BaseModel, TypeAdapter
 from typing_extensions import NotRequired, Required, Self, Unpack, is_typeddict
 
 from langgraph._internal import _serde
+from langgraph._internal._config import patch_config
 from langgraph._internal._constants import (
+    CONFIG_KEY_DELTA_CHANNELS,
     INTERRUPT,
     NS_END,
     NS_SEP,
@@ -45,7 +47,7 @@ from langgraph._internal._fields import (
     get_update_as_tuples,
 )
 from langgraph._internal._pydantic import create_model
-from langgraph._internal._runnable import coerce_to_runnable
+from langgraph._internal._runnable import RunnableCallable, coerce_to_runnable
 from langgraph._internal._timeout import coerce_timeout_policy
 from langgraph._internal._typing import EMPTY_SEQ, MISSING, DeprecatedKwargs
 from langgraph.channels.base import BaseChannel
@@ -72,6 +74,7 @@ from langgraph.managed.base import (
 )
 from langgraph.pregel import Pregel
 from langgraph.pregel._read import ChannelRead, PregelNode
+from langgraph.pregel._utils import find_subgraph_pregel
 from langgraph.pregel._write import (
     ChannelWrite,
     ChannelWriteEntry,
@@ -1388,6 +1391,64 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         return compiled.validate()
 
 
+class _SubgraphNodeRunnable(RunnableCallable):
+    """Wraps a compiled subgraph that is used directly as a node's action.
+
+    A compiled graph's `invoke` always returns every key in its output
+    schema, including keys that were only seeded from the parent's state
+    and that none of its own nodes actually wrote to during this call. For
+    a plain last value key this is harmless, since writing the same value
+    again is a no op. But for a key with a custom reducer (declared with
+    `Annotated[T, reducer]`, backed by a `BinaryOperatorAggregate` channel)
+    it is not: the reducer runs again on a value it never actually produced,
+    which for a reducer like a counter can silently double count. See
+    https://github.com/langchain-ai/langgraph/issues/6290.
+
+    Each call here is tagged with `CONFIG_KEY_DELTA_CHANNELS`, a fresh set
+    that the subgraph's own loop fills in with the channels it genuinely
+    wrote to. Only `BinaryOperatorAggregate` keyed output that is not in
+    that set gets dropped before the writers see it; every other key is
+    passed through unchanged, the same as before this wrapper existed.
+    """
+
+    def __init__(self, bound: Runnable) -> None:
+        self.subgraph_bound = bound
+        self.subgraph_reducer_channels = frozenset(
+            key
+            for key, channel in getattr(bound, "channels", {}).items()
+            if isinstance(channel, BinaryOperatorAggregate)
+        )
+        super().__init__(self._invoke, self._ainvoke, name=None, trace=False)
+
+    def get_name(self, suffix: str | None = None, *, name: str | None = None) -> str:
+        return self.subgraph_bound.get_name(suffix, name=name)
+
+    def _filter(self, output: Any, delta: set[str]) -> Any:
+        if not isinstance(output, dict):
+            return output
+        return {
+            k: v
+            for k, v in output.items()
+            if k in delta or k not in self.subgraph_reducer_channels
+        }
+
+    def _invoke(self, input: Any, config: RunnableConfig) -> Any:
+        delta: set[str] = set()
+        output = self.subgraph_bound.invoke(
+            input,
+            patch_config(config, configurable={CONFIG_KEY_DELTA_CHANNELS: delta}),
+        )
+        return self._filter(output, delta)
+
+    async def _ainvoke(self, input: Any, config: RunnableConfig) -> Any:
+        delta: set[str] = set()
+        output = await self.subgraph_bound.ainvoke(
+            input,
+            patch_config(config, configurable={CONFIG_KEY_DELTA_CHANNELS: delta}),
+        )
+        return self._filter(output, delta)
+
+
 class CompiledStateGraph(
     Pregel[StateT, ContextT, InputT, OutputT],
     Generic[StateT, ContextT, InputT, OutputT],
@@ -1515,6 +1576,18 @@ class CompiledStateGraph(
                 if node.defer
                 else EphemeralValue(Any, guard=False)
             )
+            # a node whose action is directly a compiled subgraph gets its
+            # bound runnable wrapped so its output only carries the channels
+            # it actually wrote, not its whole output schema (issue #6290).
+            # subgraphs=[subgraph] is passed explicitly below because
+            # PregelNode's own auto detection would otherwise look at the
+            # wrapper instead of the real subgraph.
+            subgraph = find_subgraph_pregel(node.runnable, deep=False)
+            bound: Runnable = (
+                _SubgraphNodeRunnable(node.runnable)
+                if subgraph is not None
+                else node.runnable
+            )
             self.nodes[key] = PregelNode(
                 triggers=[branch_channel],
                 # read state keys and managed values
@@ -1528,7 +1601,8 @@ class CompiledStateGraph(
                 cache_policy=node.cache_policy,
                 is_error_handler=node.is_error_handler,
                 error_handler_node=node.error_handler_node,
-                bound=node.runnable,  # type: ignore[arg-type]
+                bound=bound,  # type: ignore[arg-type]
+                subgraphs=[subgraph] if subgraph is not None else None,
                 timeout=node.timeout,
             )
         else:

--- a/libs/langgraph/langgraph/pregel/_draw.py
+++ b/libs/langgraph/langgraph/pregel/_draw.py
@@ -228,7 +228,18 @@ def draw_graph(
             metadata["__interrupt"] = "before"
         elif name in interrupt_after_nodes:
             metadata["__interrupt"] = "after"
-        graph.add_node(node.bound, name, metadata=metadata or None)
+        # a node's `bound` may be a thin wrapper around its actual subgraph
+        # (see `_SubgraphNodeRunnable` in `langgraph.graph.state`, used when
+        # a compiled subgraph is directly a node's action), in which case
+        # the subgraph itself, not the wrapper, is what should show up in
+        # the drawn graph. Checked by attribute rather than isinstance to
+        # avoid importing `langgraph.graph.state` here, which would create
+        # a circular import.
+        graph.add_node(
+            getattr(node.bound, "subgraph_bound", None) or node.bound,
+            name,
+            metadata=metadata or None,
+        )
     # add start node
     if START not in nodes:
         graph.add_node(None, START)

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_DELTA_CHANNELS,
     CONFIG_KEY_REPLAY_STATE,
     CONFIG_KEY_RESUME_MAP,
     CONFIG_KEY_RESUMING,
@@ -312,6 +313,9 @@ class PregelLoop:
         self.interrupt_before = interrupt_before
         self.manager = manager
         self.is_nested = CONFIG_KEY_TASK_ID in self.config.get(CONF, {})
+        self._delta_channels_sink: set[str] | None = self.config.get(CONF, {}).get(
+            CONFIG_KEY_DELTA_CHANNELS
+        )
         self.is_replaying = CONFIG_KEY_CHECKPOINT_ID in config[CONF]
         self._migrate_checkpoint = migrate_checkpoint
         self.trigger_to_nodes = trigger_to_nodes
@@ -696,6 +700,8 @@ class PregelLoop:
             self.checkpointer_get_next_version,
             self.trigger_to_nodes,
         )
+        if self._delta_channels_sink is not None:
+            self._delta_channels_sink.update(self.updated_channels)
         # produce values output
         if not self.updated_channels.isdisjoint(
             (self.output_keys,)

--- a/libs/langgraph/langgraph/pregel/_utils.py
+++ b/libs/langgraph/langgraph/pregel/_utils.py
@@ -44,17 +44,33 @@ def get_new_channel_versions(
     return new_versions
 
 
-def find_subgraph_pregel(candidate: Runnable) -> PregelProtocol | None:
+def find_subgraph_pregel(
+    candidate: Runnable, *, deep: bool = True
+) -> PregelProtocol | None:
+    """Find a `Pregel`-like runnable reachable from `candidate`.
+
+    When `deep` is `False`, only `candidate` itself is tested - the search
+    does not unwrap sequences, lambdas, or nonlocals of a plain callable.
+    Callers that need a guarantee that a subgraph they find is the runnable
+    actually invoked (e.g. to inject config into its call) should use
+    `deep=False`, since the deep search may find a subgraph buried inside a
+    user-authored function that is not guaranteed to receive injected config.
+    """
     from langgraph.pregel import Pregel
+
+    def _is_subgraph(c: Runnable) -> bool:
+        return isinstance(c, PregelProtocol) and (
+            # subgraphs that disabled checkpointing are not considered
+            not isinstance(c, Pregel) or c.checkpointer is not False
+        )
+
+    if not deep:
+        return candidate if _is_subgraph(candidate) else None
 
     candidates: list[Runnable] = [candidate]
 
     for c in candidates:
-        if (
-            isinstance(c, PregelProtocol)
-            # subgraphs that disabled checkpointing are not considered
-            and (not isinstance(c, Pregel) or c.checkpointer is not False)
-        ):
+        if _is_subgraph(c):
             return c
         elif isinstance(c, RunnableSequence) or isinstance(c, RunnableSeq):
             candidates.extend(c.steps)

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -6506,6 +6506,196 @@ def test_multiple_subgraphs(sync_checkpointer: BaseCheckpointSaver) -> None:
     }
 
 
+def test_subgraph_node_reducer_only_writes_on_real_change() -> None:
+    """A shared reducer key should only update from a subgraph node that
+    actually writes it, not from a sibling subgraph that merely echoes it
+    back unchanged. Regression test for
+    https://github.com/langchain-ai/langgraph/issues/6290.
+    """
+
+    def bump_on_flag(count: int, is_increment: bool) -> int:
+        return count + 1 if is_increment else count
+
+    class State(TypedDict):
+        retry_count: Annotated[int, bump_on_flag]
+        max_retry: int
+
+    def noop_node(state: State) -> dict:
+        return {}
+
+    subgraph_1 = (
+        StateGraph(State).add_node("noop", noop_node).add_edge(START, "noop")
+    ).compile()
+
+    def bump_node(state: State) -> dict:
+        return {"retry_count": True}
+
+    subgraph_2 = (
+        StateGraph(State).add_node("bump", bump_node).add_edge(START, "bump")
+    ).compile()
+
+    def should_continue(state: State) -> str:
+        return END if state["retry_count"] >= state["max_retry"] else "subgraph_1"
+
+    parent = (
+        StateGraph(State)
+        .add_node("subgraph_1", subgraph_1)
+        .add_node("subgraph_2", subgraph_2)
+        .add_edge(START, "subgraph_1")
+        .add_edge("subgraph_1", "subgraph_2")
+        .add_conditional_edges("subgraph_2", should_continue, ["subgraph_1", END])
+        .compile()
+    )
+
+    result = parent.invoke({"retry_count": 0, "max_retry": 3})
+    assert result["retry_count"] == 3
+
+
+def test_subgraph_node_output_excludes_untouched_shared_keys() -> None:
+    """A subgraph node's output should only carry the channels its own nodes
+    wrote to during that call, not every key in its schema. Both `a` and `b`
+    are plain last-value keys here, so the expected output is a simple
+    overwrite, not an accumulation.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: str
+
+    def write_a_only(state: State) -> dict:
+        return {"a": state["a"] + 1}
+
+    subgraph = (
+        StateGraph(State).add_node("write_a", write_a_only).add_edge(START, "write_a")
+    ).compile()
+
+    parent = (
+        StateGraph(State).add_node("sub", subgraph).add_edge(START, "sub").compile()
+    )
+
+    result = parent.invoke({"a": 0, "b": "initial"})
+    assert result == {"a": 1, "b": "initial"}
+
+    # a second, independent invocation of the same compiled parent should
+    # not carry over stray writes from a leaked delta set on the wrapper.
+    result_again = parent.invoke({"a": 10, "b": "other"})
+    assert result_again == {"a": 11, "b": "other"}
+
+
+def test_subgraph_node_no_shared_keys_unaffected() -> None:
+    """Subgraphs with an output schema disjoint from other parent keys keep
+    working as before; the delta filtering does not drop legitimate output.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: int
+
+    class Output(TypedDict):
+        result: int
+
+    def add(state: State) -> dict:
+        return {"result": state["a"] + state["b"]}
+
+    add_subgraph = (
+        StateGraph(State, output_schema=Output)
+        .add_node(add)
+        .add_edge(START, "add")
+        .compile()
+    )
+
+    parent = (
+        StateGraph(State, output_schema=Output)
+        .add_node("add_subgraph", add_subgraph)
+        .add_edge(START, "add_subgraph")
+        .compile()
+    )
+
+    assert parent.invoke({"a": 2, "b": 3}) == {"result": 5}
+
+
+def test_subgraph_node_full_write_when_all_keys_touched() -> None:
+    """A subgraph node that legitimately writes every output key on every
+    call keeps propagating all of them; the delta filter only drops keys
+    that were never actually written.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: int
+
+    def write_both(state: State) -> dict:
+        return {"a": state["a"] + 1, "b": state["b"] + 1}
+
+    subgraph = (
+        StateGraph(State)
+        .add_node("write_both", write_both)
+        .add_edge(START, "write_both")
+    ).compile()
+
+    parent = (
+        StateGraph(State).add_node("sub", subgraph).add_edge(START, "sub").compile()
+    )
+
+    assert parent.invoke({"a": 1, "b": 1}) == {"a": 2, "b": 2}
+
+
+def test_doubly_nested_subgraph_node_reducer_only_writes_on_real_change() -> None:
+    """The same untouched-key echo bug, one level deeper: a subgraph node
+    that itself contains a subgraph node should still only propagate real
+    writes up through each level.
+    """
+
+    def bump_on_flag(count: int, is_increment: bool) -> int:
+        return count + 1 if is_increment else count
+
+    class State(TypedDict):
+        retry_count: Annotated[int, bump_on_flag]
+        max_retry: int
+
+    def noop_node(state: State) -> dict:
+        return {}
+
+    inner_noop = (
+        StateGraph(State).add_node("noop", noop_node).add_edge(START, "noop")
+    ).compile()
+
+    subgraph_1 = (
+        StateGraph(State)
+        .add_node("inner_noop", inner_noop)
+        .add_edge(START, "inner_noop")
+    ).compile()
+
+    def bump_node(state: State) -> dict:
+        return {"retry_count": True}
+
+    inner_bump = (
+        StateGraph(State).add_node("bump", bump_node).add_edge(START, "bump")
+    ).compile()
+
+    subgraph_2 = (
+        StateGraph(State)
+        .add_node("inner_bump", inner_bump)
+        .add_edge(START, "inner_bump")
+    ).compile()
+
+    def should_continue(state: State) -> str:
+        return END if state["retry_count"] >= state["max_retry"] else "subgraph_1"
+
+    parent = (
+        StateGraph(State)
+        .add_node("subgraph_1", subgraph_1)
+        .add_node("subgraph_2", subgraph_2)
+        .add_edge(START, "subgraph_1")
+        .add_edge("subgraph_1", "subgraph_2")
+        .add_conditional_edges("subgraph_2", should_continue, ["subgraph_1", END])
+        .compile()
+    )
+
+    result = parent.invoke({"retry_count": 0, "max_retry": 3})
+    assert result["retry_count"] == 3
+
+
 def test_multiple_subgraphs_functional(sync_checkpointer: BaseCheckpointSaver) -> None:
     # Define addition subgraph
     @entrypoint()

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -7078,6 +7078,196 @@ async def test_multiple_subgraphs(async_checkpointer: BaseCheckpointSaver) -> No
     }
 
 
+async def test_subgraph_node_reducer_only_writes_on_real_change() -> None:
+    """A shared reducer key should only update from a subgraph node that
+    actually writes it, not from a sibling subgraph that merely echoes it
+    back unchanged. Regression test for
+    https://github.com/langchain-ai/langgraph/issues/6290.
+    """
+
+    def bump_on_flag(count: int, is_increment: bool) -> int:
+        return count + 1 if is_increment else count
+
+    class State(TypedDict):
+        retry_count: Annotated[int, bump_on_flag]
+        max_retry: int
+
+    async def noop_node(state: State) -> dict:
+        return {}
+
+    subgraph_1 = (
+        StateGraph(State).add_node("noop", noop_node).add_edge(START, "noop")
+    ).compile()
+
+    async def bump_node(state: State) -> dict:
+        return {"retry_count": True}
+
+    subgraph_2 = (
+        StateGraph(State).add_node("bump", bump_node).add_edge(START, "bump")
+    ).compile()
+
+    def should_continue(state: State) -> str:
+        return END if state["retry_count"] >= state["max_retry"] else "subgraph_1"
+
+    parent = (
+        StateGraph(State)
+        .add_node("subgraph_1", subgraph_1)
+        .add_node("subgraph_2", subgraph_2)
+        .add_edge(START, "subgraph_1")
+        .add_edge("subgraph_1", "subgraph_2")
+        .add_conditional_edges("subgraph_2", should_continue, ["subgraph_1", END])
+        .compile()
+    )
+
+    result = await parent.ainvoke({"retry_count": 0, "max_retry": 3})
+    assert result["retry_count"] == 3
+
+
+async def test_subgraph_node_output_excludes_untouched_shared_keys() -> None:
+    """A subgraph node's output should only carry the channels its own nodes
+    wrote to during that call, not every key in its schema. Both `a` and `b`
+    are plain last-value keys here, so the expected output is a simple
+    overwrite, not an accumulation.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: str
+
+    async def write_a_only(state: State) -> dict:
+        return {"a": state["a"] + 1}
+
+    subgraph = (
+        StateGraph(State).add_node("write_a", write_a_only).add_edge(START, "write_a")
+    ).compile()
+
+    parent = (
+        StateGraph(State).add_node("sub", subgraph).add_edge(START, "sub").compile()
+    )
+
+    result = await parent.ainvoke({"a": 0, "b": "initial"})
+    assert result == {"a": 1, "b": "initial"}
+
+    # a second, independent invocation of the same compiled parent should
+    # not carry over stray writes from a leaked delta set on the wrapper.
+    result_again = await parent.ainvoke({"a": 10, "b": "other"})
+    assert result_again == {"a": 11, "b": "other"}
+
+
+async def test_subgraph_node_no_shared_keys_unaffected() -> None:
+    """Subgraphs with an output schema disjoint from other parent keys keep
+    working as before; the delta filtering does not drop legitimate output.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: int
+
+    class Output(TypedDict):
+        result: int
+
+    async def add(state: State) -> dict:
+        return {"result": state["a"] + state["b"]}
+
+    add_subgraph = (
+        StateGraph(State, output_schema=Output)
+        .add_node(add)
+        .add_edge(START, "add")
+        .compile()
+    )
+
+    parent = (
+        StateGraph(State, output_schema=Output)
+        .add_node("add_subgraph", add_subgraph)
+        .add_edge(START, "add_subgraph")
+        .compile()
+    )
+
+    assert await parent.ainvoke({"a": 2, "b": 3}) == {"result": 5}
+
+
+async def test_subgraph_node_full_write_when_all_keys_touched() -> None:
+    """A subgraph node that legitimately writes every output key on every
+    call keeps propagating all of them; the delta filter only drops keys
+    that were never actually written.
+    """
+
+    class State(TypedDict):
+        a: int
+        b: int
+
+    async def write_both(state: State) -> dict:
+        return {"a": state["a"] + 1, "b": state["b"] + 1}
+
+    subgraph = (
+        StateGraph(State)
+        .add_node("write_both", write_both)
+        .add_edge(START, "write_both")
+    ).compile()
+
+    parent = (
+        StateGraph(State).add_node("sub", subgraph).add_edge(START, "sub").compile()
+    )
+
+    assert await parent.ainvoke({"a": 1, "b": 1}) == {"a": 2, "b": 2}
+
+
+async def test_doubly_nested_subgraph_node_reducer_only_writes_on_real_change() -> None:
+    """The same untouched-key echo bug, one level deeper: a subgraph node
+    that itself contains a subgraph node should still only propagate real
+    writes up through each level.
+    """
+
+    def bump_on_flag(count: int, is_increment: bool) -> int:
+        return count + 1 if is_increment else count
+
+    class State(TypedDict):
+        retry_count: Annotated[int, bump_on_flag]
+        max_retry: int
+
+    async def noop_node(state: State) -> dict:
+        return {}
+
+    inner_noop = (
+        StateGraph(State).add_node("noop", noop_node).add_edge(START, "noop")
+    ).compile()
+
+    subgraph_1 = (
+        StateGraph(State)
+        .add_node("inner_noop", inner_noop)
+        .add_edge(START, "inner_noop")
+    ).compile()
+
+    async def bump_node(state: State) -> dict:
+        return {"retry_count": True}
+
+    inner_bump = (
+        StateGraph(State).add_node("bump", bump_node).add_edge(START, "bump")
+    ).compile()
+
+    subgraph_2 = (
+        StateGraph(State)
+        .add_node("inner_bump", inner_bump)
+        .add_edge(START, "inner_bump")
+    ).compile()
+
+    def should_continue(state: State) -> str:
+        return END if state["retry_count"] >= state["max_retry"] else "subgraph_1"
+
+    parent = (
+        StateGraph(State)
+        .add_node("subgraph_1", subgraph_1)
+        .add_node("subgraph_2", subgraph_2)
+        .add_edge(START, "subgraph_1")
+        .add_edge("subgraph_1", "subgraph_2")
+        .add_conditional_edges("subgraph_2", should_continue, ["subgraph_1", END])
+        .compile()
+    )
+
+    result = await parent.ainvoke({"retry_count": 0, "max_retry": 3})
+    assert result["retry_count"] == 3
+
+
 @NEEDS_CONTEXTVARS
 async def test_multiple_subgraphs_functional(
     async_checkpointer: BaseCheckpointSaver,


### PR DESCRIPTION
Fixes #6290

A compiled subgraph always returns every key in its output schema when invoked, even keys that none of its own nodes wrote to during that call. When such a subgraph is used directly as a node, those echoed but untouched keys were treated as real writes by the parent, so a channel built with a custom reducer would run its reducer again on a value it never actually produced. In the loop described in the issue, where two subgraphs share a counter and only one of them updates it, this caused the counter to increment twice per loop instead of once.

This change tags each subgraph node invocation with a small internal config key that the loop fills in with the channels it genuinely wrote to, then filters the subgraph output down to that set before treating it as parent writes. The filtering only applies to keys backed by a custom reducer channel (`BinaryOperatorAggregate`), so ordinary last value keys keep behaving exactly as they did before, including the case where a subgraph node intentionally leaves an output schema key untouched and its current value is expected to pass through.

How I verified this works:

I reproduced the exact scenario from the issue and confirmed the counter now increments once per loop instead of twice. I added five new tests in both `test_pregel.py` and `test_pregel_async.py` covering the reducer double count case, output filtering for untouched shared keys, the common case where subgraphs have no shared keys with the parent, the case where a subgraph writes every output key on every call, and a doubly nested subgraph version of the reducer scenario. I ran `make format`, `make lint` (including the `ty` type check), and the full `make test` suite for `libs/langgraph`, all passing with 1978 passed and 4 skipped, no failures. I also confirmed `get_graph(xray=True)` still renders nested subgraphs correctly after the change.