### PR TITLE
fix(store): preserve created_at on upsert in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,11 +407,15 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                existing = self._data[namespace].get(key)
+                created_at = (
+                    existing.created_at if existing else datetime.now(timezone.utc)
+                )
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=created_at,
                     updated_at=datetime.now(timezone.utc),
                 )
 

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1044,3 +1044,16 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_upsert_preserves_created_at() -> None:
+    """created_at should survive an upsert; only updated_at should advance."""
+    store = InMemoryStore()
+    store.put(("ns",), "k1", {"v": 1})
+    original = store.get(("ns",), "k1").created_at
+
+    store.put(("ns",), "k1", {"v": 2})
+    item = store.get(("ns",), "k1")
+
+    assert item.created_at == original
+    assert item.updated_at >= original


### PR DESCRIPTION
## Summary

`InMemoryStore._apply_put_ops` set `created_at=datetime.now()` unconditionally on every `put`, so upserts replaced the original creation timestamp. Now checks for an existing item and carries forward its `created_at`.

## Changes

- `libs/checkpoint/langgraph/store/memory/__init__.py` — preserve `created_at` from existing item on upsert
- `libs/checkpoint/tests/test_store.py` — add `test_upsert_preserves_created_at`

## Test plan

- [x] `test_upsert_preserves_created_at` passes (fail-before / pass-after verified)
- [x] ruff format + check clean

Closes #8340

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>