### PR TITLE
fix(prebuilt): allow return_direct tools to run at remaining_steps=1

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -625,10 +625,12 @@ def create_react_agent(
             else False
         )
         remaining_steps = _get_state_value(state, "remaining_steps", None)
-        if remaining_steps is not None:
-            if remaining_steps < 1 and all_tools_return_direct:
-                return True
-            elif remaining_steps < 2 and has_tool_calls:
+        if remaining_steps is not None and has_tool_calls:
+            # return_direct tools only consume 1 step (tool call → done, no LLM re-entry).
+            # Non-direct tools need at least 2 steps: one for tool execution and one
+            # for the subsequent LLM call to process the tool result.
+            min_steps_needed = 1 if all_tools_return_direct else 2
+            if remaining_steps < min_steps_needed:
                 return True
 
         return False


### PR DESCRIPTION
## Summary

Fixes #8204.

`create_react_agent` uses `_are_more_steps_needed` to decide whether to abort with
"need more steps" instead of running a tool call. The logic was:

```python
# Before (buggy):
if remaining_steps < 1 and all_tools_return_direct:
    return True
elif remaining_steps < 2 and has_tool_calls:   # catches direct tools too!
    return True
```

The second branch fires for **any** tool call when `remaining_steps == 1`, including
`return_direct=True` tools that only need **one** step (tool execute → done, no
second LLM call). This causes agents using `return_direct=True` tools to fail with
the abort message instead of returning the tool result when `remaining_steps=1`.

## Root Cause

`return_direct` tools exit the agent immediately after execution — they don't
make a follow-up LLM call. They therefore need only 1 remaining step to complete,
not 2. The old code didn't distinguish between the two cases in the `< 2` guard.

## Fix

Compute the minimum steps needed based on whether all requested tools are
`return_direct`:

```python
# After (fixed):
if remaining_steps is not None and has_tool_calls:
    min_steps_needed = 1 if all_tools_return_direct else 2
    if remaining_steps < min_steps_needed:
        return True
```

This correctly allows `remaining_steps=1` to proceed when all tools are
`return_direct`, and still aborts at `remaining_steps=1` for normal (non-direct)
tools that need an extra LLM step.

## Reproduction (from the issue)

```python
@tool(return_direct=True)
def my_direct_tool() -> str:
    return "direct answer"

agent = create_react_agent(model, [my_direct_tool])
result = agent.invoke({
    "messages": [HumanMessage("run tool")],
    "remaining_steps": 1
})
# Before: AIMessage(content='Sorry, need more steps to process this request.')
# After:  ToolMessage(content='direct answer', name='my_direct_tool')
```

Closes #8204.
