### PR TITLE
fix(config): fix silenced async guard in get_config() on Python < 3.11

### DIFF
--- a/libs/langgraph/langgraph/config.py
+++ b/libs/langgraph/langgraph/config.py
@@ -16,13 +16,15 @@ def _no_op_stream_writer(c: Any) -> None:
 
 def get_config() -> RunnableConfig:
     if sys.version_info < (3, 11):
+        _in_async = False
         try:
-            if asyncio.current_task():
-                raise RuntimeError(
-                    "Python 3.11 or later required to use this in an async context"
-                )
+            _in_async = asyncio.current_task() is not None
         except RuntimeError:
             pass
+        if _in_async:
+            raise RuntimeError(
+                "Python 3.11 or later required to use this in an async context"
+            )
     if var_config := var_child_runnable_config.get():
         return var_config
     else:


### PR DESCRIPTION
## Summary

Fixes #8203.

`get_config()` in `libs/langgraph/langgraph/config.py` has an async-context guard
for Python < 3.11. The guard was meant to raise `RuntimeError` when called from an
async context on Python versions that don't propagate contextvars through
`asyncio.create_task`. Instead, it silently swallowed its own error.

## Root Cause

```python
# Before (buggy):
try:
    if asyncio.current_task():
        raise RuntimeError(           # raised here...
            "Python 3.11 or later required..."
        )
except RuntimeError:
    pass                              # ...silently swallowed here
```

The `except RuntimeError: pass` block was intended to handle the case where
`asyncio.current_task()` itself raises `RuntimeError` (Python < 3.10 with no
running event loop). It also catches the intentional raise, neutralising the guard.

## Fix

Store the result of `asyncio.current_task()` in a boolean inside the `try` block,
then raise the intentional error **outside** the `try` block:

```python
# After (fixed):
if sys.version_info < (3, 11):
    _in_async = False
    try:
        _in_async = asyncio.current_task() is not None
    except RuntimeError:
        pass                          # only catches errors from current_task()
    if _in_async:
        raise RuntimeError(           # raised outside try — cannot be caught
            "Python 3.11 or later required..."
        )
```

Closes #8203.