### PR TITLE
fix(checkpoint): preserve created_at on InMemoryStore upsert

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,11 +407,12 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=existing.created_at if existing else datetime.now(timezone.utc),
                     updated_at=datetime.now(timezone.utc),
                 )
 


### PR DESCRIPTION
Fixes #8340

InMemoryStore.upsert() overwrites the original `created_at` timestamp when updating an existing key. The `created_at` field should reflect when the item was first created, not when it was last upserted.

**Fix**: Check if the key already exists in self._data before updating, and preserve the original created_at if it does.