### PR TITLE
perf(langgraph): eliminate O(tasks²) done-set re-scan in FuturesDict.on_done

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -128,7 +128,12 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
                 self.counter -= 1
                 # Wake waiter when all tracked futures are done, or when runner-level
                 # stop condition is met (for example, a non-handled fatal exception).
-                if self.counter == 0 or self.should_stop(self.done):
+                # Only the just-completed future needs checking: every future passes
+                # through `on_done` exactly once and previously completed futures are
+                # terminal, so re-scanning `self.done` here would be O(tasks^2) waste.
+                # The authoritative stop/panic decision is still made against the full
+                # set in `tick` / `_panic_or_proceed`; this is only an early wake-up.
+                if self.counter == 0 or self.should_stop({fut}):
                     self.event.set()
 
 


### PR DESCRIPTION
Fixes #8240

`FuturesDict.on_done` iterates the complete `done` set on every task completion callback. With N concurrent tasks this results in O(N²) total work: `_should_stop_others` calls `fut.cancelled()` / `fut.exception()` (each acquiring the future's internal lock) on every already-completed future, on every callback.

**Fix**: check only the just-completed future in the early-wake stop condition. Every future passes through `on_done` exactly once, and a future already in `done` is terminal — its cancelled/exception state cannot change — so only the newly completed future can newly satisfy the stop condition. This drops the stop-check from O(N²) to O(N) total `future.exception()` calls.

**Behavior unchanged**: the waiter is still woken at the first fatal completion, and the authoritative stop/panic decision is still made against the full set in `tick` / `_panic_or_proceed` — `on_done` is only an early wake-up.

**Testing**: full `tests/test_pregel.py` (457 passed) and `tests/test_pregel_async.py` (303 passed) suites pass on the in-memory/sqlite backends, including the cancellation / interrupt / `max_concurrency` / retry tests that exercise this path. (`test_imp_nested` and `test_async_streaming_with_functional_api` are flaky/failing on unmodified `main` in my environment and were excluded from comparison.) A deterministic call-count check confirms `fut.exception()` calls drop from ~N²/2 to N for N parallel tasks.