### PR TITLE
fix(cli): require langgraph-api>=0.7.67 on Python 3.14

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -23,7 +23,10 @@ dependencies = [
 path = "langgraph_cli/__init__.py"
 [project.optional-dependencies]
 inmem = [
-    "langgraph-api>=0.5.35,<1.0.0 ; python_version >= '3.11'",
+    "langgraph-api>=0.5.35,<1.0.0 ; python_version >= '3.11' and python_version < '3.14'",
+    # langgraph-api < 0.7.67 caps jsonschema-rs below 0.34.0, the first release
+    # with Python 3.14 wheels; older versions fail to build from source on 3.14.
+    "langgraph-api>=0.7.67,<1.0.0 ; python_version >= '3.14'",
     "langgraph-runtime-inmem>=0.7 ; python_version >= '3.11'",
 ]
 

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.11' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version >= '3.11' and python_full_version < '3.14'",
     "python_full_version < '3.11'",
 ]
 
@@ -1135,7 +1136,8 @@ test = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "langgraph-api", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.5.35,<1.0.0" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'inmem'", specifier = ">=0.5.35,<1.0.0" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.14' and extra == 'inmem'", specifier = ">=0.7.67,<1.0.0" },
     { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.7" },
     { name = "langgraph-sdk", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "pathspec", specifier = ">=0.11.0" },

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1782,7 +1782,8 @@ inmem = [
 requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "langgraph-api", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.5.35,<1.0.0" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'inmem'", specifier = ">=0.5.35,<1.0.0" },
+    { name = "langgraph-api", marker = "python_full_version >= '3.14' and extra == 'inmem'", specifier = ">=0.7.67,<1.0.0" },
     { name = "langgraph-runtime-inmem", marker = "python_full_version >= '3.11' and extra == 'inmem'", specifier = ">=0.7" },
     { name = "langgraph-sdk", marker = "python_full_version >= '3.11'", specifier = ">=0.1.0" },
     { name = "pathspec", specifier = ">=0.11.0" },


### PR DESCRIPTION
Fixes #8286

On Python 3.14, `uv sync` can fail with a cryptic maturin/cargo build error for `jsonschema-rs`: `langgraph-api` versions below 0.7.67 cap `jsonschema-rs<0.30`, but the first `jsonschema-rs` release with Python 3.14 wheels is 0.34.0 (older sdists use pyo3 0.23.x, which supports up to Python 3.13). This PR applies a stricter `langgraph-api>=0.7.67` floor in the `inmem` extra only on `python_version >= '3.14'`, so resolution either lands on a working combination or fails with a clear resolver conflict instead of a Rust build trace. Behavior on Python 3.11–3.13 is unchanged.

Note: this PR intentionally changes a dependency constraint in `libs/cli/pyproject.toml` and regenerates `libs/cli/uv.lock` + `libs/langgraph/uv.lock` (the langgraph dev group includes the CLI as a path dependency) — the same pair of lockfiles updated in #8319 for the previous bound change.

## How did you verify your code works?

- **Plain install on 3.14** (`langgraph-cli[inmem]` from this branch via a path override): resolves `jsonschema-rs 0.44.1`, installs from a prebuilt wheel with no Rust build, and `import jsonschema_rs` succeeds on CPython 3.14.4.
- **Backtracking repro** (adding `langgraph-runtime-inmem>=0.24,<0.25`, which forces `langgraph-api 0.7.2x` and reproduces the issue's exact failure): `uv lock --python 3.14` now fails at resolution with a readable conflict message instead of selecting the un-buildable `jsonschema-rs 0.29.1` sdist.
- **No regression on 3.13**: the same old pins still resolve to `langgraph-api 0.7.29` + `jsonschema-rs 0.29.1` as before.
- `make format`, `make lint`, `make test` all pass in `libs/cli` (336 tests); `uv lock --check` passes in `libs/langgraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)