### PR TITLE
feat(checkpoint,checkpoint-postgres): add opt-in omit_expired to skip expired rows on read

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -240,6 +240,11 @@ class BasePostgresStore(Generic[C]):
     index_config: PostgresIndexConfig | None
     ttl_config: TTLConfig | None
 
+    @property
+    def _omit_expired(self) -> bool:
+        """Whether expired-but-unswept rows should be filtered from reads."""
+        return bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+
     def _get_batch_GET_ops_queries(
         self,
         get_ops: Sequence[tuple[int, GetOp]],
@@ -259,7 +264,7 @@ class BasePostgresStore(Generic[C]):
             namespace_groups[op.namespace].append((idx, op.key))
             refresh_ttls[op.namespace].append(op.refresh_ttl)
 
-        omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+        omit_expired = self._omit_expired
         expiry_clause = (
             "AND (s.expires_at IS NULL OR s.expires_at > NOW())" if omit_expired else ""
         )
@@ -430,7 +435,7 @@ class BasePostgresStore(Generic[C]):
         - embedding_requests: list of (original_index_in_search_ops, text_query)
         """
 
-        omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+        omit_expired = self._omit_expired
         search_expiry_clause = (
             "AND (store.expires_at IS NULL OR store.expires_at > NOW())"
             if omit_expired
@@ -606,7 +611,7 @@ class BasePostgresStore(Generic[C]):
             """
             params: list[Any] = [op.max_depth, op.max_depth]
 
-            omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+            omit_expired = self._omit_expired
             conditions = []
             if omit_expired:
                 conditions.append("(expires_at IS NULL OR expires_at > NOW())")

--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -238,6 +238,7 @@ class BasePostgresStore(Generic[C]):
     conn: C
     _deserializer: Callable[[bytes | orjson.Fragment], dict[str, Any]] | None
     index_config: PostgresIndexConfig | None
+    ttl_config: TTLConfig | None
 
     def _get_batch_GET_ops_queries(
         self,
@@ -258,12 +259,17 @@ class BasePostgresStore(Generic[C]):
             namespace_groups[op.namespace].append((idx, op.key))
             refresh_ttls[op.namespace].append(op.refresh_ttl)
 
+        omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+        expiry_clause = (
+            "AND (s.expires_at IS NULL OR s.expires_at > NOW())" if omit_expired else ""
+        )
+
         results = []
         for namespace, items in namespace_groups.items():
             _, keys = zip(*items, strict=False)
             this_refresh_ttls = refresh_ttls[namespace]
 
-            query = """
+            query = f"""
                 WITH passed_in AS (
                     SELECT unnest(%s::text[]) AS key,
                         unnest(%s::bool[])  AS do_refresh
@@ -276,12 +282,14 @@ class BasePostgresStore(Generic[C]):
                     AND s.key    = p.key
                     AND p.do_refresh = TRUE
                     AND s.ttl_minutes IS NOT NULL
+                    {expiry_clause}
                     RETURNING s.key
                 )
                 SELECT s.key, s.value, s.created_at, s.updated_at
                 FROM store s
                 JOIN passed_in p ON s.key = p.key
                 WHERE s.prefix = %s
+                {expiry_clause}
             """
             ns_text = _namespace_to_text(namespace)
             params = (
@@ -422,6 +430,13 @@ class BasePostgresStore(Generic[C]):
         - embedding_requests: list of (original_index_in_search_ops, text_query)
         """
 
+        omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+        search_expiry_clause = (
+            "AND (store.expires_at IS NULL OR store.expires_at > NOW())"
+            if omit_expired
+            else ""
+        )
+
         queries = []
         embedding_requests = []
         for idx, (_, op) in enumerate(search_ops):
@@ -491,7 +506,7 @@ class BasePostgresStore(Generic[C]):
                             {score_operator} AS neg_score
                         FROM store
                         JOIN store_vectors sv ON store.prefix = sv.prefix AND store.key = sv.key
-                        WHERE {ns_condition} {extra_filters}
+                        WHERE {ns_condition} {extra_filters} {search_expiry_clause}
                         ORDER BY {score_operator} ASC
                         LIMIT %s
                     """
@@ -527,7 +542,7 @@ class BasePostgresStore(Generic[C]):
                 base_query = f"""
                         SELECT store.prefix, store.key, store.value, store.created_at, store.updated_at, NULL AS score
                         FROM store
-                        WHERE {ns_condition} {extra_filters}
+                        WHERE {ns_condition} {extra_filters} {search_expiry_clause}
                         ORDER BY store.updated_at DESC
                         LIMIT %s
                         OFFSET %s
@@ -591,7 +606,10 @@ class BasePostgresStore(Generic[C]):
             """
             params: list[Any] = [op.max_depth, op.max_depth]
 
+            omit_expired = bool(self.ttl_config and self.ttl_config.get("omit_expired"))
             conditions = []
+            if omit_expired:
+                conditions.append("(expires_at IS NULL OR expires_at > NOW())")
             if op.match_conditions:
                 for condition in op.match_conditions:
                     if condition.match_type == "prefix":

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -739,3 +739,135 @@ async def test_store_ttl(store):
     # Now has been (TTL_SECONDS-2)*2 > TTL_SECONDS + TTL_SECONDS/2
     results = await store.asearch(ns, query="bar", refresh_ttl=False)
     assert len(results) == 0
+
+
+async def _aexpire_now(
+    store: AsyncPostgresStore, ns: tuple[str, ...], key: str
+) -> None:
+    """Backdate a row's expires_at into the past without deleting it (unswept)."""
+    async with store._cursor() as cur:
+        await cur.execute(
+            "UPDATE store SET expires_at = NOW() - INTERVAL '1 minute' "
+            "WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+
+
+async def _arow_exists(
+    store: AsyncPostgresStore, ns: tuple[str, ...], key: str
+) -> bool:
+    async with store._cursor() as cur:
+        await cur.execute(
+            "SELECT COUNT(*) AS n FROM store WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+        return (await cur.fetchone())["n"] == 1
+
+
+async def _astored_expires_at(store: AsyncPostgresStore, ns: tuple[str, ...], key: str):
+    async with store._cursor() as cur:
+        await cur.execute(
+            "SELECT expires_at FROM store WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+        return (await cur.fetchone())["expires_at"]
+
+
+async def test_omit_expired_filters_read_paths(store: AsyncPostgresStore) -> None:
+    await store.stop_ttl_sweeper()  # deterministic: no background deletion
+    store.ttl_config["omit_expired"] = True
+
+    expired_ns = ("omit", "expired")
+    control_ns = ("omit", "control")
+    await store.aput(expired_ns, "e", {"data": "gone"}, ttl=TTL_MINUTES)
+    await store.aput(control_ns, "c", {"data": "keep"}, ttl=None)
+    await _aexpire_now(store, expired_ns, "e")
+
+    # The row is expired but physically still present (unswept).
+    assert await _arow_exists(store, expired_ns, "e")
+
+    # aget omits it; the never-expiring control is still returned.
+    assert await store.aget(expired_ns, "e") is None
+    assert await store.aget(control_ns, "c") is not None
+
+    # asearch omits it but returns the control.
+    assert await store.asearch(expired_ns) == []
+    assert [i.key for i in await store.asearch(control_ns)] == ["c"]
+
+    # alist_namespaces drops the expired-only namespace, keeps the control.
+    namespaces = await store.alist_namespaces(prefix=("omit",))
+    assert expired_ns not in namespaces
+    assert control_ns in namespaces
+
+
+@pytest.mark.parametrize("omit", [None, False], ids=["default", "explicit-false"])
+async def test_omit_expired_disabled_preserves_expired_rows(
+    store: AsyncPostgresStore, omit
+) -> None:
+    await store.stop_ttl_sweeper()
+    if omit is not None:
+        store.ttl_config["omit_expired"] = omit
+
+    ns = ("keep",)
+    await store.aput(ns, "k", {"data": "still-here"}, ttl=TTL_MINUTES)
+    await _aexpire_now(store, ns, "k")
+
+    assert await store.aget(ns, "k", refresh_ttl=False) is not None
+    assert [i.key for i in await store.asearch(ns, refresh_ttl=False)] == ["k"]
+    assert ns in await store.alist_namespaces(prefix=("keep",))
+
+
+async def test_omit_expired_refresh_ttl_only_refreshes_live_rows(
+    store: AsyncPostgresStore,
+) -> None:
+    await store.stop_ttl_sweeper()
+    store.ttl_config["omit_expired"] = True
+
+    ns = ("refresh",)
+    await store.aput(ns, "expired", {"n": 0}, ttl=TTL_MINUTES)
+    await store.aput(ns, "live_get", {"n": 1}, ttl=TTL_MINUTES)
+    await store.aput(ns, "live_search", {"n": 2}, ttl=TTL_MINUTES)
+    await _aexpire_now(store, ns, "expired")
+
+    expired_before = await _astored_expires_at(store, ns, "expired")
+    get_before = await _astored_expires_at(store, ns, "live_get")
+    search_before = await _astored_expires_at(store, ns, "live_search")
+
+    # refresh_ttl=True must NOT resurrect the expired row (via aget or asearch)...
+    assert await store.aget(ns, "expired", refresh_ttl=True) is None
+    live_keys = [i.key for i in await store.asearch(ns, refresh_ttl=True)]
+    assert "expired" not in live_keys
+    assert await _astored_expires_at(store, ns, "expired") == expired_before
+
+    # ...but must still extend the live rows that were read.
+    assert await store.aget(ns, "live_get", refresh_ttl=True) is not None
+    assert await _astored_expires_at(store, ns, "live_get") > get_before
+    assert await _astored_expires_at(store, ns, "live_search") > search_before
+
+
+async def test_omit_expired_search_pagination(store: AsyncPostgresStore) -> None:
+    await store.stop_ttl_sweeper()
+    store.ttl_config["omit_expired"] = True
+
+    ns = ("page",)
+    for k in ("a", "b", "c"):
+        await store.aput(ns, k, {"k": k}, ttl=TTL_MINUTES)
+    await store.aput(ns, "expired", {"k": "x"}, ttl=TTL_MINUTES)
+    await _aexpire_now(store, ns, "expired")
+
+    # Order by updated_at DESC = a, expired, b, c, so the expired row sits inside
+    # the first limit=2 window. Correct (pre-LIMIT) filtering yields live pages
+    # [a, b] then [c]; post-LIMIT filtering would underfill page 1 to just [a].
+    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+    async with store._cursor() as cur:
+        for key, secs in seconds_ago.items():
+            await cur.execute(
+                "UPDATE store SET updated_at = NOW() - (%s * INTERVAL '1 second') "
+                "WHERE prefix = %s AND key = %s",
+                (secs, ".".join(ns), key),
+            )
+
+    page1 = await store.asearch(ns, limit=2, offset=0)
+    page2 = await store.asearch(ns, limit=2, offset=2)
+    assert [i.key for i in page1] == ["a", "b"]
+    assert [i.key for i in page2] == ["c"]

--- a/libs/checkpoint-postgres/tests/test_async_store.py
+++ b/libs/checkpoint-postgres/tests/test_async_store.py
@@ -855,10 +855,10 @@ async def test_omit_expired_search_pagination(store: AsyncPostgresStore) -> None
     await store.aput(ns, "expired", {"k": "x"}, ttl=TTL_MINUTES)
     await _aexpire_now(store, ns, "expired")
 
-    # Order by updated_at DESC = a, expired, b, c, so the expired row sits inside
+    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+    # updated_at DESC orders these a, expired, b, c, so the expired row sits inside
     # the first limit=2 window. Correct (pre-LIMIT) filtering yields live pages
     # [a, b] then [c]; post-LIMIT filtering would underfill page 1 to just [a].
-    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
     async with store._cursor() as cur:
         for key, secs in seconds_ago.items():
             await cur.execute(

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -972,10 +972,10 @@ def test_omit_expired_search_pagination(store: PostgresStore) -> None:
     store.put(ns, "expired", {"k": "x"}, ttl=TTL_MINUTES)
     _expire_now(store, ns, "expired")
 
-    # Order by updated_at DESC = a, expired, b, c, so the expired row sits inside
+    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+    # updated_at DESC orders these a, expired, b, c, so the expired row sits inside
     # the first limit=2 window. Correct (pre-LIMIT) filtering yields live pages
     # [a, b] then [c]; post-LIMIT filtering would underfill page 1 to just [a].
-    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
     with store._cursor() as cur:
         for key, secs in seconds_ago.items():
             cur.execute(

--- a/libs/checkpoint-postgres/tests/test_store.py
+++ b/libs/checkpoint-postgres/tests/test_store.py
@@ -863,6 +863,133 @@ def test_store_ttl(store):
     assert len(res) == 0
 
 
+def _expire_now(store: PostgresStore, ns: tuple[str, ...], key: str) -> None:
+    """Backdate a row's expires_at into the past without deleting it (unswept)."""
+    with store._cursor() as cur:
+        cur.execute(
+            "UPDATE store SET expires_at = NOW() - INTERVAL '1 minute' "
+            "WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+
+
+def _row_exists(store: PostgresStore, ns: tuple[str, ...], key: str) -> bool:
+    with store._cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM store WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+        return cur.fetchone()["n"] == 1
+
+
+def _stored_expires_at(store: PostgresStore, ns: tuple[str, ...], key: str):
+    with store._cursor() as cur:
+        cur.execute(
+            "SELECT expires_at FROM store WHERE prefix = %s AND key = %s",
+            (".".join(ns), key),
+        )
+        return cur.fetchone()["expires_at"]
+
+
+def test_omit_expired_filters_read_paths(store: PostgresStore) -> None:
+    store.stop_ttl_sweeper()  # deterministic: no background deletion
+    store.ttl_config["omit_expired"] = True
+
+    expired_ns = ("omit", "expired")
+    control_ns = ("omit", "control")
+    store.put(expired_ns, "e", {"data": "gone"}, ttl=TTL_MINUTES)
+    store.put(control_ns, "c", {"data": "keep"}, ttl=None)
+    _expire_now(store, expired_ns, "e")
+
+    # The row is expired but physically still present (unswept).
+    assert _row_exists(store, expired_ns, "e")
+
+    # get omits it; the never-expiring control is still returned.
+    assert store.get(expired_ns, "e") is None
+    assert store.get(control_ns, "c") is not None
+
+    # search omits it but returns the control.
+    assert store.search(expired_ns) == []
+    assert [i.key for i in store.search(control_ns)] == ["c"]
+
+    # list_namespaces drops the expired-only namespace, keeps the control.
+    namespaces = store.list_namespaces(prefix=("omit",))
+    assert expired_ns not in namespaces
+    assert control_ns in namespaces
+
+
+@pytest.mark.parametrize("omit", [None, False], ids=["default", "explicit-false"])
+def test_omit_expired_disabled_preserves_expired_rows(
+    store: PostgresStore, omit
+) -> None:
+    store.stop_ttl_sweeper()
+    if omit is not None:
+        store.ttl_config["omit_expired"] = omit
+
+    ns = ("keep",)
+    store.put(ns, "k", {"data": "still-here"}, ttl=TTL_MINUTES)
+    _expire_now(store, ns, "k")
+
+    assert store.get(ns, "k", refresh_ttl=False) is not None
+    assert [i.key for i in store.search(ns, refresh_ttl=False)] == ["k"]
+    assert ns in store.list_namespaces(prefix=("keep",))
+
+
+def test_omit_expired_refresh_ttl_only_refreshes_live_rows(
+    store: PostgresStore,
+) -> None:
+    store.stop_ttl_sweeper()
+    store.ttl_config["omit_expired"] = True
+
+    ns = ("refresh",)
+    store.put(ns, "expired", {"n": 0}, ttl=TTL_MINUTES)
+    store.put(ns, "live_get", {"n": 1}, ttl=TTL_MINUTES)
+    store.put(ns, "live_search", {"n": 2}, ttl=TTL_MINUTES)
+    _expire_now(store, ns, "expired")
+
+    expired_before = _stored_expires_at(store, ns, "expired")
+    get_before = _stored_expires_at(store, ns, "live_get")
+    search_before = _stored_expires_at(store, ns, "live_search")
+
+    # refresh_ttl=True must NOT resurrect the expired row (via get or search)...
+    assert store.get(ns, "expired", refresh_ttl=True) is None
+    assert "expired" not in [i.key for i in store.search(ns, refresh_ttl=True)]
+    assert _stored_expires_at(store, ns, "expired") == expired_before
+
+    # ...but must still extend the live rows that were read.
+    assert store.get(ns, "live_get", refresh_ttl=True) is not None
+    assert _stored_expires_at(store, ns, "live_get") > get_before
+    assert _stored_expires_at(store, ns, "live_search") > search_before
+
+
+def test_omit_expired_search_pagination(store: PostgresStore) -> None:
+    store.stop_ttl_sweeper()
+    store.ttl_config["omit_expired"] = True
+
+    ns = ("page",)
+    for k in ("a", "b", "c"):
+        store.put(ns, k, {"k": k}, ttl=TTL_MINUTES)
+    store.put(ns, "expired", {"k": "x"}, ttl=TTL_MINUTES)
+    _expire_now(store, ns, "expired")
+
+    # Order by updated_at DESC = a, expired, b, c, so the expired row sits inside
+    # the first limit=2 window. Correct (pre-LIMIT) filtering yields live pages
+    # [a, b] then [c]; post-LIMIT filtering would underfill page 1 to just [a].
+    seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+    with store._cursor() as cur:
+        for key, secs in seconds_ago.items():
+            cur.execute(
+                "UPDATE store SET updated_at = NOW() - (%s * INTERVAL '1 second') "
+                "WHERE prefix = %s AND key = %s",
+                (secs, ".".join(ns), key),
+            )
+
+    page1 = store.search(ns, limit=2, offset=0)
+    page2 = store.search(ns, limit=2, offset=2)
+    assert [i.key for i in page1] == ["a", "b"]
+    assert [i.key for i in page2] == ["c"]
+
+
 @pytest.mark.parametrize(
     "vector_type,distance_type",
     [

--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -552,6 +552,14 @@ class TTLConfig(TypedDict, total=False):
     This can be overridden per-operation by explicitly setting `refresh_ttl`.
     Defaults to `True` if not configured.
     """
+    omit_expired: bool
+    """Whether to omit expired items from read operations.
+
+    If `True`, and if the store supports this option, expired items will not be
+    returned by `GET` or `SEARCH`, or included in namespace listings, even before
+    a TTL sweep deletes them.
+    Defaults to `False` if not configured.
+    """
     default_ttl: float | None
     """Default TTL (time-to-live) in minutes for new items.
     


### PR DESCRIPTION
The Postgres store removes expired items only via the background TTL sweeper, so between sweeps a read can still return a logically expired row. Adds an opt-in flag so reads can filter expired rows at query time, closing the window without depending on sweep cadence.

## Changes
- Add `omit_expired: bool` to `TTLConfig` (default `False`). When unset or `False`, behavior is unchanged
- When enabled, inject `(expires_at IS NULL OR expires_at > NOW())` into the read query builders on `BasePostgresStore`, so `get`/`search`/`list_namespaces` do not surface an expired row:
  - **GET** (`_get_batch_GET_ops_queries`): predicate on both the final SELECT *and* the refresh `UPDATE` — the update is driven from an unfiltered key list, so gating only the SELECT would hide an expired row yet still refresh it back to life.
  - **SEARCH** (`_prepare_batch_search_queries`): inside the inner scans (before `LIMIT`/`OFFSET`), which also gates the refresh `UPDATE` fed by `search_results` and keeps pagination correct
  - **list_namespaces** (`_get_batch_list_namespaces_queries`): predicate appended to the existing scan conditions.

## Testing
- Four behaviors covered sync + async, across the `default`/`pipe`/`pool` fixtures: expired-unswept row omitted from all read paths (with a raw SQL check proving the row is still physically present), default/explicit-`False` still returns it, `refresh_ttl=True` doesn't resurrect an expired row while still extending live ones, and search pagination stays correct when an expired row falls inside the page window.
- Full `checkpoint-postgres` suite green on PG16 (210 passed); `ruff format`/`check` clean on both packages.
