### PR TITLE
docs(prebuilt): fix wrong import paths and grammar in prebuilt docstrings

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -439,7 +439,12 @@ def create_react_agent(
                 the content "Sorry, need more steps to process this request.".
                 No `GraphRecusionError` will be raised in this case.
 
-        context_schema: An optional schema for runtime context.
+        context_schema: An optional schema for runtime context. When provided, the
+            schema type annotates the `runtime` argument of dynamic callables such as
+            `prompt` and `model` (e.g., `(state, runtime: Runtime[MyContext]) -> BaseChatModel`),
+            giving them typed access to `runtime.context`. Pass the context values at
+            invocation time via the `context` argument, e.g.
+            `agent.invoke({"messages": [...]}, context=MyContext(...))`.
         checkpointer: An optional checkpoint saver object. This is used for persisting
             the state of the graph (e.g., as chat memory) for a single thread (e.g., a single conversation).
         store: An optional store object. This is used for persisting data
@@ -491,7 +496,7 @@ def create_react_agent(
             Note over A: Prompt + LLM
             loop while tool_calls present
                 A->>T: Execute tools
-                T-->>A: ToolMessage for each tool_calls
+                T-->>A: ToolMessage for each tool_call
             end
             A->>U: Return final state
     ```

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -25,7 +25,7 @@ Key Components:
 Typical Usage:
     ```python
     from langchain_core.tools import tool
-    from langchain.tools import ToolNode
+    from langgraph.prebuilt import ToolNode
 
 
     @tool
@@ -702,7 +702,7 @@ class ToolNode(RunnableCallable):
         Basic usage:
 
         ```python
-        from langchain.tools import ToolNode
+        from langgraph.prebuilt import ToolNode
         from langchain_core.tools import tool
 
         @tool
@@ -717,7 +717,7 @@ class ToolNode(RunnableCallable):
 
         ```python
         from typing_extensions import Annotated
-        from langchain.tools import InjectedState
+        from langgraph.prebuilt import InjectedState
 
         @tool
         def context_tool(query: str, state: Annotated[dict, InjectedState]) -> str:
@@ -1613,8 +1613,7 @@ def tools_condition(
 
         ```python
         from langgraph.graph import StateGraph
-        from langchain.tools import ToolNode
-        from langchain.tools.tool_node import tools_condition
+        from langgraph.prebuilt import ToolNode, tools_condition
         from typing_extensions import TypedDict
 
 
@@ -1688,7 +1687,7 @@ class ToolRuntime(_DirectlyInjectedToolArg, Generic[ContextT, StateT]):
     Example:
         ```python
         from langchain_core.tools import tool
-        from langchain.tools import ToolRuntime
+        from langgraph.prebuilt import ToolRuntime
 
         @tool
         def my_tool(x: int, runtime: ToolRuntime) -> str:
@@ -1770,7 +1769,8 @@ class InjectedState(InjectedToolArg):
         from typing_extensions import Annotated, TypedDict
 
         from langchain_core.messages import BaseMessage, AIMessage
-        from langchain.tools import InjectedState, ToolNode, tool
+        from langchain_core.tools import tool
+        from langgraph.prebuilt import InjectedState, ToolNode
 
 
         class AgentState(TypedDict):
@@ -1845,7 +1845,8 @@ class InjectedStore(InjectedToolArg):
         ```python
         from typing_extensions import Annotated
         from langgraph.store.memory import InMemoryStore
-        from langchain.tools import InjectedStore, ToolNode, tool
+        from langchain_core.tools import tool
+        from langgraph.prebuilt import InjectedStore, ToolNode
 
         @tool
         def save_preference(


### PR DESCRIPTION
Fixes #8228
Fixes #8227
Fixes #8226

Docstring-only changes in `libs/prebuilt`: the `tool_node.py` examples imported `ToolNode`/`InjectedState`/`InjectedStore`/`ToolRuntime`/`tools_condition` from `langchain.tools`, but they live in `langgraph.prebuilt` (copying them raised `ImportError`); I also fixed the "for each tool_calls" -> "tool_call" mermaid grammar and fleshed out the empty `context_schema` description in `create_react_agent`.

**How verified:** `make format`, `make lint` pass; ran `pytest tests/test_react_agent.py tests/test_tool_node.py` (139 passed; the only errors are postgres-fixture tests needing a Docker service I don't have locally, unrelated to these text changes).