### PR TITLE
fix(store): resolve memory store stale vectors and SQL LIKE data leakage

### DIFF
--- a/libs/checkpoint-postgres/langgraph/store/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/store/postgres/base.py
@@ -444,7 +444,9 @@ class BasePostgresStore(Generic[C]):
             ns_param: Sequence[str] | None = None
             if op.namespace_prefix:
                 ns_condition = "store.prefix LIKE %s"
-                ns_param = (f"{_namespace_to_text(op.namespace_prefix)}%",)
+                ns_param = (
+                    f"{_namespace_to_text(op.namespace_prefix, escape_like=True)}%",
+                )
             else:
                 ns_param = ()
 
@@ -597,12 +599,12 @@ class BasePostgresStore(Generic[C]):
                     if condition.match_type == "prefix":
                         conditions.append("prefix LIKE %s")
                         params.append(
-                            f"{_namespace_to_text(condition.path, handle_wildcards=True)}%"
+                            f"{_namespace_to_text(condition.path, handle_wildcards=True, escape_like=True)}%"
                         )
                     elif condition.match_type == "suffix":
                         conditions.append("prefix LIKE %s")
                         params.append(
-                            f"%{_namespace_to_text(condition.path, handle_wildcards=True)}"
+                            f"%{_namespace_to_text(condition.path, handle_wildcards=True, escape_like=True)}"
                         )
                     else:
                         logger.warning(
@@ -1249,11 +1251,21 @@ def _get_index_params(store: Any) -> tuple[str, dict[str, Any]]:
 
 
 def _namespace_to_text(
-    namespace: tuple[str, ...], handle_wildcards: bool = False
+    namespace: tuple[str, ...],
+    handle_wildcards: bool = False,
+    escape_like: bool = False,
 ) -> str:
     """Convert namespace tuple to text string."""
-    if handle_wildcards:
-        namespace = tuple("%" if val == "*" else val for val in namespace)
+    if escape_like or handle_wildcards:
+
+        def _escape(val: str) -> str:
+            if handle_wildcards and val == "*":
+                return "%"
+            if escape_like:
+                return val.replace("\\", "\\\\").replace("_", "\\_").replace("%", "\\%")
+            return val
+
+        namespace = tuple(_escape(val) for val in namespace)
     return ".".join(namespace)
 
 

--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -94,11 +94,21 @@ class SqliteIndexConfig(IndexConfig):
 
 
 def _namespace_to_text(
-    namespace: tuple[str, ...], handle_wildcards: bool = False
+    namespace: tuple[str, ...],
+    handle_wildcards: bool = False,
+    escape_like: bool = False,
 ) -> str:
     """Convert namespace tuple to text string."""
-    if handle_wildcards:
-        namespace = tuple("%" if val == "*" else val for val in namespace)
+    if escape_like or handle_wildcards:
+
+        def _escape(val: str) -> str:
+            if handle_wildcards and val == "*":
+                return "%"
+            if escape_like:
+                return val.replace("\\", "\\\\").replace("_", "\\_").replace("%", "\\%")
+            return val
+
+        namespace = tuple(_escape(val) for val in namespace)
     return ".".join(namespace)
 
 
@@ -461,8 +471,12 @@ class BaseSqliteStore:
                     else " AND " + " AND ".join(filter_conditions)
                 )
                 if op.namespace_prefix:
-                    prefix_filter_str = f"WHERE s.prefix LIKE ? {filter_str} "
-                    ns_args: Sequence = (f"{_namespace_to_text(op.namespace_prefix)}%",)
+                    prefix_filter_str = (
+                        f"WHERE s.prefix LIKE ? ESCAPE '\\\\' {filter_str} "
+                    )
+                    ns_args: Sequence = (
+                        f"{_namespace_to_text(op.namespace_prefix, escape_like=True)}%",
+                    )
                 else:
                     ns_args = ()
                     if filter_str:
@@ -506,9 +520,11 @@ class BaseSqliteStore:
                 base_query = """
                     SELECT prefix, key, value, created_at, updated_at, expires_at, ttl_minutes, NULL as score
                     FROM store
-                    WHERE prefix LIKE ?
+                    WHERE prefix LIKE ? ESCAPE '\\'
                 """
-                params = [f"{_namespace_to_text(op.namespace_prefix)}%"]
+                params = [
+                    f"{_namespace_to_text(op.namespace_prefix, escape_like=True)}%"
+                ]
 
                 if filter_conditions:
                     params.extend(filter_params)
@@ -550,14 +566,14 @@ class BaseSqliteStore:
             if op.match_conditions:
                 for cond in op.match_conditions:
                     if cond.match_type == "prefix":
-                        where_clauses.append("prefix LIKE ?")
+                        where_clauses.append("prefix LIKE ? ESCAPE '\\\\'")
                         params.append(
-                            f"{_namespace_to_text(cond.path, handle_wildcards=True)}%"
+                            f"{_namespace_to_text(cond.path, handle_wildcards=True, escape_like=True)}%"
                         )
                     elif cond.match_type == "suffix":
-                        where_clauses.append("prefix LIKE ?")
+                        where_clauses.append("prefix LIKE ? ESCAPE '\\\\'")
                         params.append(
-                            f"%{_namespace_to_text(cond.path, handle_wildcards=True)}"
+                            f"%{_namespace_to_text(cond.path, handle_wildcards=True, escape_like=True)}"
                         )
                     else:
                         logger.warning(

--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -212,6 +212,12 @@ class InMemoryStore(BaseStore):
             self._batch_search(search_ops, queryinmem_store, results)
 
         to_embed = self._extract_texts(put_ops)
+
+        # Clear existing vectors for any updated or deleted keys
+        for (ns, key), _ in put_ops.items():
+            if ns in self._vectors:
+                self._vectors[ns].pop(key, None)
+
         if to_embed and self.index_config and self.embeddings:
             embeddings = self.embeddings.embed_documents(list(to_embed))
             self._insertinmem_store(to_embed, embeddings)
@@ -227,6 +233,12 @@ class InMemoryStore(BaseStore):
             self._batch_search(search_ops, queryinmem_store, results)
 
         to_embed = self._extract_texts(put_ops)
+
+        # Clear existing vectors for any updated or deleted keys
+        for (ns, key), _ in put_ops.items():
+            if ns in self._vectors:
+                self._vectors[ns].pop(key, None)
+
         if to_embed and self.index_config and self.embeddings:
             embeddings = await self.embeddings.aembed_documents(list(to_embed))
             self._insertinmem_store(to_embed, embeddings)


### PR DESCRIPTION
Fixes #8300
Fixes #8214

This PR fixes unescaped SQL `LIKE` wildcards in `PostgresStore` and `SqliteStore` namespace searches to prevent unintended cross-namespace data matching. It also fixes `InMemoryStore` by ensuring stale vector embeddings are properly cleared when existing keys are updated.

## Verification
Locally verified that `make format` and `make lint` pass. Verified that the core logic implementations explicitly drop stale `_vectors` in memory, and pass `escape_like=True` when formatting namespace prefixes for SQL `LIKE` queries.

## Social handles
LinkedIn: https://www.linkedin.com/in/surajbayas
