### PR TITLE
fix: add PurePath and range support to msgpack checkpoint serializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,18 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ('builtins', 'range', (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1235,3 +1235,31 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def test_serde_jsonplus_purepath() -> None:
+    """PurePath subclasses (PurePosixPath, PureWindowsPath) survive round-trip."""
+    serde = JsonPlusSerializer()
+
+    for p in [
+        pathlib.PurePosixPath("/tmp/foo/bar"),
+        pathlib.PurePosixPath("relative/path"),
+        pathlib.PurePosixPath("."),
+    ]:
+        assert serde.loads_typed(serde.dumps_typed(p)) == p
+
+
+def test_serde_jsonplus_range() -> None:
+    """range objects survive round-trip."""
+    serde = JsonPlusSerializer()
+
+    for r in [
+        range(10),
+        range(0, 10, 2),
+        range(5, 0, -1),
+        range(0),
+    ]:
+        result = serde.loads_typed(serde.dumps_typed(r))
+        assert result == r
+        assert isinstance(result, range)
+


### PR DESCRIPTION
## Summary

`JsonPlusSerializer._msgpack_default` has two gaps:

1. **`isinstance(obj, pathlib.Path)` misses `PurePath` subclasses** — `PurePosixPath` and `PureWindowsPath` don't inherit from `pathlib.Path`, only from `pathlib.PurePath`. Any checkpoint state containing a `PurePath` raises `TypeError`.

2. **`range` objects are not handled** — a `range` in checkpoint state (e.g. as a parameter or slice) raises `TypeError: Object of type range is not serializable`.

## Fix

1. Changed `isinstance(obj, pathlib.Path)` → `isinstance(obj, pathlib.PurePath)` — covers all path types (PurePosixPath, PureWindowsPath, PosixPath, WindowsPath).

2. Added `range` serialization via `EXT_CONSTRUCTOR_POS_ARGS` as `('builtins', 'range', (start, stop, step))`, which round-trips correctly through the existing deserialization path (`range(*args)`).

Added tests for both types in `test_jsonplus.py`.

Closes #8350
