### PR TITLE
fix: remove AsyncPipeline support from AsyncPostgresSaver to prevent SSL connection errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -66,14 +66,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
         cls,
         conn_string: str,
         *,
-        pipeline: bool = False,
         serde: SerializerProtocol | None = None,
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
         Args:
             conn_string: The Postgres connection info string.
-            pipeline: whether to use AsyncPipeline
 
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
@@ -81,11 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
         async with await AsyncConnection.connect(
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
-            if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
-            else:
-                yield cls(conn=conn, serde=serde)
+            yield cls(conn=conn, serde=serde)
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## What
The AsyncPostgresSaver with `pipeline=True` consistently fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when used in a LangGraph that makes LLM calls (which introduce `await` points). The pipeline is not flushed before the coroutine yields control, leading to a protocol violation that forces the server to close the connection.

## Fix
Remove the `pipeline` parameter from `from_conn_string` and the associated `AsyncPipeline` usage. The checkpointer does sequential operations with context switches (e.g., LLM calls), which is incompatible with pipelining. Using a simple connection without pipelining is safe and avoids this SSL error.

Closes #5675