### PR TITLE
fix(serde): msgpack serialization for pathlib.PurePath and range

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -33,6 +33,7 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),
+        ("builtins", "range"),
         ("collections", "deque"),
         # ip addresses
         ("ipaddress", "IPv4Address"),
@@ -45,6 +46,9 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("pathlib", "Path"),
         ("pathlib", "PosixPath"),
         ("pathlib", "WindowsPath"),
+        ("pathlib", "PurePath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "PureWindowsPath"),
         # pathlib in Python 3.13+
         ("pathlib._local", "Path"),
         ("pathlib._local", "PosixPath"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,18 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "range", (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):


### PR DESCRIPTION
## Summary

Fixes #8350.

### Problem
The msgpack/JSON+ serializer fails on `pathlib.PurePath` subclasses (like `PurePosixPath` and `PureWindowsPath`) because it strictly checks `isinstance(obj, pathlib.Path)` instead of `pathlib.PurePath`. It also fails on `range` objects because they have no serializer, though they are commonly used in iteration state.

### Changes
- **jsonplus.py**: Changed `pathlib.Path` to `pathlib.PurePath` to cover all path variants. Added serialization for `range` by encoding `(start, stop, step)`.
- **_msgpack.py**: Added `builtins.range` and the `PurePath` variants to `SAFE_MSGPACK_TYPES` to allow deserialization under `LANGGRAPH_STRICT_MSGPACK=true`.
