### PR TITLE
fix(checkpoint): serialize pathlib.PurePath subclasses and range in msgpack encoder

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,18 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "range", (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1235,3 +1235,30 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def test_serde_jsonplus_purepath() -> None:
+    """PurePath subclasses (PurePosixPath, PureWindowsPath) survive round-trip."""
+    serde = JsonPlusSerializer()
+
+    for p in [
+        pathlib.PurePosixPath("/tmp/foo/bar"),
+        pathlib.PurePosixPath("relative/path"),
+        pathlib.PurePosixPath("."),
+    ]:
+        assert serde.loads_typed(serde.dumps_typed(p)) == p
+
+
+def test_serde_jsonplus_range() -> None:
+    """range objects survive round-trip."""
+    serde = JsonPlusSerializer()
+
+    for r in [
+        range(10),
+        range(0, 10, 2),
+        range(5, 0, -1),
+        range(0),
+    ]:
+        result = serde.loads_typed(serde.dumps_typed(r))
+        assert result == r
+        assert isinstance(result, range)


### PR DESCRIPTION
The msgpack checkpoint serializer only handled concrete pathlib.Path instances, so any PurePath subclass that isn't also a Path (like PurePosixPath, PureWindowsPath) hit the generic fallback and failed to round-trip — which breaks checkpointer state that contains those types. range objects had no serializer at all and failed the same way.

I widened the Path branch to isinstance(obj, pathlib.PurePath) so all path variants serialize via the same constructor-args path (class module/name/parts), and added a dedicated range branch that reconstructs from (start, stop, step). Both preserve the exact subclass on deserialization.

Added round-trip tests covering PurePosixPath (absolute/relative/dot) and range with default, stepped, descending, and empty variants. Existing Path serialization is unchanged and still covered.

Fixes #8350
