### PR TITLE
fix(langgraph): infer edges from `Command` return hints using a union of `Literal`s

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -127,6 +127,24 @@ def _get_node_name(node: StateNode[Any, ContextT]) -> str:
         raise TypeError(f"Unsupported node type: {type(node)}")
 
 
+def _extract_command_ends(command_arg: Any) -> tuple[Any, ...] | None:
+    """Extract the `goto` destinations declared in a `Command` type argument.
+
+    Accepts either a single `Literal["a", "b"]` or a union of literals such as
+    `Literal["a"] | Literal["b"]`, which the typing spec treats as equivalent.
+    Returns `None` when the destinations can't be read statically.
+    """
+    if get_origin(command_arg) is Literal:
+        return get_args(command_arg)
+    if get_origin(command_arg) is Union:
+        members = get_args(command_arg)
+        if all(get_origin(member) is Literal for member in members):
+            return (
+                tuple(value for member in members for value in get_args(member)) or None
+            )
+    return None
+
+
 class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
     """A graph whose nodes communicate by reading and writing to a shared state.
 
@@ -840,8 +858,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                     if (
                         rtn_origin is Command
                         and (rargs := get_args(rtn))
-                        and get_origin(rargs[0]) is Literal
-                        and (vals := get_args(rargs[0]))
+                        and (vals := _extract_command_ends(rargs[0])) is not None
                     ):
                         ends = vals
         except (NameError, TypeError, StopIteration):

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -2,7 +2,7 @@ import inspect
 import operator
 import warnings
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Union
+from typing import Annotated, Any, Literal, Union
 from typing import Annotated as Annotated2
 
 import pytest
@@ -14,10 +14,12 @@ from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.graph.state import (
     StateGraph,
+    _extract_command_ends,
     _get_node_name,
     _is_field_channel,
     _warn_invalid_state_schema,
 )
+from langgraph.types import Command
 
 
 class State(BaseModel):
@@ -371,3 +373,37 @@ def test_is_field_channel() -> None:
     # No channel cases
     assert _is_field_channel(int) is None
     assert _is_field_channel(Annotated[int, "just_metadata"]) is None
+
+
+def test_extract_command_ends_handles_union_of_literals() -> None:
+    # A single Literal with multiple values.
+    assert _extract_command_ends(Literal["a", "b"]) == ("a", "b")
+    # A union of single-value Literals is equivalent per the typing spec.
+    assert _extract_command_ends(Literal["a"] | Literal["b"]) == ("a", "b")
+    assert _extract_command_ends(Union[Literal["a"], Literal["b"]]) == ("a", "b")  # noqa: UP007
+    # Not statically resolvable to a set of destinations.
+    assert _extract_command_ends(Literal["a"] | str) is None
+    assert _extract_command_ends(str) is None
+
+
+def test_command_return_hint_union_of_literals_infers_ends() -> None:
+    """Regression for edge inference (#8369): a node returning
+    Command[Literal["a"] | Literal["b"]] must expose the same destinations as
+    Command[Literal["a", "b"]], so conditional edges are inferred and drawn."""
+
+    class S(TypedDict):
+        x: str
+
+    def router(state: S) -> Command[Literal["a"] | Literal["b"]]:
+        return Command(goto="a")
+
+    union_builder = StateGraph(S)
+    union_builder.add_node(router)
+    assert union_builder.nodes["router"].ends == ("a", "b")
+
+    def router_single(state: S) -> Command[Literal["a", "b"]]:
+        return Command(goto="a")
+
+    single_builder = StateGraph(S)
+    single_builder.add_node("router", router_single)
+    assert single_builder.nodes["router"].ends == ("a", "b")


### PR DESCRIPTION
Fixes #8369

## Problem

A node whose return hint is a `Command` parameterized with a union of `Literal`s, e.g. `Command[Literal["a"] | Literal["b"]]`, had no destinations inferred, so its conditional edges were missing from the compiled graph and from `draw_mermaid()`. The equivalent `Command[Literal["a", "b"]]` works. The two are equivalent per the typing spec, and the union form arises naturally when routing targets are defined as reusable `Literal` type aliases and combined with `|`.

The edge-inference in `StateGraph.add_node` only accepted a single `Literal[...]` as the `Command` type argument (`get_origin(rargs[0]) is Literal`), so a `Union` of literals fell through and no `ends` were recorded.

## Fix

Extract the destinations from either form via a small helper, `_extract_command_ends`, which returns the literal values for a bare `Literal[...]` or, for a union, the concatenation of every member's literal values (and `None` when a member isn't a `Literal`, so genuinely unresolvable hints are left untouched).

## Tests

Added to `libs/langgraph/tests/test_state.py`:
- `test_extract_command_ends_handles_union_of_literals` covers the helper directly, including the non-resolvable cases
- `test_command_return_hint_union_of_literals_infers_ends` builds a graph with a `Command[Literal["a"] | Literal["b"]]` router and asserts the inferred `ends` match the single-`Literal` form

Verified against the real source that the union form yields `ends == ()` before this change and `("a", "b")` after.
