### PR TITLE
fix(graph): warn when nodes return undeclared state keys

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1446,6 +1446,18 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
+                undeclared = [k for k in input if k not in output_keys]
+                if undeclared:
+                    warnings.warn(
+                        (
+                            f"Node '{key}' returned state keys not declared in the "
+                            f"graph state schema and they were ignored: {undeclared}. "
+                            "Add them to the state schema (or stop returning them) to "
+                            "persist these values."
+                        ),
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:

--- a/libs/langgraph/tests/test_issue_8320_undeclared_keys.py
+++ b/libs/langgraph/tests/test_issue_8320_undeclared_keys.py
@@ -1,0 +1,62 @@
+"""Regression tests for silent drop of undeclared node output keys (#8320)."""
+
+from __future__ import annotations
+
+import warnings
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+
+def test_undeclared_node_output_key_emits_user_warning() -> None:
+    class State(TypedDict):
+        x: int
+
+    def node(state: State) -> dict:
+        return {"x": 1, "undeclared_key": "this was dropped silently"}
+
+    graph = StateGraph(State)
+    graph.add_node("n", node)
+    graph.add_edge(START, "n")
+    graph.add_edge("n", END)
+    app = graph.compile()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        result = app.invoke({"x": 0})
+
+    assert result == {"x": 1}
+    undeclared_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning)
+        and "undeclared_key" in str(w.message)
+        and "not declared" in str(w.message)
+    ]
+    assert undeclared_warnings, "expected UserWarning for dropped undeclared state keys"
+    assert "Node 'n'" in str(undeclared_warnings[0].message)
+
+
+def test_declared_keys_only_do_not_warn() -> None:
+    class State(TypedDict):
+        x: int
+
+    def node(state: State) -> dict:
+        return {"x": 2}
+
+    graph = StateGraph(State)
+    graph.add_node("n", node)
+    graph.add_edge(START, "n")
+    graph.add_edge("n", END)
+    app = graph.compile()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        result = app.invoke({"x": 0})
+
+    assert result == {"x": 2}
+    assert not [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning) and "not declared" in str(w.message)
+    ]


### PR DESCRIPTION
## Summary
Fixes #8320.

`StateGraph` silently dropped keys returned by a node that were not declared in the state schema (`_get_updates` filtered with `if k in output_keys`), so runs stayed green while developer state disappeared.

### Change
- Emit a `UserWarning` naming the node and dropped keys at the `_get_updates` dict boundary.
- Keep filtering behavior for backward compatibility (no hard fail / strict mode yet — easy to extend if maintainers prefer).

### Tests
- `tests/test_issue_8320_undeclared_keys.py` (warning on undeclared key; no warning when only declared keys).

### Note on prior PRs
#8325 / #8363 appear to have been auto-closed by the require-issue-link bot for unassigned authors. I've requested assignment on #8320. Happy to iterate on warning vs strict-mode if preferred.

## Test plan
- [x] `uv run pytest tests/test_issue_8320_undeclared_keys.py -q` (2 passed)
- [ ] CI on this PR