### PR TITLE
fix(checkpoint): don't crash InMemoryStore search on non-numeric filter values

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -578,15 +578,26 @@ def _apply_operator(value: Any, operator: str, op_value: Any) -> bool:
     """Apply a comparison operator, matching PostgreSQL's JSONB behavior."""
     if operator == "$eq":
         return value == op_value
-    elif operator == "$gt":
-        return float(value) > float(op_value)
-    elif operator == "$gte":
-        return float(value) >= float(op_value)
-    elif operator == "$lt":
-        return float(value) < float(op_value)
-    elif operator == "$lte":
-        return float(value) <= float(op_value)
     elif operator == "$ne":
         return value != op_value
+    elif operator in ("$gt", "$gte", "$lt", "$lte"):
+        try:
+            numeric_value = float(value)
+            numeric_op_value = float(op_value)
+        except (TypeError, ValueError):
+            # A missing (None) or non-numeric value cannot satisfy a numeric
+            # comparison, so the item simply does not match. This mirrors
+            # Postgres, whose comparison yields NULL/false for such rows rather
+            # than raising, and avoids crashing an entire search because a
+            # single item lacks the field or stores an incomparable value.
+            return False
+        if operator == "$gt":
+            return numeric_value > numeric_op_value
+        elif operator == "$gte":
+            return numeric_value >= numeric_op_value
+        elif operator == "$lt":
+            return numeric_value < numeric_op_value
+        else:  # "$lte"
+            return numeric_value <= numeric_op_value
     else:
         raise ValueError(f"Unsupported operator: {operator}")

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -716,6 +716,29 @@ async def test_async_vector_update_with_embedding(
     assert not any(r.key == "doc4" for r in results_new)
 
 
+def test_search_numeric_filter_with_missing_or_non_numeric_values() -> None:
+    """Range operators must not crash when items lack the field or store a
+    non-numeric value; such items simply do not match."""
+    store = InMemoryStore()
+    store.put(("users",), "alice", {"name": "Alice", "age": 30})
+    store.put(("users",), "bob", {"name": "Bob"})  # missing "age"
+    store.put(("users",), "cara", {"name": "Cara", "age": "unknown"})  # non-numeric
+
+    # Previously raised TypeError/ValueError from float(None) / float("unknown").
+    for operator, threshold in (("$gt", 25), ("$gte", 30), ("$lt", 40), ("$lte", 30)):
+        results = store.search(("users",), filter={"age": {operator: threshold}})
+        # only the comparable numeric item can match; missing/non-numeric drop out
+        assert [r.key for r in results] == ["alice"]
+
+    # A threshold that excludes the only numeric item yields no matches (no error)
+    assert store.search(("users",), filter={"age": {"$gt": 100}}) == []
+
+    # Numeric comparisons still work across multiple comparable items
+    store.put(("users",), "dave", {"name": "Dave", "age": 45})
+    keys = {r.key for r in store.search(("users",), filter={"age": {"$gte": 30}})}
+    assert keys == {"alice", "dave"}
+
+
 def test_vector_search_with_filters(fake_embeddings: CharacterEmbeddings) -> None:
     """Test combining vector search with filters."""
     inmem_store = InMemoryStore(


### PR DESCRIPTION
Fixes #8365

`_apply_operator` called `float(value)` unconditionally for `$gt`/`$gte`/`$lt`/`$lte`, so a single item missing the filtered field (`None`) or holding a non-numeric value aborted the whole search with `TypeError`/`ValueError`. This guards the numeric conversion and treats non-comparable items as non-matching, mirroring the Postgres store (`value->>%s > %s`), which yields NULL/false for such rows rather than erroring — the behavior this function's docstring already claims to follow.

Added a regression test covering missing and non-numeric values across the range operators.

**Verification:** `make format`, `make lint`, and `make test` pass in `libs/checkpoint` (174 passed).