### PR TITLE
fix(checkpoint): avoid nan cosine scores for zero-norm vectors in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -505,8 +505,10 @@ def _cosine_similarity(X: list[float], Y: list[list[float]]) -> list[float]:
         X_norm = np.linalg.norm(X_arr)
         Y_norm = np.linalg.norm(Y_arr, axis=1)
 
-        # Avoid division by zero
-        mask = Y_norm != 0
+        # Avoid division by zero: a zero-norm query or candidate vector has an
+        # undefined cosine similarity, so score it 0.0 (matching the pure-Python
+        # path below) instead of producing nan.
+        mask = (Y_norm != 0) & (X_norm != 0)
         similarities = np.zeros_like(Y_norm)
         similarities[mask] = np.dot(Y_arr[mask], X_arr) / (Y_norm[mask] * X_norm)
         return similarities.tolist()

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -716,6 +716,28 @@ async def test_async_vector_update_with_embedding(
     assert not any(r.key == "doc4" for r in results_new)
 
 
+@pytest.mark.parametrize("use_numpy", [True, False])
+def test_cosine_similarity_zero_norm_vectors(use_numpy: bool) -> None:
+    """A zero-norm query or candidate vector must score 0.0, not nan, on both
+    the numpy and pure-Python code paths."""
+    import langgraph.store.memory as memory_module
+    from langgraph.store.memory import _cosine_similarity
+
+    original = memory_module._check_numpy
+    memory_module._check_numpy = lambda: use_numpy
+    try:
+        # zero-norm query vector against non-zero candidates
+        result = _cosine_similarity([0.0, 0.0], [[1.0, 2.0], [3.0, 4.0]])
+        assert result == [0.0, 0.0]
+
+        # zero-norm candidate vector mixed with a normal one
+        mixed = _cosine_similarity([1.0, 0.0], [[0.0, 0.0], [1.0, 0.0]])
+        assert mixed[0] == 0.0
+        assert mixed[1] == pytest.approx(1.0)
+    finally:
+        memory_module._check_numpy = original
+
+
 def test_vector_search_with_filters(fake_embeddings: CharacterEmbeddings) -> None:
     """Test combining vector search with filters."""
     inmem_store = InMemoryStore(


### PR DESCRIPTION
Fixes #8367

The numpy path of `_cosine_similarity` masked zero-norm candidate vectors (`Y`) but not a zero-norm query vector (`X`), so a zero-norm query embedding divided by zero and produced `nan` scores — which sort unpredictably and silently corrupt vector-search ordering. The pure-Python fallback already returns `0.0` for this case. This masks `X_norm == 0` as well so both paths agree.

Added a regression test (parametrized over the numpy and pure-Python paths) covering zero-norm query and candidate vectors.

**Verification:** `make format`, `make lint`, and `make test` pass in `libs/checkpoint` (174 passed).