### PR TITLE
fix: infer command destinations from literal unions

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, is_dataclass
 from datetime import timedelta
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
-from types import FunctionType
+from types import FunctionType, UnionType
 from types import NoneType as NoneType
 from typing import (
     Any,
@@ -96,6 +96,36 @@ logger = logging.getLogger(__name__)
 
 _CHANNEL_BRANCH_TO = "branch:to:{}"
 _DEFAULT_ERROR_HANDLER_NODE = "__default_error_handler__"
+
+
+def _is_union_type(hint: Any) -> bool:
+    return get_origin(hint) in (Union, UnionType)
+
+
+def _get_literal_values(hint: Any) -> tuple[str, ...]:
+    if get_origin(hint) is Literal:
+        return get_args(hint)
+
+    if _is_union_type(hint):
+        return tuple(
+            value for arg in get_args(hint) for value in _get_literal_values(arg)
+        )
+
+    return EMPTY_SEQ
+
+
+def _get_command_destinations(hint: Any) -> tuple[str, ...]:
+    if get_origin(hint) is Command and (command_args := get_args(hint)):
+        return _get_literal_values(command_args[0])
+
+    if _is_union_type(hint):
+        return tuple(
+            destination
+            for arg in get_args(hint)
+            for destination in _get_command_destinations(arg)
+        )
+
+    return EMPTY_SEQ
 
 
 @dataclass(slots=True)
@@ -824,26 +854,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                         if isinstance(input_hint, type) and get_type_hints(input_hint):
                             inferred_input_schema = input_hint
                 if rtn := hints.get("return"):
-                    # Handle Union types
-                    rtn_origin = get_origin(rtn)
-                    if rtn_origin is Union:
-                        rtn_args = get_args(rtn)
-                        # Look for Command in the union
-                        for arg in rtn_args:
-                            arg_origin = get_origin(arg)
-                            if arg_origin is Command:
-                                rtn = arg
-                                rtn_origin = arg_origin
-                                break
-
-                    # Check if it's a Command type
-                    if (
-                        rtn_origin is Command
-                        and (rargs := get_args(rtn))
-                        and get_origin(rargs[0]) is Literal
-                        and (vals := get_args(rargs[0]))
-                    ):
-                        ends = vals
+                    if destinations := _get_command_destinations(rtn):
+                        ends = destinations
         except (NameError, TypeError, StopIteration):
             pass
 

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -2,7 +2,7 @@ import inspect
 import operator
 import warnings
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Union
+from typing import Annotated, Any, Literal, Union
 from typing import Annotated as Annotated2
 
 import pytest
@@ -18,6 +18,7 @@ from langgraph.graph.state import (
     _is_field_channel,
     _warn_invalid_state_schema,
 )
+from langgraph.types import Command
 
 
 class State(BaseModel):
@@ -133,6 +134,49 @@ def test_state_schema_with_type_hint():
             assert c[node_name] == foo_state
         else:
             assert c[node_name] == output_state
+
+
+def test_command_literal_union_infers_node_ends() -> None:
+    class State(TypedDict):
+        foo: str
+
+    def router_one_command(
+        state: State,
+    ) -> Command[Literal["foo", "bar"]]:
+        return Command(goto="foo")
+
+    def router_one_command_union_literal(
+        state: State,
+    ) -> Command[Literal["foo"] | Literal["bar"]]:
+        return Command(goto="foo")
+
+    def router_union_command(
+        state: State,
+    ) -> Command[Literal["foo"]] | Command[Literal["bar"]]:
+        return Command(goto="foo")
+
+    def node(state: State) -> State:
+        return state
+
+    for router in (
+        router_one_command,
+        router_one_command_union_literal,
+        router_union_command,
+    ):
+        builder = StateGraph(State)
+        builder.add_node("router", router)
+        builder.add_node("foo", node)
+        builder.add_node("bar", node)
+        builder.add_edge("__start__", "router")
+        builder.add_edge("foo", "__end__")
+        builder.add_edge("bar", "__end__")
+
+        graph = builder.compile().get_graph()
+
+        router_edges = {
+            edge.target for edge in graph.edges if edge.source == "router"
+        }
+        assert router_edges == {"foo", "bar"}
 
 
 @pytest.mark.parametrize("total_", [True, False])


### PR DESCRIPTION
﻿## Summary

- infer `StateGraph.add_node` destinations from `Command[Literal["a"] | Literal["b"]]`
- also infer destinations from `Command[Literal["a"]] | Command[Literal["b"]]`
- add regression coverage for existing and newly supported `Command` return annotations

## Why

`StateGraph.add_node` inferred destination edges only when `Command` was parameterized with a single `Literal[...]`, such as `Command[Literal["foo", "bar"]]`. Equivalent union forms did not populate node `ends`, so the compiled graph and Mermaid rendering omitted the conditional edges.

This updates the return annotation parsing to recursively collect `Literal` destinations from `Command[...]`, `typing.Union[...]`, and PEP 604 `|` unions.

Fixes #8369

## Testing

- `uv run --no-sync pytest tests/test_state.py -k command_literal_union_infers_node_ends`
- `uv run --no-sync pytest tests/test_state.py`
- `uv run --no-sync python -m py_compile langgraph/graph/state.py tests/test_state.py`
- `git diff --check`

Note: full `make test` / `uv sync --group test` could not run locally on Windows because `uvloop==0.22.1` does not support Windows.
