### PR TITLE
fix(sdk): reject reserved x-api-key header case-insensitively

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_shared/utilities.py
+++ b/libs/sdk-py/langgraph_sdk/_shared/utilities.py
@@ -54,8 +54,11 @@ def _get_headers(
 ) -> dict[str, str]:
     """Combine api_key and custom user-provided headers."""
     custom_headers = custom_headers or {}
+    # HTTP field names are case-insensitive, so compare case-folded to stop a
+    # mixed-case spelling (e.g. "X-API-Key") from bypassing the guard.
+    lowered_custom = {name.lower() for name in custom_headers}
     for header in RESERVED_HEADERS:
-        if header in custom_headers:
+        if header in lowered_custom:
             raise ValueError(f"Cannot set reserved header '{header}'")
 
     headers = {

--- a/libs/sdk-py/tests/test_reserved_headers.py
+++ b/libs/sdk-py/tests/test_reserved_headers.py
@@ -1,0 +1,28 @@
+"""Tests that the reserved-header guard is case-insensitive."""
+
+import pytest
+
+from langgraph_sdk import get_client, get_sync_client
+
+
+class TestReservedHeaderGuard:
+    """``x-api-key`` must be rejected as a custom header regardless of casing."""
+
+    @pytest.mark.parametrize("header_name", ["x-api-key", "X-API-Key", "X-Api-Key"])
+    def test_get_client_rejects_reserved_header(self, header_name):
+        with pytest.raises(ValueError, match="reserved header"):
+            get_client(url="http://localhost:8123", headers={header_name: "custom"})
+
+    @pytest.mark.parametrize("header_name", ["x-api-key", "X-API-Key", "X-Api-Key"])
+    def test_get_sync_client_rejects_reserved_header(self, header_name):
+        with pytest.raises(ValueError, match="reserved header"):
+            get_sync_client(
+                url="http://localhost:8123", headers={header_name: "custom"}
+            )
+
+    def test_get_sync_client_allows_non_reserved_header(self):
+        client = get_sync_client(
+            url="http://localhost:8123", headers={"X-Custom": "value"}
+        )
+        assert client.http.client.headers["X-Custom"] == "value"
+        client.close()


### PR DESCRIPTION
## Summary

The Python SDK's reserved-header guard could be bypassed by changing the casing of `x-api-key`.

## Root cause

`_get_headers` checked custom header names against `RESERVED_HEADERS` with case-sensitive membership. HTTP field names are case-insensitive, so a mixed-case spelling such as `X-API-Key` passed the check. When an `api_key` was also configured, the resulting client carried both the custom value and the auto-configured `x-api-key`.

## Fix

Case-fold custom header names before comparing against `RESERVED_HEADERS`, so every case variant is rejected consistently. The `ValueError` message is unchanged. This covers both `get_client` and `get_sync_client`.

## Test before/after

Added `tests/test_reserved_headers.py`, parametrized over `x-api-key`, `X-API-Key`, and `X-Api-Key` for both client factories.

- Before: mixed-case spellings are accepted (no error) while lowercase raises.
- After: all case variants raise `ValueError`; a non-reserved custom header is still accepted.

Closes #8378
