### PR TITLE
fix(checkpoint): preserve Counter and OrderedDict type through msgpack round-trip

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -34,6 +34,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("builtins", "set"),
         ("builtins", "frozenset"),
         ("collections", "deque"),
+        ("collections", "Counter"),
+        ("collections", "OrderedDict"),
         # ip addresses
         ("ipaddress", "IPv4Address"),
         ("ipaddress", "IPv4Interface"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -10,7 +10,7 @@ import pathlib
 import pickle
 import re
 import sys
-from collections import deque
+from collections import Counter, OrderedDict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
@@ -378,6 +378,34 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
             ),
         )
+    elif isinstance(obj, Counter):
+        # Counter is a dict subclass; without OPT_PASSTHROUGH_SUBCLASS ormsgpack
+        # would encode it as a plain map and lose the type. Reconstruct via
+        # Counter(dict(items)) — Counter's __init__ accepts a dict and preserves
+        # count semantics (.most_common(), arithmetic, etc.).
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, dict(obj)),
+            ),
+        )
+    elif isinstance(obj, OrderedDict):
+        # OrderedDict is a dict subclass; encode as list of pairs so
+        # OrderedDict([(k, v), ...]) round-trips and order is explicit
+        # (matters for code that relies on move_to_end / iteration order
+        # semantics that differ from plain dict in some edge cases).
+        # Use EXT_CONSTRUCTOR_SINGLE_ARG (not POS_ARGS) because OrderedDict's
+        # __init__ takes a single iterable of pairs, not multiple positional args.
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    list(obj.items()),
+                ),
+            ),
+        )
     elif isinstance(obj, (set, frozenset, deque)):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
@@ -531,6 +559,20 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
     elif isinstance(obj, BaseException):
         return repr(obj)
     else:
+        # OPT_PASSTHROUGH_SUBCLASS routes all native-base subclasses (str/int/
+        # float/list/dict/bytes subclasses, including numpy scalars like np.int64)
+        # through this default function rather than letting ormsgpack encode them
+        # natively. The branches above handle the subclasses we explicitly care
+        # about (Counter, OrderedDict, set/frozenset/deque subclasses, Enum, etc.);
+        # for any *other* native-base subclass, fall back to encoding the instance
+        # as its base type so we don't regress on types that ormsgpack previously
+        # encoded directly. This mirrors what ormsgpack does internally without
+        # OPT_PASSTHROUGH_SUBCLASS, restoring the pre-passthrough behavior for
+        # unregistered subclasses while still letting our explicit branches above
+        # intercept the ones we want to round-trip with type preservation.
+        for base_type in (str, int, float, bool, list, dict, bytes, bytearray):
+            if isinstance(obj, base_type):
+                return base_type(obj)
         raise TypeError(f"Object of type {obj.__class__.__name__} is not serializable")
 
 
@@ -851,6 +893,7 @@ _option = (
     | ormsgpack.OPT_PASSTHROUGH_DATACLASS
     | ormsgpack.OPT_PASSTHROUGH_DATETIME
     | ormsgpack.OPT_PASSTHROUGH_ENUM
+    | ormsgpack.OPT_PASSTHROUGH_SUBCLASS
     | ormsgpack.OPT_PASSTHROUGH_UUID
     | ormsgpack.OPT_REPLACE_SURROGATES
 )

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -580,9 +580,9 @@ def test_lc2_json_safe_type_pickle_payload_does_not_execute() -> None:
     except Exception:
         pass
 
-    assert not os.path.exists(marker), (
-        "Pickle gadget executed via parse_raw on AIMessage lc=2 envelope"
-    )
+    assert not os.path.exists(
+        marker
+    ), "Pickle gadget executed via parse_raw on AIMessage lc=2 envelope"
 
 
 def test_serde_jsonplus_bytearray() -> None:
@@ -814,9 +814,9 @@ def test_msgpack_safe_types_no_warning(caplog: pytest.LogCaptureFixture) -> None
         caplog.clear()
         dumped = serde.dumps_typed(obj)
         result = serde.loads_typed(dumped)
-        assert "unregistered type" not in caplog.text.lower(), (
-            f"Unexpected warning for {type(obj)}"
-        )
+        assert (
+            "unregistered type" not in caplog.text.lower()
+        ), f"Unexpected warning for {type(obj)}"
         assert result is not None
 
 
@@ -1235,3 +1235,146 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+# --- Counter / OrderedDict round-trip tests (issue #8184) ---
+
+
+def test_serde_jsonplus_counter_roundtrip() -> None:
+    """Counter (a dict subclass) must survive a msgpack round-trip with type and
+    count semantics intact, instead of being silently downcast to plain dict.
+
+    Regression coverage for issue #8184.
+    """
+    from collections import Counter
+
+    serde = JsonPlusSerializer()
+    original = Counter({"a": 3, "b": 1, "c": 2})
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert (
+        type(restored) is Counter
+    ), f"Counter must round-trip as Counter, got {type(restored).__name__}"
+    assert restored == original, "Counter values must be preserved"
+    # Counter-specific behaviour must survive the round-trip
+    assert restored.most_common(2) == original.most_common(
+        2
+    ), "Counter.most_common() must work on restored instance"
+
+
+def test_serde_jsonplus_ordereddict_roundtrip() -> None:
+    """OrderedDict (a dict subclass) must survive a msgpack round-trip with type
+    and order intact, instead of being silently downcast to plain dict.
+
+    Regression coverage for issue #8184.
+    """
+    from collections import OrderedDict
+
+    serde = JsonPlusSerializer()
+    # Use non-alphabetical key order so order preservation is observable
+    original = OrderedDict([("z", 1), ("a", 2), ("m", 3)])
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert (
+        type(restored) is OrderedDict
+    ), f"OrderedDict must round-trip as OrderedDict, got {type(restored).__name__}"
+    assert restored == original, "OrderedDict values must be preserved"
+    assert list(restored.keys()) == list(
+        original.keys()
+    ), "OrderedDict insertion order must be preserved"
+    # OrderedDict-specific behaviour must survive the round-trip
+    restored.move_to_end("z")
+    assert list(restored.keys()) == [
+        "a",
+        "m",
+        "z",
+    ], "OrderedDict.move_to_end() must work on restored instance"
+
+
+def test_serde_jsonplus_counter_in_nested_state() -> None:
+    """A Counter held inside a larger state dict must round-trip with its type
+    preserved, mirroring how it would be used in real graph state.
+    """
+    from collections import Counter
+
+    serde = JsonPlusSerializer()
+    state = {
+        "counts": Counter({"red": 2, "blue": 5, "green": 1}),
+        "name": "test",
+        "plain_dict": {"keep": "me"},
+    }
+
+    restored = serde.loads_typed(serde.dumps_typed(state))
+
+    assert (
+        type(restored["counts"]) is Counter
+    ), f"Nested Counter must round-trip as Counter, got {type(restored['counts']).__name__}"
+    assert restored["counts"] == state["counts"]
+    assert (
+        type(restored["plain_dict"]) is dict
+    ), "Plain dict must remain plain dict (not be upcast)"
+
+
+def test_serde_jsonplus_ordereddict_in_nested_state() -> None:
+    """An OrderedDict held inside a larger state dict must round-trip with its
+    type and order preserved.
+    """
+    from collections import OrderedDict
+
+    serde = JsonPlusSerializer()
+    state = {
+        "ordered": OrderedDict([("first", 1), ("second", 2), ("third", 3)]),
+        "name": "test",
+    }
+
+    restored = serde.loads_typed(serde.dumps_typed(state))
+
+    assert (
+        type(restored["ordered"]) is OrderedDict
+    ), f"Nested OrderedDict must round-trip as OrderedDict, got {type(restored['ordered']).__name__}"
+    assert list(restored["ordered"].keys()) == ["first", "second", "third"]
+
+
+def test_serde_jsonplus_empty_counter_roundtrip() -> None:
+    """An empty Counter must round-trip without error (edge case)."""
+    from collections import Counter
+
+    serde = JsonPlusSerializer()
+    original = Counter()
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert type(restored) is Counter
+    assert restored == original
+    assert len(restored) == 0
+
+
+def test_serde_jsonplus_empty_ordereddict_roundtrip() -> None:
+    """An empty OrderedDict must round-trip without error (edge case)."""
+    from collections import OrderedDict
+
+    serde = JsonPlusSerializer()
+    original = OrderedDict()
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert type(restored) is OrderedDict
+    assert restored == original
+    assert len(restored) == 0
+
+
+def test_serde_jsonplus_plain_dict_still_round_trips_as_dict() -> None:
+    """Backward-compat: plain dicts must continue to round-trip as plain dict,
+    not be upcast to OrderedDict or Counter by accident.
+    """
+    serde = JsonPlusSerializer()
+    original = {"a": 1, "b": 2}
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert (
+        type(restored) is dict
+    ), f"Plain dict must round-trip as dict, got {type(restored).__name__}"
+    assert restored == original


### PR DESCRIPTION
Fixes #8184

`JsonPlusSerializer` was silently downcasting dict subclasses (`Counter`, `OrderedDict`) to plain `dict` on checkpoint round-trip. A `Counter` held in graph state would lose `.most_common()` / count semantics, and an `OrderedDict` would lose `move_to_end()` / explicit-order semantics. The failure was silent at write time and only surfaced later when resumed code relied on the subclass behaviour — classic "works until restore" failure mode (same shape as the bounded-`deque` issue #8157).

Scoped to `Counter` + `OrderedDict`; `defaultdict` deferred to a follow-up — see "Out of scope" below.

## Root cause

`ormsgpack` encodes `dict` subclasses through its native map path, which discards the subclass type. The `_msgpack_default` fallback that already handles `set`/`frozenset`/`deque` was never reached for `dict` subclasses because `ormsgpack` short-circuited them before calling `default`.

## What changed

| File | Change |
|------|--------|
| `libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py` | 1) Add `ormsgpack.OPT_PASSTHROUGH_SUBCLASS` to the encoder option bitmask so `dict` subclasses (and other native-base subclasses) are routed through `_msgpack_default` instead of being encoded natively. 2) Add explicit `Counter` and `OrderedDict` branches in `_msgpack_default` that encode via `EXT_CONSTRUCTOR_SINGLE_ARG` — `Counter(dict(items))` and `OrderedDict(list_of_pairs)` both reconstruct correctly from a single positional arg. 3) Add a fallback branch that converts any *other* native-base subclass (`str`/`int`/`float`/`bool`/`list`/`dict`/`bytes`/`bytearray` subclasses, including numpy scalars like `np.int64`) to its base type, restoring the pre-passthrough behaviour so the `OPT_PASSTHROUGH_SUBCLASS` change doesn't regress them. |
| `libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py` | Add `("collections", "Counter")` and `("collections", "OrderedDict")` to `SAFE_MSGPACK_TYPES` so they pass the `_check_allowed` gate under strict mode (`LANGGRAPH_STRICT_MSGPACK=true`). |
| `libs/checkpoint/tests/test_jsonplus.py` | 7 new round-trip tests (see below). |

**No decoder changes needed** — the existing `EXT_CONSTRUCTOR_SINGLE_ARG` decoder branch already does `getattr(import_module(module), name)(arg)`, so `Counter(dict)` and `OrderedDict(list_of_pairs)` both reconstruct correctly.

## Why this approach

Building on @ly-wang19's analysis in the issue thread:

- **`OPT_PASSTHROUGH_SUBCLASS` + explicit branches** is the cleanest interception point. The alternative (intercepting only via `isinstance` checks without the option) doesn't work because ormsgpack never calls `default` for native-type subclasses unless `OPT_PASSTHROUGH_SUBCLASS` is set.
- **`EXT_CONSTRUCTOR_SINGLE_ARG` for both** (not `POS_ARGS` for `OrderedDict`) because `OrderedDict.__init__` takes a single iterable of pairs, not multiple positional args. I initially used `POS_ARGS` and the decoder returned `None` because `OrderedDict(*[(k,v), ...])` raises `TypeError: expected at most 1 arguments, got N`. Fixed by switching to `SINGLE_ARG`.
- **Fallback branch for unhandled subclasses** is required to avoid regressing numpy scalars (`np.int64` etc.) and any other native-base subclass that ormsgpack previously encoded directly. The fallback converts the instance to its base type via `base_type(obj)`, mirroring what ormsgpack does internally without `OPT_PASSTHROUGH_SUBCLASS`. (Note: `np.int64` was *already* broken on `main` — it raised `TypeError: Object of type int64 is not serializable` — so this PR preserves that pre-existing behaviour rather than making it worse. A proper numpy-scalar fix is a separate concern.)
- **`defaultdict` deferred**: its `default_factory` can be a lambda or custom callable that is not safely encodable without a pickle fallback. That needs a separate design call (pickle fallback vs. warn-and-downcast) and is better handled in a follow-up PR. The issue thread explicitly flagged this as the awkward case.

## Backward compatibility

Pre-fix checkpoints deserialize unchanged (as plain `dict`), so the change is purely additive on the encode side — no migration debt, no risk of breaking existing sessions.

## Tests and Documentation

7 new round-trip tests in `libs/checkpoint/tests/test_jsonplus.py`:

- `test_serde_jsonplus_counter_roundtrip` — type preservation + `.most_common()` survival
- `test_serde_jsonplus_ordereddict_roundtrip` — type preservation + order preservation + `.move_to_end()` survival
- `test_serde_jsonplus_counter_in_nested_state` — nested in a larger state dict
- `test_serde_jsonplus_ordereddict_in_nested_state` — nested in a larger state dict
- `test_serde_jsonplus_empty_counter_roundtrip` — empty-instance edge case
- `test_serde_jsonplus_empty_ordereddict_roundtrip` — empty-instance edge case
- `test_serde_jsonplus_plain_dict_still_round_trips_as_dict` — backward-compat: plain dict still round-trips as plain dict (not upcast)

### Test commands run and results

```bash
# 1. New tests only
$ python -m pytest libs/checkpoint/tests/test_jsonplus.py -v -k "counter or ordereddict or plain_dict_still"
======================= 7 passed, 99 deselected in 0.41s =======================

# 2. Full test_jsonplus.py suite (no regressions)
$ python -m pytest libs/checkpoint/tests/test_jsonplus.py
============================= 106 passed in 0.49s =============================

# 3. Broader checkpoint test suite (test_jsonplus + test_memory + test_store)
$ python -m pytest libs/checkpoint/tests/test_jsonplus.py libs/checkpoint/tests/test_memory.py libs/checkpoint/tests/test_store.py
============================= 146 passed in 0.77s =============================

# 4. Lint + format
$ ruff check libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py libs/checkpoint/tests/test_jsonplus.py
All checks passed!
$ black --check libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py libs/checkpoint/tests/test_jsonplus.py
All done. ✨ 🍰 ✨
```

## Out of scope (follow-up)

`defaultdict` is intentionally NOT covered in this PR. Its `default_factory` can be:
- a builtin (`list`, `int`, `set`) — encodable as `(module, name)` and reconstructed via import
- `None` — trivially encodable
- a lambda / custom callable — not safely encodable without pickle fallback

The first two cover the overwhelmingly common case. The third needs a design call (pickle fallback vs. warn-and-downcast) and is better handled in a follow-up PR. Happy to open that follow-up if maintainers confirm the preferred approach.

## AI assistance disclosure

Drafted with AI assistance (Claude), reviewed and tested by me before submission. I have read every line of the diff, run the full test suite locally (106 + 146 tests pass), and verified the fix end-to-end against the reproduction case in the issue body. The scoping decision (Counter + OrderedDict only, defaultdict deferred) was mine, based on @ly-wang19's analysis in the issue thread and the encodability tradeoff for `default_factory`.

Co-authored-by: Claude <noreply@anthropic.com>
