### PR TITLE
fix: properly sync AsyncPipeline on exit to prevent SSL connection closure (#5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -83,7 +83,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                    try:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
+                    finally:
+                        await pipe.sync()  # Ensure all pending operations are flushed
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
AsyncPostgresSaver using `AsyncPipeline` mode consistently fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This occurs because the pipeline's internal buffers are not properly flushed when the context manager exits, especially when user code within the `async with AsyncPostgresSaver` block raises an exception or executes LLM calls that cause delays, leaving the pipeline in an inconsistent state.

## Fix
Ensure that when `pipeline=True` is used, the pipeline is explicitly synchronized (`pipe.sync()`) in a `finally` block upon exit from the `from_conn_string` context manager. This guarantees all pending queries are sent and acknowledged before the connection is closed, preventing SSL/connection corruption.

Closes #5675