### PR TITLE
fix(sdk-py): honor raise_error in sync wait; case-insensitive reserved headers

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_shared/utilities.py
+++ b/libs/sdk-py/langgraph_sdk/_shared/utilities.py
@@ -54,8 +54,10 @@ def _get_headers(
 ) -> dict[str, str]:
     """Combine api_key and custom user-provided headers."""
     custom_headers = custom_headers or {}
+    # HTTP header names are case-insensitive; reject any casing of reserved keys.
+    lower_custom = {str(name).lower() for name in custom_headers}
     for header in RESERVED_HEADERS:
-        if header in custom_headers:
+        if header in lower_custom:
             raise ValueError(f"Cannot set reserved header '{header}'")
 
     headers = {

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -815,7 +815,6 @@ class SyncRunsClient:
             "checkpoint_during": checkpoint_during,
             "on_completion": on_completion,
             "after_seconds": after_seconds,
-            "raise_error": raise_error,
             "durability": durability,
             "langsmith_tracer": langsmith_tracing,
         }
@@ -830,7 +829,7 @@ class SyncRunsClient:
             if thread_id is not None
             else "/runs/wait"
         )
-        return self.http.request_reconnect(
+        response = self.http.request_reconnect(
             endpoint,
             "POST",
             json={k: v for k, v in payload.items() if v is not None},
@@ -838,6 +837,19 @@ class SyncRunsClient:
             headers=headers,
             on_response=on_response if on_run_created else None,
         )
+        # Mirror the async client: raise client-side when the run payload carries
+        # an error envelope. Previously raise_error was only forwarded in the
+        # request body and never enforced here (#8383).
+        if (
+            raise_error
+            and isinstance(response, dict)
+            and "__error__" in response
+            and isinstance(response["__error__"], dict)
+        ):
+            raise Exception(
+                f"{response['__error__'].get('error')}: {response['__error__'].get('message')}"
+            )
+        return response
 
     def list(
         self,

--- a/libs/sdk-py/tests/test_wait_raise_error_and_reserved_headers.py
+++ b/libs/sdk-py/tests/test_wait_raise_error_and_reserved_headers.py
@@ -1,0 +1,63 @@
+"""Regression tests for #8383 and #8378."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from langgraph_sdk import get_sync_client
+from langgraph_sdk._sync.runs import SyncRunsClient
+
+
+def test_sync_wait_raises_on_error_envelope_when_raise_error_true():
+    response = {
+        "__error__": {
+            "error": "RuntimeError",
+            "message": "boom",
+        }
+    }
+    http = MagicMock()
+    http.request_reconnect.return_value = response
+    client = SyncRunsClient(http)
+
+    with pytest.raises(Exception, match="RuntimeError: boom"):
+        client.wait(
+            None,
+            "agent",
+            input={"messages": []},
+            raise_error=True,
+        )
+
+    # raise_error must not be forwarded as a request body field
+    kwargs = http.request_reconnect.call_args.kwargs
+    assert "raise_error" not in (kwargs.get("json") or {})
+
+
+def test_sync_wait_returns_error_envelope_when_raise_error_false():
+    response = {
+        "__error__": {
+            "error": "RuntimeError",
+            "message": "boom",
+        }
+    }
+    http = MagicMock()
+    http.request_reconnect.return_value = response
+    client = SyncRunsClient(http)
+
+    result = client.wait(
+        None,
+        "agent",
+        input={"messages": []},
+        raise_error=False,
+    )
+    assert result == response
+
+
+def test_reserved_x_api_key_header_rejected_case_insensitively():
+    with pytest.raises(ValueError, match="reserved header"):
+        get_sync_client(
+            url="http://localhost:8123",
+            api_key="configured",
+            headers={"X-API-Key": "custom"},
+        )


### PR DESCRIPTION
## Summary
Two Python SDK correctness bugs, fixed in one PR (single contribution to this repo):

### #8383 — `SyncRunsClient.wait` ignored `raise_error`
The async client raises when the wait payload contains an `__error__` envelope. The sync client only put `raise_error` into the request body and always returned the envelope. Failed runs no longer raised on the sync path.

### #8378 — reserved `x-api-key` header check was case-sensitive
`_get_headers` rejected only the exact lowercase name. Mixed-case variants like `X-API-Key` were accepted and could coexist with the auto-configured API key.

## Change
- Mirror async client-side `__error__` raising in `SyncRunsClient.wait`
- Stop sending `raise_error` as a body field from the sync client
- Compare reserved headers case-insensitively
- Unit tests for both behaviors

## Test plan
- [x] Added `libs/sdk-py/tests/test_wait_raise_error_and_reserved_headers.py`
- Manual: repros from both issues now match expected behavior

Fixes #8383
Fixes #8378
