### PR TITLE
fix: ensure pipeline context is properly managed in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,10 +82,18 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
+                # Pipeline must be managed carefully: the connection must not
+                # be used outside the pipeline context. We yield the instance
+                # and then flush/sync before exiting.
                 async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                    instance = cls(conn=conn, pipe=pipe, serde=serde)
+                    await instance.setup()  # ensure migrations run inside pipeline
+                    yield instance
+                    # Flush pending operations before exiting pipeline
+                    await pipe.sync()
             else:
-                yield cls(conn=conn, serde=serde)
+                instance = cls(conn=conn, serde=serde)
+                yield instance
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver.from_conn_string` with `pipeline=True`, the connection enters a pipeline context but exits before the saver is fully used. Subsequent operations (e.g., `setup()`) can fail with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` because the pipeline state is not properly synchronized.

## Fix
- Ensure that `setup()` (migrations) runs inside the pipeline context when `pipeline=True`.
- Explicitly call `pipe.sync()` before exiting the pipeline context to flush pending operations and avoid leaving the connection in an inconsistent state.
- The fix ensures that the pipeline lifecycle is fully managed within the `from_conn_string` context manager.

Closes #5675