### PR TITLE
fix: collect writes for plain-value seeds in InMemorySaver.get_delta_channel_history

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -205,11 +205,12 @@ class InMemorySaver(
             ):
                 if ch not in remaining:
                     continue
-                blob_value = blob_value_by_ch.get(ch)
-                if blob_value is not None and not isinstance(
-                    blob_value, _DeltaSnapshot
-                ):
-                    continue
+                # Always collect writes for visited ancestors, matching the
+                # reference BaseCheckpointSaver.get_delta_channel_history and
+                # the SqliteSaver override.  A plain-value (pre-migration) seed
+                # does NOT subsume its own checkpoint's pending writes, so
+                # skipping them silently loses the first post-migration write
+                # (fixes #8384).
                 collected_by_ch[ch].append(
                     (tid, ch, self.serde.loads_typed(serialized))
                 )


### PR DESCRIPTION
## Summary

Fixes #8384.

`InMemorySaver.get_delta_channel_history()` silently and permanently drops the first write made after migrating a thread's channel from `BinaryOperatorAggregate` to `DeltaChannel`.

## Root Cause

The optimized `InMemorySaver` override has a special case that skips pending writes for a visited ancestor when that ancestor's stored blob is a plain value (not a `_DeltaSnapshot`):

```python
blob_value = blob_value_by_ch.get(ch)
if blob_value is not None and not isinstance(blob_value, _DeltaSnapshot):
    continue
```

This is incorrect for migrated threads. A plain-value seed checkpoint (written under the pre-migration channel type) does **not** subsume its own checkpoint's pending writes. In the failing case, the stored plain value is `["a"]` while the pending writes attached to that same checkpoint contain `["b"]` — the first post-migration write. Skipping them discards required replay data.

Neither the reference `BaseCheckpointSaver.get_delta_channel_history` nor the `SqliteSaver`/`AsyncSqliteSaver` override has this special case — they collect writes at every visited ancestor until replay terminates.

## Fix

Remove the special case so writes are always collected for visited ancestors, matching the reference implementation and the SQLite optimized path.

## Verification

The issue reporter confirmed that removing this special case:
- Fixes the failing repro (migrate → one non-snapshotting write → cold read via `get_state()`)
- Passes all 42 existing delta-channel tests (`test_delta_channel_migration.py`, `test_delta_channel_exit_mode.py`, `test_delta_channel_update_state.py`, `test_delta_channel_id_stability.py`, `test_delta_channel_supersteps_bound.py`)
- Matches `BaseCheckpointSaver` fallback and `SqliteSaver` behavior across edge cases

## Changes

- `libs/checkpoint/langgraph/checkpoint/memory/__init__.py`: Remove the `if blob_value is not None and not isinstance(blob_value, _DeltaSnapshot): continue` special case; add clarifying comment.