### PR TITLE
fix: ToolNode interrupt propagation and related audit fixes

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -167,25 +167,35 @@ class PostgresSaver(BasePostgresSaver):
                 for v in values
                 if v["checkpoint"]["v"] < 4 and v["parent_checkpoint_id"]
             ]:
-                cur.execute(
-                    self.SELECT_PENDING_SENDS_SQL,
-                    (
-                        values[0]["thread_id"],
-                        [v["parent_checkpoint_id"] for v in to_migrate],
-                    ),
-                )
+                # the results may span multiple threads, and the pending
+                # sends query filters by a single thread_id, so group by
+                # (thread_id, parent_checkpoint_id) and run the query once
+                # per distinct thread_id
                 grouped_by_parent = defaultdict(list)
+                parent_ids_by_thread = defaultdict(set)
                 for value in to_migrate:
-                    grouped_by_parent[value["parent_checkpoint_id"]].append(value)
-                for sends in cur:
-                    for value in grouped_by_parent[sends["checkpoint_id"]]:
-                        if value["channel_values"] is None:
-                            value["channel_values"] = []
-                        self._migrate_pending_sends(
-                            sends["sends"],
-                            value["checkpoint"],
-                            value["channel_values"],
-                        )
+                    grouped_by_parent[
+                        (value["thread_id"], value["parent_checkpoint_id"])
+                    ].append(value)
+                    parent_ids_by_thread[value["thread_id"]].add(
+                        value["parent_checkpoint_id"]
+                    )
+                for thread_id, parent_ids in parent_ids_by_thread.items():
+                    cur.execute(
+                        self.SELECT_PENDING_SENDS_SQL,
+                        (thread_id, list(parent_ids)),
+                    )
+                    for sends in cur.fetchall():
+                        for value in grouped_by_parent[
+                            (thread_id, sends["checkpoint_id"])
+                        ]:
+                            if value["channel_values"] is None:
+                                value["channel_values"] = []
+                            self._migrate_pending_sends(
+                                sends["sends"],
+                                value["checkpoint"],
+                                value["channel_values"],
+                            )
             for value in values:
                 yield self._load_checkpoint_tuple(value)
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -167,15 +167,20 @@ class PostgresSaver(BasePostgresSaver):
                 for v in values
                 if v["checkpoint"]["v"] < 4 and v["parent_checkpoint_id"]
             ]:
-                # the results may span multiple threads, and the pending
-                # sends query filters by a single thread_id, so group by
-                # (thread_id, parent_checkpoint_id) and run the query once
-                # per distinct thread_id
+                # the results may span multiple threads and namespaces;
+                # checkpoint identity is (thread_id, checkpoint_ns,
+                # checkpoint_id), so group by the full identity of the parent
+                # and run the query once per distinct thread_id, matching
+                # rows only within their namespace
                 grouped_by_parent = defaultdict(list)
                 parent_ids_by_thread = defaultdict(set)
                 for value in to_migrate:
                     grouped_by_parent[
-                        (value["thread_id"], value["parent_checkpoint_id"])
+                        (
+                            value["thread_id"],
+                            value["checkpoint_ns"],
+                            value["parent_checkpoint_id"],
+                        )
                     ].append(value)
                     parent_ids_by_thread[value["thread_id"]].add(
                         value["parent_checkpoint_id"]
@@ -187,7 +192,11 @@ class PostgresSaver(BasePostgresSaver):
                     )
                     for sends in cur.fetchall():
                         for value in grouped_by_parent[
-                            (thread_id, sends["checkpoint_id"])
+                            (
+                                thread_id,
+                                sends["checkpoint_ns"],
+                                sends["checkpoint_id"],
+                            )
                         ]:
                             if value["channel_values"] is None:
                                 value["channel_values"] = []
@@ -259,7 +268,16 @@ class PostgresSaver(BasePostgresSaver):
                     self.SELECT_PENDING_SENDS_SQL,
                     (thread_id, [value["parent_checkpoint_id"]]),
                 )
-                if sends := cur.fetchone():
+                # the same checkpoint_id may exist in other namespaces; only
+                # this namespace's writes belong to this checkpoint's parent
+                if sends := next(
+                    (
+                        row
+                        for row in cur.fetchall()
+                        if row["checkpoint_ns"] == value["checkpoint_ns"]
+                    ),
+                    None,
+                ):
                     if value["channel_values"] is None:
                         value["channel_values"] = []
                     self._migrate_pending_sends(

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -156,25 +156,35 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 for v in values
                 if v["checkpoint"]["v"] < 4 and v["parent_checkpoint_id"]
             ]:
-                await cur.execute(
-                    self.SELECT_PENDING_SENDS_SQL,
-                    (
-                        values[0]["thread_id"],
-                        [v["parent_checkpoint_id"] for v in to_migrate],
-                    ),
-                )
+                # the results may span multiple threads, and the pending
+                # sends query filters by a single thread_id, so group by
+                # (thread_id, parent_checkpoint_id) and run the query once
+                # per distinct thread_id
                 grouped_by_parent = defaultdict(list)
+                parent_ids_by_thread = defaultdict(set)
                 for value in to_migrate:
-                    grouped_by_parent[value["parent_checkpoint_id"]].append(value)
-                async for sends in cur:
-                    for value in grouped_by_parent[sends["checkpoint_id"]]:
-                        if value["channel_values"] is None:
-                            value["channel_values"] = []
-                        self._migrate_pending_sends(
-                            sends["sends"],
-                            value["checkpoint"],
-                            value["channel_values"],
-                        )
+                    grouped_by_parent[
+                        (value["thread_id"], value["parent_checkpoint_id"])
+                    ].append(value)
+                    parent_ids_by_thread[value["thread_id"]].add(
+                        value["parent_checkpoint_id"]
+                    )
+                for thread_id, parent_ids in parent_ids_by_thread.items():
+                    await cur.execute(
+                        self.SELECT_PENDING_SENDS_SQL,
+                        (thread_id, list(parent_ids)),
+                    )
+                    for sends in await cur.fetchall():
+                        for value in grouped_by_parent[
+                            (thread_id, sends["checkpoint_id"])
+                        ]:
+                            if value["channel_values"] is None:
+                                value["channel_values"] = []
+                            self._migrate_pending_sends(
+                                sends["sends"],
+                                value["checkpoint"],
+                                value["channel_values"],
+                            )
             for value in values:
                 yield await self._load_checkpoint_tuple(value)
 

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -156,15 +156,20 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 for v in values
                 if v["checkpoint"]["v"] < 4 and v["parent_checkpoint_id"]
             ]:
-                # the results may span multiple threads, and the pending
-                # sends query filters by a single thread_id, so group by
-                # (thread_id, parent_checkpoint_id) and run the query once
-                # per distinct thread_id
+                # the results may span multiple threads and namespaces;
+                # checkpoint identity is (thread_id, checkpoint_ns,
+                # checkpoint_id), so group by the full identity of the parent
+                # and run the query once per distinct thread_id, matching
+                # rows only within their namespace
                 grouped_by_parent = defaultdict(list)
                 parent_ids_by_thread = defaultdict(set)
                 for value in to_migrate:
                     grouped_by_parent[
-                        (value["thread_id"], value["parent_checkpoint_id"])
+                        (
+                            value["thread_id"],
+                            value["checkpoint_ns"],
+                            value["parent_checkpoint_id"],
+                        )
                     ].append(value)
                     parent_ids_by_thread[value["thread_id"]].add(
                         value["parent_checkpoint_id"]
@@ -176,7 +181,11 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     )
                     for sends in await cur.fetchall():
                         for value in grouped_by_parent[
-                            (thread_id, sends["checkpoint_id"])
+                            (
+                                thread_id,
+                                sends["checkpoint_ns"],
+                                sends["checkpoint_id"],
+                            )
                         ]:
                             if value["channel_values"] is None:
                                 value["channel_values"] = []
@@ -228,7 +237,16 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     self.SELECT_PENDING_SENDS_SQL,
                     (thread_id, [value["parent_checkpoint_id"]]),
                 )
-                if sends := await cur.fetchone():
+                # the same checkpoint_id may exist in other namespaces; only
+                # this namespace's writes belong to this checkpoint's parent
+                if sends := next(
+                    (
+                        row
+                        for row in await cur.fetchall()
+                        if row["checkpoint_ns"] == value["checkpoint_ns"]
+                    ),
+                    None,
+                ):
                     if value["channel_values"] is None:
                         value["channel_values"] = []
                     self._migrate_pending_sends(

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -119,13 +119,14 @@ from checkpoints """
 
 SELECT_PENDING_SENDS_SQL = f"""
 select
+    checkpoint_ns,
     checkpoint_id,
     array_agg(array[type::bytea, blob] order by task_path, task_id, idx) as sends
 from checkpoint_writes
 where thread_id = %s
     and checkpoint_id = any(%s)
     and channel = '{TASKS}'
-group by checkpoint_id
+group by checkpoint_ns, checkpoint_id
 """
 
 UPSERT_CHECKPOINT_BLOBS_SQL = """

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -386,6 +386,55 @@ async def test_pending_sends_migration_multiple_threads(saver_name: str) -> None
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+async def test_pending_sends_migration_namespace_isolation(saver_name: str) -> None:
+    """Regression test: two namespaces reusing the same parent checkpoint id
+    must each migrate only their own pending sends — checkpoint identity is
+    (thread_id, checkpoint_ns, checkpoint_id)."""
+    async with _saver(saver_name) as saver:
+        parent_id = "00000000-0000-0000-0000-000000000000"
+        child_id = "11111111-1111-1111-1111-111111111111"
+        sends_by_ns = {"": ["root-send"], "child:sub": ["sub-send-1", "sub-send-2"]}
+        for ns, sends in sends_by_ns.items():
+            config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ns}}
+            checkpoint_0 = empty_checkpoint()
+            checkpoint_0["id"] = parent_id
+            config = await saver.aput(config, checkpoint_0, {}, {})
+            await saver.aput_writes(
+                config, [(TASKS, s) for s in sends], task_id="task-1"
+            )
+            checkpoint_1 = create_checkpoint(checkpoint_0, {}, 1, id=child_id)
+            await saver.aput(config, checkpoint_1, {}, {})
+
+        for ns, sends in sends_by_ns.items():
+            # aget_tuple must only see its own namespace's sends
+            tup = await saver.aget_tuple(
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": ns,
+                        "checkpoint_id": child_id,
+                    }
+                }
+            )
+            assert tup is not None
+            assert tup.checkpoint["channel_values"].get(TASKS) == sends, ns
+
+        # cross-namespace list() must attach each namespace's sends only to
+        # its own descendant
+        results = [
+            c
+            async for c in saver.alist({"configurable": {"thread_id": "thread-1"}})
+            if c.parent_config is not None
+        ]
+        assert len(results) == 2
+        by_ns = {
+            c.config["configurable"]["checkpoint_ns"]: c.checkpoint["channel_values"]
+            for c in results
+        }
+        assert by_ns == {ns: {TASKS: sends} for ns, sends in sends_by_ns.items()}
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 async def test_get_checkpoint_no_channel_values(
     monkeypatch, saver_name: str, test_data
 ) -> None:

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -343,6 +343,49 @@ async def test_pending_sends_migration(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+async def test_pending_sends_migration_multiple_threads(saver_name: str) -> None:
+    """Regression test: listing checkpoints across multiple threads must
+    migrate pending sends for every thread, not just the first row's thread."""
+    async with _saver(saver_name) as saver:
+        sends_by_thread = {
+            "thread-1": ["send-1", "send-2"],
+            "thread-2": ["send-3", "send-4"],
+        }
+        for thread_id, sends in sends_by_thread.items():
+            config = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": "",
+                }
+            }
+            # create the first checkpoint and put some pending sends
+            checkpoint_0 = empty_checkpoint()
+            config = await saver.aput(config, checkpoint_0, {}, {})
+            await saver.aput_writes(
+                config, [(TASKS, s) for s in sends], task_id="task-1"
+            )
+            # create the second checkpoint (pending sends attach to it)
+            checkpoint_1 = create_checkpoint(checkpoint_0, {}, 1)
+            await saver.aput(config, checkpoint_1, {}, {})
+
+        # list across all threads: each thread's second checkpoint must have
+        # its own migrated pending sends
+        search_results = [c async for c in saver.alist(None)]
+        assert len(search_results) == 4
+        migrated = [c for c in search_results if c.parent_config is not None]
+        assert len(migrated) == 2
+        channel_values_by_thread = {
+            c.config["configurable"]["thread_id"]: c.checkpoint["channel_values"]
+            for c in migrated
+        }
+        assert channel_values_by_thread == {
+            thread_id: {TASKS: sends} for thread_id, sends in sends_by_thread.items()
+        }
+        for c in migrated:
+            assert TASKS in c.checkpoint["channel_versions"]
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 async def test_get_checkpoint_no_channel_values(
     monkeypatch, saver_name: str, test_data
 ) -> None:

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -331,6 +331,47 @@ def test_pending_sends_migration(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+def test_pending_sends_migration_multiple_threads(saver_name: str) -> None:
+    """Regression test: listing checkpoints across multiple threads must
+    migrate pending sends for every thread, not just the first row's thread."""
+    with _saver(saver_name) as saver:
+        sends_by_thread = {
+            "thread-1": ["send-1", "send-2"],
+            "thread-2": ["send-3", "send-4"],
+        }
+        for thread_id, sends in sends_by_thread.items():
+            config = {
+                "configurable": {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": "",
+                }
+            }
+            # create the first checkpoint and put some pending sends
+            checkpoint_0 = empty_checkpoint()
+            config = saver.put(config, checkpoint_0, {}, {})
+            saver.put_writes(config, [(TASKS, s) for s in sends], task_id="task-1")
+            # create the second checkpoint (pending sends attach to it)
+            checkpoint_1 = create_checkpoint(checkpoint_0, {}, 1)
+            saver.put(config, checkpoint_1, {}, {})
+
+        # list across all threads: each thread's second checkpoint must have
+        # its own migrated pending sends
+        search_results = list(saver.list(None))
+        assert len(search_results) == 4
+        migrated = [c for c in search_results if c.parent_config is not None]
+        assert len(migrated) == 2
+        channel_values_by_thread = {
+            c.config["configurable"]["thread_id"]: c.checkpoint["channel_values"]
+            for c in migrated
+        }
+        assert channel_values_by_thread == {
+            thread_id: {TASKS: sends} for thread_id, sends in sends_by_thread.items()
+        }
+        for c in migrated:
+            assert TASKS in c.checkpoint["channel_versions"]
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 def test_get_checkpoint_no_channel_values(
     monkeypatch, saver_name: str, test_data
 ) -> None:

--- a/libs/checkpoint-postgres/tests/test_sync.py
+++ b/libs/checkpoint-postgres/tests/test_sync.py
@@ -372,6 +372,53 @@ def test_pending_sends_migration_multiple_threads(saver_name: str) -> None:
 
 
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+def test_pending_sends_migration_namespace_isolation(saver_name: str) -> None:
+    """Regression test: two namespaces reusing the same parent checkpoint id
+    must each migrate only their own pending sends — checkpoint identity is
+    (thread_id, checkpoint_ns, checkpoint_id)."""
+    with _saver(saver_name) as saver:
+        parent_id = "00000000-0000-0000-0000-000000000000"
+        child_id = "11111111-1111-1111-1111-111111111111"
+        sends_by_ns = {"": ["root-send"], "child:sub": ["sub-send-1", "sub-send-2"]}
+        for ns, sends in sends_by_ns.items():
+            config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ns}}
+            checkpoint_0 = empty_checkpoint()
+            checkpoint_0["id"] = parent_id
+            config = saver.put(config, checkpoint_0, {}, {})
+            saver.put_writes(config, [(TASKS, s) for s in sends], task_id="task-1")
+            checkpoint_1 = create_checkpoint(checkpoint_0, {}, 1, id=child_id)
+            saver.put(config, checkpoint_1, {}, {})
+
+        for ns, sends in sends_by_ns.items():
+            # get_tuple must only see its own namespace's sends
+            tup = saver.get_tuple(
+                {
+                    "configurable": {
+                        "thread_id": "thread-1",
+                        "checkpoint_ns": ns,
+                        "checkpoint_id": child_id,
+                    }
+                }
+            )
+            assert tup is not None
+            assert tup.checkpoint["channel_values"].get(TASKS) == sends, ns
+
+        # cross-namespace list() must attach each namespace's sends only to
+        # its own descendant
+        results = [
+            c
+            for c in saver.list({"configurable": {"thread_id": "thread-1"}})
+            if c.parent_config is not None
+        ]
+        assert len(results) == 2
+        by_ns = {
+            c.config["configurable"]["checkpoint_ns"]: c.checkpoint["channel_values"]
+            for c in results
+        }
+        assert by_ns == {ns: {TASKS: sends} for ns, sends in sends_by_ns.items()}
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
 def test_get_checkpoint_no_channel_values(
     monkeypatch, saver_name: str, test_data
 ) -> None:

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -79,6 +79,18 @@ def _warn_once(
     logger.warning(msg, *args)
 
 
+def _warn_reconstruction_failed(module: str, name: str, exc: BaseException) -> None:
+    logger.warning(
+        "Failed to reconstruct %s.%s from checkpoint: %s: %s. "
+        "Returning the raw deserialized payload instead. This usually means "
+        "the type's definition changed since the checkpoint was written.",
+        module,
+        name,
+        type(exc).__name__,
+        exc,
+    )
+
+
 class JsonPlusSerializer(SerializerProtocol):
     """Serializer that uses ormsgpack, with optional fallbacks.
 
@@ -647,8 +659,14 @@ def _create_msgpack_ext_hook(
                     # is using this in the context of a pydantic state, etc., then
                     # it would be validated upon construction.
                     return tup[2]
-                # module, name, arg
-                return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
+                try:
+                    # module, name, arg
+                    return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
+                except Exception as exc:
+                    # Degrade to the raw payload (same as blocked types) rather
+                    # than silently replacing the value with None.
+                    _warn_reconstruction_failed(tup[0], tup[1], exc)
+                    return tup[2]
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_POS_ARGS:
@@ -658,10 +676,14 @@ def _create_msgpack_ext_hook(
                 )
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
-                if tup[0] == "langgraph.types" and tup[1] == "Send":
-                    return _send_from_args(tup[2])
-                # module, name, args
-                return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
+                try:
+                    if tup[0] == "langgraph.types" and tup[1] == "Send":
+                        return _send_from_args(tup[2])
+                    # module, name, args
+                    return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
+                except Exception as exc:
+                    _warn_reconstruction_failed(tup[0], tup[1], exc)
+                    return tup[2]
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_KW_ARGS:
@@ -671,8 +693,12 @@ def _create_msgpack_ext_hook(
                 )
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
-                # module, name, kwargs
-                return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
+                try:
+                    # module, name, kwargs
+                    return getattr(importlib.import_module(tup[0]), tup[1])(**tup[2])
+                except Exception as exc:
+                    _warn_reconstruction_failed(tup[0], tup[1], exc)
+                    return tup[2]
             except Exception:
                 return None
         elif code == EXT_METHOD_SINGLE_ARG:
@@ -682,10 +708,14 @@ def _create_msgpack_ext_hook(
                 )
                 if not _check_allowed_method(tup[0], tup[1], tup[3]):
                     return tup[2]
-                # module, name, arg, method
-                return getattr(
-                    getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
-                )(tup[2])
+                try:
+                    # module, name, arg, method
+                    return getattr(
+                        getattr(importlib.import_module(tup[0]), tup[1]), tup[3]
+                    )(tup[2])
+                except Exception as exc:
+                    _warn_reconstruction_failed(tup[0], f"{tup[1]}.{tup[3]}", exc)
+                    return tup[2]
             except Exception:
                 return None
         elif code == EXT_PYDANTIC_V1:
@@ -701,13 +731,15 @@ def _create_msgpack_ext_hook(
                     return cls(**tup[2])
                 except Exception:
                     return cls.construct(**tup[2])
-            except Exception:
+            except Exception as exc:
                 # for pydantic objects we can't find/reconstruct
                 # let's return the kwargs dict instead
                 try:
-                    return tup[2]
+                    payload = tup[2]
                 except NameError:
                     return None
+                _warn_reconstruction_failed(tup[0], tup[1], exc)
+                return payload
         elif code == EXT_PYDANTIC_V2:
             try:
                 tup = ormsgpack.unpackb(
@@ -721,13 +753,15 @@ def _create_msgpack_ext_hook(
                     return cls(**tup[2])
                 except Exception:
                     return cls.model_construct(**tup[2])
-            except Exception:
+            except Exception as exc:
                 # for pydantic objects we can't find/reconstruct
                 # let's return the kwargs dict instead
                 try:
-                    return tup[2]
+                    payload = tup[2]
                 except NameError:
                     return None
+                _warn_reconstruction_failed(tup[0], tup[1], exc)
+                return payload
         elif code == EXT_NUMPY_ARRAY:
             try:
                 import numpy as _np

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -30,6 +30,7 @@ from langgraph.checkpoint.serde.event_hooks import (
     register_serde_event_listener,
 )
 from langgraph.checkpoint.serde.jsonplus import (
+    EXT_CONSTRUCTOR_POS_ARGS,
     EXT_METHOD_SINGLE_ARG,
     InvalidModuleError,
     JsonPlusSerializer,
@@ -99,6 +100,21 @@ class MyEnum(Enum):
 @dataclasses.dataclass
 class Person:
     name: str
+
+
+@dataclasses.dataclass
+class DriftingDataclass:
+    foo: str
+    bar: int
+
+
+class DriftingEnum(Enum):
+    ALPHA = "alpha"
+    BETA = "beta"
+
+
+class DriftingPydantic(BaseModel):
+    foo: str
 
 
 def test_serde_jsonplus() -> None:
@@ -1235,3 +1251,168 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def _reconstruction_warnings(
+    caplog: pytest.LogCaptureFixture, needle: str
+) -> list[logging.LogRecord]:
+    return [
+        r
+        for r in caplog.records
+        if r.name == "langgraph.checkpoint.serde.jsonplus"
+        and r.levelno == logging.WARNING
+        and "failed to reconstruct" in r.getMessage().lower()
+        and needle in r.getMessage()
+    ]
+
+
+def test_msgpack_allowed_dataclass_drift_degrades_to_payload(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconstruction failure of an allowed dataclass (EXT_CONSTRUCTOR_KW_ARGS)
+    must degrade to the raw kwargs payload and log a warning, not become None."""
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[("tests.test_jsonplus", "DriftingDataclass")]
+    )
+    dumped = serde.dumps_typed(DriftingDataclass(foo="x", bar=1))
+
+    # Simulate schema drift: ``bar`` was renamed to ``baz`` between the time
+    # the checkpoint was written and the time it is read back, so the
+    # constructor rejects the stored kwargs.
+    @dataclasses.dataclass
+    class DriftedDataclass:
+        foo: str
+        baz: int
+
+    monkeypatch.setattr(sys.modules[__name__], "DriftingDataclass", DriftedDataclass)
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    caplog.clear()
+    result = serde.loads_typed(dumped)
+
+    assert result == {"foo": "x", "bar": 1}, (
+        "Reconstruction failure of an allowed type must degrade to the raw "
+        f"payload dict, got: {result!r}"
+    )
+    records = _reconstruction_warnings(caplog, "tests.test_jsonplus.DriftingDataclass")
+    assert records, (
+        "Expected a WARNING referencing tests.test_jsonplus.DriftingDataclass; "
+        f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert "TypeError" in records[0].getMessage()
+
+
+def test_msgpack_allowed_enum_drift_degrades_to_payload(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconstruction failure of an allowed enum (EXT_CONSTRUCTOR_SINGLE_ARG)
+    must degrade to the raw enum value and log a warning, not become None."""
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[("tests.test_jsonplus", "DriftingEnum")]
+    )
+    dumped = serde.dumps_typed(DriftingEnum.BETA)
+
+    # Simulate schema drift: the ``BETA`` member was removed after the
+    # checkpoint was written, so ``DriftingEnum("beta")`` raises ValueError.
+    class DriftedEnum(Enum):
+        ALPHA = "alpha"
+
+    monkeypatch.setattr(sys.modules[__name__], "DriftingEnum", DriftedEnum)
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    caplog.clear()
+    result = serde.loads_typed(dumped)
+
+    assert result == "beta"
+    records = _reconstruction_warnings(caplog, "tests.test_jsonplus.DriftingEnum")
+    assert records, (
+        "Expected a WARNING referencing tests.test_jsonplus.DriftingEnum; "
+        f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert "ValueError" in records[0].getMessage()
+
+
+def test_msgpack_allowed_pos_args_drift_degrades_to_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Reconstruction failure of an allowed type via EXT_CONSTRUCTOR_POS_ARGS
+    must degrade to the raw positional-args payload, not None."""
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[("tests.test_jsonplus", "DriftingDataclass")]
+    )
+    # DriftingDataclass requires two args; a single positional arg simulates a
+    # signature change between write and read.
+    payload = ormsgpack.packb(
+        ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(("tests.test_jsonplus", "DriftingDataclass", ("only",))),
+        ),
+        option=ormsgpack.OPT_NON_STR_KEYS,
+    )
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    caplog.clear()
+    result = serde.loads_typed(("msgpack", payload))
+
+    assert result == ["only"]
+    records = _reconstruction_warnings(caplog, "tests.test_jsonplus.DriftingDataclass")
+    assert records, (
+        "Expected a WARNING referencing tests.test_jsonplus.DriftingDataclass; "
+        f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_msgpack_allowed_method_failure_degrades_to_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Failure of an allowed method call (EXT_METHOD_SINGLE_ARG) must degrade
+    to the raw argument payload, not None."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+    # datetime.datetime.fromisoformat is in SAFE_MSGPACK_METHODS but raises
+    # ValueError on a malformed timestamp.
+    payload = ormsgpack.packb(
+        ormsgpack.Ext(
+            EXT_METHOD_SINGLE_ARG,
+            _msgpack_enc(("datetime", "datetime", "not-a-date", "fromisoformat")),
+        ),
+        option=ormsgpack.OPT_NON_STR_KEYS,
+    )
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    caplog.clear()
+    result = serde.loads_typed(("msgpack", payload))
+
+    assert result == "not-a-date"
+    records = _reconstruction_warnings(caplog, "datetime.datetime.fromisoformat")
+    assert records, (
+        "Expected a WARNING referencing datetime.datetime.fromisoformat; "
+        f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_msgpack_allowed_pydantic_missing_class_degrades_with_warning(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An allowed pydantic model whose class no longer exists degrades to its
+    kwargs dict (existing behavior) and now logs a warning."""
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[("tests.test_jsonplus", "DriftingPydantic")]
+    )
+    dumped = serde.dumps_typed(DriftingPydantic(foo="x"))
+
+    # Simulate the class being deleted/renamed between write and read.
+    monkeypatch.delattr(sys.modules[__name__], "DriftingPydantic")
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    caplog.clear()
+    result = serde.loads_typed(dumped)
+
+    assert result == {"foo": "x"}
+    records = _reconstruction_warnings(caplog, "tests.test_jsonplus.DriftingPydantic")
+    assert records, (
+        "Expected a WARNING referencing tests.test_jsonplus.DriftingPydantic; "
+        f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )

--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import platform
 import threading
-import urllib.error
 import urllib.request
 from typing import Any, TypedDict
 
@@ -15,6 +14,11 @@ from langgraph_cli.constants import (
     SUPABASE_URL,
 )
 from langgraph_cli.version import __version__
+
+# Upper bound (seconds) on the telemetry POST so an unreachable host can't hang
+# the CLI. The default socket timeout is None (block forever), which combined
+# with a non-daemon worker thread would stall interpreter exit.
+ANALYTICS_TIMEOUT_SECONDS = 1.0
 
 
 class LogData(TypedDict):
@@ -78,8 +82,12 @@ def log_data(data: LogData) -> None:
     )
 
     try:
-        urllib.request.urlopen(req)
-    except urllib.error.URLError:
+        # Bound the request so a black-holed/unreachable telemetry host cannot
+        # block the worker thread (and, in turn, interpreter exit) indefinitely.
+        urllib.request.urlopen(req, timeout=ANALYTICS_TIMEOUT_SECONDS)
+    except Exception:
+        # Telemetry is best-effort and must never surface to the user; swallow
+        # every failure (network errors, timeouts, unexpected responses).
         pass
 
 
@@ -98,7 +106,9 @@ def log_command(func):
             "params": get_anonymized_params(kwargs, cli_command=func.__name__),
         }
 
-        background_thread = threading.Thread(target=log_data, args=(data,))
+        # daemon=True so a slow/hung telemetry request never keeps the
+        # interpreter alive after the command's own work is done.
+        background_thread = threading.Thread(target=log_data, args=(data,), daemon=True)
         background_thread.start()
         return func(*args, **kwargs)
 

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -6,7 +6,7 @@ import re
 import shlex
 import textwrap
 from collections import Counter
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import click
 import httpx
@@ -1129,36 +1129,51 @@ def _build_python_install_commands(
     return local_reqs_pip_install, global_reqs_pip_install, pip_config_file_str
 
 
+def _json_env_value(obj: Any) -> str:
+    """Serialize `obj` to JSON safe to wrap in single quotes in a Dockerfile.
+
+    `json.dumps` does not escape ASCII single quotes, so a `'` inside any
+    config value would terminate the surrounding quote in `ENV KEY='...'`,
+    breaking the build (and allowing Dockerfile line injection). Escape it
+    as `\\u0027`, which is a valid JSON string escape: `json.loads`
+    round-trips it, so consumers parsing the env var as JSON see the
+    original value. Output is unchanged for values without single quotes.
+    """
+    return json.dumps(obj).replace("'", "\\u0027")
+
+
 def _build_runtime_env_vars(config: Config) -> list[str]:
     env_vars = []
 
     if (store_config := config.get("store")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_STORE='{json.dumps(store_config)}'")
+        env_vars.append(f"ENV LANGGRAPH_STORE='{_json_env_value(store_config)}'")
 
     if (auth_config := config.get("auth")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_AUTH='{json.dumps(auth_config)}'")
+        env_vars.append(f"ENV LANGGRAPH_AUTH='{_json_env_value(auth_config)}'")
 
     if (encryption_config := config.get("encryption")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_ENCRYPTION='{json.dumps(encryption_config)}'")
+        env_vars.append(
+            f"ENV LANGGRAPH_ENCRYPTION='{_json_env_value(encryption_config)}'"
+        )
 
     if (http_config := config.get("http")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_HTTP='{json.dumps(http_config)}'")
+        env_vars.append(f"ENV LANGGRAPH_HTTP='{_json_env_value(http_config)}'")
 
     if (webhooks_config := config.get("webhooks")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_WEBHOOKS='{json.dumps(webhooks_config)}'")
+        env_vars.append(f"ENV LANGGRAPH_WEBHOOKS='{_json_env_value(webhooks_config)}'")
 
     if (checkpointer_config := config.get("checkpointer")) is not None:
         env_vars.append(
-            f"ENV LANGGRAPH_CHECKPOINTER='{json.dumps(checkpointer_config)}'"
+            f"ENV LANGGRAPH_CHECKPOINTER='{_json_env_value(checkpointer_config)}'"
         )
 
     if (ui := config.get("ui")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_UI='{json.dumps(ui)}'")
+        env_vars.append(f"ENV LANGGRAPH_UI='{_json_env_value(ui)}'")
 
     if (ui_config := config.get("ui_config")) is not None:
-        env_vars.append(f"ENV LANGGRAPH_UI_CONFIG='{json.dumps(ui_config)}'")
+        env_vars.append(f"ENV LANGGRAPH_UI_CONFIG='{_json_env_value(ui_config)}'")
 
-    env_vars.append(f"ENV LANGSERVE_GRAPHS='{json.dumps(config['graphs'])}'")
+    env_vars.append(f"ENV LANGSERVE_GRAPHS='{_json_env_value(config['graphs'])}'")
     return env_vars
 
 

--- a/libs/cli/langgraph_cli/exec.py
+++ b/libs/cli/langgraph_cli/exec.py
@@ -138,10 +138,12 @@ async def monitor_stream(
 
         if display:
             sys.stdout.buffer.write(line)
-        if overrun:
-            return
         if collect:
+            # collect overrun chunks too, so the returned output is complete
             ba.extend(line)
+        if overrun:
+            # skip on_line for partial chunks — it expects whole lines
+            return
         if on_line:
             if on_line(line.decode()):
                 on_line = None

--- a/libs/cli/langgraph_cli/exec.py
+++ b/libs/cli/langgraph_cli/exec.py
@@ -159,9 +159,14 @@ async def monitor_stream(
             overrun = False
         except asyncio.LimitOverrunError as e:
             if stream._buffer.startswith(sep, e.consumed):
-                line = stream._buffer[: e.consumed + seplen]
+                line = bytes(stream._buffer[: e.consumed + seplen])
+                # remove the consumed bytes, otherwise the next readuntil()
+                # raises the same LimitOverrunError forever (infinite loop)
+                del stream._buffer[: e.consumed + seplen]
             else:
-                line = stream._buffer.clear()
+                # bytearray.clear() returns None, so capture the bytes first
+                line = bytes(stream._buffer)
+                stream._buffer.clear()
             overrun = True
             stream._maybe_resume_transport()
         await asyncio.to_thread(handle, line, overrun)

--- a/libs/cli/tests/unit_tests/test_analytics.py
+++ b/libs/cli/tests/unit_tests/test_analytics.py
@@ -9,6 +9,8 @@ import threading
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from langgraph_cli import analytics
 
 
@@ -35,11 +37,20 @@ def test_log_data_uses_timeout() -> None:
     assert analytics.ANALYTICS_TIMEOUT_SECONDS > 0
 
 
-def test_log_data_swallows_all_errors() -> None:
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("blackholed host"),
+        OSError("network unreachable"),
+        ConnectionResetError("reset by peer"),
+        ValueError("unexpected response"),
+    ],
+)
+def test_log_data_swallows_all_errors(error: Exception) -> None:
     """Telemetry is best-effort: timeouts and other errors must not surface."""
     with patch(
         "langgraph_cli.analytics.urllib.request.urlopen",
-        side_effect=TimeoutError("blackholed host"),
+        side_effect=error,
     ):
         # Must not raise.
         analytics.log_data(_sample_data())

--- a/libs/cli/tests/unit_tests/test_analytics.py
+++ b/libs/cli/tests/unit_tests/test_analytics.py
@@ -1,0 +1,66 @@
+"""Regression tests for telemetry never blocking the CLI.
+
+A black-holed/unreachable telemetry host previously hung the CLI at exit: the
+POST had no timeout and ran in a non-daemon thread, so the interpreter waited
+for it forever.
+"""
+
+import threading
+from typing import Any
+from unittest.mock import patch
+
+from langgraph_cli import analytics
+
+
+def _sample_data() -> analytics.LogData:
+    return {
+        "os": "linux",
+        "os_version": "1",
+        "python_version": "3.11",
+        "cli_version": "0.0.0",
+        "cli_command": "build",
+        "params": {},
+    }
+
+
+def test_log_data_uses_timeout() -> None:
+    """The telemetry request must pass a bounded timeout."""
+    with patch("langgraph_cli.analytics.urllib.request.urlopen") as mock_urlopen:
+        analytics.log_data(_sample_data())
+
+    assert mock_urlopen.call_count == 1
+    _args, kwargs = mock_urlopen.call_args
+    assert kwargs.get("timeout") == analytics.ANALYTICS_TIMEOUT_SECONDS
+    assert isinstance(analytics.ANALYTICS_TIMEOUT_SECONDS, (int, float))
+    assert analytics.ANALYTICS_TIMEOUT_SECONDS > 0
+
+
+def test_log_data_swallows_all_errors() -> None:
+    """Telemetry is best-effort: timeouts and other errors must not surface."""
+    with patch(
+        "langgraph_cli.analytics.urllib.request.urlopen",
+        side_effect=TimeoutError("blackholed host"),
+    ):
+        # Must not raise.
+        analytics.log_data(_sample_data())
+
+
+def test_log_command_spawns_daemon_thread() -> None:
+    """The telemetry worker thread must be a daemon so a hung request never
+    keeps the interpreter alive after the command finishes."""
+    captured: dict[str, Any] = {}
+    started = threading.Event()
+
+    def fake_log_data(_data: analytics.LogData) -> None:
+        captured["daemon"] = threading.current_thread().daemon
+        started.set()
+
+    @analytics.log_command
+    def some_command(**kwargs: Any) -> str:
+        return "ok"
+
+    with patch("langgraph_cli.analytics.log_data", side_effect=fake_log_data):
+        assert some_command() == "ok"
+        assert started.wait(timeout=5), "telemetry thread never ran"
+
+    assert captured["daemon"] is True

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -11,7 +11,9 @@ import pytest
 
 from langgraph_cli.config import (
     _BUILD_TOOLS,
+    _build_runtime_env_vars,
     _get_pip_cleanup_lines,
+    _json_env_value,
     config_to_compose,
     config_to_docker,
     default_base_image,
@@ -3424,3 +3426,62 @@ class TestHasDisallowedBuildCommandContent:
     )
     def test_valid_commands_allowed(self, cmd: str) -> None:
         assert not has_disallowed_build_command_content(cmd)
+
+
+class TestRuntimeEnvVarQuoting:
+    """Single quotes in config values must not break Dockerfile ENV quoting.
+
+    `json.dumps` does not escape `'`, so `ENV KEY='{json}'` was terminated
+    early by any apostrophe in a config value. `_json_env_value` escapes it
+    as `\\u0027`, which `json.loads` round-trips.
+    """
+
+    def _payload(self, env_line: str, key: str) -> str:
+        prefix = f"ENV {key}='"
+        assert env_line.startswith(prefix), env_line
+        assert env_line.endswith("'"), env_line
+        return env_line[len(prefix) : -1]
+
+    def test_single_quote_in_store_field(self) -> None:
+        config = validate_config(
+            {
+                "dependencies": ["."],
+                "graphs": {"agent": "./agent.py:graph"},
+                "store": {"index": {"embed": "./emb.py:embed", "fields": ["O'Brien"]}},
+            }
+        )
+        env_vars = _build_runtime_env_vars(config)
+        store_line = next(line for line in env_vars if "LANGGRAPH_STORE" in line)
+        payload = self._payload(store_line, "LANGGRAPH_STORE")
+        # no raw single quote inside the single-quoted JSON payload
+        assert "'" not in payload
+        # json.loads round-trips the original value
+        assert json.loads(payload) == config["store"]
+        assert json.loads(payload)["index"]["fields"] == ["O'Brien"]
+
+    def test_single_quote_in_graph_id(self) -> None:
+        config = validate_config(
+            {
+                "dependencies": ["."],
+                "graphs": {"O'Brien": "./agent.py:graph"},
+            }
+        )
+        env_vars = _build_runtime_env_vars(config)
+        graphs_line = next(line for line in env_vars if "LANGSERVE_GRAPHS" in line)
+        payload = self._payload(graphs_line, "LANGSERVE_GRAPHS")
+        assert "'" not in payload
+        assert json.loads(payload) == {"O'Brien": "./agent.py:graph"}
+
+    def test_output_unchanged_without_single_quotes(self) -> None:
+        obj = {"agent": "./agent.py:graph", "n": 3, "nested": {"a": [1, 2]}}
+        assert _json_env_value(obj) == json.dumps(obj)
+
+    def test_control_chars_and_backslashes_stay_escaped(self) -> None:
+        obj = {"k": "line1\nline2\ttab\\slash'quote"}
+        payload = _json_env_value(obj)
+        # json.dumps escapes control characters; no raw newline, tab or
+        # single quote may reach the Dockerfile line
+        assert "\n" not in payload
+        assert "\t" not in payload
+        assert "'" not in payload
+        assert json.loads(payload) == obj

--- a/libs/cli/tests/unit_tests/test_exec.py
+++ b/libs/cli/tests/unit_tests/test_exec.py
@@ -1,0 +1,82 @@
+import asyncio
+
+from langgraph_cli.exec import monitor_stream
+
+
+async def test_monitor_stream_overrun_without_separator_passes_bytes() -> None:
+    """A chunk longer than the limit with no newline must reach the handler.
+
+    Regression test: the LimitOverrunError branch used
+    `line = stream._buffer.clear()`, which returns None, so the oversized
+    data was silently dropped and `handle(None, overrun=True)` raised
+    TypeError in display mode (`sys.stdout.buffer.write(None)`).
+    """
+    limit = 16
+    stream = asyncio.StreamReader(limit=limit)
+    payload = b"x" * (limit * 4)  # no newline anywhere
+    stream.feed_data(payload)
+    stream.feed_eof()
+
+    seen: list[tuple[bytes, bool]] = []
+
+    def display_like_handler(line: bytes, overrun: bool) -> None:
+        # mimics the display branch: crashes with TypeError if line is None
+        assert isinstance(line, (bytes, bytearray)), (
+            f"handler received {type(line).__name__}, expected bytes"
+        )
+        seen.append((bytes(line), overrun))
+
+    # drive monitor_stream but intercept lines via a collecting on_line is not
+    # possible for overrun chunks (they skip on_line), so patch display path:
+    # display=True routes every chunk (incl. overrun) through
+    # sys.stdout.buffer.write(line), which is where the TypeError fired.
+    import sys
+
+    class _FakeBuffer:
+        def write(self, data: bytes) -> int:
+            display_like_handler(data, True)
+            return len(data)
+
+    class _FakeStdout:
+        buffer = _FakeBuffer()
+
+        def __getattr__(self, name):
+            return getattr(sys.__stdout__, name)
+
+    real_stdout = sys.stdout
+    sys.stdout = _FakeStdout()  # type: ignore[assignment]
+    try:
+        result = await monitor_stream(stream, collect=True, display=True)
+    finally:
+        sys.stdout = real_stdout
+
+    # the oversized chunk must have been displayed as bytes, not dropped
+    displayed = b"".join(chunk for chunk, _ in seen)
+    assert payload in displayed, (
+        f"oversized chunk was dropped; displayed only {displayed!r}"
+    )
+    # overrun chunks are intentionally excluded from the collected output
+    assert result == b""
+
+
+async def test_monitor_stream_overrun_with_separator_after_limit() -> None:
+    """Separator found beyond the limit: line up to the separator is kept."""
+    limit = 8
+    stream = asyncio.StreamReader(limit=limit)
+    long_line = b"y" * (limit * 3) + b"\n"
+    stream.feed_data(long_line + b"tail\n")
+    stream.feed_eof()
+
+    collected = await monitor_stream(stream, collect=True, display=False)
+    # non-overrun data after the long line is still collected
+    assert collected is not None
+    assert b"tail\n" in bytes(collected)
+
+
+async def test_monitor_stream_plain_lines_collected() -> None:
+    stream = asyncio.StreamReader(limit=64)
+    stream.feed_data(b"hello\nworld\n")
+    stream.feed_eof()
+
+    collected = await monitor_stream(stream, collect=True, display=False)
+    assert bytes(collected) == b"hello\nworld\n"

--- a/libs/cli/tests/unit_tests/test_exec.py
+++ b/libs/cli/tests/unit_tests/test_exec.py
@@ -55,12 +55,12 @@ async def test_monitor_stream_overrun_without_separator_passes_bytes() -> None:
     assert payload in displayed, (
         f"oversized chunk was dropped; displayed only {displayed!r}"
     )
-    # overrun chunks are intentionally excluded from the collected output
-    assert result == b""
+    # overrun chunks are collected too, so returned output is complete
+    assert bytes(result) == payload
 
 
 async def test_monitor_stream_overrun_with_separator_after_limit() -> None:
-    """Separator found beyond the limit: line up to the separator is kept."""
+    """Separator found beyond the limit: full output is collected."""
     limit = 8
     stream = asyncio.StreamReader(limit=limit)
     long_line = b"y" * (limit * 3) + b"\n"
@@ -68,9 +68,28 @@ async def test_monitor_stream_overrun_with_separator_after_limit() -> None:
     stream.feed_eof()
 
     collected = await monitor_stream(stream, collect=True, display=False)
-    # non-overrun data after the long line is still collected
+    # the oversized line and the data after it are both collected
     assert collected is not None
-    assert b"tail\n" in bytes(collected)
+    assert bytes(collected) == long_line + b"tail\n"
+
+
+async def test_monitor_stream_collect_preserves_oversized_chunks() -> None:
+    """Regression test: `collect=True` must not silently drop oversized lines.
+
+    Previously `handle()` returned on overrun before `ba.extend(line)`, so
+    `subp_exec(..., collect=True, verbose=False)` lost every line longer
+    than the stream limit.
+    """
+    limit = 8
+    stream = asyncio.StreamReader(limit=limit)
+    stream.feed_data(b"x" * 24 + b"\n" + b"tail\n")
+    stream.feed_eof()
+
+    collected = await monitor_stream(stream, collect=True, display=False)
+    assert collected is not None
+    out = bytes(collected)
+    assert out.count(b"x") == 24, f"lost oversized data: {out!r}"
+    assert b"tail\n" in out
 
 
 async def test_monitor_stream_plain_lines_collected() -> None:

--- a/libs/langgraph/langgraph/_internal/_config.py
+++ b/libs/langgraph/langgraph/_internal/_config.py
@@ -171,12 +171,15 @@ def merge_configs(*configs: RunnableConfig | None) -> RunnableConfig:
                 if base_value := base.get(key):
                     base[key] = [*base_value, *value]  # type: ignore
                 else:
-                    base[key] = value  # type: ignore[literal-required]
+                    # copy, not alias: callers mutate merged configs in place,
+                    # which must not corrupt the input config's list
+                    base[key] = list(value)  # type: ignore[literal-required]
             elif key == CONF:
                 if base_value := base.get(key):
                     base[key] = {**base_value, **value}  # type: ignore[dict-item]
                 else:
-                    base[key] = value
+                    # copy, not alias: same reasoning as tags above
+                    base[key] = dict(value)
             elif key == "callbacks":
                 base["callbacks"] = _merge_callbacks(
                     base.get("callbacks"), cast(Callbacks, value)

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -123,9 +123,6 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     def update(self, values: Sequence[Value]) -> bool:
         if not values:
             return False
-        if self.value is MISSING:
-            self.value = values[0]
-            values = values[1:]
         seen_overwrite: bool = False
         for value in values:
             is_overwrite, overwrite_value = _get_overwrite(value)
@@ -139,7 +136,11 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
                 self.value = overwrite_value
                 seen_overwrite = True
                 continue
-            if not seen_overwrite:
+            if seen_overwrite:
+                continue
+            if self.value is MISSING:
+                self.value = value
+            else:
                 self.value = self.operator(self.value, value)
         return True
 

--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -44,13 +44,18 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         return empty
 
     def checkpoint(self) -> set[Value]:
-        return self.seen
+        # return a snapshot, not the live set: update() mutates self.seen
+        # in place, which would otherwise mutate previously captured
+        # checkpoints before they are serialized
+        return set(self.seen)
 
     def from_checkpoint(self, checkpoint: set[Value]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            # copy on ingest: update() mutates self.seen in place, which
+            # would otherwise mutate the caller's checkpoint value
+            empty.seen = set(checkpoint)
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -122,13 +127,20 @@ class NamedBarrierValueAfterFinish(
         return empty
 
     def checkpoint(self) -> tuple[set[Value], bool]:
-        return (self.seen, self.finished)
+        # return a snapshot, not the live set: update() mutates self.seen
+        # in place, which would otherwise mutate previously captured
+        # checkpoints before they are serialized
+        return (set(self.seen), self.finished)
 
     def from_checkpoint(self, checkpoint: tuple[set[Value], bool]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            seen, finished = checkpoint
+            # copy on ingest: update() mutates self.seen in place, which
+            # would otherwise mutate the caller's checkpoint value
+            empty.seen = set(seen)
+            empty.finished = finished
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -61,17 +61,22 @@ class Topic(
         return empty
 
     def checkpoint(self) -> list[Value]:
-        return self.values
+        # return a snapshot, not the live list: update() mutates self.values
+        # in place, which would otherwise mutate previously captured
+        # checkpoints before they are serialized
+        return list(self.values)
 
     def from_checkpoint(self, checkpoint: list[Value]) -> Self:
         empty = self.__class__(self.typ, self.accumulate)
         empty.key = self.key
         if checkpoint is not MISSING:
+            # copy on ingest: update() mutates self.values in place, which
+            # would otherwise mutate the caller's checkpoint value
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
-                empty.values = checkpoint[1]
+                empty.values = list(checkpoint[1])
             else:
-                empty.values = checkpoint
+                empty.values = list(checkpoint)
         return empty
 
     def update(self, values: Sequence[Value | list[Value]]) -> bool:

--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -413,6 +413,7 @@ def push_message(
     if message.id is None:
         raise ValueError("Message ID is required")
 
+    handlers: list[BaseCallbackHandler] = []
     if isinstance(config["callbacks"], BaseCallbackManager):
         manager = config["callbacks"]
         handlers = manager.handlers

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -6,7 +6,7 @@ import typing
 import warnings
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Hashable, Sequence
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, is_dataclass, replace
 from datetime import timedelta
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
@@ -1274,16 +1274,20 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         # Apply builder defaults to node specs. Per-node values always win.
         # Error-handler routing and cache_policy are only assigned to regular
         # nodes. Retry and timeout defaults also apply to error-handler nodes.
+        # Work on a local copy of the nodes mapping (with copy-on-write specs)
+        # so that compile() never mutates the builder — the same builder can be
+        # compiled multiple times (e.g. once bare, once with a checkpointer).
         defaults = self._node_defaults
         default_handler_name: str | None = None
+        nodes: dict[str, StateNodeSpec[Any, ContextT]] = dict(self.nodes)
         if defaults.error_handler is not None:
-            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+            if _DEFAULT_ERROR_HANDLER_NODE in nodes:
                 raise ValueError(
                     f"Auto-generated default error handler node "
                     f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
                 )
             default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
-            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
+            nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
                 coerce_to_runnable(
                     defaults.error_handler,  # type: ignore[arg-type]
                     name=default_handler_name,
@@ -1296,8 +1300,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 is_error_handler=True,
             )
 
-        # Apply builder defaults to node specs. Per-node values always win.
-        for spec in self.nodes.values():
+        for key, spec in list(nodes.items()):
+            updates: dict[str, Any] = {}
             # error_handler: regular nodes only — handlers must never
             # catch themselves or other handlers.
             if (
@@ -1305,11 +1309,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 and default_handler_name is not None
                 and spec.error_handler_node is None
             ):
-                spec.error_handler_node = default_handler_name
+                updates["error_handler_node"] = default_handler_name
             # retry: all nodes — handlers should be retried on transient
             # failures just like regular nodes.
             if defaults.retry_policy is not None and spec.retry_policy is None:
-                spec.retry_policy = defaults.retry_policy
+                updates["retry_policy"] = defaults.retry_policy
             # cache: regular nodes only — caching an error-handler result
             # is unsafe because the input (failed-node state) may differ
             # across failures even when the cache key matches.
@@ -1318,15 +1322,18 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 and defaults.cache_policy is not None
                 and spec.cache_policy is None
             ):
-                spec.cache_policy = defaults.cache_policy
+                updates["cache_policy"] = defaults.cache_policy
             # timeout: all nodes — a stuck handler should be cancelled the
             # same way a stuck regular node would be.
             if defaults.timeout is not None and spec.timeout is None:
-                spec.timeout = defaults.timeout
+                updates["timeout"] = defaults.timeout
+            if updates:
+                # copy-on-write: never mutate the builder's shared spec
+                nodes[key] = replace(spec, **updates)
 
         node_error_handler_map = {
             node_name: spec.error_handler_node
-            for node_name, spec in self.nodes.items()
+            for node_name, spec in nodes.items()
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
 
@@ -1358,7 +1365,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         compiled._serde_allowlist = serde_allowlist
 
         compiled.attach_node(START, None)
-        for key, node in self.nodes.items():
+        for key, node in nodes.items():
             compiled.attach_node(key, node)
 
         # Record output/state mappers for v2 stream coercion (pydantic/dataclass only)

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -814,6 +814,15 @@ def _next_retry_delay(
     policy's `max_attempts` budget or inflate its backoff — a node that
     exhausts retries for `ValueError` still gets the full budget when it later
     raises `KeyError`.
+
+    Independent budgets are additionally bounded by an overall safeguard: the
+    total failed tries across all policies never reach the most permissive
+    policy's `max_attempts`. This preserves the documented per-node ceiling
+    ("maximum number of attempts ... including the first") — total executions
+    never exceed `max(max_attempts)` — which is the same worst-case bound the
+    single-counter implementation had, while still letting a late-appearing
+    exception type spend its own budget up to that ceiling instead of being
+    denied retries by another policy's failures.
     """
     for idx, policy in enumerate(retry_policy):
         if _should_retry_on(policy, exc):
@@ -822,6 +831,10 @@ def _next_retry_delay(
         return None
     attempts = policy_attempts[idx] = policy_attempts.get(idx, 0) + 1
     if attempts >= policy.max_attempts:
+        return None
+    # Overall safeguard: only failures that matched a policy are counted, so
+    # the sum across policies is the node's total failed tries.
+    if sum(policy_attempts.values()) >= max(p.max_attempts for p in retry_policy):
         return None
     interval = min(
         policy.max_interval,

--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -582,6 +582,9 @@ def run_with_retry(
         # this is a runtime safety net for paths that may bypass that validation.
         raise sync_timeout_unsupported(task.name)
     attempts = 0
+    # failed tries per policy (keyed by index in retry_policy) — kept separate
+    # from `attempts` so each policy spends only its own max_attempts budget
+    policy_attempts: dict[int, int] = {}
     node_first_attempt_time = time.time()
     config = task.config
     if configurable is not None:
@@ -644,33 +647,12 @@ def run_with_retry(
             if not retry_policy:
                 raise
 
-            # Check which retry policy applies to this exception
-            matching_policy = None
-            for policy in retry_policy:
-                if _should_retry_on(policy, exc):
-                    matching_policy = policy
-                    break
-
-            if not matching_policy:
+            sleep_time = _next_retry_delay(retry_policy, exc, policy_attempts)
+            if sleep_time is None:
+                # no policy matches, or the matching policy is out of attempts
                 raise
-
             # attempts tracks failed tries only; it increments after a failure.
             attempts += 1
-            # check if we should give up
-            if attempts >= matching_policy.max_attempts:
-                raise
-            # sleep before retrying
-            interval = matching_policy.initial_interval
-            # Apply backoff factor based on attempt count
-            interval = min(
-                matching_policy.max_interval,
-                interval * (matching_policy.backoff_factor ** (attempts - 1)),
-            )
-
-            # Apply jitter if configured
-            sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
-            )
             time.sleep(sleep_time)
 
             # log the retry
@@ -696,6 +678,9 @@ async def arun_with_retry(
         _resolve_timeout(task.timeout) if task.timeout is not None else None
     )
     attempts = 0
+    # failed tries per policy (keyed by index in retry_policy) — kept separate
+    # from `attempts` so each policy spends only its own max_attempts budget
+    policy_attempts: dict[int, int] = {}
     node_first_attempt_time = time.time()
     config = task.config
     if configurable is not None:
@@ -799,34 +784,13 @@ async def arun_with_retry(
             if not retry_policy:
                 raise
 
-            # Check which retry policy applies to this exception
-            matching_policy = None
-            for policy in retry_policy:
-                if _should_retry_on(policy, exc):
-                    matching_policy = policy
-                    break
-
-            if not matching_policy:
+            sleep_time = _next_retry_delay(retry_policy, exc, policy_attempts)
+            if sleep_time is None:
+                # no policy matches, or the matching policy is out of attempts
                 raise
-
             # attempts tracks failed tries only; it increments after a failure.
             # The next execution's node_attempt is derived as attempts + 1.
             attempts += 1
-            # check if we should give up
-            if attempts >= matching_policy.max_attempts:
-                raise
-            # sleep before retrying
-            interval = matching_policy.initial_interval
-            # Apply backoff factor based on attempt count
-            interval = min(
-                matching_policy.max_interval,
-                interval * (matching_policy.backoff_factor ** (attempts - 1)),
-            )
-
-            # Apply jitter if configured
-            sleep_time = (
-                interval + random.uniform(0, 1) if matching_policy.jitter else interval
-            )
             await asyncio.sleep(sleep_time)
 
             # log the retry
@@ -836,6 +800,34 @@ async def arun_with_retry(
             )
             # signal subgraphs to resume (if available)
             config = patch_configurable(config, {CONFIG_KEY_RESUMING: True})
+
+
+def _next_retry_delay(
+    retry_policy: Sequence[RetryPolicy],
+    exc: Exception,
+    policy_attempts: dict[int, int],
+) -> float | None:
+    """Return the sleep before the next retry, or None if `exc` must not be retried.
+
+    Attempts are tracked per policy (keyed by position in `retry_policy` via
+    `policy_attempts`) so that one policy's failures never consume another
+    policy's `max_attempts` budget or inflate its backoff — a node that
+    exhausts retries for `ValueError` still gets the full budget when it later
+    raises `KeyError`.
+    """
+    for idx, policy in enumerate(retry_policy):
+        if _should_retry_on(policy, exc):
+            break
+    else:
+        return None
+    attempts = policy_attempts[idx] = policy_attempts.get(idx, 0) + 1
+    if attempts >= policy.max_attempts:
+        return None
+    interval = min(
+        policy.max_interval,
+        policy.initial_interval * policy.backoff_factor ** (attempts - 1),
+    )
+    return interval + random.uniform(0, 1) if policy.jitter else interval
 
 
 def _should_retry_on(retry_policy: RetryPolicy, exc: Exception) -> bool:

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -281,7 +281,13 @@ class PregelRunner:
         handled_futures: set[concurrent.futures.Future[Any]] = set()
         while len(futures) > (1 if get_waiter is not None else 0):
             done, inflight = concurrent.futures.wait(
-                futures,
+                # wait over a snapshot: worker threads can insert new futures
+                # into `futures` (via `call()` -> `_call`) while we wait, and
+                # `concurrent.futures.wait` iterates the collection it's given.
+                # Any future added after the snapshot is picked up on the next
+                # loop iteration (the loop re-reads `futures`), and the final
+                # `futures.event.wait()` below covers all tracked futures.
+                tuple(futures),
                 return_when=concurrent.futures.FIRST_COMPLETED,
                 timeout=(max(0, end_time - time.monotonic()) if end_time else None),
             )
@@ -370,11 +376,7 @@ class PregelRunner:
             Awaitable[PregelExecutableTask | None],
         ],
     ) -> AsyncIterator[None]:
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        loop = asyncio.get_running_loop()
         tasks = tuple(tasks)
         futures = FuturesDict(
             callback=weakref.WeakMethod(self.commit),

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2984,8 +2984,10 @@ class Pregel(
                     loop.after_tick()
                     emit_graph_lifecycle_events(loop)
                     # wait for checkpoint
-                    if durability_ == "sync":
-                        loop._put_checkpoint_fut.result()
+                    if durability_ == "sync" and (
+                        put_checkpoint_fut := getattr(loop, "_put_checkpoint_fut", None)
+                    ):
+                        put_checkpoint_fut.result()
             emit_graph_lifecycle_events(loop)
             # emit output
             yield from _output(
@@ -3458,8 +3460,12 @@ class Pregel(
                         loop.after_tick()
                         await aemit_graph_lifecycle_events(loop)
                         # wait for checkpoint
-                        if durability_ == "sync":
-                            await cast(asyncio.Future, loop._put_checkpoint_fut)
+                        if durability_ == "sync" and (
+                            put_checkpoint_fut := getattr(
+                                loop, "_put_checkpoint_fut", None
+                            )
+                        ):
+                            await cast(asyncio.Future, put_checkpoint_fut)
                 finally:
                     # ensure waiter doesn't remain pending on cancel/shutdown
                     if _cleanup_waiter is not None:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -12,6 +12,10 @@ from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
+from langgraph.channels.named_barrier_value import (
+    NamedBarrierValue,
+    NamedBarrierValueAfterFinish,
+)
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
@@ -173,6 +177,97 @@ def test_untracked_value() -> None:
     new_channel = UntrackedValue(dict).from_checkpoint(checkpoint)
     with pytest.raises(EmptyChannelError):
         new_channel.get()
+
+
+def test_topic_checkpoint_isolated_from_later_updates() -> None:
+    channel = Topic(str, accumulate=True).from_checkpoint(MISSING)
+    channel.update(["a", "b"])
+
+    checkpoint = channel.checkpoint()
+    assert checkpoint == ["a", "b"]
+
+    # a later update must not mutate the previously captured checkpoint
+    channel.update(["c"])
+    assert checkpoint == ["a", "b"]
+
+    # non-accumulating topics must also return isolated snapshots
+    channel = Topic(str).from_checkpoint(MISSING)
+    channel.update(["a"])
+    checkpoint = channel.checkpoint()
+    assert checkpoint == ["a"]
+    channel.update(["b"])
+    assert checkpoint == ["a"]
+
+
+def test_topic_from_checkpoint_does_not_mutate_checkpoint() -> None:
+    stored = ["a", "b"]
+
+    channel = Topic(str, accumulate=True).from_checkpoint(stored)
+    channel.update(["c"])
+    assert channel.get() == ["a", "b", "c"]
+    # the stored checkpoint value must be untouched
+    assert stored == ["a", "b"]
+
+    # restoring a second time from the same checkpoint must start fresh
+    channel2 = Topic(str, accumulate=True).from_checkpoint(stored)
+    assert channel2.get() == ["a", "b"]
+
+    # backwards-compat tuple form must also be isolated
+    legacy_values = ["x"]
+    channel3 = Topic(str, accumulate=True).from_checkpoint((None, legacy_values))
+    channel3.update(["y"])
+    assert legacy_values == ["x"]
+
+
+def test_named_barrier_value_checkpoint_isolated_from_later_updates() -> None:
+    channel = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(MISSING)
+    channel.update(["a"])
+
+    checkpoint = channel.checkpoint()
+    assert checkpoint == {"a"}
+
+    # a later update must not mutate the previously captured checkpoint
+    channel.update(["b"])
+    assert checkpoint == {"a"}
+
+
+def test_named_barrier_value_from_checkpoint_does_not_mutate_checkpoint() -> None:
+    stored = {"a"}
+
+    channel = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(stored)
+    channel.update(["b"])
+    assert channel.is_available()
+    # the stored checkpoint value must be untouched
+    assert stored == {"a"}
+
+    # restoring a second time from the same checkpoint must start fresh
+    channel2 = NamedBarrierValue(str, {"a", "b"}).from_checkpoint(stored)
+    assert not channel2.is_available()
+
+
+def test_named_barrier_value_after_finish_checkpoint_isolated() -> None:
+    channel = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(MISSING)
+    channel.update(["a"])
+
+    checkpoint = channel.checkpoint()
+    assert checkpoint[0] == {"a"}
+
+    # a later update must not mutate the previously captured checkpoint
+    channel.update(["b"])
+    assert checkpoint[0] == {"a"}
+
+
+def test_named_barrier_value_after_finish_from_checkpoint_isolated() -> None:
+    stored = ({"a"}, False)
+
+    channel = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(stored)
+    channel.update(["b"])
+    # the stored checkpoint value must be untouched
+    assert stored[0] == {"a"}
+
+    # restoring a second time from the same checkpoint must start fresh
+    channel2 = NamedBarrierValueAfterFinish(str, {"a", "b"}).from_checkpoint(stored)
+    assert channel2.seen == {"a"}
 
 
 # ---------------------------------------------------------------------------

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -105,6 +105,52 @@ def test_binop() -> None:
     assert channel.get() == 10
 
 
+def test_binop_overwrite_on_empty_channel() -> None:
+    """A leading `Overwrite` on an empty channel must be unwrapped, not stored
+    as the wrapper object itself."""
+    # `int | None` is not instantiable, so the channel starts empty (MISSING)
+    channel = BinaryOperatorAggregate(int | None, operator.add)
+    assert not channel.is_available()
+
+    channel.update([Overwrite(5)])
+    assert channel.get() == 5
+
+    # subsequent reduces must operate on the unwrapped value
+    channel.update([1, 2])
+    assert channel.get() == 8
+
+
+def test_binop_overwrite_dict_forms_on_empty_channel() -> None:
+    """Both dict-encoded `Overwrite` forms must be unwrapped when they are the
+    first-ever update on an empty channel."""
+    from langgraph._internal._constants import OVERWRITE
+
+    for update in ({OVERWRITE: 7}, {"type": OVERWRITE, "value": 7}):
+        channel = BinaryOperatorAggregate(int | None, operator.add)
+        channel.update([update])
+        assert channel.get() == 7
+
+
+def test_binop_overwrite_then_value_on_empty_channel() -> None:
+    """Values after an `Overwrite` in the same step are ignored, mirroring the
+    non-empty channel semantics."""
+    channel = BinaryOperatorAggregate(int | None, operator.add)
+    channel.update([Overwrite(5), 100])
+    assert channel.get() == 5
+
+    # same semantics as when the channel already holds a value
+    non_empty = BinaryOperatorAggregate(int, operator.add)
+    non_empty.update([Overwrite(5), 100])
+    assert non_empty.get() == 5
+
+
+def test_binop_two_overwrites_on_empty_channel_raises() -> None:
+    """Two Overwrites in one super-step must raise, even on an empty channel."""
+    channel = BinaryOperatorAggregate(int | None, operator.add)
+    with pytest.raises(InvalidUpdateError):
+        channel.update([Overwrite(1), Overwrite(2)])
+
+
 def test_untracked_value() -> None:
     channel = UntrackedValue(dict).from_checkpoint(MISSING)
     assert channel.ValueType is dict

--- a/libs/langgraph/tests/test_messages_state.py
+++ b/libs/langgraph/tests/test_messages_state.py
@@ -367,3 +367,25 @@ def test_push_messages_in_graph():
             messages.append(message)
 
     assert values["messages"] == messages
+
+
+@pytest.mark.parametrize(
+    "callbacks",
+    [
+        None,
+        [object()],  # list with non-BaseCallbackHandler elements
+    ],
+)
+def test_push_message_without_usable_callbacks(callbacks) -> None:
+    """push_message must not raise UnboundLocalError when config callbacks are
+    None or a list containing non-handler objects; it should behave like an
+    empty handler list (no stream emit, message still returned)."""
+    from langchain_core.runnables.config import var_child_runnable_config
+
+    config = {"callbacks": callbacks, "metadata": {}, "configurable": {}}
+    token = var_child_runnable_config.set(config)
+    try:
+        message = push_message(AIMessage(content="Hello", id="1"), state_key=None)
+        assert message == AIMessage(content="Hello", id="1")
+    finally:
+        var_child_runnable_config.reset(token)

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2579,6 +2579,44 @@ def test_set_node_defaults_error_handler_collides_with_user_node():
         builder.compile()
 
 
+def test_set_node_defaults_error_handler_compile_twice():
+    """compile() must not mutate the builder: the auto-generated default error
+    handler node must not leak into `builder.nodes`, and compiling the same
+    builder multiple times (e.g. once bare, once with a checkpointer) works."""
+
+    class State(TypedDict):
+        foo: str
+
+    def always_failing(state: State) -> State:
+        raise RuntimeError("boom")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": f"handled_{error.node}"}
+
+    builder = (
+        StateGraph(State)
+        .set_node_defaults(error_handler=default_handler)
+        .add_node("always_failing", always_failing)
+        .add_edge(START, "always_failing")
+    )
+
+    graph1 = builder.compile()
+    # the builder must not be polluted by compile()
+    assert "__default_error_handler__" not in builder.nodes
+    assert builder.nodes["always_failing"].error_handler_node is None
+
+    # second compile of the same builder (supported pattern) must not raise
+    graph2 = builder.compile(checkpointer=MemorySaver())
+    assert "__default_error_handler__" not in builder.nodes
+
+    # both compiled graphs route failures to the default handler
+    assert graph1.invoke({"foo": ""})["foo"] == "handled_always_failing"
+    result2 = graph2.invoke(
+        {"foo": ""}, config={"configurable": {"thread_id": str(uuid4())}}
+    )
+    assert result2["foo"] == "handled_always_failing"
+
+
 def test_set_node_defaults_retry_policy():
     class State(TypedDict):
         foo: str

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -50,6 +50,7 @@ from langgraph.pregel._read import PregelNode
 from langgraph.pregel._retry import (
     _checkpoint_ns_for_parent_command,
     _ensure_execution_info,
+    _next_retry_delay,
     _should_retry_on,
     _TimedAttemptScope,
     arun_with_retry,
@@ -441,6 +442,87 @@ def test_graph_with_multiple_retry_policies():
 
     assert attempt_counts["key_error"] == 3
     assert result_key_error["foo"] == "recovered_from_key_error"
+
+
+def test_multiple_retry_policies_use_independent_budgets():
+    """Each policy spends only its own max_attempts budget.
+
+    Regression: a single shared attempts counter meant earlier failures under
+    one policy consumed another policy's budget — after two ValueErrors, the
+    first KeyError was already "attempt 3", so a max_attempts=3 KeyError
+    policy gave up without retrying it even once.
+    """
+
+    class State(TypedDict):
+        foo: str
+
+    errors = deque([ValueError("v1"), ValueError("v2"), KeyError("k1"), KeyError("k2")])
+
+    def flaky(state):
+        if errors:
+            raise errors.popleft()
+        return {"foo": "recovered"}
+
+    graph = (
+        StateGraph(State)
+        .add_node(
+            "flaky",
+            flaky,
+            retry_policy=(
+                RetryPolicy(
+                    max_attempts=5,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                ),
+                RetryPolicy(
+                    max_attempts=3,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=KeyError,
+                ),
+            ),
+        )
+        .add_edge(START, "flaky")
+        .compile()
+    )
+
+    with patch("time.sleep"):
+        result = graph.invoke({"foo": ""})
+
+    assert result["foo"] == "recovered"
+    assert not errors
+
+
+def test_next_retry_delay_tracks_backoff_per_policy():
+    """Backoff escalation for one policy must not inflate another's."""
+    policies = [
+        RetryPolicy(
+            max_attempts=10,
+            initial_interval=1.0,
+            backoff_factor=2.0,
+            max_interval=100.0,
+            jitter=False,
+            retry_on=ValueError,
+        ),
+        RetryPolicy(
+            max_attempts=10,
+            initial_interval=1.0,
+            backoff_factor=2.0,
+            max_interval=100.0,
+            jitter=False,
+            retry_on=KeyError,
+        ),
+    ]
+    counts: dict[int, int] = {}
+    # consecutive ValueError failures escalate the first policy's backoff
+    assert _next_retry_delay(policies, ValueError(), counts) == 1.0
+    assert _next_retry_delay(policies, ValueError(), counts) == 2.0
+    assert _next_retry_delay(policies, ValueError(), counts) == 4.0
+    # the first KeyError starts at the beginning of its own schedule
+    assert _next_retry_delay(policies, KeyError(), counts) == 1.0
+    # an unmatched exception is never retried
+    assert _next_retry_delay(policies, TypeError(), counts) is None
 
 
 def test_graph_with_max_attempts_exceeded():

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -525,6 +525,145 @@ def test_next_retry_delay_tracks_backoff_per_policy():
     assert _next_retry_delay(policies, TypeError(), counts) is None
 
 
+def test_multiple_retry_policies_respect_overall_attempt_ceiling():
+    """Total executions never exceed the most permissive policy's max_attempts.
+
+    Per-policy budgets alone would allow up to `1 + sum(max_attempts_i - 1)`
+    executions; the overall safeguard keeps the documented per-node ceiling
+    ("including the first") at `max(max_attempts)` — the same worst-case bound
+    as the original single-counter implementation.
+    """
+
+    class State(TypedDict):
+        foo: str
+
+    executions = {"count": 0}
+
+    def alternating(state):
+        executions["count"] += 1
+        if executions["count"] % 2 == 1:
+            raise ValueError(f"exec {executions['count']}")
+        raise KeyError(f"exec {executions['count']}")
+
+    graph = (
+        StateGraph(State)
+        .add_node(
+            "alternating",
+            alternating,
+            retry_policy=(
+                RetryPolicy(
+                    max_attempts=3,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                ),
+                RetryPolicy(
+                    max_attempts=3,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=KeyError,
+                ),
+            ),
+        )
+        .add_edge(START, "alternating")
+        .compile()
+    )
+
+    with patch("time.sleep"), pytest.raises(ValueError):
+        graph.invoke({"foo": ""})
+
+    assert executions["count"] == 3
+
+
+def test_multiple_retry_policies_exhaust_after_cross_policy_transition():
+    """A policy's own budget still gives up correctly after switching policies."""
+
+    class State(TypedDict):
+        foo: str
+
+    errors = deque([ValueError("v1"), KeyError("k1"), KeyError("k2")])
+
+    def flaky(state):
+        if errors:
+            raise errors.popleft()
+        return {"foo": "unreachable"}
+
+    graph = (
+        StateGraph(State)
+        .add_node(
+            "flaky",
+            flaky,
+            retry_policy=(
+                RetryPolicy(
+                    max_attempts=5,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                ),
+                RetryPolicy(
+                    max_attempts=2,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=KeyError,
+                ),
+            ),
+        )
+        .add_edge(START, "flaky")
+        .compile()
+    )
+
+    # KeyError budget (max_attempts=2) exhausts on its own second failure,
+    # well under both the ValueError budget and the overall ceiling.
+    with patch("time.sleep"), pytest.raises(KeyError, match="k2"):
+        graph.invoke({"foo": ""})
+    assert len(errors) == 0
+
+
+@pytest.mark.anyio
+async def test_multiple_retry_policies_use_independent_budgets_async():
+    """Async counterpart of the independent-budgets regression test."""
+
+    class State(TypedDict):
+        foo: str
+
+    errors = deque([ValueError("v1"), ValueError("v2"), KeyError("k1"), KeyError("k2")])
+
+    async def flaky(state):
+        if errors:
+            raise errors.popleft()
+        return {"foo": "recovered"}
+
+    graph = (
+        StateGraph(State)
+        .add_node(
+            "flaky",
+            flaky,
+            retry_policy=(
+                RetryPolicy(
+                    max_attempts=5,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=ValueError,
+                ),
+                RetryPolicy(
+                    max_attempts=3,
+                    initial_interval=0.01,
+                    jitter=False,
+                    retry_on=KeyError,
+                ),
+            ),
+        )
+        .add_edge(START, "flaky")
+        .compile()
+    )
+
+    with patch("asyncio.sleep"):
+        result = await graph.ainvoke({"foo": ""})
+
+    assert result["foo"] == "recovered"
+    assert not errors
+
+
 def test_graph_with_max_attempts_exceeded():
     """Test a graph where max_attempts is exceeded."""
 

--- a/libs/langgraph/tests/test_runner_regressions.py
+++ b/libs/langgraph/tests/test_runner_regressions.py
@@ -1,0 +1,104 @@
+"""Regression tests for Pregel runner/main engine fixes.
+
+Covers:
+- sync `PregelRunner.tick` waiting over a snapshot of the futures dict, so
+  worker threads inserting new futures via `call()` cannot trigger
+  `RuntimeError: dictionary changed size during iteration` inside
+  `concurrent.futures.wait`.
+- `durability="sync"` arriving via config on a graph compiled without a
+  checkpointer no longer raises `AttributeError` for `_put_checkpoint_fut`.
+"""
+
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph._internal._constants import CONFIG_KEY_DURABILITY
+from langgraph.func import entrypoint, task
+from langgraph.graph import START, StateGraph
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_call_fanout_from_worker_threads() -> None:
+    """Stress: `call()` inserts futures from worker threads while the driver
+    thread is blocked in `concurrent.futures.wait` over the same FuturesDict.
+
+    Pre-fix this was timing-dependent (could raise `RuntimeError: dictionary
+    changed size during iteration`); post-fix it must pass deterministically.
+    """
+
+    @task
+    def leaf(i: int) -> int:
+        return i
+
+    @task
+    def branch(i: int) -> int:
+        # tasks spawning tasks: more insertions from more worker threads
+        futs = [leaf(i * 10 + j) for j in range(5)]
+        return sum(f.result() for f in futs)
+
+    @entrypoint()
+    def graph(n: int) -> int:
+        futs = [branch(i) for i in range(n)]
+        return sum(f.result() for f in futs)
+
+    # NOTE: keep the nested fan-out narrow: each `branch` (and the
+    # entrypoint) blocks a pool thread in `.result()`, so a wide nested
+    # fan-out can exhaust the executor pool and deadlock regardless of
+    # the wait-snapshot fix
+    expected = sum(i * 10 + j for i in range(3) for j in range(5))
+    for _ in range(5):
+        assert graph.invoke(3) == expected
+
+    @task
+    def double(i: int) -> int:
+        return i * 2
+
+    @entrypoint()
+    def wide(n: int) -> int:
+        # 50 children spawned in quick succession from the entrypoint's
+        # worker thread while the driver waits
+        futs = [double(i) for i in range(n)]
+        return sum(f.result() for f in futs)
+
+    for _ in range(5):
+        assert wide.invoke(50) == sum(i * 2 for i in range(50))
+
+
+class _State(TypedDict):
+    foo: str
+
+
+def _node(state: _State) -> _State:
+    return {"foo": "bar"}
+
+
+def _compile_without_checkpointer():
+    builder = StateGraph(_State)
+    builder.add_node("node", _node)
+    builder.add_edge(START, "node")
+    return builder.compile()
+
+
+def test_durability_sync_without_checkpointer() -> None:
+    """`durability="sync"` injected via config (as a parent graph does for
+    subgraphs) on a checkpointer-less graph used to raise AttributeError on
+    `loop._put_checkpoint_fut`."""
+    graph = _compile_without_checkpointer()
+    result = graph.invoke(
+        {"foo": ""}, config={"configurable": {CONFIG_KEY_DURABILITY: "sync"}}
+    )
+    assert result == {"foo": "bar"}
+
+
+async def test_durability_sync_without_checkpointer_async() -> None:
+    graph = _compile_without_checkpointer()
+    result = await graph.ainvoke(
+        {"foo": ""}, config={"configurable": {CONFIG_KEY_DURABILITY: "sync"}}
+    )
+    assert result == {"foo": "bar"}

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -610,6 +610,22 @@ def test_ensure_config_metadata_later_wins_per_key() -> None:
     assert merged["metadata"]["shared"] == "from_b"
 
 
+def test_merge_configs_copies_single_source_mutables() -> None:
+    """Mutating a merged config must never corrupt the input configs.
+
+    Regression: when only one input carried `configurable` or `tags`, the
+    merged config aliased that input's dict/list instead of copying it, so
+    in-place mutation of the merge result silently corrupted the caller's
+    (often shared parent) config.
+    """
+    c1: RunnableConfig = {"configurable": {"a": 1}, "tags": ["t1"]}
+    merged = merge_configs(c1, {"metadata": {"m": 1}})
+    merged["configurable"]["b"] = 2
+    merged["tags"].append("t2")
+    assert c1["configurable"] == {"a": 1}
+    assert c1["tags"] == ["t1"]
+
+
 def test_merge_configs_merges_metadata_lc_versions() -> None:
     a = {
         "metadata": {

--- a/libs/langgraph/tests/test_utils.py
+++ b/libs/langgraph/tests/test_utils.py
@@ -625,6 +625,14 @@ def test_merge_configs_copies_single_source_mutables() -> None:
     assert c1["configurable"] == {"a": 1}
     assert c1["tags"] == ["t1"]
 
+    # same guarantee when the mutables come from a LATER input only
+    c2: RunnableConfig = {"configurable": {"x": 1}, "tags": ["late"]}
+    merged_late = merge_configs({"metadata": {"m": 1}}, c2)
+    merged_late["configurable"]["y"] = 2
+    merged_late["tags"].append("t3")
+    assert c2["configurable"] == {"x": 1}
+    assert c2["tags"] == ["late"]
+
 
 def test_merge_configs_merges_metadata_lc_versions() -> None:
     a = {

--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -626,7 +626,7 @@ def create_react_agent(
         )
         remaining_steps = _get_state_value(state, "remaining_steps", None)
         if remaining_steps is not None:
-            if remaining_steps < 1 and all_tools_return_direct:
+            if remaining_steps < 1 and has_tool_calls and all_tools_return_direct:
                 return True
             elif remaining_steps < 2 and has_tool_calls:
                 return True
@@ -930,11 +930,13 @@ def create_react_agent(
                 m.tool_call_id for m in messages if isinstance(m, ToolMessage)
             ]
             last_ai_message = next(
-                m for m in reversed(messages) if isinstance(m, AIMessage)
+                (m for m in reversed(messages) if isinstance(m, AIMessage)), None
             )
-            pending_tool_calls = [
-                c for c in last_ai_message.tool_calls if c["id"] not in tool_messages
-            ]
+            pending_tool_calls = (
+                [c for c in last_ai_message.tool_calls if c["id"] not in tool_messages]
+                if last_ai_message is not None
+                else []
+            )
 
             if pending_tool_calls:
                 return [
@@ -948,7 +950,7 @@ def create_react_agent(
                     )
                     for call in pending_tool_calls
                 ]
-            elif isinstance(messages[-1], ToolMessage):
+            elif messages and isinstance(messages[-1], ToolMessage):
                 return entrypoint
             elif response_format is not None:
                 return "generate_structured_response"
@@ -968,7 +970,11 @@ def create_react_agent(
     )
 
     def route_tool_responses(state: StateSchema) -> str:
-        for m in reversed(_get_state_value(state, "messages")):
+        messages = _get_state_value(state, "messages")
+        if not messages:
+            msg = "No messages found in state"
+            raise ValueError(msg)
+        for m in reversed(messages):
             if not isinstance(m, ToolMessage):
                 break
             if m.name in should_return_direct:

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -945,7 +945,7 @@ class ToolNode(RunnableCallable):
         #     graph called as a tool
         # (2 and 3 can happen in a "supervisor w/ tools" multi-agent architecture)
         if isinstance(e, GraphBubbleUp):
-            raise e
+            raise
 
         # Determine which exception types are handled
         handled_types: tuple[type[Exception], ...]
@@ -965,7 +965,7 @@ class ToolNode(RunnableCallable):
 
         # Check if this error should be handled
         if not self._handle_tool_errors or not isinstance(e, handled_types):
-            raise e
+            raise
 
         # Error is handled - create error ToolMessage
         content = _handle_tool_error(e, flag=self._handle_tool_errors)

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -50,6 +50,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ForwardRef,
     Generic,
     Literal,
     TypedDict,
@@ -1936,6 +1937,19 @@ def _get_injection_from_type(
     return None
 
 
+def _is_tool_runtime_forward_ref(type_: Any) -> bool:
+    """Check if an annotation is an unresolved forward reference to ToolRuntime.
+
+    Handles string annotations (e.g. `"ToolRuntime"` or `"ToolRuntime[Ctx, State]"`)
+    and `ForwardRef` instances that could not be resolved to the actual class.
+    """
+    if isinstance(type_, ForwardRef):
+        type_ = type_.__forward_arg__
+    if isinstance(type_, str):
+        return type_ == "ToolRuntime" or type_.startswith("ToolRuntime[")
+    return False
+
+
 def _get_all_injected_args(tool: BaseTool) -> _InjectedArgs:
     """Extract all injected arguments from tool in a single pass.
 
@@ -1971,8 +1985,11 @@ def _get_all_injected_args(tool: BaseTool) -> _InjectedArgs:
         if _is_injected_arg_type(type_):
             all_injected_keys.add(name)
 
-        # Check for runtime (special case: parameter named "runtime")
-        if name == "runtime":
+        # Check for an unresolved `ToolRuntime` forward reference on a parameter
+        # named "runtime". A parameter merely named `runtime` with a different
+        # annotation (e.g. `runtime: str`) is a regular model-provided argument
+        # and must not be hijacked for injection.
+        if name == "runtime" and _is_tool_runtime_forward_ref(type_):
             runtime_arg = name
 
         # Check for InjectedState

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -919,6 +919,63 @@ class ToolNode(RunnableCallable):
             combined_outputs.append(parent_command)
         return combined_outputs
 
+    def _handle_tool_call_exception(self, e: Exception, call: ToolCall) -> ToolMessage:
+        """Route a tool-execution exception through `handle_tool_errors`.
+
+        Shared by the direct-execution paths (`_execute_tool_sync` /
+        `_execute_tool_async`) and the wrapper paths (`_run_one` /
+        `_arun_one`) so all four handle errors identically.
+
+        `GraphBubbleUp` (raised by `interrupt()` and by interrupted
+        subgraphs) is always re-raised so human-in-the-loop pauses are
+        never swallowed into an error `ToolMessage`. Exceptions whose type
+        is not covered by `handle_tool_errors` are re-raised too. Only a
+        handled exception is converted to an error `ToolMessage`.
+
+        Must be called from within an active `except` block.
+        """
+        # GraphInterrupt is a special exception that will always be raised.
+        # It can be triggered in the following scenarios,
+        # Where GraphInterrupt(GraphBubbleUp) is raised from an `interrupt`
+        # invocation most commonly:
+        # (1) a GraphInterrupt is raised inside a tool
+        # (2) a GraphInterrupt is raised inside a graph node for a graph called
+        #     as a tool
+        # (3) a GraphInterrupt is raised when a subgraph is interrupted inside a
+        #     graph called as a tool
+        # (2 and 3 can happen in a "supervisor w/ tools" multi-agent architecture)
+        if isinstance(e, GraphBubbleUp):
+            raise e
+
+        # Determine which exception types are handled
+        handled_types: tuple[type[Exception], ...]
+        if isinstance(self._handle_tool_errors, type) and issubclass(
+            self._handle_tool_errors, Exception
+        ):
+            handled_types = (self._handle_tool_errors,)
+        elif isinstance(self._handle_tool_errors, tuple):
+            handled_types = self._handle_tool_errors
+        elif callable(self._handle_tool_errors) and not isinstance(
+            self._handle_tool_errors, type
+        ):
+            handled_types = _infer_handled_types(self._handle_tool_errors)
+        else:
+            # default behavior is catching all exceptions
+            handled_types = (Exception,)
+
+        # Check if this error should be handled
+        if not self._handle_tool_errors or not isinstance(e, handled_types):
+            raise e
+
+        # Error is handled - create error ToolMessage
+        content = _handle_tool_error(e, flag=self._handle_tool_errors)
+        return ToolMessage(
+            content=content,
+            name=call["name"],
+            tool_call_id=call["id"],
+            status="error",
+        )
+
     def _execute_tool_sync(
         self,
         request: ToolCallRequest,
@@ -970,46 +1027,8 @@ class ToolNode(RunnableCallable):
                 response, request.tool_call, input_type
             )
 
-        # GraphInterrupt is a special exception that will always be raised.
-        # It can be triggered in the following scenarios,
-        # Where GraphInterrupt(GraphBubbleUp) is raised from an `interrupt` invocation
-        # most commonly:
-        # (1) a GraphInterrupt is raised inside a tool
-        # (2) a GraphInterrupt is raised inside a graph node for a graph called as a tool
-        # (3) a GraphInterrupt is raised when a subgraph is interrupted inside a graph
-        #     called as a tool
-        # (2 and 3 can happen in a "supervisor w/ tools" multi-agent architecture)
-        except GraphBubbleUp:
-            raise
         except Exception as e:
-            # Determine which exception types are handled
-            handled_types: tuple[type[Exception], ...]
-            if isinstance(self._handle_tool_errors, type) and issubclass(
-                self._handle_tool_errors, Exception
-            ):
-                handled_types = (self._handle_tool_errors,)
-            elif isinstance(self._handle_tool_errors, tuple):
-                handled_types = self._handle_tool_errors
-            elif callable(self._handle_tool_errors) and not isinstance(
-                self._handle_tool_errors, type
-            ):
-                handled_types = _infer_handled_types(self._handle_tool_errors)
-            else:
-                # default behavior is catching all exceptions
-                handled_types = (Exception,)
-
-            # Check if this error should be handled
-            if not self._handle_tool_errors or not isinstance(e, handled_types):
-                raise
-
-            # Error is handled - create error ToolMessage
-            content = _handle_tool_error(e, flag=self._handle_tool_errors)
-            return ToolMessage(
-                content=content,
-                name=call["name"],
-                tool_call_id=call["id"],
-                status="error",
-            )
+            return self._handle_tool_call_exception(e, call)
 
     def _run_one(
         self,
@@ -1054,17 +1073,11 @@ class ToolNode(RunnableCallable):
         try:
             return self._wrap_tool_call(tool_request, execute)
         except Exception as e:
-            # Wrapper threw an exception
-            if not self._handle_tool_errors:
-                raise
-            # Convert to error message
-            content = _handle_tool_error(e, flag=self._handle_tool_errors)
-            return ToolMessage(
-                content=content,
-                name=tool_request.tool_call["name"],
-                tool_call_id=tool_request.tool_call["id"],
-                status="error",
-            )
+            # Wrapper (or the wrapped tool) threw. Route through the shared
+            # handler so GraphBubbleUp still propagates and the configured
+            # handle_tool_errors type filter is respected, exactly as on the
+            # non-wrapped path.
+            return self._handle_tool_call_exception(e, tool_request.tool_call)
 
     async def _execute_tool_async(
         self,
@@ -1117,46 +1130,8 @@ class ToolNode(RunnableCallable):
                 response, request.tool_call, input_type
             )
 
-        # GraphInterrupt is a special exception that will always be raised.
-        # It can be triggered in the following scenarios,
-        # Where GraphInterrupt(GraphBubbleUp) is raised from an `interrupt` invocation
-        # most commonly:
-        # (1) a GraphInterrupt is raised inside a tool
-        # (2) a GraphInterrupt is raised inside a graph node for a graph called as a tool
-        # (3) a GraphInterrupt is raised when a subgraph is interrupted inside a graph
-        #     called as a tool
-        # (2 and 3 can happen in a "supervisor w/ tools" multi-agent architecture)
-        except GraphBubbleUp:
-            raise
         except Exception as e:
-            # Determine which exception types are handled
-            handled_types: tuple[type[Exception], ...]
-            if isinstance(self._handle_tool_errors, type) and issubclass(
-                self._handle_tool_errors, Exception
-            ):
-                handled_types = (self._handle_tool_errors,)
-            elif isinstance(self._handle_tool_errors, tuple):
-                handled_types = self._handle_tool_errors
-            elif callable(self._handle_tool_errors) and not isinstance(
-                self._handle_tool_errors, type
-            ):
-                handled_types = _infer_handled_types(self._handle_tool_errors)
-            else:
-                # default behavior is catching all exceptions
-                handled_types = (Exception,)
-
-            # Check if this error should be handled
-            if not self._handle_tool_errors or not isinstance(e, handled_types):
-                raise
-
-            # Error is handled - create error ToolMessage
-            content = _handle_tool_error(e, flag=self._handle_tool_errors)
-            return ToolMessage(
-                content=content,
-                name=call["name"],
-                tool_call_id=call["id"],
-                status="error",
-            )
+            return self._handle_tool_call_exception(e, call)
 
     async def _arun_one(
         self,
@@ -1209,17 +1184,11 @@ class ToolNode(RunnableCallable):
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
             return self._wrap_tool_call(tool_request, _sync_execute)
         except Exception as e:
-            # Wrapper threw an exception
-            if not self._handle_tool_errors:
-                raise
-            # Convert to error message
-            content = _handle_tool_error(e, flag=self._handle_tool_errors)
-            return ToolMessage(
-                content=content,
-                name=tool_request.tool_call["name"],
-                tool_call_id=tool_request.tool_call["id"],
-                status="error",
-            )
+            # Wrapper (or the wrapped tool) threw. Route through the shared
+            # handler so GraphBubbleUp still propagates and the configured
+            # handle_tool_errors type filter is respected, exactly as on the
+            # non-wrapped path.
+            return self._handle_tool_call_exception(e, tool_request.tool_call)
 
     def _parse_input(
         self,

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1196,6 +1196,9 @@ class ToolNode(RunnableCallable):
     ) -> tuple[list[ToolCall], Literal["list", "dict", "tool_calls"]]:
         input_type: Literal["list", "dict", "tool_calls"]
         if isinstance(input, list):
+            if not input:
+                msg = "No message found in input"
+                raise ValueError(msg)
             if isinstance(input[-1], dict) and input[-1].get("type") == "tool_call":
                 input_type = "tool_calls"
                 tool_calls = cast("list[ToolCall]", input)
@@ -1614,7 +1617,7 @@ def tools_condition(
         tool calls are present, which is the standard output format for tool-calling
         language models.
     """
-    if isinstance(state, list):
+    if isinstance(state, list) and state:
         ai_message = state[-1]
     elif (isinstance(state, dict) and (messages := state.get(messages_key, []))) or (
         messages := getattr(state, messages_key, [])

--- a/libs/prebuilt/langgraph/prebuilt/tool_validator.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_validator.py
@@ -188,7 +188,16 @@ class ValidationNode(RunnableCallable):
         output_type, message = self._get_message(input)
 
         def run_one(call: ToolCall) -> ToolMessage:
-            schema = self.schemas_by_name[call["name"]]
+            schema = self.schemas_by_name.get(call["name"])
+            if schema is None:
+                valid_names = ", ".join(self.schemas_by_name.keys())
+                return ToolMessage(
+                    content=f"Error: {call['name']} is not a valid tool, try one of [{valid_names}].",
+                    name=call["name"],
+                    tool_call_id=cast(str, call["id"]),
+                    status="error",
+                    additional_kwargs={"is_error": True},
+                )
             try:
                 if issubclass(schema, BaseModel):
                     output = schema.model_validate(call["args"])

--- a/libs/prebuilt/tests/test_on_tool_call.py
+++ b/libs/prebuilt/tests/test_on_tool_call.py
@@ -1,12 +1,14 @@
 """Unit tests for tool call interceptor in ToolNode."""
 
 from collections.abc import Callable
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
+from langgraph.errors import GraphBubbleUp
 from langgraph.store.base import BaseStore
 from langgraph.types import Command
 
@@ -1471,3 +1473,144 @@ def test_tool_call_request_is_frozen() -> None:
     assert fresh_new_request.tool == add  # Other fields should remain the same
     assert fresh_new_request.state == state
     assert fresh_new_request.runtime is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: the wrap_tool_call path must handle exceptions exactly
+# like the non-wrapped path — GraphBubbleUp (interrupts) must always
+# propagate, and the handle_tool_errors type filter must be respected.
+# ---------------------------------------------------------------------------
+
+
+@tool
+def interrupting_tool(a: int) -> int:
+    """A tool that bubbles up a GraphInterrupt (as `interrupt()` does)."""
+    raise GraphBubbleUp("please confirm")
+
+
+@tool
+def key_error_tool(a: int) -> int:
+    """A tool that raises a KeyError."""
+    raise KeyError("missing")
+
+
+def _interrupt_message() -> dict[str, Any]:
+    return {
+        "messages": [
+            AIMessage(
+                "calling",
+                tool_calls=[
+                    {"name": "interrupting_tool", "args": {"a": 1}, "id": "call_int"}
+                ],
+            )
+        ]
+    }
+
+
+def _key_error_message() -> dict[str, Any]:
+    return {
+        "messages": [
+            AIMessage(
+                "calling",
+                tool_calls=[
+                    {"name": "key_error_tool", "args": {"a": 1}, "id": "call_ke"}
+                ],
+            )
+        ]
+    }
+
+
+@pytest.mark.parametrize("handle_tool_errors", [True, "handled", (GraphBubbleUp,)])
+def test_wrap_tool_call_propagates_interrupt(handle_tool_errors: Any) -> None:
+    """A GraphBubbleUp raised through a wrapper must not be swallowed.
+
+    Regression: previously the wrap_tool_call ``except Exception`` converted
+    the interrupt into an error ToolMessage whenever handle_tool_errors was
+    truthy, silently breaking human-in-the-loop.
+    """
+
+    def passthrough(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return execute(request)
+
+    tool_node = ToolNode(
+        [interrupting_tool],
+        wrap_tool_call=passthrough,
+        handle_tool_errors=handle_tool_errors,
+    )
+
+    with pytest.raises(GraphBubbleUp):
+        tool_node.invoke(_interrupt_message(), config=_create_config_with_runtime())
+
+
+@pytest.mark.parametrize("handle_tool_errors", [True, "handled", (GraphBubbleUp,)])
+async def test_wrap_tool_call_propagates_interrupt_async(
+    handle_tool_errors: Any,
+) -> None:
+    """Async counterpart of ``test_wrap_tool_call_propagates_interrupt``."""
+
+    def passthrough(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return execute(request)
+
+    tool_node = ToolNode(
+        [interrupting_tool],
+        wrap_tool_call=passthrough,
+        handle_tool_errors=handle_tool_errors,
+    )
+
+    with pytest.raises(GraphBubbleUp):
+        await tool_node.ainvoke(
+            _interrupt_message(), config=_create_config_with_runtime()
+        )
+
+
+def test_wrap_tool_call_respects_error_type_filter() -> None:
+    """A wrapper path must honor a tuple handle_tool_errors type filter.
+
+    Regression: previously the wrapper path caught every exception once
+    handle_tool_errors was truthy, ignoring the configured type filter — so a
+    KeyError was swallowed even though only ValueError was meant to be handled.
+    """
+
+    def passthrough(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return execute(request)
+
+    # KeyError is not in the handled set -> must propagate.
+    tool_node = ToolNode(
+        [key_error_tool],
+        wrap_tool_call=passthrough,
+        handle_tool_errors=(ValueError,),
+    )
+    with pytest.raises(KeyError):
+        tool_node.invoke(_key_error_message(), config=_create_config_with_runtime())
+
+    # ValueError IS in the handled set -> converted to an error ToolMessage.
+    tool_node_handled = ToolNode(
+        [failing_tool],  # raises ValueError
+        wrap_tool_call=passthrough,
+        handle_tool_errors=(ValueError,),
+    )
+    result = tool_node_handled.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "calling",
+                    tool_calls=[
+                        {"name": "failing_tool", "args": {"a": 1}, "id": "call_ve"}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+    message = result["messages"][-1]
+    assert isinstance(message, ToolMessage)
+    assert message.status == "error"

--- a/libs/prebuilt/tests/test_on_tool_call.py
+++ b/libs/prebuilt/tests/test_on_tool_call.py
@@ -1569,6 +1569,76 @@ async def test_wrap_tool_call_propagates_interrupt_async(
         )
 
 
+@pytest.mark.parametrize("handle_tool_errors", [True, "handled", (GraphBubbleUp,)])
+async def test_awrap_tool_call_propagates_interrupt(handle_tool_errors: Any) -> None:
+    """An ASYNC wrapper (`awrap_tool_call`) must not swallow interrupts either.
+
+    Distinct from the `wrap_tool_call`-fallback async test: this exercises the
+    `self._awrap_tool_call is not None` branch of `_arun_one`.
+    """
+
+    async def apassthrough(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage | Command:
+        return await execute(request)
+
+    tool_node = ToolNode(
+        [interrupting_tool],
+        awrap_tool_call=apassthrough,
+        handle_tool_errors=handle_tool_errors,
+    )
+
+    with pytest.raises(GraphBubbleUp):
+        await tool_node.ainvoke(
+            _interrupt_message(), config=_create_config_with_runtime()
+        )
+
+
+async def test_awrap_tool_call_respects_error_type_filter() -> None:
+    """The async wrapper path must honor the handle_tool_errors type filter."""
+
+    async def apassthrough(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage | Command:
+        return await execute(request)
+
+    # KeyError is not in the handled set -> must propagate.
+    tool_node = ToolNode(
+        [key_error_tool],
+        awrap_tool_call=apassthrough,
+        handle_tool_errors=(ValueError,),
+    )
+    with pytest.raises(KeyError):
+        await tool_node.ainvoke(
+            _key_error_message(), config=_create_config_with_runtime()
+        )
+
+    # ValueError IS in the handled set -> converted to an error ToolMessage.
+    tool_node_handled = ToolNode(
+        [failing_tool],
+        awrap_tool_call=apassthrough,
+        handle_tool_errors=(ValueError,),
+    )
+    result = await tool_node_handled.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "calling",
+                    tool_calls=[
+                        {"name": "failing_tool", "args": {"a": 1}, "id": "call_ve_a"}
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+    message = result["messages"][-1]
+    assert isinstance(message, ToolMessage)
+    assert message.status == "error"
+
+
 def test_wrap_tool_call_respects_error_type_filter() -> None:
     """A wrapper path must honor a tuple handle_tool_errors type filter.
 

--- a/libs/prebuilt/tests/test_react_agent.py
+++ b/libs/prebuilt/tests/test_react_agent.py
@@ -2154,3 +2154,118 @@ def test_create_react_agent_inject_vars_with_post_model_hook(
         AIMessage("hi-hi-6", id="1"),
     ]
     assert result["foo"] == 2
+
+
+class _StateWithPlainRemainingSteps(TypedDict):
+    """State schema with a regular (non-managed) `remaining_steps` channel.
+
+    Allows tests to set `remaining_steps` directly in the input, which is not
+    possible with the managed `RemainingSteps` value.
+    """
+
+    messages: Annotated[list[AnyMessage], add_messages]
+    remaining_steps: int
+
+
+@dec_tool
+def _echo_weather(city: str) -> str:
+    """Get the weather in a city."""
+    return "sunny"
+
+
+@dec_tool(return_direct=True)
+def _echo_weather_direct(city: str) -> str:
+    """Get the weather in a city."""
+    return "sunny"
+
+
+def test_final_answer_preserved_when_remaining_steps_exhausted() -> None:
+    """A response with no tool calls is a final answer and must be kept even
+    when `remaining_steps` is exhausted (previously `all([])` made
+    `all_tools_return_direct` truthy and replaced it with a 'Sorry' message)."""
+    model = FakeToolCallingModel()  # never emits tool calls
+    agent = create_react_agent(
+        model, [_echo_weather], state_schema=_StateWithPlainRemainingSteps
+    )
+    result = agent.invoke(
+        {"messages": [HumanMessage("what is the weather?")], "remaining_steps": 0}
+    )
+    last_message = result["messages"][-1]
+    assert last_message.content == "what is the weather?"
+    assert "Sorry, need more steps" not in last_message.content
+
+
+async def test_final_answer_preserved_when_remaining_steps_exhausted_async() -> None:
+    """Async variant of the final-answer preservation test."""
+    model = FakeToolCallingModel()
+    agent = create_react_agent(
+        model, [_echo_weather], state_schema=_StateWithPlainRemainingSteps
+    )
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("what is the weather?")], "remaining_steps": 0}
+    )
+    last_message = result["messages"][-1]
+    assert last_message.content == "what is the weather?"
+    assert "Sorry, need more steps" not in last_message.content
+
+
+def test_return_direct_tool_calls_still_blocked_when_out_of_steps() -> None:
+    """A response whose tool calls are all `return_direct` at
+    `remaining_steps < 1` must still be replaced with the 'Sorry' message."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {"city": "sf"}, "id": "1", "name": "_echo_weather_direct"}],
+            [],
+        ]
+    )
+    agent = create_react_agent(
+        model, [_echo_weather_direct], state_schema=_StateWithPlainRemainingSteps
+    )
+    result = agent.invoke(
+        {"messages": [HumanMessage("what is the weather?")], "remaining_steps": 0}
+    )
+    last_message = result["messages"][-1]
+    assert last_message.content == "Sorry, need more steps to process this request."
+
+
+def test_route_tool_responses_empty_messages() -> None:
+    """`route_tool_responses` must raise a clear ValueError on empty messages
+    instead of an unbound-variable NameError."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {"city": "sf"}, "id": "1", "name": "_echo_weather_direct"}],
+            [],
+        ]
+    )
+    # a `return_direct` tool is required for the `route_tool_responses`
+    # conditional edge to be added
+    agent = create_react_agent(model, [_echo_weather_direct])
+    route = agent.builder.branches["tools"]["route_tool_responses"].path
+    with pytest.raises(ValueError, match="No messages found in state"):
+        route.invoke({"messages": []})
+
+
+def test_post_model_hook_router_no_ai_message() -> None:
+    """`post_model_hook_router` must not crash when the post model hook
+    removed all messages (no AIMessage left): the run ends gracefully."""
+
+    def post_model_hook(state: dict) -> dict:
+        return {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES)]}
+
+    model = FakeToolCallingModel()  # plain answer, no tool calls
+    agent = create_react_agent(model, [_echo_weather], post_model_hook=post_model_hook)
+    result = agent.invoke({"messages": [HumanMessage("hi")]})
+    # all messages were removed by the hook and the graph ended without error
+    assert result["messages"] == []
+
+
+def test_post_model_hook_router_no_ai_message_direct() -> None:
+    """Direct check: the router returns END when no AIMessage is in state."""
+
+    def post_model_hook(state: dict) -> dict:
+        return {}
+
+    model = FakeToolCallingModel()
+    agent = create_react_agent(model, [_echo_weather], post_model_hook=post_model_hook)
+    route = agent.builder.branches["post_model_hook"]["post_model_hook_router"].path
+    assert route.invoke({"messages": []}) == "__end__"

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2462,3 +2462,100 @@ def test_tools_condition_empty_dict_messages() -> None:
     """Sanity check: empty dict state raises the same ValueError."""
     with pytest.raises(ValueError, match="No messages found in input state"):
         tools_condition({"messages": []})
+
+
+def test_tool_node_param_named_runtime_with_other_annotation_not_hijacked() -> None:
+    """A parameter merely named `runtime` with a non-ToolRuntime annotation is a
+    regular model-provided argument: it stays in the tool schema and receives
+    the model-supplied value instead of an injected ToolRuntime instance."""
+
+    @dec_tool
+    def sched(task: str, runtime: str) -> str:
+        """Schedule a task at the given runtime."""
+        assert isinstance(runtime, str)
+        return f"scheduled {task} at {runtime}"
+
+    # The param must remain visible in the schema presented to the model.
+    assert "runtime" in sched.tool_call_schema.model_json_schema()["properties"]
+
+    from langgraph.prebuilt.tool_node import _get_all_injected_args
+
+    assert _get_all_injected_args(sched).runtime is None
+
+    result = ToolNode([sched]).invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "sched",
+                            "args": {"task": "standup", "runtime": "9am"},
+                            "id": "call_sched",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+    tool_message = result["messages"][-1]
+    assert tool_message.status != "error"
+    assert tool_message.content == "scheduled standup at 9am"
+
+
+def test_tool_node_param_annotated_tool_runtime_still_injected() -> None:
+    """A parameter annotated with ToolRuntime is still injected and hidden
+    from the tool schema presented to the model."""
+
+    @dec_tool
+    def rt_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that accesses runtime."""
+        assert isinstance(runtime, ToolRuntime)
+        return f"x={x}, tool_call_id={runtime.tool_call_id}"
+
+    assert "runtime" not in rt_tool.tool_call_schema.model_json_schema().get(
+        "properties", {}
+    )
+
+    from langgraph.prebuilt.tool_node import _get_all_injected_args
+
+    assert _get_all_injected_args(rt_tool).runtime == "runtime"
+
+    result = ToolNode([rt_tool]).invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "rt_tool",
+                            "args": {"x": 1},
+                            "id": "call_rt",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+    tool_message = result["messages"][-1]
+    assert tool_message.status != "error"
+    assert tool_message.content == "x=1, tool_call_id=call_rt"
+
+
+def test_tool_runtime_forward_ref_detection() -> None:
+    """String/ForwardRef annotations naming ToolRuntime are treated as the
+    runtime slot; anything else is not."""
+    from typing import ForwardRef
+
+    from langgraph.prebuilt.tool_node import _is_tool_runtime_forward_ref
+
+    assert _is_tool_runtime_forward_ref("ToolRuntime")
+    assert _is_tool_runtime_forward_ref("ToolRuntime[Context, State]")
+    assert _is_tool_runtime_forward_ref(ForwardRef("ToolRuntime"))
+    assert not _is_tool_runtime_forward_ref("str")
+    assert not _is_tool_runtime_forward_ref(str)
+    assert not _is_tool_runtime_forward_ref(ToolRuntime)  # real class handled elsewhere

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2428,3 +2428,37 @@ def test_tool_node_list_return_mixed_with_regular_tool() -> None:
     tool_call_ids = {m.tool_call_id for m in all_msgs}
     assert list_tool_id in tool_call_ids
     assert regular_tool_id in tool_call_ids
+
+
+@dec_tool
+def _simple_add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def test_tool_node_empty_list_input() -> None:
+    """An empty message list must raise the intended 'No message found in
+    input' ValueError instead of an IndexError from `input[-1]`."""
+    node = ToolNode([_simple_add])
+    with pytest.raises(ValueError, match="No message found in input"):
+        node.invoke([], _create_config_with_runtime())
+
+
+async def test_tool_node_empty_list_input_async() -> None:
+    """Async variant of the empty message list guard."""
+    node = ToolNode([_simple_add])
+    with pytest.raises(ValueError, match="No message found in input"):
+        await node.ainvoke([], _create_config_with_runtime())
+
+
+def test_tools_condition_empty_list() -> None:
+    """An empty message list must follow the same 'no messages' ValueError
+    path as the dict/attr branches instead of raising an IndexError."""
+    with pytest.raises(ValueError, match="No messages found in input state"):
+        tools_condition([])
+
+
+def test_tools_condition_empty_dict_messages() -> None:
+    """Sanity check: empty dict state raises the same ValueError."""
+    with pytest.raises(ValueError, match="No messages found in input state"):
+        tools_condition({"messages": []})

--- a/libs/prebuilt/tests/test_validation_node.py
+++ b/libs/prebuilt/tests/test_validation_node.py
@@ -86,3 +86,42 @@ async def test_validation_node(tool_schema: Any, use_message_key: bool):
     if use_message_key:
         result_sync = result_sync["messages"]
     check_results(result_sync)
+
+
+async def test_validation_node_unknown_tool_name():
+    """A tool call naming an unknown tool must produce an error ToolMessage
+    instead of raising an uncaught KeyError."""
+    validation_node = ValidationNode([MyModel])
+    inputs = [
+        AIMessage(
+            "hi?",
+            tool_calls=[
+                {
+                    "name": "not_a_tool",
+                    "args": {"some_val": 1},
+                    "id": "call 0",
+                },
+                {
+                    "name": "MyModel",
+                    "args": {"some_val": 1, "some_other_val": "foo"},
+                    "id": "call 1",
+                },
+            ],
+        ),
+    ]
+
+    def check_results(messages: list):
+        assert len(messages) == 2
+        assert all(m.type == "tool" for m in messages)
+        error_msg = messages[0]
+        assert error_msg.status == "error"
+        assert error_msg.additional_kwargs.get("is_error")
+        assert error_msg.name == "not_a_tool"
+        assert error_msg.tool_call_id == "call 0"
+        assert "not_a_tool is not a valid tool" in error_msg.content
+        assert "MyModel" in error_msg.content
+        # The valid call is still validated normally.
+        assert not messages[1].additional_kwargs.get("is_error")
+
+    check_results(validation_node.invoke(inputs))
+    check_results(await validation_node.ainvoke(inputs))

--- a/libs/sdk-py/langgraph_sdk/_shared/utilities.py
+++ b/libs/sdk-py/langgraph_sdk/_shared/utilities.py
@@ -54,8 +54,10 @@ def _get_headers(
 ) -> dict[str, str]:
     """Combine api_key and custom user-provided headers."""
     custom_headers = custom_headers or {}
-    for header in RESERVED_HEADERS:
-        if header in custom_headers:
+    # HTTP header names are case-insensitive, so compare lowercased names to
+    # prevent variants like `X-Api-Key` from bypassing the reserved check.
+    for header in custom_headers:
+        if header.lower() in RESERVED_HEADERS:
             raise ValueError(f"Cannot set reserved header '{header}'")
 
     headers = {

--- a/libs/sdk-py/tests/test_skip_auto_load_api_key.py
+++ b/libs/sdk-py/tests/test_skip_auto_load_api_key.py
@@ -3,6 +3,7 @@
 import pytest
 
 from langgraph_sdk import get_client, get_sync_client
+from langgraph_sdk._shared.utilities import _get_headers
 
 
 class TestSkipAutoLoadApiKey:
@@ -68,3 +69,45 @@ class TestSkipAutoLoadApiKey:
         assert "x-api-key" in client.http.client.headers
         assert client.http.client.headers["x-api-key"] == "explicit-key"
         client.close()
+
+
+class TestReservedHeaders:
+    """Reserved headers must be rejected regardless of the caller's casing."""
+
+    def test_get_headers_rejects_lowercase_reserved_header(self):
+        with pytest.raises(ValueError, match="x-api-key"):
+            _get_headers("explicit-key", {"x-api-key": "sneaky"})
+
+    @pytest.mark.parametrize("name", ["X-Api-Key", "X-API-KEY", "x-API-key"])
+    def test_get_headers_rejects_mixed_case_reserved_header(self, name):
+        """HTTP header names are case-insensitive; casing must not bypass the guard."""
+        with pytest.raises(ValueError, match=name):
+            _get_headers("explicit-key", {name: "sneaky"})
+
+    @pytest.mark.parametrize("name", ["x-api-key", "X-Api-Key"])
+    def test_get_headers_rejects_reserved_header_without_api_key(self, name):
+        """The guard applies even when no api_key is supplied (current intent)."""
+        with pytest.raises(ValueError, match=r"(?i)x-api-key"):
+            _get_headers(None, {name: "sneaky"})
+
+    @pytest.mark.asyncio
+    async def test_get_client_rejects_mixed_case_reserved_header(self):
+        with pytest.raises(ValueError, match="X-Api-Key"):
+            get_client(
+                url="http://localhost:8123",
+                api_key="explicit-key",
+                headers={"X-Api-Key": "sneaky"},
+            )
+
+    def test_get_sync_client_rejects_mixed_case_reserved_header(self):
+        with pytest.raises(ValueError, match="X-Api-Key"):
+            get_sync_client(
+                url="http://localhost:8123",
+                api_key="explicit-key",
+                headers={"X-Api-Key": "sneaky"},
+            )
+
+    def test_non_reserved_headers_pass_through(self):
+        headers = _get_headers("explicit-key", {"X-Custom": "ok"})
+        assert headers["X-Custom"] == "ok"
+        assert headers["x-api-key"] == "explicit-key"


### PR DESCRIPTION
Fixes #8394

Fixes ToolNode interrupt swallowing through wrap_tool_call, plus related audit defects (retry budgets, CLI telemetry hang, config aliasing, Postgres pending-sends migration, checkpoint/serde hazards, and other edge-case crashes). Each fix is a separate commit with regression tests.

**Note:** This touches multiple packages. Happy to split into package-scoped PRs if maintainers prefer that over a single change set. Working fork PR with review history: https://github.com/wilsonhj/langgraph/pull/1

### How did you verify your code works?

Local pytest (fresh runs on the fork head), including:
- `libs/prebuilt`: tool_call / tool_node / react_agent suites
- `libs/langgraph`: retry, utils, channels, messages_state, runner regressions
- `libs/cli`: unit tests
- `libs/sdk-py`: reserved-header tests
- `libs/checkpoint`: jsonplus type-drift tests

`make format` / `make lint` clean in touched packages. Postgres migration tests need a live DB (will rely on CI). Fork currently has no Actions enabled.

### Breaking / behavior notes

- Multi-policy retries: per-policy budgets under an overall `max(max_attempts)` ceiling (doc parity).
- ToolNode wrappers now propagate `GraphBubbleUp` instead of converting interrupts to error ToolMessages.