### PR TITLE
fix: remove stored pipeline reference to prevent SSL connection closed errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -45,17 +45,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
     def __init__(
         self,
         conn: _ainternal.Conn,
-        pipe: AsyncPipeline | None = None,
         serde: SerializerProtocol | None = None,
     ) -> None:
         super().__init__(serde=serde)
-        if isinstance(conn, AsyncConnectionPool) and pipe is not None:
-            raise ValueError(
-                "Pipeline should be used only with a single AsyncConnection, not AsyncConnectionPool."
-            )
-
         self.conn = conn
-        self.pipe = pipe
         self.lock = asyncio.Lock()
         self.loop = asyncio.get_running_loop()
         self.supports_pipeline = Capabilities().has_pipeline()


### PR DESCRIPTION
## What
`AsyncPostgresSaver` stored an `AsyncPipeline` reference passed to `__init__`, which outlives the pipeline context manager used in `from_conn_string`. This caused `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when the saver attempted to use the connection after the pipeline was closed.

## Fix
Remove the `pipe` parameter from `__init__` and stop storing the pipeline reference. Pipeline usage should be handled internally via `async with self.conn.pipeline():` in methods that benefit from pipelining, not via an externally managed pipeline context across the saver's lifetime.

Closes #5675