### PR TITLE
fix: compare task ID instead of task object in PUSH child dedup

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -735,7 +735,7 @@ def _call(
             (
                 f
                 for f, t in list(futures().items())  # type: ignore[union-attr]
-                if t is not None and t == next_task.id
+                if t is not None and t.id == next_task.id
             ),
             None,
         ):
@@ -882,7 +882,7 @@ async def _acall_impl(
                 (
                     f
                     for f, t in list(futures().items())  # type: ignore[union-attr]
-                    if t is not None and t == next_task.id
+                    if t is not None and t.id == next_task.id
                 ),
                 None,
             ):


### PR DESCRIPTION
## Problem

When a parent task is retried while a PUSH child task is still in-flight, the deduplication logic in `_call` (sync) and `_acall` (async) should detect the existing child and reuse its future. Instead, it schedules a duplicate because:

```python
if t is not None and t == next_task.id
```

compares a `PregelExecutableTask` object (`t`) to a string (`next_task.id`), which is **always False** in Python. The dedup never fires.

## Impact

- Duplicate child task execution on parent retry
- Duplicate side effects (duplicate writes, API calls, etc.)
- Potential graph state corruption

## Fix

Compare the task's `id` attribute instead of the task object:

```python
if t is not None and t.id == next_task.id
```

Applied in both the sync (`_call`, line 738) and async (`_acall`, line 885) paths.

## Testing

The reproduction from #8393 confirms the fix: with `t.id == next_task.id`, the existing future is found and no duplicate is scheduled.

Fixes #8393