### PR TITLE
fix(langgraph): warn when node returns keys not declared in state schema

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1446,12 +1446,31 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
+                undeclared = [k for k in input if k not in output_keys]
+                if undeclared:
+                    warnings.warn(
+                        f"Node '{key}' returned keys not declared in the state "
+                        f"schema: {undeclared}. These keys will be ignored. "
+                        f"Add them to your state TypedDict/dataclass to persist them.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:
                     return None
+                tuples = input._update_as_tuples()
+                undeclared = [k for k, _ in tuples if k not in output_keys]
+                if undeclared:
+                    warnings.warn(
+                        f"Node '{key}' returned Command with keys not declared in "
+                        f"the state schema: {undeclared}. These keys will be ignored. "
+                        f"Add them to your state TypedDict/dataclass to persist them.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 return [
-                    (k, v) for k, v in input._update_as_tuples() if k in output_keys
+                    (k, v) for k, v in tuples if k in output_keys
                 ]
             elif (
                 isinstance(input, (list, tuple))


### PR DESCRIPTION
## Problem

When a node returns keys not declared in the state `TypedDict`, they are **silently dropped** with no warning or error. This is a common trap when adding a new field to state and forgetting to update the schema.

```python
from typing import TypedDict
from langgraph.graph import StateGraph, START, END

class State(TypedDict):
    x: int

def node(state):
    return {"x": 1, "undeclared_key": "this gets dropped silently"}

g = StateGraph(State)
g.add_node("n", node)
g.add_edge(START, "n")
g.add_edge("n", END)
result = g.compile().invoke({"x": 0})
# result == {"x": 1}  -- "undeclared_key" vanished with no warning
```

## Fix

Added a `UserWarning` in `_get_updates()` (the closure that processes node output in `attach_node`) that fires when any returned key is not in `output_keys`:

```
UserWarning: Node 'n' returned keys not declared in the state schema: 
['undeclared_key']. These keys will be ignored. Add them to your state 
TypedDict/dataclass to persist them.
```

Covers both the plain `dict` return path and the `Command` return path.

## Design Decisions

- **UserWarning** (not an error): preserves backward compatibility — existing code continues to work, users just get visibility
- **stacklevel=2**: points the warning at the user's node function, not internal LangGraph code
- **No opt-out flag needed**: users can suppress via standard `warnings.filterwarnings()` if desired

Fixes #8320