### PR TITLE
fix(langgraph): yield task_result events with errors in single debug stream mode

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -245,6 +245,7 @@ class PregelRunner:
                         ):
                             tb = tb.tb_next
                         exc.__traceback__ = tb
+                    yield  # drain stream queue before raising (e.g. task_result events)
                     raise
             if not futures and not scheduled_error_handler:
                 # maybe `t` scheduled another task
@@ -436,6 +437,7 @@ class PregelRunner:
                         ):
                             tb = tb.tb_next
                         exc.__traceback__ = tb
+                    yield  # drain stream queue before raising (e.g. task_result events)
                     raise
             if not futures and not scheduled_error_handler:
                 # maybe `t` scheduled another task

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -4590,6 +4590,45 @@ def test_debug_nested_subgraphs(
                 assert stream_task.get("state") == history_task.state
 
 
+def test_debug_stream_error_events(durability: Durability):
+    """task_result events with errors must be yielded when stream_mode='debug'.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/5764.
+    """
+    class State(TypedDict):
+        pass
+
+    def failing_node(state: State):
+        raise ValueError("node failure")
+
+    builder = StateGraph(State)
+    builder.add_node("failer", failing_node)
+    builder.add_edge(START, "failer")
+    builder.add_edge("failer", END)
+    graph = builder.compile()
+
+    task_result_found = False
+    try:
+        for event in graph.stream(
+            {},
+            stream_mode="debug",
+            durability=durability,
+        ):
+            if (
+                isinstance(event, dict)
+                and event.get("type") == "task_result"
+                and event.get("payload", {}).get("error") is not None
+            ):
+                task_result_found = True
+    except Exception:
+        pass
+
+    assert task_result_found, (
+        "Expected a task_result event with error when using stream_mode='debug'. "
+        "The error event was not yielded before the exception was raised."
+    )
+
+
 def test_add_sequence():
     class State(TypedDict):
         foo: Annotated[list[str], operator.add]


### PR DESCRIPTION
Fixes #5764: When stream_mode=debug alone, the runner fast path raises immediately after commit(t, exc) without yielding, preventing the stream queue from draining the error-bearing task_result event. Multi-mode already yields before raising.

Fix: Add yield before raise on both sync (tick) and async (atick) fast paths in _runner.py.

Test: Added test_debug_stream_error_events verifying error events are yielded.

Closes #5764