### PR TITLE
feat(langgraph): drop tags from TracePolicy

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -700,8 +700,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             trace_policy: Optional policy controlling how this node's run is traced. Its
                 `process_inputs` callable transforms the node's input before it is
                 recorded (e.g. to omit or summarize large message history) without
-                changing the value passed to the node, and `tags` attaches tags to the
-                run (e.g. to hide it from the trace tree). Does not affect execution.
+                changing the value passed to the node. Does not affect execution.
             destinations: Destinations that indicate where a node can route to.
 
                 Useful for edgeless graphs with nodes that return `Command` objects.
@@ -1529,7 +1528,6 @@ class CompiledStateGraph(
                 if node.defer
                 else EphemeralValue(Any, guard=False)
             )
-            trace_tags = node.trace_policy.tags if node.trace_policy else None
             self.nodes[key] = PregelNode(
                 triggers=[branch_channel],
                 # read state keys and managed values
@@ -1538,7 +1536,6 @@ class CompiledStateGraph(
                 mapper=mapper,
                 # publish to state keys
                 writers=[ChannelWrite(write_entries)],
-                tags=list(trace_tags) if trace_tags else None,
                 metadata=node.metadata,
                 retry_policy=node.retry_policy,
                 cache_policy=node.cache_policy,

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from collections import deque
 from collections.abc import Callable, Hashable, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
@@ -546,9 +546,6 @@ class TracePolicy:
     """Optional callable to transform the node's input before it is recorded on the
     node's trace run. Use to omit or summarize large payloads (e.g. message history).
     Does not affect the value passed to the node."""
-
-    tags: list[str] = field(default_factory=list)
-    """Tags to attach to this node's trace run."""
 
 
 _DEFAULT_INTERRUPT_ID = "placeholder-id"

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -17,6 +17,7 @@ from typing import (
 )
 from warnings import warn
 
+from langchain_core._api import beta
 from langchain_core.messages import AnyMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph.checkpoint.base import BaseCheckpointSaver, CheckpointMetadata
@@ -528,6 +529,7 @@ class CachePolicy(Generic[KeyFuncT]):
     """Time to live for the cache entry in seconds. If `None`, the entry never expires."""
 
 
+@beta()
 @dataclass(**_DC_KWARGS)
 class TracePolicy:
     """Configuration for how a node's run is traced.

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -17,7 +17,6 @@ from typing import (
 )
 from warnings import warn
 
-from langchain_core._api import beta
 from langchain_core.messages import AnyMessage
 from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph.checkpoint.base import BaseCheckpointSaver, CheckpointMetadata
@@ -529,7 +528,6 @@ class CachePolicy(Generic[KeyFuncT]):
     """Time to live for the cache entry in seconds. If `None`, the entry never expires."""
 
 
-@beta()
 @dataclass(**_DC_KWARGS)
 class TracePolicy:
     """Configuration for how a node's run is traced.

--- a/libs/langgraph/tests/test_trace_policy.py
+++ b/libs/langgraph/tests/test_trace_policy.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for `TracePolicy` (input processing + hidden tag) on node runs."""
+"""End-to-end tests for `TracePolicy` input processing on node trace runs."""
 
 from typing import Any
 
@@ -86,24 +86,3 @@ async def test_trace_policy_transforms_recorded_inputs_async() -> None:
     run = _node_run(tracer, "n")
     assert run.inputs == {"scrubbed_in": True}
     assert run.outputs == {"value": 6}
-
-
-def test_trace_policy_tags_applied_to_run() -> None:
-    graph = (
-        StateGraph(State)
-        .add_node("shown", _incr)
-        .add_node(
-            "hush", _incr, trace_policy=TracePolicy(tags=["langsmith:hidden_middleware"])
-        )
-        .add_edge(START, "shown")
-        .add_edge("shown", "hush")
-        .add_edge("hush", END)
-        .compile()
-    )
-
-    tracer = FakeTracer()
-    graph.invoke({"value": 0}, {"callbacks": [tracer]})
-
-    # the policy's tags land on the node's run; other nodes are unaffected
-    assert "langsmith:hidden_middleware" in _node_run(tracer, "hush").tags
-    assert "langsmith:hidden_middleware" not in _node_run(tracer, "shown").tags

--- a/libs/langgraph/tests/test_trace_policy.py
+++ b/libs/langgraph/tests/test_trace_policy.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for `TracePolicy` (input processing + hidden tag) on node runs."""
+"""End-to-end tests for `TracePolicy` (input processing + run tags) on node runs."""
 
 from typing import Any
 
@@ -8,6 +8,11 @@ from typing_extensions import TypedDict
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import TracePolicy
 from tests.fake_tracer import FakeTracer, Run
+
+# TracePolicy is marked @beta; constructing it here (outside langchain) would warn.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning"
+)
 
 
 class State(TypedDict):

--- a/libs/langgraph/tests/test_trace_policy.py
+++ b/libs/langgraph/tests/test_trace_policy.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for `TracePolicy` (input processing + run tags) on node runs."""
+"""End-to-end tests for `TracePolicy` (input processing + hidden tag) on node runs."""
 
 from typing import Any
 
@@ -8,11 +8,6 @@ from typing_extensions import TypedDict
 from langgraph.graph import END, START, StateGraph
 from langgraph.types import TracePolicy
 from tests.fake_tracer import FakeTracer, Run
-
-# TracePolicy is marked @beta; constructing it here (outside langchain) would warn.
-pytestmark = pytest.mark.filterwarnings(
-    "ignore::langchain_core._api.beta_decorator.LangChainBetaWarning"
-)
 
 
 class State(TypedDict):


### PR DESCRIPTION
Following https://github.com/langchain-ai/langgraph/pull/8362

Drops `tags` from TracePolicy (not yet released).