### PR TITLE
fix: extend msgpack serializer to PurePath subclasses and range objects

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,18 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1082,6 +1082,34 @@ def test_msgpack_regex_still_works_strict(caplog: pytest.LogCaptureFixture) -> N
     assert result.flags == pattern.flags
 
 
+
+
+def test_msgpack_purepath_serialization() -> None:
+    """PurePosixPath and PureWindowsPath must serialize without error."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+    p = pathlib.PurePosixPath("/foo/bar")
+    result = serde.loads_typed(serde.dumps_typed(p))
+    assert result == p, f"Expected {p}, got {result}"
+
+    p = pathlib.PureWindowsPath(r"C:\foo\bar")
+    result = serde.loads_typed(serde.dumps_typed(p))
+    assert result == p, f"Expected {p}, got {result}"
+
+
+def test_msgpack_range_serialization() -> None:
+    """range objects must serialize and deserialize faithfully."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+    for r in (range(10), range(0, 10, 2), range(5, -5, -1)):
+        result = serde.loads_typed(serde.dumps_typed(r))
+        assert result == r, f"Expected {r}, got {result}"
+
+
+def test_msgpack_slice_serialization() -> None:
+    """slice serialization is a regression guard — slice is also not a Collection."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+    s = slice(1, 10, 2)
+    result = serde.loads_typed(serde.dumps_typed(s))
+    assert result == s, f"Expected {s}, got {result}"
 def test_msgpack_path_constructor_still_works() -> None:
     serde = JsonPlusSerializer(allowed_msgpack_modules=None)
     path_obj = pathlib.Path("/tmp/foo")


### PR DESCRIPTION
Fixes #8350

The msgpack default encoder used isinstance(obj, pathlib.Path) for
path serialization, which missed PurePosixPath and PureWindowsPath
instances. Both share the same .parts attribute and constructor
signature, so checking against pathlib.PurePath catches the base
class including Path itself.

Added range serialization via EXT_CONSTRUCTOR_POS_ARGS, encoding
(start, stop, step) for faithful round-trip reconstruction.

## Files
- libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
- libs/checkpoint/tests/test_jsonplus.py (3 new tests)