### PR TITLE
fix(checkpoint): serialize PurePath variants and range objects in msgpack

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -42,13 +42,21 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("ipaddress", "IPv6Interface"),
         ("ipaddress", "IPv6Network"),
         # pathlib
+        ("pathlib", "PurePath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "PureWindowsPath"),
         ("pathlib", "Path"),
         ("pathlib", "PosixPath"),
         ("pathlib", "WindowsPath"),
         # pathlib in Python 3.13+
+        ("pathlib._local", "PurePath"),
+        ("pathlib._local", "PurePosixPath"),
+        ("pathlib._local", "PureWindowsPath"),
         ("pathlib._local", "Path"),
         ("pathlib._local", "PosixPath"),
         ("pathlib._local", "WindowsPath"),
+        # range
+        ("builtins", "range"),
         # zoneinfo
         ("zoneinfo", "ZoneInfo"),
         # regex

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,18 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "range", (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):

--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,11 +407,16 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
+                    created_at=(
+                        existing.created_at
+                        if existing is not None
+                        else datetime.now(timezone.utc)
+                    ),
                     updated_at=datetime.now(timezone.utc),
                 )
 

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1212,6 +1212,73 @@ def test_msgpack_safe_types_value_equality(caplog: pytest.LogCaptureFixture) -> 
             assert result == obj, f"Value mismatch for {type(obj)}: {result} != {obj}"
 
 
+def test_serde_purepath_roundtrip() -> None:
+    """PurePath variants (not just Path) must serialize and deserialize."""
+    serde = JsonPlusSerializer()
+    cases = [
+        pathlib.PurePosixPath("/foo/bar"),
+        pathlib.PureWindowsPath("C:\\Users\\test"),
+        pathlib.PurePath("relative/path"),
+    ]
+    for p in cases:
+        dumped = serde.dumps_typed(p)
+        assert dumped[0] == "msgpack"
+        result = serde.loads_typed(dumped)
+        assert result == p, f"Failed for {type(p).__name__}: {result} != {p}"
+        assert isinstance(result, type(p))
+
+
+def test_serde_range_roundtrip() -> None:
+    """range objects must serialize and deserialize with correct values."""
+    serde = JsonPlusSerializer()
+    cases = [
+        range(10),
+        range(0, 10, 2),
+        range(5, 1, -1),
+        range(0, 100, 1),
+    ]
+    for r in cases:
+        dumped = serde.dumps_typed(r)
+        assert dumped[0] == "msgpack"
+        result = serde.loads_typed(dumped)
+        assert isinstance(result, range)
+        assert result == r, f"Failed for range({r.start}, {r.stop}, {r.step})"
+        assert list(result) == list(r)
+
+
+def test_serde_purepath_and_range_in_dict() -> None:
+    """PurePath and range inside a dict must survive a round-trip."""
+    serde = JsonPlusSerializer()
+    obj = {
+        "paths": [pathlib.PurePosixPath("/a/b"), pathlib.PureWindowsPath("C:\\d")],
+        "ranges": [range(5), range(0, 10, 3)],
+        "mixed": pathlib.PurePath("just/a/path"),
+    }
+    dumped = serde.dumps_typed(obj)
+    result = serde.loads_typed(dumped)
+    assert result == obj
+
+
+def test_msgpack_safe_types_purepath_and_range(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """PurePath variants and range must deserialize without warnings in strict mode."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+
+    for obj in [
+        pathlib.PurePosixPath("/tmp/test"),
+        pathlib.PureWindowsPath("C:\\tmp"),
+        range(10),
+        range(0, 5, 2),
+    ]:
+        caplog.clear()
+        dumped = serde.dumps_typed(obj)
+        result = serde.loads_typed(dumped)
+        assert "blocked" not in caplog.text.lower()
+        assert "unregistered" not in caplog.text.lower(), f"Warning for {type(obj)}"
+        assert result == obj
+
+
 def test_msgpack_nested_pydantic_serializes_as_dict(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -1044,3 +1044,17 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_upsert_preserves_created_at() -> None:
+    store = InMemoryStore()
+    store.put(("ns",), "k", {"v": 1})
+    # Simulate an item that was originally created in the past.
+    original = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    store._data[("ns",)]["k"].created_at = original
+    # Upsert the same key with a new value.
+    store.put(("ns",), "k", {"v": 2})
+    item = store.get(("ns",), "k")
+    assert item is not None
+    assert item.created_at == original  # creation timestamp must be retained
+    assert item.updated_at > original  # update timestamp should advance


### PR DESCRIPTION
Fixes #8326, fixes #8350