### PR TITLE
feat(sdk-py): support v2 stream format in join_stream

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_async/runs.py
@@ -1104,7 +1104,8 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         last_event_id: str | None = None,
-    ) -> AsyncIterator[StreamPart]:
+        version: StreamVersion = "v1",
+    ) -> AsyncIterator[StreamPart | StreamPartV2]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
         not be received here.
@@ -1119,6 +1120,8 @@ class RunsClient:
             headers: Optional custom headers to include with the request.
             params: Optional query parameters to include with the request.
             last_event_id: The last event ID to use for the stream.
+            version: Stream format version. "v1" (default) returns raw SSE `StreamPart`
+                NamedTuples. "v2" returns typed dicts with `type`, `ns`, and `data` keys.
 
         Returns:
             The stream of parts.
@@ -1142,7 +1145,7 @@ class RunsClient:
         }
         if params:
             query_params.update(params)
-        return self.http.stream(
+        raw = self.http.stream(
             f"/threads/{_quote_path_param(thread_id)}/runs/{_quote_path_param(run_id)}/stream",
             "GET",
             params=query_params,
@@ -1152,6 +1155,9 @@ class RunsClient:
             }
             or None,
         )
+        if version == "v2":
+            return _wrap_stream_v2(raw)
+        return raw
 
     async def delete(
         self,

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -1086,7 +1086,8 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         last_event_id: str | None = None,
-    ) -> Iterator[StreamPart]:
+        version: StreamVersion = "v1",
+    ) -> Iterator[StreamPart | StreamPartV2]:
         """Stream output from a run in real-time, until the run is done.
         Output is not buffered, so any output produced before this call will
         not be received here.
@@ -1101,9 +1102,11 @@ class SyncRunsClient:
             headers: Optional custom headers to include with the request.
             params: Optional query parameters to include with the request.
             last_event_id: The last event ID to use for the stream.
+            version: Stream format version. "v1" (default) returns raw SSE `StreamPart`
+                NamedTuples. "v2" returns typed dicts with `type`, `ns`, and `data` keys.
 
         Returns:
-            `None`
+            The stream of parts.
 
         ???+ example "Example Usage"
 
@@ -1123,7 +1126,7 @@ class SyncRunsClient:
         }
         if params:
             query_params.update(params)
-        return self.http.stream(
+        raw = self.http.stream(
             f"/threads/{_quote_path_param(thread_id)}/runs/{_quote_path_param(run_id)}/stream",
             "GET",
             params=query_params,
@@ -1133,6 +1136,9 @@ class SyncRunsClient:
             }
             or None,
         )
+        if version == "v2":
+            return _wrap_stream_v2_sync(raw)
+        return raw
 
     def delete(
         self,

--- a/libs/sdk-py/tests/test_client_stream.py
+++ b/libs/sdk-py/tests/test_client_stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -438,6 +438,125 @@ def test_sync_stream_v2_client_side_conversion() -> None:
         "data": {"state": "full"},
         "interrupts": [],
     }
+
+
+# --- join_stream honors the v2 stream format ---
+
+
+class _FakeAsyncHttp:
+    """Minimal async http stub whose `stream` replays a fixed list of parts."""
+
+    def __init__(self, parts: list[StreamPart]) -> None:
+        self._parts = parts
+
+    def stream(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+        async def gen() -> Any:
+            for part in self._parts:
+                yield part
+
+        return gen()
+
+
+class _FakeSyncHttp:
+    """Minimal sync http stub whose `stream` replays a fixed list of parts."""
+
+    def __init__(self, parts: list[StreamPart]) -> None:
+        self._parts = parts
+
+    def stream(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+        def gen() -> Any:
+            yield from self._parts
+
+        return gen()
+
+
+@pytest.mark.asyncio
+async def test_async_join_stream_v2_wraps_parts() -> None:
+    from langgraph_sdk._async.runs import RunsClient
+
+    raw_parts = [
+        StreamPart(event="metadata", data={"run_id": "r1"}),
+        StreamPart(event="values", data={"messages": [{"role": "user"}]}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    client = RunsClient(cast(HttpClient, _FakeAsyncHttp(raw_parts)))
+
+    parts = [part async for part in client.join_stream("t1", "r1", version="v2")]
+
+    # `end` carries no data and is dropped by the v2 conversion.
+    assert len(parts) == 2
+    for part in parts:
+        _assert_v2_shape(part)
+    assert parts[0] == {
+        "type": "metadata",
+        "ns": [],
+        "data": {"run_id": "r1"},
+        "interrupts": [],
+    }
+    assert parts[1] == {
+        "type": "values",
+        "ns": [],
+        "data": {"messages": [{"role": "user"}]},
+        "interrupts": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_join_stream_defaults_to_v1_raw_parts() -> None:
+    from langgraph_sdk._async.runs import RunsClient
+
+    raw_parts = [
+        StreamPart(event="values", data={"x": 1}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    client = RunsClient(cast(HttpClient, _FakeAsyncHttp(raw_parts)))
+
+    parts = [part async for part in client.join_stream("t1", "r1")]
+
+    assert parts == raw_parts
+
+
+def test_sync_join_stream_v2_wraps_parts() -> None:
+    from langgraph_sdk._sync.runs import SyncRunsClient
+
+    raw_parts = [
+        StreamPart(event="metadata", data={"run_id": "r1"}),
+        StreamPart(event="values", data={"state": "full"}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    client = SyncRunsClient(cast(SyncHttpClient, _FakeSyncHttp(raw_parts)))
+
+    parts = list(client.join_stream("t1", "r1", version="v2"))
+
+    assert len(parts) == 2
+    for part in parts:
+        _assert_v2_shape(part)
+    assert parts[0] == {
+        "type": "metadata",
+        "ns": [],
+        "data": {"run_id": "r1"},
+        "interrupts": [],
+    }
+    assert parts[1] == {
+        "type": "values",
+        "ns": [],
+        "data": {"state": "full"},
+        "interrupts": [],
+    }
+
+
+def test_sync_join_stream_defaults_to_v1_raw_parts() -> None:
+    from langgraph_sdk._sync.runs import SyncRunsClient
+
+    raw_parts = [
+        StreamPart(event="values", data={"x": 1}),
+        StreamPart(event="end", data=None),  # ty: ignore[invalid-argument-type]
+    ]
+    client = SyncRunsClient(cast(SyncHttpClient, _FakeSyncHttp(raw_parts)))
+
+    parts = list(client.join_stream("t1", "r1"))
+
+    assert parts == raw_parts
 
 
 # --- type narrowing compile-time checks ---


### PR DESCRIPTION
## Description

`RunsClient.stream()` exposes `version="v2"` to receive typed v2 stream parts (client-side wrapping via `_wrap_stream_v2` / `_wrap_stream_v2_sync`), but `join_stream()` never got that option. As a result, runs re-joined or replayed through `join_stream` (e.g. background runs) could only be consumed in the v1 format, which blocks v2 migration for callers that rely on `join_stream`'s replay-from-start behavior.

This adds a `version` parameter to `join_stream` in both the async and sync clients, mirroring `stream()`:

- `version="v1"` (default) — unchanged, returns raw `StreamPart` NamedTuples
- `version="v2"` — wraps the raw SSE iterator with `_wrap_stream_v2` / `_wrap_stream_v2_sync`, yielding the typed `StreamPartV2` dicts

Client-side only; no server changes. The return type is widened to `(Async)Iterator[StreamPart | StreamPartV2]`, matching `stream()`.

## Tests

Added coverage in `test_client_stream.py` for both clients: `version="v2"` wraps parts into v2 dicts, and the default (`v1`) returns raw parts unchanged.

`make format`, `make lint` (ruff + `ty`), and `make test` all pass locally.

Closes #8087
