### PR TITLE
fix: improve pipeline compatibility with PgBouncer and SSL connections (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -71,9 +71,14 @@ class AsyncPostgresSaver(BasePostgresSaver):
     ) -> AsyncIterator[AsyncPostgresSaver]:
         """Create a new AsyncPostgresSaver instance from a connection string.
 
+        Warning:
+            Pipeline mode is not compatible with PgBouncer or other connection
+            poolers that use statement-level pooling. It also may not work with
+            SSL connections (e.g., Supabase). Use with direct database connections only.
+
         Args:
             conn_string: The Postgres connection info string.
-            pipeline: whether to use AsyncPipeline
+            pipeline: whether to use AsyncPipeline (incompatible with PgBouncer/SSL).
 
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.


### PR DESCRIPTION
## What

Users connecting to Supabase or other PostgreSQL services via PgBouncer with SSL see `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when pipeline mode is enabled. The default `pipeline=False` already avoids this, but the documentation doesn't warn about the incompatibility. Additionally, `Capabilities().has_pipeline()` is unreliable because it checks client capabilities, not server support.

## Fix

- Add a warning in the docstring of `from_conn_string` that pipeline mode is incompatible with PgBouncer and SSL connections.
- Keep `pipeline=False` as default (no code change needed for behavior).
- Consider removing or fixing the unreliable `Capabilities().has_pipeline()` check in a follow-up.

Closes #5675