### PR TITLE
fix(langgraph): merge and format messages after REMOVE_ALL_MESSAGES

### DIFF
--- a/libs/langgraph/langgraph/graph/message.py
+++ b/libs/langgraph/langgraph/graph/message.py
@@ -209,8 +209,13 @@ def add_messages(
         if isinstance(m, RemoveMessage) and m.id == REMOVE_ALL_MESSAGES:
             remove_all_idx = idx
 
+    # REMOVE_ALL clears prior state and any messages before the sentinel.
+    # The remaining tail must still go through ID merge / RemoveMessage
+    # tombstoning and optional formatting — otherwise duplicate IDs and
+    # RemoveMessage objects can leak into message history.
     if remove_all_idx is not None:
-        return right[remove_all_idx + 1 :]
+        left = []
+        right = right[remove_all_idx + 1 :]
 
     # merge
     merged = left.copy()

--- a/libs/langgraph/tests/test_messages_state.py
+++ b/libs/langgraph/tests/test_messages_state.py
@@ -337,6 +337,75 @@ def test_remove_all_messages():
         _AnyIdHumanMessage(content="Updated hi there"),
     ]
 
+    # messages after REMOVE_ALL still participate in ID merge/replace
+    left = [HumanMessage(content="old", id="0")]
+    right = [
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="Hello", id="1"),
+        AIMessage(content="Hi", id="1"),
+    ]
+    result = add_messages(left, right)
+    assert result == [AIMessage(content="Hi", id="1")]
+
+    # RemoveMessage tombstones after REMOVE_ALL are applied to the new history
+    left = [HumanMessage(content="old", id="0")]
+    right = [
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        HumanMessage(content="temp", id="1"),
+        RemoveMessage(id="1"),
+    ]
+    result = add_messages(left, right)
+    assert result == []
+
+
+@pytest.mark.skipif(
+    condition=not ((CORE_MINOR == 3 and CORE_PATCH >= 11) or CORE_MINOR > 3),
+    reason="Requires langchain_core>=0.3.11.",
+)
+def test_remove_all_messages_applies_format():
+    # format must still run on the post-clear tail
+    right = [
+        RemoveMessage(id=REMOVE_ALL_MESSAGES),
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "hi",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
+    result = add_messages([], right, format="langchain-openai")
+    assert len(result) == 1
+    assert result[0].content == "hi"
+
+
+def test_remove_all_messages_in_graph():
+    class State(TypedDict):
+        messages: Annotated[list[AnyMessage], add_messages]
+
+    def clear_and_rewrite(_: State) -> dict:
+        return {
+            "messages": [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                HumanMessage(content="a", id="1"),
+                AIMessage(content="b", id="1"),
+                HumanMessage(content="temp", id="2"),
+                RemoveMessage(id="2"),
+            ]
+        }
+
+    builder = StateGraph(State)
+    builder.add_node("n", clear_and_rewrite)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    app = builder.compile()
+
+    out = app.invoke({"messages": [HumanMessage(content="old", id="0")]})
+    assert out["messages"] == [AIMessage(content="b", id="1")]
+
 
 def test_push_messages_in_graph():
     class MessagesState(TypedDict):


### PR DESCRIPTION
## Summary

`add_messages` returns the raw message tail immediately after encountering
`RemoveMessage(id=REMOVE_ALL_MESSAGES)`.

Because of that early return, messages after the sentinel do not pass through the
normal ID merge, removal, and formatting logic.

## Reproduction

A single update that clears the existing history and then rewrites messages can
produce incorrect state when the post-sentinel tail contains:

- a message whose ID already appears elsewhere in the same tail
- a `RemoveMessage` tombstone
- messages that should be transformed by `format=`

For example, conceptually:

```python
add_messages(
    existing_messages,
    [
        RemoveMessage(id=REMOVE_ALL_MESSAGES),
        AIMessage(id="1", content="first"),
        AIMessage(id="1", content="replacement"),
    ],
)