### PR TITLE
feat: fetch() — a native service-to-service data-dependency primitive

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -21,6 +21,8 @@ from langgraph.checkpoint.serde.encrypted import EncryptedSerializer
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import (
     ERROR,
+    FETCH,
+    FETCH_RESULT,
     INTERRUPT,
     RESUME,
     SCHEDULED,
@@ -691,7 +693,14 @@ Special writes (e.g. errors) map to negative indices, to avoid those writes from
 conflicting with regular writes.
 Each Checkpointer implementation should use this mapping in put_writes.
 """
-WRITES_IDX_MAP = {ERROR: -1, SCHEDULED: -2, INTERRUPT: -3, RESUME: -4}
+WRITES_IDX_MAP = {
+    ERROR: -1,
+    SCHEDULED: -2,
+    INTERRUPT: -3,
+    RESUME: -4,
+    FETCH: -5,
+    FETCH_RESULT: -6,
+}
 
 EXCLUDED_METADATA_KEYS = {
     "thread_id",

--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -75,6 +75,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("langgraph.types", "Send"),
         ("langgraph.types", "TimeoutPolicy"),
         ("langgraph.types", "Interrupt"),
+        ("langgraph.types", "FetchRequest"),
+        ("langgraph.types", "FetchResult"),
         ("langgraph.types", "Command"),
         ("langgraph.types", "StateSnapshot"),
         ("langgraph.types", "PregelTask"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/types.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/types.py
@@ -13,6 +13,8 @@ ERROR = "__error__"
 SCHEDULED = "__scheduled__"
 INTERRUPT = "__interrupt__"
 RESUME = "__resume__"
+FETCH = "__fetch__"
+FETCH_RESULT = "__fetch_result__"
 TASKS = "__pregel_tasks"
 
 

--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -10,6 +10,10 @@ INTERRUPT = sys.intern("__interrupt__")
 # for dynamic interrupts raised by nodes
 RESUME = sys.intern("__resume__")
 # for values passed to resume a node after an interrupt
+FETCH = sys.intern("__fetch__")
+# for data dependencies declared by nodes via fetch(); sibling of INTERRUPT
+FETCH_RESULT = sys.intern("__fetch_result__")
+# for values fulfilling a fetch(), keyed by content-addressed id; sibling of RESUME
 ERROR = sys.intern("__error__")
 # for errors raised by nodes
 ERROR_SOURCE_NODE = sys.intern("__error_source_node__")
@@ -71,6 +75,8 @@ CONFIG_KEY_RUNTIME = sys.intern("__pregel_runtime")
 # holds a `Runtime` instance with context, store, stream writer, etc.
 CONFIG_KEY_RESUME_MAP = sys.intern("__pregel_resume_map")
 # holds a mapping of task ns -> resume value for resuming tasks
+CONFIG_KEY_FETCH_MAP = sys.intern("__pregel_fetch_map")
+# holds a mapping of fetch content-id -> value for fulfilling fetch() dependencies
 CONFIG_KEY_STREAM_MESSAGES_V2 = sys.intern("__pregel_stream_messages_v2")
 # when True, attach StreamMessagesHandlerV2 so content-block (v2) events
 # flow through stream_mode="messages"; set by StreamingHandler only.
@@ -104,6 +110,8 @@ RESERVED = {
     INPUT,
     INTERRUPT,
     RESUME,
+    FETCH,
+    FETCH_RESULT,
     ERROR,
     ERROR_SOURCE_NODE,
     NO_WRITES,

--- a/libs/langgraph/langgraph/_internal/_scratchpad.py
+++ b/libs/langgraph/langgraph/_internal/_scratchpad.py
@@ -15,5 +15,15 @@ class PregelScratchpad:
     interrupt_counter: Callable[[], int]
     get_null_resume: Callable[[bool], Any]
     resume: list[Any]
+    # fetch: content-addressed id -> terminal FetchResult persisted from prior runs.
+    fetch_results: dict[str, Any]
+    # fetch: content-addressed id -> value/FetchResult delivered this run via
+    # Command(fetch=...). Kept separate from fetch_results so a deadline can be enforced
+    # on fresh deliveries (a late fulfillment is rejected) but not on already-recorded
+    # terminal results.
+    fetch_delivered: dict[str, Any]
+    # fetch: content-addressed id -> the FetchRequest persisted at first suspension, so
+    # re-execution reuses the original deadline/created_at instead of recomputing them.
+    fetch_pending: dict[str, Any]
     # subgraph
     subgraph_counter: Callable[[], int]

--- a/libs/langgraph/langgraph/errors.py
+++ b/libs/langgraph/langgraph/errors.py
@@ -10,7 +10,7 @@ from warnings import warn
 from langgraph.checkpoint.base import EmptyChannelError  # noqa: F401
 from typing_extensions import deprecated
 
-from langgraph.types import Command, Interrupt
+from langgraph.types import Command, FetchRequest, Interrupt
 from langgraph.warnings import LangGraphDeprecatedSinceV10
 
 __all__ = (
@@ -106,6 +106,17 @@ class GraphInterrupt(GraphBubbleUp):
         super().__init__(interrupts)
 
 
+class GraphFetch(GraphBubbleUp):
+    """Raised when a node declares a service-to-service data dependency via
+    [`fetch`][langgraph.types.fetch]. Sibling of `GraphInterrupt` (both bubble up
+    without failing the run), but routed separately: fetches are resolved by
+    content-addressed id, not by the positional human-interrupt resume path.
+    Never raised directly, or surfaced to the user."""
+
+    def __init__(self, requests: Sequence[FetchRequest] = ()) -> None:
+        super().__init__(requests)
+
+
 @deprecated(
     "NodeInterrupt is deprecated. Please use [`interrupt`][langgraph.types.interrupt] instead.",
     category=None,
@@ -130,6 +141,34 @@ class ParentCommand(GraphBubbleUp):
 
     def __init__(self, command: Command) -> None:
         super().__init__(command)
+
+
+class FetchError(Exception):
+    """Raised inside a node when a [`fetch()`][langgraph.types.fetch] data dependency
+    resolves to a terminal failure instead of a value.
+
+    Unlike `GraphFetch` (an internal suspend signal), `FetchError` is surfaced to the
+    node: a fetch that expired past its SLA, failed closed, or was cancelled raises this
+    so the node can `try/except` it or let the run fail deterministically.
+
+    !!! version-added "Added in version 0.6.x"
+    """
+
+    def __init__(
+        self,
+        id: str,
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        self.id = id
+        """Content-addressed id of the failed dependency."""
+        self.status = status
+        """Terminal outcome: `"expired"`, `"failed"`, or `"cancelled"`."""
+        self.error = error
+        """Optional error detail provided by the serving layer (for `failed`)."""
+        super().__init__(
+            f"fetch {id!r} resolved as {status!r}" + (f": {error}" if error else "")
+        )
 
 
 class EmptyInputError(Exception):

--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -39,6 +39,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
     CONFIG_KEY_CHECKPOINTER,
+    CONFIG_KEY_FETCH_MAP,
     CONFIG_KEY_NODE_ERROR,
     CONFIG_KEY_READ,
     CONFIG_KEY_RESUME_MAP,
@@ -49,6 +50,8 @@ from langgraph._internal._constants import (
     CONFIG_KEY_THREAD_ID,
     ERROR,
     ERROR_SOURCE_NODE,
+    FETCH,
+    FETCH_RESULT,
     INTERRUPT,
     NO_WRITES,
     NS_END,
@@ -300,6 +303,8 @@ def apply_writes(
                 PUSH,
                 RESUME,
                 INTERRUPT,
+                FETCH,
+                FETCH_RESULT,
                 RETURN,
                 ERROR,
                 ERROR_SOURCE_NODE,
@@ -631,6 +636,7 @@ def prepare_single_task(
                 config[CONF].get(CONFIG_KEY_RESUME_MAP),
                 step,
                 stop,
+                config[CONF].get(CONFIG_KEY_FETCH_MAP),
             )
             # create task input
             try:
@@ -878,6 +884,7 @@ def prepare_push_task_functional(
             configurable.get(CONFIG_KEY_RESUME_MAP),
             step,
             stop,
+            configurable.get(CONFIG_KEY_FETCH_MAP),
         )
         runtime = cast(Runtime, configurable.get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME))
         runtime = runtime.override(
@@ -1040,6 +1047,7 @@ def prepare_push_task_send(
             config[CONF].get(CONFIG_KEY_RESUME_MAP),
             step,
             stop,
+            config[CONF].get(CONFIG_KEY_FETCH_MAP),
         )
         runtime = cast(Runtime, configurable.get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME))
         runtime = runtime.override(
@@ -1189,6 +1197,7 @@ def prepare_node_error_handler_task(
         config[CONF].get(CONFIG_KEY_RESUME_MAP),
         step,
         stop,
+        config[CONF].get(CONFIG_KEY_FETCH_MAP),
     )
     runtime = cast(Runtime, configurable.get(CONFIG_KEY_RUNTIME, DEFAULT_RUNTIME))
     runtime = runtime.override(
@@ -1285,7 +1294,26 @@ def _scratchpad(
     resume_map: dict[str, Any] | None,
     step: int,
     stop: int,
+    fetch_map: dict[str, Any] | None = None,
 ) -> PregelScratchpad:
+    # build fetch state for this task, keyed by content-addressed fetch id:
+    #  - fetch_results: terminal FetchResults persisted from prior runs (FETCH_RESULT)
+    #  - fetch_pending: FetchRequests from prior suspension (FETCH), for deadline reuse
+    #  - fetch_delivered: fresh Command(fetch=...) deliveries threaded via fetch_map
+    # fetch()/fetch_all() look up their own ids across these.
+    fetch_results: dict[str, Any] = {}
+    fetch_pending: dict[str, Any] = {}
+    for w in pending_writes:
+        if w[0] != task_id:
+            continue
+        if w[1] == FETCH_RESULT and isinstance(w[2], dict):
+            fetch_results.update(w[2])
+        elif w[1] == FETCH:
+            for req in w[2] if isinstance(w[2], (list, tuple)) else [w[2]]:
+                rid = getattr(req, "id", None)
+                if rid is not None:
+                    fetch_pending[rid] = req
+    fetch_delivered: dict[str, Any] = dict(fetch_map) if fetch_map else {}
     if len(pending_writes) > 0:
         # find global resume value
         for w in pending_writes:
@@ -1340,6 +1368,10 @@ def _scratchpad(
         interrupt_counter=LazyAtomicCounter(),
         resume=task_resume_write,
         get_null_resume=get_null_resume,
+        # fetch
+        fetch_results=fetch_results,
+        fetch_delivered=fetch_delivered,
+        fetch_pending=fetch_pending,
         # subgraph
         subgraph_counter=LazyAtomicCounter(),
     )

--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 
 from langgraph._internal._constants import (
     ERROR,
+    FETCH,
     INTERRUPT,
     NULL_TASK_ID,
     RESUME,
@@ -127,6 +128,7 @@ def map_output_updates(
         if (not t.config or TAG_HIDDEN not in t.config.get("tags", EMPTY_SEQ))
         and ww[0][0] != ERROR
         and ww[0][0] != INTERRUPT
+        and ww[0][0] != FETCH
     ]
     if not output_tasks:
         return

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CHECKPOINT_ID,
     CONFIG_KEY_CHECKPOINT_MAP,
     CONFIG_KEY_CHECKPOINT_NS,
+    CONFIG_KEY_FETCH_MAP,
     CONFIG_KEY_REPLAY_STATE,
     CONFIG_KEY_RESUME_MAP,
     CONFIG_KEY_RESUMING,
@@ -52,6 +53,8 @@ from langgraph._internal._constants import (
     CONFIG_KEY_THREAD_ID,
     ERROR,
     ERROR_SOURCE_NODE,
+    FETCH,
+    FETCH_RESULT,
     INPUT,
     INTERRUPT,
     NS_END,
@@ -75,6 +78,7 @@ from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.constants import TAG_HIDDEN
 from langgraph.errors import (
     EmptyInputError,
+    GraphFetch,
     GraphInterrupt,
 )
 from langgraph.managed.base import (
@@ -662,7 +666,8 @@ class PregelLoop:
 
     def _match_writes(self, tasks: Mapping[str, PregelExecutableTask]) -> None:
         for tid, k, v in self.checkpoint_pending_writes:
-            if k in (ERROR, ERROR_SOURCE_NODE, INTERRUPT, RESUME):
+            if k in (ERROR, ERROR_SOURCE_NODE, INTERRUPT, RESUME, FETCH, FETCH_RESULT):
+                # fetch-related writes do not mark tasks as done; they should re-run
                 continue
             if task := tasks.get(tid):
                 task.writes.append((k, v))
@@ -753,7 +758,9 @@ class PregelLoop:
 
         # map command to writes
         if input_is_command:
-            if (resume := cast(Command, self.input).resume) is not None:
+            command = cast(Command, self.input)
+            resume_is_map = False
+            if (resume := command.resume) is not None:
                 if not self.checkpointer:
                     raise RuntimeError(
                         "Cannot use Command(resume=...) without checkpointer"
@@ -771,12 +778,29 @@ class PregelLoop:
                             "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
                         )
 
+            # fulfill data dependencies declared via fetch(), keyed by content-id
+            fetch_is_map = False
+            if command.fetch is not None:
+                if not self.checkpointer:
+                    raise RuntimeError(
+                        "Cannot use Command(fetch=...) without checkpointer"
+                    )
+                if not (
+                    isinstance(command.fetch, dict)
+                    and all(is_xxh3_128_hexdigest(k) for k in command.fetch)
+                ):
+                    raise ValueError(
+                        "Command(fetch=...) must be a mapping of FetchRequest.id -> value"
+                    )
+                self.config[CONF][CONFIG_KEY_FETCH_MAP] = command.fetch
+                fetch_is_map = True
+
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)
             # group writes by task ID
-            for tid, c, v in map_command(cmd=cast(Command, self.input)):
+            for tid, c, v in map_command(cmd=command):
                 if not (c == RESUME and resume_is_map):
                     writes[tid].append((c, v))
-            if not writes and not resume_is_map:
+            if not writes and not resume_is_map and not fetch_is_map:
                 raise EmptyInputError("Received empty Command input")
             # save writes
             for tid, ws in writes.items():
@@ -1027,11 +1051,12 @@ class PregelLoop:
         ):
             self._put_checkpoint(self.checkpoint_metadata)
             self._put_pending_writes()
-        # suppress interrupt
-        if isinstance(exc_value, GraphInterrupt) and not self.is_nested:
-            interrupt = exc_value
-            interrupts = tuple(interrupt.args[0]) if interrupt.args else ()
-            self._push_graph_lifecycle_event("interrupt", interrupts=interrupts)
+        # suppress interrupt / fetch — both bubble up to suspend the graph
+        if isinstance(exc_value, (GraphInterrupt, GraphFetch)) and not self.is_nested:
+            is_interrupt = isinstance(exc_value, GraphInterrupt)
+            payload = tuple(exc_value.args[0]) if exc_value.args else ()
+            if is_interrupt:
+                self._push_graph_lifecycle_event("interrupt", interrupts=payload)
             # emit one last "values" event, with pending writes applied
             if (
                 hasattr(self, "tasks")
@@ -1057,16 +1082,16 @@ class PregelLoop:
                         [w for t in self.tasks.values() for w in t.writes],
                         self.channels,
                     )
-            # emit INTERRUPT if exception is empty (otherwise emitted by put_writes)
-            if not interrupt.args or not interrupt.args[0]:
-                interrupt_payload = interrupt.args[0] if interrupt.args else ()
+            # emit marker if exception is empty (otherwise emitted by put_writes)
+            if not exc_value.args or not exc_value.args[0]:
+                marker_key = INTERRUPT if is_interrupt else FETCH
                 self._emit(
                     "updates",
-                    lambda: iter([{INTERRUPT: interrupt_payload}]),
+                    lambda: iter([{marker_key: payload}]),
                 )
             # save final output
             self.output = read_channels(self.channels, self.output_keys)
-            # suppress interrupt
+            # suppress interrupt / fetch
             return True
         elif exc_type is None:
             # save final output
@@ -1144,6 +1169,24 @@ class PregelLoop:
                     # self.output_keys is a string, stream chunk contains only interrupts
                     else:
                         self._emit("values", lambda: iter(interrupts))
+            elif writes[0][0] == FETCH:
+                # emit data-dependency requests on the updates stream, keyed by FETCH
+                fetch_reqs = [
+                    {
+                        FETCH: tuple(
+                            v
+                            for w in writes
+                            if w[0] == FETCH
+                            for v in (w[1] if isinstance(w[1], Sequence) else (w[1],))
+                        )
+                    }
+                ]
+                if (
+                    fetch_reqs[0][FETCH]
+                    and self.stream
+                    and "updates" in self.stream.modes
+                ):
+                    self._emit("updates", lambda: iter(fetch_reqs))
             elif writes[0][0] != ERROR:
                 self._emit(
                     "updates",

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -31,6 +31,8 @@ from langgraph._internal._constants import (
     CONFIG_KEY_CALL,
     CONFIG_KEY_SCRATCHPAD,
     ERROR,
+    FETCH,
+    FETCH_RESULT,
     INTERRUPT,
     NO_WRITES,
     RESUME,
@@ -40,7 +42,7 @@ from langgraph._internal._future import chain_future, run_coroutine_threadsafe
 from langgraph._internal._scratchpad import PregelScratchpad
 from langgraph._internal._typing import MISSING
 from langgraph.constants import TAG_HIDDEN
-from langgraph.errors import GraphBubbleUp, GraphInterrupt
+from langgraph.errors import GraphBubbleUp, GraphFetch, GraphInterrupt
 from langgraph.pregel._algo import Call
 from langgraph.pregel._executor import Submit
 from langgraph.pregel._retry import arun_with_retry, run_with_retry
@@ -585,8 +587,20 @@ class PregelRunner:
                 # save interrupt to checkpointer
                 if exception.args[0]:
                     writes = [(INTERRUPT, exception.args[0])]
-                    if resumes := [w for w in task.writes if w[0] == RESUME]:
-                        writes.extend(resumes)
+                    # preserve resolution writes (resume values + fetch results) so a
+                    # fetch resolved before the interrupt stays resolved on re-run
+                    writes.extend(
+                        w for w in task.writes if w[0] in (RESUME, FETCH_RESULT)
+                    )
+                    self.put_writes()(task.id, writes)  # type: ignore[misc]
+            elif isinstance(exception, GraphFetch):
+                # save data-dependency requests to checkpointer (sibling of INTERRUPT)
+                if exception.args[0]:
+                    writes = [(FETCH, exception.args[0])]
+                    # preserve resolution writes (resume values + fetch results)
+                    writes.extend(
+                        w for w in task.writes if w[0] in (RESUME, FETCH_RESULT)
+                    )
                     self.put_writes()(task.id, writes)  # type: ignore[misc]
             elif isinstance(exception, GraphBubbleUp):
                 # exception will be raised in _panic_or_proceed
@@ -666,6 +680,7 @@ def _panic_or_proceed(
         else:
             inflight.add(fut)
     interrupts: list[GraphInterrupt] = []
+    fetches: list[GraphFetch] = []
     while done:
         # if any task failed
         fut = done.pop()
@@ -682,11 +697,17 @@ def _panic_or_proceed(
                 if isinstance(exc, GraphInterrupt):
                     # collect interrupts
                     interrupts.append(exc)
+                elif isinstance(exc, GraphFetch):
+                    # collect fetch (data-dependency) suspensions
+                    fetches.append(exc)
                 elif fut not in SKIP_RERAISE_SET:
                     raise exc
-    # raise combined interrupts
+    # raise combined interrupts (human interrupts take precedence; fetch requests
+    # are already persisted as FETCH writes and will be surfaced regardless)
     if interrupts:
         raise GraphInterrupt(tuple(i for exc in interrupts for i in exc.args[0]))
+    if fetches:
+        raise GraphFetch(tuple(r for exc in fetches for r in exc.args[0]))
     if inflight:
         # if we got here means we timed out
         while inflight:

--- a/libs/langgraph/langgraph/pregel/debug.py
+++ b/libs/langgraph/langgraph/pregel/debug.py
@@ -13,6 +13,8 @@ from langgraph._internal._constants import (
     CONF,
     CONFIG_KEY_CHECKPOINT_NS,
     ERROR,
+    FETCH,
+    FETCH_RESULT,
     INTERRUPT,
     NS_END,
     NS_SEP,
@@ -24,6 +26,7 @@ from langgraph.constants import TAG_HIDDEN
 from langgraph.pregel._io import read_channels
 from langgraph.types import (
     CheckpointPayload,
+    FetchRequest,
     PregelExecutableTask,
     PregelTask,
     StateSnapshot,
@@ -212,10 +215,26 @@ def tasks_w_writes(
             for v in (vv if isinstance(vv, Sequence) else [vv])
         )
 
+        # ids already fulfilled for this task (persisted as FETCH_RESULT); a stale
+        # FETCH request whose id is fulfilled is no longer pending (e.g. a fetch
+        # resolved before the node hit a later interrupt)
+        fulfilled_fetch_ids: set[str] = set()
+        for tid, n, vv in pending_writes:
+            if tid == task.id and n == FETCH_RESULT and isinstance(vv, dict):
+                fulfilled_fetch_ids.update(vv)
+        task_fetches = tuple(
+            v
+            for tid, n, vv in pending_writes
+            if tid == task.id and n == FETCH
+            for v in (vv if isinstance(vv, Sequence) else [vv])
+            if isinstance(v, FetchRequest) and v.id not in fulfilled_fetch_ids
+        )
+
         task_writes = [
             (chan, val)
             for tid, chan, val in pending_writes
-            if tid == task.id and chan not in (ERROR, INTERRUPT, RETURN)
+            if tid == task.id
+            and chan not in (ERROR, INTERRUPT, FETCH, FETCH_RESULT, RETURN)
         ]
 
         if rtn is not MISSING:
@@ -239,7 +258,8 @@ def tasks_w_writes(
             task_result = mapped_writes if filtered_writes else {}
 
         has_writes = rtn is not MISSING or any(
-            w[0] == task.id and w[1] not in (ERROR, INTERRUPT) for w in pending_writes
+            w[0] == task.id and w[1] not in (ERROR, INTERRUPT, FETCH, FETCH_RESULT)
+            for w in pending_writes
         )
 
         out.append(
@@ -251,6 +271,7 @@ def tasks_w_writes(
                 task_interrupts,
                 states.get(task.id) if states else None,
                 task_result if has_writes else None,
+                task_fetches,
             )
         )
     return tuple(out)

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -84,6 +84,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
     ERROR,
+    FETCH_RESULT,
     INPUT,
     INTERRUPT,
     NS_END,
@@ -388,6 +389,34 @@ class NodeBuilder:
 # namespaces flow through scoped muxes. Forwarding either to the inner
 # ``stream(...)`` would silently break v3's invariants, so we raise instead.
 _V3_INVARIANT_KWARGS: tuple[str, ...] = ("stream_mode", "subgraphs")
+
+
+def _fulfillment(id: str, value: Any, source: str | None) -> Any:
+    """Build the Command(fetch=...) payload for a fulfillment: a raw value when no
+    provenance is given, else a FetchResult carrying the source origin."""
+    if source is None:
+        return value
+    return FetchResult(id=id, value=value, source=source)
+
+
+def _collect_fetch_results(
+    tuples: Iterable[CheckpointTuple],
+) -> list[FetchResult]:
+    """Collect resolved FetchResults (provenance records) across a thread's checkpoint
+    tuples, deduped by dependency id. Walking history (not just the latest checkpoint)
+    is required: once a graph completes, the FETCH_RESULT lives on the pre-completion
+    checkpoint, not the final one."""
+    out: dict[str, FetchResult] = {}
+    for tup in tuples:
+        if not tup.pending_writes:  # pending_writes is list | None
+            continue
+        for _tid, chan, val in tup.pending_writes:
+            if chan == FETCH_RESULT and isinstance(val, dict):
+                for fid, res in val.items():
+                    # first-seen wins; list() is newest-first, terminal results immutable
+                    if isinstance(res, FetchResult):
+                        out.setdefault(fid, res)
+    return list(out.values())
 
 
 def _reject_v3_invariant_kwargs(kwargs: dict[str, Any]) -> None:
@@ -1412,17 +1441,65 @@ class Pregel(
         state = await self.aget_state(config)
         return [f for task in state.tasks for f in task.fetches]
 
-    def fulfill(self, config: RunnableConfig, id: str, value: Any) -> Any:
+    def resolved_fetches(self, config: RunnableConfig) -> list[FetchResult]:
+        """Return the resolved data dependencies recorded at the checkpoint in `config`.
+
+        The provenance/audit trail complementing [`pending_fetches`][langgraph.pregel.Pregel.pending_fetches]:
+        each [`FetchResult`][langgraph.types.FetchResult] carries `status`,
+        `value_digest`, `resolved_at`, and `source` — enough to verify what a `fetch()`
+        resolved to, when, and from where (reproducibility / drift detection) without
+        holding the value. Pass a config with a specific `checkpoint_id` to inspect a
+        past point in the thread's history.
+        """
+        checkpointer = ensure_config(config)[CONF].get(
+            CONFIG_KEY_CHECKPOINTER, self.checkpointer
+        )
+        if not isinstance(checkpointer, BaseCheckpointSaver):
+            return []
+        cfg = merge_configs(self.config, config) if self.config else config
+        return _collect_fetch_results(checkpointer.list(cfg))
+
+    async def aresolved_fetches(self, config: RunnableConfig) -> list[FetchResult]:
+        """Async variant of [`resolved_fetches`][langgraph.pregel.Pregel.resolved_fetches]."""
+        checkpointer = ensure_config(config)[CONF].get(
+            CONFIG_KEY_CHECKPOINTER, self.checkpointer
+        )
+        if not isinstance(checkpointer, BaseCheckpointSaver):
+            return []
+        cfg = merge_configs(self.config, config) if self.config else config
+        return _collect_fetch_results([t async for t in checkpointer.alist(cfg)])
+
+    def fulfill(
+        self,
+        config: RunnableConfig,
+        id: str,
+        value: Any,
+        *,
+        source: str | None = None,
+    ) -> Any:
         """Fulfill a data dependency by content-addressed id and resume the graph.
 
         One value satisfies exactly one dependency. A fulfillment arriving past the
         request's deadline is rejected (the dependency resolves as `expired`).
-        """
-        return self.invoke(Command(fetch={id: value}), config)
 
-    async def afulfill(self, config: RunnableConfig, id: str, value: Any) -> Any:
+        Args:
+            source: Optional provenance — where the value actually resolved from (a
+                source URI or dataset version), recorded on the `FetchResult` for audit.
+        """
+        return self.invoke(Command(fetch={id: _fulfillment(id, value, source)}), config)
+
+    async def afulfill(
+        self,
+        config: RunnableConfig,
+        id: str,
+        value: Any,
+        *,
+        source: str | None = None,
+    ) -> Any:
         """Async variant of [`fulfill`][langgraph.pregel.Pregel.fulfill]."""
-        return await self.ainvoke(Command(fetch={id: value}), config)
+        return await self.ainvoke(
+            Command(fetch={id: _fulfillment(id, value, source)}), config
+        )
 
     def fail_fetch(
         self, config: RunnableConfig, id: str, error: str | None = None

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -4,7 +4,10 @@ import asyncio
 import concurrent
 import concurrent.futures
 import contextlib
+import logging
 import queue
+import threading
+import time
 import warnings
 import weakref
 from collections import defaultdict, deque
@@ -12,6 +15,7 @@ from collections.abc import (
     AsyncIterator,
     Awaitable,
     Callable,
+    Iterable,
     Iterator,
     Mapping,
     Sequence,
@@ -178,6 +182,8 @@ from langgraph.types import (
     Checkpointer,
     Command,
     Durability,
+    FetchRequest,
+    FetchResult,
     GraphOutput,
     Interrupt,
     Send,
@@ -197,6 +203,8 @@ except ImportError:
     _StreamingCallbackHandler = None  # type: ignore
 
 __all__ = ("NodeBuilder", "Pregel")
+
+logger = logging.getLogger(__name__)
 
 _WriteValue = Callable[[Input], Output] | Any
 
@@ -1387,6 +1395,185 @@ class Pregel(
             tuple([i for task in tasks_with_writes for i in task.interrupts]),
         )
 
+    # --- fetch() serving layer ------------------------------------------------
+    # Convenience surface for driving service-to-service data dependencies declared
+    # with fetch()/fetch_all(). Fulfillment is always keyed by content-addressed id.
+
+    def pending_fetches(self, config: RunnableConfig) -> list[FetchRequest]:
+        """Return the data dependencies (`fetch()`) awaiting fulfillment on `config`.
+
+        Distinct from `get_state().tasks[].interrupts` — these are automated requests
+        the serving layer is expected to fulfill by id, not human interrupts.
+        """
+        return [f for task in self.get_state(config).tasks for f in task.fetches]
+
+    async def apending_fetches(self, config: RunnableConfig) -> list[FetchRequest]:
+        """Async variant of [`pending_fetches`][langgraph.pregel.Pregel.pending_fetches]."""
+        state = await self.aget_state(config)
+        return [f for task in state.tasks for f in task.fetches]
+
+    def fulfill(self, config: RunnableConfig, id: str, value: Any) -> Any:
+        """Fulfill a data dependency by content-addressed id and resume the graph.
+
+        One value satisfies exactly one dependency. A fulfillment arriving past the
+        request's deadline is rejected (the dependency resolves as `expired`).
+        """
+        return self.invoke(Command(fetch={id: value}), config)
+
+    async def afulfill(self, config: RunnableConfig, id: str, value: Any) -> Any:
+        """Async variant of [`fulfill`][langgraph.pregel.Pregel.fulfill]."""
+        return await self.ainvoke(Command(fetch={id: value}), config)
+
+    def fail_fetch(
+        self, config: RunnableConfig, id: str, error: str | None = None
+    ) -> Any:
+        """Fail a data dependency closed by id — it resolves as `failed`, raising
+        `FetchError` inside the node."""
+        return self.invoke(
+            Command(fetch={id: FetchResult(id=id, status="failed", error=error)}),
+            config,
+        )
+
+    async def afail_fetch(
+        self, config: RunnableConfig, id: str, error: str | None = None
+    ) -> Any:
+        """Async variant of [`fail_fetch`][langgraph.pregel.Pregel.fail_fetch]."""
+        return await self.ainvoke(
+            Command(fetch={id: FetchResult(id=id, status="failed", error=error)}),
+            config,
+        )
+
+    def _due_fetch_ids(self, pending: list[FetchRequest], now: float) -> list[str]:
+        return [f.id for f in pending if f.deadline is not None and now > f.deadline]
+
+    def expire_fetches(self, config: RunnableConfig) -> list[str]:
+        """Resume `config` so any past-deadline fetches self-resolve as `expired`.
+
+        This is the mechanism the background sweeper drives (see
+        [`start_fetch_sweeper`][langgraph.pregel.Pregel.start_fetch_sweeper]): the node
+        re-runs, records the terminal `expired` outcome, and advances. Returns the ids
+        that were past their deadline. May raise `FetchError` if a node lets the
+        terminal failure propagate (fail-closed).
+        """
+        due = self._due_fetch_ids(self.pending_fetches(config), time.time())
+        if due:
+            self.invoke(None, config)
+        return due
+
+    async def aexpire_fetches(self, config: RunnableConfig) -> list[str]:
+        """Async variant of [`expire_fetches`][langgraph.pregel.Pregel.expire_fetches]."""
+        due = self._due_fetch_ids(await self.apending_fetches(config), time.time())
+        if due:
+            await self.ainvoke(None, config)
+        return due
+
+    def cancel_fetches(
+        self, config: RunnableConfig, ids: Sequence[str] | None = None
+    ) -> list[str]:
+        """Cancel pending data dependencies (all, or the given `ids`).
+
+        Each resolves as `cancelled` — a terminal failure raising `FetchError` inside
+        the node. Returns the cancelled ids.
+        """
+        target = (
+            list(ids)
+            if ids is not None
+            else [f.id for f in self.pending_fetches(config)]
+        )
+        if target:
+            self.invoke(
+                Command(
+                    fetch={i: FetchResult(id=i, status="cancelled") for i in target}
+                ),
+                config,
+            )
+        return target
+
+    async def acancel_fetches(
+        self, config: RunnableConfig, ids: Sequence[str] | None = None
+    ) -> list[str]:
+        """Async variant of [`cancel_fetches`][langgraph.pregel.Pregel.cancel_fetches]."""
+        target = (
+            list(ids)
+            if ids is not None
+            else [f.id for f in await self.apending_fetches(config)]
+        )
+        if target:
+            await self.ainvoke(
+                Command(
+                    fetch={i: FetchResult(id=i, status="cancelled") for i in target}
+                ),
+                config,
+            )
+        return target
+
+    def start_fetch_sweeper(
+        self,
+        threads: Callable[[], Iterable[RunnableConfig]] | Iterable[RunnableConfig],
+        *,
+        interval_seconds: float = 300.0,
+    ) -> concurrent.futures.Future[None]:
+        """Start an in-process daemon that periodically expires past-deadline fetches.
+
+        Models the store TTL sweeper: an opt-in background thread that, every
+        `interval_seconds`, calls [`expire_fetches`][langgraph.pregel.Pregel.expire_fetches]
+        for each thread in `threads` — so a graph that is never otherwise resumed still
+        reaches its terminal `expired` state within its SLA.
+
+        `threads` may be a static iterable of thread configs or a callable returning
+        one (re-evaluated each sweep, so newly-created threads are picked up). Errors in
+        a single thread's sweep are logged and do not stop the loop.
+
+        Returns a `Future` that can be cancelled; call
+        [`stop_fetch_sweeper`][langgraph.pregel.Pregel.stop_fetch_sweeper] to stop.
+
+        Note: this covers deployments with a running host process. Discovering *all*
+        threads is checkpointer-specific — pass a `threads` provider that enumerates
+        them (e.g. via `checkpointer.list`). Scaled-to-zero deployments need an external
+        durable timer instead.
+        """
+        existing = getattr(self, "_fetch_sweeper_thread", None)
+        if existing is not None and existing.is_alive():
+            fut: concurrent.futures.Future[None] = concurrent.futures.Future()
+            fut.set_result(None)
+            return fut
+        stop_event = threading.Event()
+        self._fetch_sweeper_stop = stop_event
+        future: concurrent.futures.Future[None] = concurrent.futures.Future()
+
+        def _sweep_loop() -> None:
+            try:
+                while not stop_event.is_set():
+                    if stop_event.wait(interval_seconds):
+                        break
+                    configs = threads() if callable(threads) else threads
+                    for cfg in configs:
+                        try:
+                            self.expire_fetches(cfg)
+                        except Exception as exc:  # noqa: BLE001
+                            logger.exception(
+                                "fetch sweep failed for thread", exc_info=exc
+                            )
+                future.set_result(None)
+            except Exception as exc:  # noqa: BLE001
+                future.set_exception(exc)
+
+        thread = threading.Thread(target=_sweep_loop, daemon=True, name="fetch-sweeper")
+        self._fetch_sweeper_thread = thread
+        thread.start()
+        future.add_done_callback(lambda f: stop_event.set() if f.cancelled() else None)
+        return future
+
+    def stop_fetch_sweeper(self) -> None:
+        """Stop the background fetch sweeper started by `start_fetch_sweeper`."""
+        stop_event = getattr(self, "_fetch_sweeper_stop", None)
+        if stop_event is not None:
+            stop_event.set()
+        thread = getattr(self, "_fetch_sweeper_thread", None)
+        if thread is not None:
+            thread.join(timeout=5)
+            self._fetch_sweeper_thread = None  # type: ignore[assignment]
+
     def get_state(
         self, config: RunnableConfig, *, subgraphs: bool = False
     ) -> StateSnapshot:
@@ -1474,6 +1661,10 @@ class Pregel(
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
         )
+
+    # --- fetch() serving layer ------------------------------------------------
+    # Convenience surface for driving service-to-service data dependencies declared
+    # with fetch()/fetch_all(). Fulfillment is always keyed by content-addressed id.
 
     def get_state_history(
         self,
@@ -1987,6 +2178,7 @@ class Pregel(
                                     None,
                                     step,
                                     step + 2,
+                                    None,
                                 ),
                                 channels,
                                 managed,
@@ -2432,6 +2624,7 @@ class Pregel(
                                     None,
                                     step,
                                     step + 2,
+                                    None,
                                 ),
                                 channels,
                                 managed,

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -540,7 +540,7 @@ class Interrupt:
         * `resumable`
         * `interrupt_id`, deprecated in favor of `id`
 
-    !!! version-changed "Changed in version v0.6.x"
+    !!! version-changed "Changed in version v1.2.0a7"
         * `kind` field added to distinguish human-in-the-loop interrupts from
           automated data-fetch requests. Defaults to `"human"` for backwards
           compatibility.

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -79,6 +79,7 @@ __all__ = (
     "Command",
     "Durability",
     "interrupt",
+    "fetch",
     "Overwrite",
     "GraphOutput",
     "ensure_valid_checkpointer",
@@ -538,6 +539,11 @@ class Interrupt:
         * `when`
         * `resumable`
         * `interrupt_id`, deprecated in favor of `id`
+
+    !!! version-changed "Changed in version v0.6.x"
+        * `kind` field added to distinguish human-in-the-loop interrupts from
+          automated data-fetch requests. Defaults to `"human"` for backwards
+          compatibility.
     """
 
     value: Any
@@ -546,13 +552,25 @@ class Interrupt:
     id: str
     """The ID of the interrupt. Can be used to resume the interrupt directly."""
 
+    kind: Literal["human", "fetch"]
+    """Semantic kind of this interrupt.
+
+    - `"human"`: execution is paused waiting for a human decision. Resume is
+      indeterminate — may never happen.
+    - `"fetch"`: execution is paused waiting for an automated data dependency.
+      The serving layer is expected to fulfill the request and always resume,
+      within a bounded SLA.
+    """
+
     def __init__(
         self,
         value: Any,
         id: str = _DEFAULT_INTERRUPT_ID,
+        kind: Literal["human", "fetch"] = "human",
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         self.value = value
+        self.kind = kind
 
         if (
             (ns := deprecated_kwargs.get("ns", MISSING)) is not MISSING
@@ -564,8 +582,13 @@ class Interrupt:
             self.id = id
 
     @classmethod
-    def from_ns(cls, value: Any, ns: str) -> Interrupt:
-        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()))
+    def from_ns(
+        cls,
+        value: Any,
+        ns: str,
+        kind: Literal["human", "fetch"] = "human",
+    ) -> Interrupt:
+        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()), kind=kind)
 
     @property
     @deprecated("`interrupt_id` is deprecated. Use `id` instead.", category=None)
@@ -594,6 +617,15 @@ class PregelTask(NamedTuple):
     interrupts: tuple[Interrupt, ...] = ()
     state: None | RunnableConfig | StateSnapshot = None
     result: Any | None = None
+
+    @property
+    def fetches(self) -> tuple[Interrupt, ...]:
+        """Interrupts with `kind="fetch"` — automated data dependencies.
+
+        Serving layer code can use this to distinguish data-fetch requests
+        from human-in-the-loop interrupts without inspecting interrupt payloads.
+        """
+        return tuple(i for i in self.interrupts if i.kind == "fetch")
 
 
 if sys.version_info > (3, 11):
@@ -798,7 +830,7 @@ class Command(Generic[N], ToolOutputMixin):
     PARENT: ClassVar[Literal["__parent__"]] = "__parent__"
 
 
-def interrupt(value: Any) -> Any:
+def interrupt(value: Any, *, _kind: Literal["human", "fetch"] = "human") -> Any:
     """Interrupt the graph with a resumable exception from within a node.
 
     The `interrupt` function enables human-in-the-loop workflows by pausing graph
@@ -919,9 +951,47 @@ def interrupt(value: Any) -> Any:
             Interrupt.from_ns(
                 value=value,
                 ns=conf[CONFIG_KEY_CHECKPOINT_NS],
+                kind=_kind,
             ),
         )
     )
+
+
+def fetch(value: Any) -> Any:
+    """Declare a data dependency from within a node or tool.
+
+    Semantically distinct from `interrupt()`: a `fetch()` call signals that
+    the graph needs an automated data response — not a human decision. The
+    serving layer is expected to always fulfill the request and resume execution
+    within a bounded SLA.
+
+    Thin wrapper over `interrupt()` that sets `kind="fetch"` on the resulting
+    `Interrupt`, enabling the serving layer to route fetch requests separately
+    from human interrupts without inspecting payloads:
+
+    ```python
+    snapshot = graph.get_state(config)
+    for task in snapshot.tasks:
+        for req in task.fetches:          # kind="fetch" — always automated
+            result = data_layer.get(req.value)
+            graph.invoke(Command(resume={req.id: result}), config)
+        for intr in task.interrupts:
+            if intr.kind == "human":
+                ui.show(intr.value)
+    ```
+
+    Args:
+        value: Describes the data needed. Surfaced to the serving layer as
+            `Interrupt.value` on the suspended task.
+
+    Returns:
+        Any: The value provided by the serving layer when resuming.
+
+    Raises:
+        GraphInterrupt: On the first invocation within the node, checkpoints
+            state and suspends execution.
+    """
+    return interrupt(value, _kind="fetch")
 
 
 @dataclass(slots=True)

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -658,6 +658,12 @@ class FetchResult:
     resolved_at: float | None = None
     """When the terminal outcome was recorded (epoch seconds)."""
 
+    source: str | None = None
+    """Where the value actually resolved from (e.g. a source URI or dataset version),
+    set by the serving layer when fulfilling. Distinct from `FetchRequest.owner`, which
+    is the *expected* fulfiller: `source` is the *actual* origin, recorded for audit and
+    reproducibility (a reviewer can ask "which version did it resolve against?")."""
+
 
 class PregelTask(NamedTuple):
     """A Pregel task."""

--- a/libs/langgraph/langgraph/types.py
+++ b/libs/langgraph/langgraph/types.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import sys
+import time
 from collections import deque
 from collections.abc import Callable, Hashable, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
@@ -80,6 +81,7 @@ __all__ = (
     "Durability",
     "interrupt",
     "fetch",
+    "fetch_all",
     "Overwrite",
     "GraphOutput",
     "ensure_valid_checkpointer",
@@ -552,25 +554,13 @@ class Interrupt:
     id: str
     """The ID of the interrupt. Can be used to resume the interrupt directly."""
 
-    kind: Literal["human", "fetch"]
-    """Semantic kind of this interrupt.
-
-    - `"human"`: execution is paused waiting for a human decision. Resume is
-      indeterminate — may never happen.
-    - `"fetch"`: execution is paused waiting for an automated data dependency.
-      The serving layer is expected to fulfill the request and always resume,
-      within a bounded SLA.
-    """
-
     def __init__(
         self,
         value: Any,
         id: str = _DEFAULT_INTERRUPT_ID,
-        kind: Literal["human", "fetch"] = "human",
         **deprecated_kwargs: Unpack[DeprecatedKwargs],
     ) -> None:
         self.value = value
-        self.kind = kind
 
         if (
             (ns := deprecated_kwargs.get("ns", MISSING)) is not MISSING
@@ -582,13 +572,8 @@ class Interrupt:
             self.id = id
 
     @classmethod
-    def from_ns(
-        cls,
-        value: Any,
-        ns: str,
-        kind: Literal["human", "fetch"] = "human",
-    ) -> Interrupt:
-        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()), kind=kind)
+    def from_ns(cls, value: Any, ns: str) -> Interrupt:
+        return cls(value=value, id=xxh3_128_hexdigest(ns.encode()))
 
     @property
     @deprecated("`interrupt_id` is deprecated. Use `id` instead.", category=None)
@@ -607,6 +592,73 @@ class StateUpdate(NamedTuple):
     task_id: str | None = None
 
 
+@final
+@dataclass(frozen=True)
+class FetchRequest:
+    """A service-to-service data dependency declared via [`fetch`][langgraph.types.fetch].
+
+    Sibling of [`Interrupt`][langgraph.types.Interrupt] but for automated data
+    dependencies rather than human decisions. The serving layer is expected to
+    fulfill the request and resume execution within a bounded SLA. Surfaced on a
+    suspended task via `PregelTask.fetches`, and fulfilled by content-addressed
+    `id` (never positionally).
+
+    !!! version-added "Added in version 0.6.x"
+    """
+
+    id: str
+    """Content-addressed dependency id. Deterministic for a given (thread, node,
+    request); used to fulfill this specific dependency."""
+
+    value: Any
+    """The request payload surfaced to the serving layer (what data is needed)."""
+
+    deadline: float | None = None
+    """Absolute SLA expiry (epoch seconds). Past this the request resolves as
+    `expired` — a terminal failure, never a silent success. `None` never expires."""
+
+    created_at: float | None = None
+    """When the dependency was first declared (epoch seconds)."""
+
+    owner: str | None = None
+    """Optional source service expected to fulfill this dependency. Lets the serving
+    layer route requests without inspecting the payload."""
+
+
+FetchStatus = Literal["fulfilled", "failed", "expired", "cancelled"]
+"""Terminal outcome of a data dependency. `fulfilled` returns a value; the rest
+raise [`FetchError`][langgraph.errors.FetchError] inside the node."""
+
+
+@final
+@dataclass(frozen=True)
+class FetchResult:
+    """The terminal resolution of a [`FetchRequest`][langgraph.types.FetchRequest].
+
+    !!! version-added "Added in version 0.6.x"
+    """
+
+    id: str
+    """The content-addressed id of the request this resolves."""
+
+    value: Any = None
+    """The value provided by the serving layer (for `status="fulfilled"`)."""
+
+    status: FetchStatus = "fulfilled"
+    """Terminal outcome. `fulfilled` returns `value`; `failed`/`expired`/`cancelled`
+    raise `FetchError`."""
+
+    error: str | None = None
+    """Optional error detail (for `status="failed"`)."""
+
+    value_digest: str | None = None
+    """Content digest of `value`, recorded on fulfillment. Lets the serving layer
+    verify/deduplicate what satisfied the dependency without holding the value."""
+
+    resolved_at: float | None = None
+    """When the terminal outcome was recorded (epoch seconds)."""
+
+
 class PregelTask(NamedTuple):
     """A Pregel task."""
 
@@ -617,15 +669,12 @@ class PregelTask(NamedTuple):
     interrupts: tuple[Interrupt, ...] = ()
     state: None | RunnableConfig | StateSnapshot = None
     result: Any | None = None
+    fetches: tuple[FetchRequest, ...] = ()
+    """Data dependencies declared via `fetch()` — separate from human interrupts.
 
-    @property
-    def fetches(self) -> tuple[Interrupt, ...]:
-        """Interrupts with `kind="fetch"` — automated data dependencies.
-
-        Serving layer code can use this to distinguish data-fetch requests
-        from human-in-the-loop interrupts without inspecting interrupt payloads.
-        """
-        return tuple(i for i in self.interrupts if i.kind == "fetch")
+    Serving layer code uses this to route automated data-fetch requests without
+    inspecting interrupt payloads.
+    """
 
 
 if sys.version_info > (3, 11):
@@ -804,6 +853,13 @@ class Command(Generic[N], ToolOutputMixin):
     update: Any | None = None
     resume: dict[str, Any] | Any | None = None
     goto: Send | Sequence[Send | N] | N = ()
+    fetch: dict[str, Any] | None = None
+    """Fulfill one or more data dependencies declared via [`fetch()`][langgraph.types.fetch].
+
+    A mapping of `FetchRequest.id` -> value. Unlike `resume`, fetch fulfillment is
+    always keyed by content-addressed id (never positional), so one value satisfies
+    exactly one dependency.
+    """
 
     def __repr__(self) -> str:
         # get all non-None values
@@ -830,7 +886,7 @@ class Command(Generic[N], ToolOutputMixin):
     PARENT: ClassVar[Literal["__parent__"]] = "__parent__"
 
 
-def interrupt(value: Any, *, _kind: Literal["human", "fetch"] = "human") -> Any:
+def interrupt(value: Any) -> Any:
     """Interrupt the graph with a resumable exception from within a node.
 
     The `interrupt` function enables human-in-the-loop workflows by pausing graph
@@ -951,47 +1007,225 @@ def interrupt(value: Any, *, _kind: Literal["human", "fetch"] = "human") -> Any:
             Interrupt.from_ns(
                 value=value,
                 ns=conf[CONFIG_KEY_CHECKPOINT_NS],
-                kind=_kind,
             ),
         )
     )
 
 
-def fetch(value: Any) -> Any:
-    """Declare a data dependency from within a node or tool.
+def _fetch_id(ns: str, value: Any, key: Hashable | None) -> str:
+    """Content-addressed id for a data dependency.
 
-    Semantically distinct from `interrupt()`: a `fetch()` call signals that
-    the graph needs an automated data response — not a human decision. The
-    serving layer is expected to always fulfill the request and resume execution
-    within a bounded SLA.
+    Deterministic for a given (task namespace, request) so that re-execution and
+    retries are idempotent, and a *different* request yields a *different* id (no
+    stale replay). `key` overrides the request digest when the payload is not
+    stably hashable, or to deliberately share an id (opt-in fan-out / dedup).
+    """
+    digest = key if key is not None else default_cache_key(value)
+    return xxh3_128_hexdigest(f"{ns}|{digest}".encode())
 
-    Thin wrapper over `interrupt()` that sets `kind="fetch"` on the resulting
-    `Interrupt`, enabling the serving layer to route fetch requests separately
-    from human interrupts without inspecting payloads:
+
+def _value_digest(value: Any) -> str:
+    """Stable content digest of a fulfilled value (for FetchResult.value_digest)."""
+    try:
+        return xxh3_128_hexdigest(str(default_cache_key(value)).encode())
+    except Exception:
+        return xxh3_128_hexdigest(repr(value).encode())
+
+
+def _resolve_fetch(
+    conf: dict,
+    scratchpad: Any,
+    fid: str,
+    value: Any,
+    deadline_ttl: float | None,
+    now: float,
+    owner: str | None = None,
+) -> Any:
+    """Resolve a single data dependency by content-addressed id.
+
+    Returns the fulfilled value, a pending `FetchRequest` (caller suspends via
+    `GraphFetch`), or raises `FetchError` on a terminal failure (expired / failed /
+    cancelled). Records terminal outcomes as a `FETCH_RESULT` write so re-execution is
+    deterministic.
+    """
+    from langgraph._internal._constants import CONFIG_KEY_SEND, FETCH_RESULT
+    from langgraph.errors import FetchError
+
+    def _record(result: FetchResult) -> Any:
+        # stamp resolved_at (and value_digest for fulfilled) if the serving layer
+        # didn't already provide them
+        if result.resolved_at is None:
+            result = replace(result, resolved_at=now)
+        if result.status == "fulfilled" and result.value_digest is None:
+            result = replace(result, value_digest=_value_digest(result.value))
+        # accumulate in the (persisted) results map and re-send the full map, so
+        # multiple resolutions in one run and later re-suspensions all persist.
+        scratchpad.fetch_results[fid] = result
+        conf[CONFIG_KEY_SEND]([(FETCH_RESULT, dict(scratchpad.fetch_results))])
+        if result.status == "fulfilled":
+            return result.value
+        raise FetchError(fid, result.status, result.error)
+
+    # 1. already recorded terminal result — honor as-is. A value fulfilled before its
+    #    deadline stays valid even if the graph resumes later (fulfillment-deadline is
+    #    not resume-timing).
+    recorded = scratchpad.fetch_results.get(fid)
+    if isinstance(recorded, FetchResult):
+        if recorded.status == "fulfilled":
+            return recorded.value
+        raise FetchError(fid, recorded.status, recorded.error)
+
+    # deadline: reuse the one fixed at first suspension, else compute from the ttl.
+    existing = scratchpad.fetch_pending.get(fid)
+    if existing is not None:
+        deadline = existing.deadline
+        created_at = existing.created_at
+        owner = existing.owner if existing.owner is not None else owner
+    else:
+        created_at = now
+        deadline = now + deadline_ttl if deadline_ttl is not None else None
+    expired = deadline is not None and now > deadline
+
+    # 2. fresh delivery this run via Command(fetch=...).
+    if fid in scratchpad.fetch_delivered:
+        delivered = scratchpad.fetch_delivered[fid]
+        result = (
+            delivered
+            if isinstance(delivered, FetchResult)
+            else FetchResult(id=fid, value=delivered, status="fulfilled")
+        )
+        # D5: the deadline is authoritative — a late fulfillment is rejected, never a
+        # silent success.
+        if expired and result.status == "fulfilled":
+            result = FetchResult(id=fid, status="expired")
+        return _record(result)
+
+    # 3. no delivery: lazy expiry (deadline authoritative), else still pending.
+    if expired:
+        return _record(FetchResult(id=fid, status="expired"))
+    return FetchRequest(
+        id=fid, value=value, deadline=deadline, created_at=created_at, owner=owner
+    )
+
+
+def fetch(
+    value: Any,
+    *,
+    key: Hashable | None = None,
+    deadline: float | None = None,
+    owner: str | None = None,
+) -> Any:
+    """Declare a service-to-service data dependency from within a node or tool.
+
+    Semantically distinct from [`interrupt()`][langgraph.types.interrupt]: a
+    `fetch()` signals that the graph needs an automated data response — not a
+    human decision. The serving layer is expected to fulfill the request and
+    resume execution within a bounded SLA.
+
+    `fetch()` is a **sibling** of `interrupt()`, not a variant of it. On the first
+    invocation it suspends the graph (via `GraphFetch`), surfacing a
+    [`FetchRequest`][langgraph.types.FetchRequest] on the task's `fetches`. Unlike
+    interrupts, fetches are fulfilled by **content-addressed id** — one value
+    satisfies exactly one dependency:
 
     ```python
     snapshot = graph.get_state(config)
     for task in snapshot.tasks:
-        for req in task.fetches:          # kind="fetch" — always automated
+        for req in task.fetches:              # automated data dependencies
             result = data_layer.get(req.value)
-            graph.invoke(Command(resume={req.id: result}), config)
-        for intr in task.interrupts:
-            if intr.kind == "human":
-                ui.show(intr.value)
+            graph.invoke(Command(fetch={req.id: result}), config)
+        for intr in task.interrupts:          # human decisions
+            ui.show(intr.value)
     ```
+
+    A checkpointer must be enabled, as suspension relies on persisting state.
 
     Args:
         value: Describes the data needed. Surfaced to the serving layer as
-            `Interrupt.value` on the suspended task.
+            `FetchRequest.value` on the suspended task.
+        key: Optional stable key for the content-addressed id. Provide when
+            `value` is not stably hashable, or to deliberately share an id across
+            calls (fan-out / dedup). Defaults to a digest of `value`.
+        deadline: Optional SLA in seconds from when the dependency is first
+            declared. Past it, the fetch resolves as `expired` — raising
+            [`FetchError`][langgraph.errors.FetchError] inside the node — and a
+            late fulfillment is rejected. `None` never expires.
+        owner: Optional source service expected to fulfill the request, surfaced on
+            `FetchRequest.owner` for routing.
 
     Returns:
-        Any: The value provided by the serving layer when resuming.
+        Any: The value provided by the serving layer when the dependency is
+            fulfilled.
 
     Raises:
-        GraphInterrupt: On the first invocation within the node, checkpoints
-            state and suspends execution.
+        GraphFetch: On the first invocation within the node, checkpoints state and
+            suspends execution until the dependency is fulfilled.
+        FetchError: If the dependency resolves to a terminal failure (expired,
+            failed, or cancelled).
     """
-    return interrupt(value, _kind="fetch")
+    from langgraph._internal._constants import (
+        CONFIG_KEY_CHECKPOINT_NS,
+        CONFIG_KEY_SCRATCHPAD,
+    )
+    from langgraph.config import get_config
+    from langgraph.errors import GraphFetch
+
+    conf = get_config()["configurable"]
+    scratchpad = conf[CONFIG_KEY_SCRATCHPAD]
+    ns = conf[CONFIG_KEY_CHECKPOINT_NS]
+    fid = _fetch_id(ns, value, key)
+    resolved = _resolve_fetch(
+        conf, scratchpad, fid, value, deadline, time.time(), owner
+    )
+    if isinstance(resolved, FetchRequest):
+        raise GraphFetch((resolved,))
+    return resolved
+
+
+def fetch_all(values: Sequence[Any], *, deadline: float | None = None) -> list[Any]:
+    """Declare multiple data dependencies at once — one suspension, resolved together.
+
+    Equivalent to calling [`fetch()`][langgraph.types.fetch] per value, but suspends
+    with all still-pending requests in a single `GraphFetch` so the serving layer can
+    fulfill them concurrently. On re-execution the already-fulfilled dependencies
+    return immediately and only the outstanding ones re-suspend (partial fulfillment).
+
+    Args:
+        values: The data dependencies to declare.
+        deadline: Optional SLA in seconds applied to each dependency (see
+            [`fetch()`][langgraph.types.fetch]).
+
+    Returns:
+        list[Any]: The fulfilled values, in the same order as `values`.
+
+    Raises:
+        FetchError: If any dependency resolves to a terminal failure.
+    """
+    from langgraph._internal._constants import (
+        CONFIG_KEY_CHECKPOINT_NS,
+        CONFIG_KEY_SCRATCHPAD,
+    )
+    from langgraph.config import get_config
+    from langgraph.errors import GraphFetch
+
+    conf = get_config()["configurable"]
+    scratchpad = conf[CONFIG_KEY_SCRATCHPAD]
+    ns = conf[CONFIG_KEY_CHECKPOINT_NS]
+    now = time.time()
+
+    results: list[Any] = []
+    pending: list[FetchRequest] = []
+    for value in values:
+        fid = _fetch_id(ns, value, None)
+        resolved = _resolve_fetch(conf, scratchpad, fid, value, deadline, now)
+        if isinstance(resolved, FetchRequest):
+            results.append(MISSING)
+            pending.append(resolved)
+        else:
+            results.append(resolved)
+    if pending:
+        raise GraphFetch(tuple(pending))
+    return results
 
 
 @dataclass(slots=True)

--- a/libs/langgraph/tests/test_fetch.py
+++ b/libs/langgraph/tests/test_fetch.py
@@ -1,0 +1,181 @@
+"""Tests for the fetch() primitive and Interrupt.kind field."""
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, Interrupt, fetch, interrupt
+
+pytestmark = pytest.mark.anyio
+
+
+class State(TypedDict):
+    result: str
+
+
+def _graph_with_fetch():
+    def node(state: State):
+        data = fetch({"resource": "transactions", "user_id": "123"})
+        return {"result": data}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+def _graph_with_both():
+    def node(state: State):
+        data = fetch({"resource": "accounts"})
+        answer = interrupt("what do you want to do?")
+        return {"result": f"{data}:{answer}"}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+# ── Interrupt.kind ────────────────────────────────────────────────────────────
+
+
+def test_interrupt_kind_default_is_human():
+    intr = Interrupt(value="please respond", id="abc")
+    assert intr.kind == "human"
+
+
+def test_interrupt_kind_fetch():
+    intr = Interrupt(value={"resource": "transactions"}, id="abc", kind="fetch")
+    assert intr.kind == "fetch"
+
+
+def test_interrupt_from_ns_default_kind():
+    intr = Interrupt.from_ns(value="hi", ns="some-ns")
+    assert intr.kind == "human"
+
+
+def test_interrupt_from_ns_fetch_kind():
+    intr = Interrupt.from_ns(value={"resource": "accounts"}, ns="some-ns", kind="fetch")
+    assert intr.kind == "fetch"
+
+
+# ── PregelTask.fetches ────────────────────────────────────────────────────────
+
+
+def test_pregeltask_fetches_filters_by_kind():
+    from langgraph.types import PregelTask
+
+    human_intr = Interrupt(value="question?", id="h1", kind="human")
+    fetch_intr = Interrupt(value={"resource": "txn"}, id="f1", kind="fetch")
+    task = PregelTask(
+        id="t1", name="node", path=(), interrupts=(human_intr, fetch_intr)
+    )
+    assert task.fetches == (fetch_intr,)
+    assert len(task.interrupts) == 2  # all still visible in interrupts
+
+
+def test_pregeltask_fetches_empty_when_no_fetch():
+    from langgraph.types import PregelTask
+
+    task = PregelTask(
+        id="t1",
+        name="node",
+        path=(),
+        interrupts=(Interrupt(value="hi", id="h1", kind="human"),),
+    )
+    assert task.fetches == ()
+
+
+# ── fetch() function ──────────────────────────────────────────────────────────
+
+
+def test_fetch_suspends_with_kind_fetch():
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t1"}}
+
+    graph.invoke({"result": ""}, config)
+
+    snapshot = graph.get_state(config)
+    assert len(snapshot.tasks) == 1
+    task = snapshot.tasks[0]
+
+    # task.fetches returns only fetch-kind interrupts
+    assert len(task.fetches) == 1
+    req = task.fetches[0]
+    assert req.kind == "fetch"
+    assert req.value == {"resource": "transactions", "user_id": "123"}
+
+    # all interrupts also contains it
+    assert req in task.interrupts
+
+
+def test_fetch_resumes_with_data():
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t2"}}
+
+    graph.invoke({"result": ""}, config)
+    result = graph.invoke(Command(resume="account_data"), config)
+    assert result["result"] == "account_data"
+
+
+def test_fetch_kind_does_not_appear_in_human_interrupts():
+    """Serving layer can filter: task.interrupts where kind == human."""
+    graph = _graph_with_fetch()
+    config = {"configurable": {"thread_id": "t3"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+
+    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
+    assert human_interrupts == []
+
+
+def test_interrupt_still_defaults_to_human_kind():
+    """Existing interrupt() calls are unaffected — kind defaults to human."""
+
+    def node(state: State):
+        answer = interrupt("please confirm")
+        return {"result": answer}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "t4"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+
+    assert len(task.interrupts) == 1
+    assert task.interrupts[0].kind == "human"
+    assert task.fetches == ()
+
+
+def test_fetch_and_interrupt_coexist_in_same_node():
+    """A node can mix fetch() and interrupt() — task.fetches separates them."""
+    graph = _graph_with_both()
+    config = {"configurable": {"thread_id": "t5"}}
+
+    # First invoke — hits fetch(), suspends
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+    assert len(task.fetches) == 1
+    assert task.fetches[0].value == {"resource": "accounts"}
+
+    # Resume fetch — hits interrupt(), suspends
+    graph.invoke(Command(resume="account_data"), config)
+    snapshot = graph.get_state(config)
+    task = snapshot.tasks[0]
+    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
+    assert len(human_interrupts) == 1
+    assert human_interrupts[0].value == "what do you want to do?"
+
+    # Resume human interrupt — completes
+    result = graph.invoke(Command(resume="nothing"), config)
+    assert result["result"] == "account_data:nothing"

--- a/libs/langgraph/tests/test_fetch.py
+++ b/libs/langgraph/tests/test_fetch.py
@@ -120,6 +120,35 @@ def test_fetch_resumes_with_data():
     assert result["result"] == "account_data"
 
 
+def test_fetch_checkpoint_persists_across_graph_recompile():
+    saver = InMemorySaver()
+
+    def node(state: State):
+        data = fetch({"resource": "transactions", "user_id": "123"})
+        return {"result": data}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+
+    graph = builder.compile(checkpointer=saver)
+    config = {"configurable": {"thread_id": "t6"}}
+
+    graph.invoke({"result": ""}, config)
+    snapshot = graph.get_state(config)
+
+    assert snapshot.tasks[0].fetches[0].value == {
+        "resource": "transactions",
+        "user_id": "123",
+    }
+
+    # Recompile with the same saver and resume using the persisted checkpoint.
+    graph_reloaded = builder.compile(checkpointer=saver)
+    result = graph_reloaded.invoke(Command(resume="account_data"), config)
+    assert result["result"] == "account_data"
+
+
 def test_fetch_kind_does_not_appear_in_human_interrupts():
     """Serving layer can filter: task.interrupts where kind == human."""
     graph = _graph_with_fetch()

--- a/libs/langgraph/tests/test_fetch.py
+++ b/libs/langgraph/tests/test_fetch.py
@@ -1,10 +1,28 @@
-"""Tests for the fetch() primitive and Interrupt.kind field."""
+"""Tests for the fetch() / fetch_all() primitive and GraphFetch.
+
+fetch() is a sibling of interrupt(): a service-to-service data dependency that
+suspends the graph and is fulfilled by content-addressed id (never positionally).
+"""
+
+import time
+
 import pytest
+from langgraph.checkpoint.memory import InMemorySaver
 from typing_extensions import TypedDict
 
-from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import FetchError, GraphBubbleUp, GraphFetch, GraphInterrupt
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Command, Interrupt, fetch, interrupt
+from langgraph.types import (
+    Command,
+    FetchRequest,
+    FetchResult,
+    Interrupt,
+    PregelTask,
+    _fetch_id,
+    fetch,
+    fetch_all,
+    interrupt,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -12,199 +30,478 @@ pytestmark = pytest.mark.anyio
 class State(TypedDict):
     result: str
 
+    result: str
 
-def _graph_with_fetch():
-    def node(state: State):
-        data = fetch({"resource": "transactions", "user_id": "123"})
-        return {"result": data}
 
+def _graph(node):
     builder = StateGraph(State)
     builder.add_node("node", node)
     builder.add_edge(START, "node")
-    builder.add_edge("node", END)
     return builder.compile(checkpointer=InMemorySaver())
 
 
-def _graph_with_both():
-    def node(state: State):
-        data = fetch({"resource": "accounts"})
-        answer = interrupt("what do you want to do?")
-        return {"result": f"{data}:{answer}"}
-
-    builder = StateGraph(State)
-    builder.add_node("node", node)
-    builder.add_edge(START, "node")
-    builder.add_edge("node", END)
-    return builder.compile(checkpointer=InMemorySaver())
+# ── Exception hierarchy (GraphFetch is a sibling of GraphInterrupt) ──────────────
 
 
-# ── Interrupt.kind ────────────────────────────────────────────────────────────
+def test_graphfetch_is_bubbleup_not_interrupt():
+    assert issubclass(GraphFetch, GraphBubbleUp)
+    assert not issubclass(GraphFetch, GraphInterrupt)
+    assert not issubclass(GraphInterrupt, GraphFetch)
 
 
-def test_interrupt_kind_default_is_human():
+def test_interrupt_has_no_kind_field():
+    """interrupt() is untouched — no fetch-specific fields leak into Interrupt."""
     intr = Interrupt(value="please respond", id="abc")
-    assert intr.kind == "human"
+    assert not hasattr(intr, "kind")
 
 
-def test_interrupt_kind_fetch():
-    intr = Interrupt(value={"resource": "transactions"}, id="abc", kind="fetch")
-    assert intr.kind == "fetch"
+# ── content-addressed id ────────────────────────────────────────────────────────
 
 
-def test_interrupt_from_ns_default_kind():
-    intr = Interrupt.from_ns(value="hi", ns="some-ns")
-    assert intr.kind == "human"
+def test_fetch_id_deterministic():
+    assert _fetch_id("ns", {"a": 1}, None) == _fetch_id("ns", {"a": 1}, None)
 
 
-def test_interrupt_from_ns_fetch_kind():
-    intr = Interrupt.from_ns(value={"resource": "accounts"}, ns="some-ns", kind="fetch")
-    assert intr.kind == "fetch"
+def test_fetch_id_differs_by_request():
+    assert _fetch_id("ns", {"a": 1}, None) != _fetch_id("ns", {"a": 2}, None)
 
 
-# ── PregelTask.fetches ────────────────────────────────────────────────────────
+def test_fetch_id_differs_by_ns():
+    assert _fetch_id("ns1", {"a": 1}, None) != _fetch_id("ns2", {"a": 1}, None)
 
 
-def test_pregeltask_fetches_filters_by_kind():
-    from langgraph.types import PregelTask
-
-    human_intr = Interrupt(value="question?", id="h1", kind="human")
-    fetch_intr = Interrupt(value={"resource": "txn"}, id="f1", kind="fetch")
-    task = PregelTask(
-        id="t1", name="node", path=(), interrupts=(human_intr, fetch_intr)
-    )
-    assert task.fetches == (fetch_intr,)
-    assert len(task.interrupts) == 2  # all still visible in interrupts
+def test_fetch_id_explicit_key_overrides_payload():
+    # same key -> same id even with different payloads (opt-in fan-out / dedup)
+    assert _fetch_id("ns", {"a": 1}, "k") == _fetch_id("ns", {"a": 999}, "k")
 
 
-def test_pregeltask_fetches_empty_when_no_fetch():
-    from langgraph.types import PregelTask
+# ── PregelTask.fetches ──────────────────────────────────────────────────────────
 
+
+def test_pregeltask_fetches_field_default_empty():
+    task = PregelTask(id="t1", name="node", path=())
+    assert task.fetches == ()
+
+
+def test_pregeltask_fetches_independent_of_interrupts():
+    req = FetchRequest(id="f1", value={"resource": "txn"})
     task = PregelTask(
         id="t1",
         name="node",
         path=(),
-        interrupts=(Interrupt(value="hi", id="h1", kind="human"),),
+        interrupts=(Interrupt(value="q?", id="h1"),),
+        fetches=(req,),
     )
-    assert task.fetches == ()
-
-
-# ── fetch() function ──────────────────────────────────────────────────────────
-
-
-def test_fetch_suspends_with_kind_fetch():
-    graph = _graph_with_fetch()
-    config = {"configurable": {"thread_id": "t1"}}
-
-    graph.invoke({"result": ""}, config)
-
-    snapshot = graph.get_state(config)
-    assert len(snapshot.tasks) == 1
-    task = snapshot.tasks[0]
-
-    # task.fetches returns only fetch-kind interrupts
-    assert len(task.fetches) == 1
-    req = task.fetches[0]
-    assert req.kind == "fetch"
-    assert req.value == {"resource": "transactions", "user_id": "123"}
-
-    # all interrupts also contains it
-    assert req in task.interrupts
-
-
-def test_fetch_resumes_with_data():
-    graph = _graph_with_fetch()
-    config = {"configurable": {"thread_id": "t2"}}
-
-    graph.invoke({"result": ""}, config)
-    result = graph.invoke(Command(resume="account_data"), config)
-    assert result["result"] == "account_data"
-
-
-def test_fetch_checkpoint_persists_across_graph_recompile():
-    saver = InMemorySaver()
-
-    def node(state: State):
-        data = fetch({"resource": "transactions", "user_id": "123"})
-        return {"result": data}
-
-    builder = StateGraph(State)
-    builder.add_node("node", node)
-    builder.add_edge(START, "node")
-    builder.add_edge("node", END)
-
-    graph = builder.compile(checkpointer=saver)
-    config = {"configurable": {"thread_id": "t6"}}
-
-    graph.invoke({"result": ""}, config)
-    snapshot = graph.get_state(config)
-
-    assert snapshot.tasks[0].fetches[0].value == {
-        "resource": "transactions",
-        "user_id": "123",
-    }
-
-    # Recompile with the same saver and resume using the persisted checkpoint.
-    graph_reloaded = builder.compile(checkpointer=saver)
-    result = graph_reloaded.invoke(Command(resume="account_data"), config)
-    assert result["result"] == "account_data"
-
-
-def test_fetch_kind_does_not_appear_in_human_interrupts():
-    """Serving layer can filter: task.interrupts where kind == human."""
-    graph = _graph_with_fetch()
-    config = {"configurable": {"thread_id": "t3"}}
-
-    graph.invoke({"result": ""}, config)
-    snapshot = graph.get_state(config)
-    task = snapshot.tasks[0]
-
-    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
-    assert human_interrupts == []
-
-
-def test_interrupt_still_defaults_to_human_kind():
-    """Existing interrupt() calls are unaffected — kind defaults to human."""
-
-    def node(state: State):
-        answer = interrupt("please confirm")
-        return {"result": answer}
-
-    builder = StateGraph(State)
-    builder.add_node("node", node)
-    builder.add_edge(START, "node")
-    builder.add_edge("node", END)
-    graph = builder.compile(checkpointer=InMemorySaver())
-    config = {"configurable": {"thread_id": "t4"}}
-
-    graph.invoke({"result": ""}, config)
-    snapshot = graph.get_state(config)
-    task = snapshot.tasks[0]
-
+    assert task.fetches == (req,)
     assert len(task.interrupts) == 1
-    assert task.interrupts[0].kind == "human"
-    assert task.fetches == ()
 
 
-def test_fetch_and_interrupt_coexist_in_same_node():
-    """A node can mix fetch() and interrupt() — task.fetches separates them."""
-    graph = _graph_with_both()
+# ── fetch() suspend + fulfill ───────────────────────────────────────────────────
+
+
+def test_fetch_suspends_with_request():
+    graph = _graph(lambda s: {"result": fetch({"resource": "txn", "user_id": "1"})})
+    config = {"configurable": {"thread_id": "t1"}}
+    graph.invoke({"result": ""}, config)
+
+    task = graph.get_state(config).tasks[0]
+    assert len(task.fetches) == 1
+    assert task.interrupts == ()
+    req = task.fetches[0]
+    assert isinstance(req, FetchRequest)
+    assert req.value == {"resource": "txn", "user_id": "1"}
+
+
+def test_fetch_fulfilled_by_id():
+    graph = _graph(lambda s: {"result": fetch({"resource": "txn"})})
+    config = {"configurable": {"thread_id": "t2"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+
+    out = graph.invoke(Command(fetch={req.id: "ACCOUNT_DATA"}), config)
+    assert out["result"] == "ACCOUNT_DATA"
+
+
+def test_fetch_requires_checkpointer_for_fulfillment():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    # no checkpointer would fail earlier; here just assert Command(fetch) validation
+    with pytest.raises(ValueError):
+        graph.invoke(
+            Command(fetch={"not-a-valid-id": "v"}),
+            {"configurable": {"thread_id": "tX"}},
+        )
+
+
+# ── fetch_all() batch + partial fulfillment ─────────────────────────────────────
+
+
+def _fetch_all_node(state):
+    a, b = fetch_all([{"r": "A"}, {"r": "B"}])
+    return {"result": f"{a}:{b}"}
+
+
+def test_fetch_all_suspends_with_all_requests():
+    graph = _graph(_fetch_all_node)
+    config = {"configurable": {"thread_id": "t3"}}
+    graph.invoke({"result": ""}, config)
+    fetches = graph.get_state(config).tasks[0].fetches
+    assert len(fetches) == 2
+    assert {f.value["r"] for f in fetches} == {"A", "B"}
+
+
+def test_fetch_all_partial_fulfillment():
+    graph = _graph(_fetch_all_node)
+    config = {"configurable": {"thread_id": "t4"}}
+    graph.invoke({"result": ""}, config)
+    ids = {f.value["r"]: f.id for f in graph.get_state(config).tasks[0].fetches}
+
+    # fulfill only A -> B still pending
+    graph.invoke(Command(fetch={ids["A"]: "AA"}), config)
+    still = graph.get_state(config).tasks[0].fetches
+    assert len(still) == 1 and still[0].value["r"] == "B"
+
+    # fulfill B -> completes, order preserved
+    out = graph.invoke(Command(fetch={ids["B"]: "BB"}), config)
+    assert out["result"] == "AA:BB"
+
+
+# ── coexistence with interrupt() (no cross-resume) ──────────────────────────────
+
+
+def _fetch_then_interrupt(state):
+    data = fetch({"resource": "accounts"})
+    answer = interrupt("what do you want to do?")
+    return {"result": f"{data}:{answer}"}
+
+
+def test_fetch_and_interrupt_coexist_no_cross_resume():
+    graph = _graph(_fetch_then_interrupt)
     config = {"configurable": {"thread_id": "t5"}}
 
-    # First invoke — hits fetch(), suspends
+    # first invoke -> suspends on fetch (no human interrupt yet)
     graph.invoke({"result": ""}, config)
-    snapshot = graph.get_state(config)
-    task = snapshot.tasks[0]
+    task = graph.get_state(config).tasks[0]
     assert len(task.fetches) == 1
-    assert task.fetches[0].value == {"resource": "accounts"}
+    assert len(task.interrupts) == 0
 
-    # Resume fetch — hits interrupt(), suspends
-    graph.invoke(Command(resume="account_data"), config)
-    snapshot = graph.get_state(config)
-    task = snapshot.tasks[0]
-    human_interrupts = [i for i in task.interrupts if i.kind == "human"]
-    assert len(human_interrupts) == 1
-    assert human_interrupts[0].value == "what do you want to do?"
+    # fulfilling the fetch does NOT satisfy the human interrupt: node advances
+    # to interrupt(), and the stale fetch request is cleared
+    graph.invoke(Command(fetch={task.fetches[0].id: "ACCT"}), config)
+    task = graph.get_state(config).tasks[0]
+    assert len(task.interrupts) == 1
+    assert task.interrupts[0].value == "what do you want to do?"
+    assert len(task.fetches) == 0
 
-    # Resume human interrupt — completes
-    result = graph.invoke(Command(resume="nothing"), config)
-    assert result["result"] == "account_data:nothing"
+    # resuming the human interrupt completes the node
+    out = graph.invoke(Command(resume="go"), config)
+    assert out["result"] == "ACCT:go"
+
+
+def test_resume_does_not_fulfill_fetch():
+    """Command(resume=...) must not satisfy a data dependency — it re-suspends."""
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "t6"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+
+    # a resume value is not a fetch fulfillment: the dependency stays pending
+    out = graph.invoke(Command(resume="not-the-data"), config)
+    assert out.get("result") in (None, "")
+    still = graph.get_state(config).tasks[0].fetches
+    assert len(still) == 1 and still[0].id == req.id
+
+    # only fulfilling by id delivers the data
+    out = graph.invoke(Command(fetch={req.id: "the-data"}), config)
+    assert out["result"] == "the-data"
+
+
+# ── interrupt() is unaffected ───────────────────────────────────────────────────
+
+
+def test_interrupt_still_works():
+    graph = _graph(lambda s: {"result": interrupt("please confirm")})
+    config = {"configurable": {"thread_id": "t7"}}
+    graph.invoke({"result": ""}, config)
+    task = graph.get_state(config).tasks[0]
+    assert len(task.interrupts) == 1
+    assert task.interrupts[0].kind if hasattr(task.interrupts[0], "kind") else True
+    assert task.fetches == ()
+
+    out = graph.invoke(Command(resume="confirmed"), config)
+    assert out["result"] == "confirmed"
+
+
+def test_fetch_idempotent_across_reexecution():
+    """A fulfilled dependency stays fulfilled if the node re-runs (re-suspends later)."""
+    calls = {"n": 0}
+
+    def node(state):
+        calls["n"] += 1
+        a = fetch({"step": 1})
+        b = fetch({"step": 2})  # second, distinct dependency
+        return {"result": f"{a}:{b}"}
+
+    graph = _graph(node)
+    config = {"configurable": {"thread_id": "t8"}}
+    graph.invoke({"result": ""}, config)
+    a_id = graph.get_state(config).tasks[0].fetches[0].id
+    graph.invoke(Command(fetch={a_id: "first"}), config)
+    # now suspended on the second fetch; first must remain fulfilled
+    b_id = graph.get_state(config).tasks[0].fetches[0].id
+    out = graph.invoke(Command(fetch={b_id: "second"}), config)
+    assert out["result"] == "first:second"
+
+
+# ── PR-2: deadline / SLA expiry, terminal failures (D5, D7, D10) ────────────────
+
+
+def test_fetch_carries_deadline():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"}, deadline=1000)})
+    config = {"configurable": {"thread_id": "d1"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+    assert req.deadline is not None
+    assert req.created_at is not None
+
+
+def test_fetch_no_deadline_never_expires():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "d2"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+    assert req.deadline is None
+    # fulfilling much later still works (no SLA)
+    out = graph.invoke(Command(fetch={req.id: "ok"}), config)
+    assert out["result"] == "ok"
+
+
+def test_deadline_fulfilled_in_time_succeeds():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"}, deadline=1000)})
+    config = {"configurable": {"thread_id": "d3"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+    out = graph.invoke(Command(fetch={req.id: "in-time"}), config)
+    assert out["result"] == "in-time"
+
+
+def test_late_fulfillment_rejected_as_expired():
+    """D5: past the deadline, a fulfillment is rejected and the node fails closed."""
+    graph = _graph(lambda s: {"result": fetch({"r": "x"}, deadline=0.001)})
+    config = {"configurable": {"thread_id": "d4"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+    time.sleep(0.05)  # let the deadline pass
+    with pytest.raises(FetchError) as exc:
+        graph.invoke(Command(fetch={req.id: "too-late"}), config)
+    assert exc.value.status == "expired"
+    assert exc.value.id == req.id
+
+
+def test_lazy_expiry_on_resume_without_fulfillment():
+    """D10: a resume past the deadline drives the fetch to a terminal expired failure."""
+    graph = _graph(lambda s: {"result": fetch({"r": "x"}, deadline=0.001)})
+    config = {"configurable": {"thread_id": "d5"}}
+    graph.invoke({"result": ""}, config)
+    time.sleep(0.05)
+    # a bare resume (poke) re-runs the node, which self-expires
+    with pytest.raises(FetchError) as exc:
+        graph.invoke(Command(resume="anything"), config)
+    assert exc.value.status == "expired"
+
+
+def test_fail_fetch_raises_fetch_error():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "d6"}}
+    graph.invoke({"result": ""}, config)
+    req = graph.get_state(config).tasks[0].fetches[0]
+    marker = FetchResult(id=req.id, status="failed", error="upstream 500")
+    with pytest.raises(FetchError) as exc:
+        graph.invoke(Command(fetch={req.id: marker}), config)
+    assert exc.value.status == "failed"
+    assert exc.value.error == "upstream 500"
+
+
+def test_node_can_catch_fetch_error():
+    """A node may handle a terminal fetch failure gracefully instead of crashing."""
+
+    def node(state):
+        try:
+            data = fetch({"r": "x"}, deadline=0.001)
+        except FetchError as e:
+            return {"result": f"fallback:{e.status}"}
+        return {"result": data}
+
+    graph = _graph(node)
+    config = {"configurable": {"thread_id": "d7"}}
+    graph.invoke({"result": ""}, config)
+    time.sleep(0.05)
+    out = graph.invoke(Command(resume="poke"), config)
+    assert out["result"] == "fallback:expired"
+
+
+def test_expired_fetch_not_surfaced_as_pending():
+    """Once expired (terminal), the request is no longer a pending fetch."""
+
+    def node(state):
+        try:
+            return {"result": fetch({"r": "x"}, deadline=0.001)}
+        except FetchError:
+            return {"result": "done"}
+
+    graph = _graph(node)
+    config = {"configurable": {"thread_id": "d8"}}
+    graph.invoke({"result": ""}, config)
+    time.sleep(0.05)
+    out = graph.invoke(Command(resume="poke"), config)
+    assert out["result"] == "done"
+    assert graph.get_state(config).tasks == () or all(
+        t.fetches == () for t in graph.get_state(config).tasks
+    )
+
+
+# ── serving-layer API: pending_fetches / fulfill / fail_fetch / cancel / expire ──
+
+
+def test_pending_fetches_and_fulfill_method():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"}, owner="billing")})
+    config = {"configurable": {"thread_id": "m1"}}
+    graph.invoke({"result": ""}, config)
+    pending = graph.pending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].owner == "billing"
+    out = graph.fulfill(config, pending[0].id, "DATA")
+    assert out["result"] == "DATA"
+    assert graph.pending_fetches(config) == []
+
+
+def test_fail_fetch_method():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "m2"}}
+    graph.invoke({"result": ""}, config)
+    fid = graph.pending_fetches(config)[0].id
+    with pytest.raises(FetchError) as exc:
+        graph.fail_fetch(config, fid, "boom")
+    assert exc.value.status == "failed" and exc.value.error == "boom"
+
+
+def test_cancel_fetches_method():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "m3"}}
+    graph.invoke({"result": ""}, config)
+    with pytest.raises(FetchError) as exc:
+        graph.cancel_fetches(config)
+    assert exc.value.status == "cancelled"
+
+
+def test_expire_fetches_method():
+    def node(state):
+        try:
+            return {"result": fetch({"r": "x"}, deadline=0.001)}
+        except FetchError as e:
+            return {"result": f"exp:{e.status}"}
+
+    graph = _graph(node)
+    config = {"configurable": {"thread_id": "m4"}}
+    graph.invoke({"result": ""}, config)
+    time.sleep(0.05)
+    due = graph.expire_fetches(config)
+    assert len(due) == 1
+    assert graph.get_state(config).values["result"] == "exp:expired"
+
+
+def test_value_digest_recorded_on_fulfillment():
+    """value_digest is stamped on the persisted FetchResult (readable via checkpointer)."""
+    from langgraph._internal._constants import FETCH_RESULT
+
+    saver = InMemorySaver()
+    builder = StateGraph(State)
+    builder.add_node("node", lambda s: {"result": fetch({"r": "x"})})
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    graph = builder.compile(checkpointer=saver)
+    config = {"configurable": {"thread_id": "m5"}}
+    graph.invoke({"result": ""}, config)
+    fid = graph.pending_fetches(config)[0].id
+    graph.fulfill(config, fid, "DATA")
+    # find the persisted FETCH_RESULT among the checkpoint writes
+    results = {}
+    for _, chan, val in saver.get_tuple(config).pending_writes or []:
+        if chan == FETCH_RESULT and isinstance(val, dict):
+            results.update(val)
+    # after completion a new (clean) checkpoint may exist; walk history if needed
+    if fid not in results:
+        for snap in graph.get_state_history(config):
+            tup = saver.get_tuple(snap.config)
+            for _, chan, val in tup.pending_writes or []:
+                if chan == FETCH_RESULT and isinstance(val, dict):
+                    results.update(val)
+    assert fid in results
+    assert results[fid].status == "fulfilled"
+    assert results[fid].value_digest is not None
+    assert results[fid].resolved_at is not None
+
+
+# ── background sweeper + async + subgraph nesting ───────────────────────────────
+
+
+def test_fetch_sweeper_expires_idle_graph():
+    """D10/D11: the daemon sweeper drives a never-resumed graph to terminal expired."""
+
+    def node(state):
+        try:
+            return {"result": fetch({"r": "x"}, deadline=0.001)}
+        except FetchError as e:
+            return {"result": f"exp:{e.status}"}
+
+    graph = _graph(node)
+    config = {"configurable": {"thread_id": "sw1"}}
+    graph.invoke({"result": ""}, config)
+    graph.start_fetch_sweeper([config], interval_seconds=0.05)
+    deadline = time.time() + 5
+    try:
+        while time.time() < deadline:
+            if graph.get_state(config).values.get("result") == "exp:expired":
+                break
+            time.sleep(0.05)
+    finally:
+        graph.stop_fetch_sweeper()
+    assert graph.get_state(config).values["result"] == "exp:expired"
+
+
+async def test_async_fetch_serving_methods():
+    graph = _graph(lambda s: {"result": fetch({"r": "x"})})
+    config = {"configurable": {"thread_id": "as1"}}
+    await graph.ainvoke({"result": ""}, config)
+    pending = await graph.apending_fetches(config)
+    assert len(pending) == 1
+    out = await graph.afulfill(config, pending[0].id, "ADATA")
+    assert out["result"] == "ADATA"
+
+
+def test_fetch_in_subgraph():
+    """A fetch declared inside a subgraph suspends and fulfills through the parent."""
+
+    class Inner(TypedDict):
+        result: str
+
+    def inner_node(state):
+        return {"result": fetch({"r": "sub"})}
+
+    inner = StateGraph(Inner)
+    inner.add_node("inner_node", inner_node)
+    inner.add_edge(START, "inner_node")
+    inner.add_edge("inner_node", END)
+
+    parent = StateGraph(State)
+    parent.add_node("sub", inner.compile())
+    parent.add_edge(START, "sub")
+    parent.add_edge("sub", END)
+    graph = parent.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "sg1"}}
+
+    graph.invoke({"result": ""}, config)
+    pending = graph.pending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].value == {"r": "sub"}
+    out = graph.invoke(Command(fetch={pending[0].id: "SUBDATA"}), config)
+    assert out["result"] == "SUBDATA"

--- a/libs/langgraph/tests/test_fetch_e2e.py
+++ b/libs/langgraph/tests/test_fetch_e2e.py
@@ -293,4 +293,251 @@ async def test_e2e_async_multi_node(
     assert out["result"] == "hello Ada"
 
 
+# ── subgraph nesting: a fetch() inside a subgraph must bubble up to the parent ───
 
+
+def test_e2e_fetch_inside_subgraph(sync_checkpointer: BaseCheckpointSaver) -> None:
+    """A fetch() declared in a subgraph node surfaces at the parent and is
+    fulfilled by id through the parent — the content-id carries the subgraph ns."""
+
+    def inner(state):
+        return {"result": fetch({"resource": "inner-data"})}
+
+    sub = StateGraph(State)
+    sub.add_node("inner", inner)
+    sub.add_edge(START, "inner")
+    sub.add_edge("inner", END)
+    subgraph = sub.compile()
+
+    parent = StateGraph(State)
+    parent.add_node("sub", subgraph)
+    parent.add_edge(START, "sub")
+    parent.add_edge("sub", END)
+    graph = parent.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    pending = graph.pending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].value == {"resource": "inner-data"}
+
+    out = graph.invoke(Command(fetch={pending[0].id: "SUBDATA"}), config)
+    assert out["result"] == "SUBDATA"
+    assert graph.pending_fetches(config) == []
+
+
+async def test_e2e_async_fetch_inside_subgraph(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def inner(state):
+        return {"result": fetch({"resource": "inner-data"})}
+
+    sub = StateGraph(State)
+    sub.add_node("inner", inner)
+    sub.add_edge(START, "inner")
+    sub.add_edge("inner", END)
+    subgraph = sub.compile()
+
+    parent = StateGraph(State)
+    parent.add_node("sub", subgraph)
+    parent.add_edge(START, "sub")
+    parent.add_edge("sub", END)
+    graph = parent.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    pending = await graph.apending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].value == {"resource": "inner-data"}
+    out = await graph.afulfill(config, pending[0].id, "SUBDATA")
+    assert out["result"] == "SUBDATA"
+
+
+# ── ToolNode: fetch() inside an agent tool suspends and resumes (bubbles up) ─────
+
+
+def test_e2e_fetch_inside_tool_node(sync_checkpointer: BaseCheckpointSaver) -> None:
+    """A tool run by ToolNode may call fetch(); the GraphFetch bubbles up (ToolNode
+    re-raises GraphBubbleUp), suspends the graph, and resumes with the fetched data."""
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import ToolNode
+
+    from langgraph.graph import MessagesState
+
+    @tool
+    def get_profile(user_id: str) -> str:
+        """Fetch a user's profile from the profile service."""
+        return fetch({"resource": "profile", "user_id": user_id})
+
+    def agent(state):
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "get_profile",
+                            "args": {"user_id": "u1"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ]
+        }
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("agent", agent)
+    builder.add_node("tools", ToolNode([get_profile]))
+    builder.add_edge(START, "agent")
+    builder.add_edge("agent", "tools")
+    builder.add_edge("tools", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"messages": []}, config)
+    pending = graph.pending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].value == {"resource": "profile", "user_id": "u1"}
+
+    out = graph.invoke(Command(fetch={pending[0].id: "Ada Lovelace"}), config)
+    last = out["messages"][-1]
+    assert "Ada Lovelace" in last.content
+
+
+async def test_e2e_async_fetch_inside_tool_node(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import ToolNode
+
+    from langgraph.graph import MessagesState
+
+    @tool
+    async def get_profile(user_id: str) -> str:
+        """Fetch a user's profile from the profile service."""
+        return fetch({"resource": "profile", "user_id": user_id})
+
+    def agent(state):
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "get_profile",
+                            "args": {"user_id": "u1"},
+                            "id": "call_1",
+                        }
+                    ],
+                )
+            ]
+        }
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("agent", agent)
+    builder.add_node("tools", ToolNode([get_profile]))
+    builder.add_edge(START, "agent")
+    builder.add_edge("agent", "tools")
+    builder.add_edge("tools", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"messages": []}, config)
+    pending = await graph.apending_fetches(config)
+    assert len(pending) == 1
+    out = await graph.afulfill(config, pending[0].id, "Ada Lovelace")
+    assert "Ada Lovelace" in out["messages"][-1].content
+
+
+# ── provenance / audit: source, value_digest, resolved_at + resolved_fetches ─────
+
+
+def test_e2e_resolved_fetches_records_provenance(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """After fulfillment, resolved_fetches() surfaces the audit record: digest,
+    resolved_at, and the serving-layer-provided source."""
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"result": fetch({"clause": "penalty"})})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    req = graph.pending_fetches(config)[0]
+    # fulfill with provenance (where the value actually resolved from)
+    graph.fulfill(config, req.id, "5% of contract value", source="cms://contract/v7")
+
+    resolved = graph.resolved_fetches(config)
+    assert len(resolved) == 1
+    r = resolved[0]
+    assert r.id == req.id
+    assert r.status == "fulfilled"
+    assert r.source == "cms://contract/v7"
+    assert r.value_digest is not None  # content hash stamped
+    assert r.resolved_at is not None  # point-in-time bound
+
+
+def test_e2e_resolved_fetches_records_terminal_failure(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """A failed/expired dependency is also auditable via resolved_fetches()."""
+
+    def node(state):
+        try:
+            return {"result": fetch({"r": "x"})}
+        except FetchError as e:
+            return {"result": f"handled:{e.status}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    req = graph.pending_fetches(config)[0]
+    graph.fail_fetch(config, req.id, "upstream 503")
+
+    resolved = graph.resolved_fetches(config)
+    assert len(resolved) == 1
+    assert resolved[0].status == "failed"
+    assert resolved[0].error == "upstream 503"
+    assert resolved[0].resolved_at is not None
+
+
+def test_e2e_value_digest_detects_drift(sync_checkpointer: BaseCheckpointSaver) -> None:
+    """Reproducibility: two different resolved values yield different digests."""
+    from langgraph.types import _value_digest
+
+    assert _value_digest("5% of contract value") == _value_digest(
+        "5% of contract value"
+    )
+    assert _value_digest("5% of contract value") != _value_digest(
+        "7% of contract value"
+    )
+
+
+async def test_e2e_async_resolved_fetches_records_provenance(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"result": fetch({"clause": "penalty"})})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    req = (await graph.apending_fetches(config))[0]
+    await graph.afulfill(config, req.id, "settled", source="ledger://tx/42")
+
+    resolved = await graph.aresolved_fetches(config)
+    assert len(resolved) == 1
+    assert resolved[0].source == "ledger://tx/42"
+    assert resolved[0].value_digest is not None
+    assert resolved[0].resolved_at is not None

--- a/libs/langgraph/tests/test_fetch_e2e.py
+++ b/libs/langgraph/tests/test_fetch_e2e.py
@@ -1,0 +1,296 @@
+"""End-to-end tests for fetch() across checkpointer backends (sync + async).
+
+Unlike test_fetch.py (which pins InMemorySaver), these drive the full graph runtime
+over every parametrized `sync_checkpointer` / `async_checkpointer` backend — so the
+FETCH / FETCH_RESULT writes and the FetchRequest / FetchResult payloads are proven to
+persist and round-trip through each backend's serde (memory, sqlite, postgres). They
+also cover multi-node graphs and streaming, not just single-node suspend/resume.
+"""
+
+import time
+
+import pytest
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from typing_extensions import TypedDict
+
+from langgraph.errors import FetchError
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, fetch, fetch_all, interrupt
+
+pytestmark = pytest.mark.anyio
+
+
+class State(TypedDict):
+    result: str
+
+
+class MultiState(TypedDict):
+    fetched: str
+    result: str
+
+
+# ── sync, parametrized over every sync checkpointer backend ─────────────────────
+
+
+def test_e2e_suspend_and_fulfill(sync_checkpointer: BaseCheckpointSaver) -> None:
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"result": fetch({"resource": "txn"})})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    # FetchRequest must have round-tripped through the backend serde
+    pending = graph.pending_fetches(config)
+    assert len(pending) == 1
+    assert pending[0].value == {"resource": "txn"}
+
+    out = graph.invoke(Command(fetch={pending[0].id: "DATA"}), config)
+    assert out["result"] == "DATA"
+    assert graph.pending_fetches(config) == []
+
+
+def test_e2e_fetch_all_partial(sync_checkpointer: BaseCheckpointSaver) -> None:
+    def node(state):
+        a, b = fetch_all([{"r": "A"}, {"r": "B"}])
+        return {"result": f"{a}:{b}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    ids = {f.value["r"]: f.id for f in graph.pending_fetches(config)}
+    graph.invoke(Command(fetch={ids["A"]: "AA"}), config)
+    assert [f.value["r"] for f in graph.pending_fetches(config)] == ["B"]
+    out = graph.invoke(Command(fetch={ids["B"]: "BB"}), config)
+    assert out["result"] == "AA:BB"
+
+
+def test_e2e_deadline_expiry(sync_checkpointer: BaseCheckpointSaver) -> None:
+    def node(state):
+        try:
+            return {"result": fetch({"r": "x"}, deadline=0.001)}
+        except FetchError as e:
+            return {"result": f"exp:{e.status}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    time.sleep(0.05)
+    graph.expire_fetches(config)
+    assert graph.get_state(config).values["result"] == "exp:expired"
+
+
+def test_e2e_fail_fetch(sync_checkpointer: BaseCheckpointSaver) -> None:
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"result": fetch({"r": "x"})})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    fid = graph.pending_fetches(config)[0].id
+    with pytest.raises(FetchError) as exc:
+        graph.fail_fetch(config, fid, "upstream 500")
+    assert exc.value.status == "failed"
+
+
+def test_e2e_fetch_and_interrupt_coexist(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    def node(state):
+        data = fetch({"resource": "accounts"})
+        answer = interrupt("what next?")
+        return {"result": f"{data}:{answer}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"result": ""}, config)
+    task = graph.get_state(config).tasks[0]
+    assert len(task.fetches) == 1 and len(task.interrupts) == 0
+
+    graph.invoke(Command(fetch={task.fetches[0].id: "ACCT"}), config)
+    task = graph.get_state(config).tasks[0]
+    assert len(task.interrupts) == 1 and len(task.fetches) == 0
+
+    out = graph.invoke(Command(resume="go"), config)
+    assert out["result"] == "ACCT:go"
+
+
+def test_e2e_multi_node_downstream_consumes(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Node A fetches; a downstream node B consumes the fetched value."""
+
+    def a(state):
+        return {"fetched": fetch({"resource": "profile"})}
+
+    def b(state):
+        return {"result": f"hello {state['fetched']}"}
+
+    builder = StateGraph(MultiState)
+    builder.add_node("a", a)
+    builder.add_node("b", b)
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    graph.invoke({"fetched": "", "result": ""}, config)
+    fid = graph.pending_fetches(config)[0].id
+    out = graph.invoke(Command(fetch={fid: "Ada"}), config)
+    assert out["fetched"] == "Ada"
+    assert out["result"] == "hello Ada"
+
+
+def test_e2e_streaming_emits_fetch_then_resumes(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    from langgraph._internal._constants import FETCH
+
+    builder = StateGraph(State)
+    builder.add_node("n", lambda s: {"result": fetch({"r": "x"})})
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    chunks = list(graph.stream({"result": ""}, config, stream_mode="updates"))
+    assert any(isinstance(c, dict) and FETCH in c for c in chunks)
+
+    fid = graph.pending_fetches(config)[0].id
+    out = graph.invoke(Command(fetch={fid: "DATA"}), config)
+    assert out["result"] == "DATA"
+
+
+# ── async, parametrized over every async checkpointer backend ───────────────────
+
+
+async def test_e2e_async_suspend_and_fulfill(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def node(state):
+        return {"result": fetch({"resource": "txn"})}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    pending = await graph.apending_fetches(config)
+    assert len(pending) == 1
+    out = await graph.afulfill(config, pending[0].id, "DATA")
+    assert out["result"] == "DATA"
+
+
+async def test_e2e_async_fetch_all_partial(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def node(state):
+        a, b = fetch_all([{"r": "A"}, {"r": "B"}])
+        return {"result": f"{a}:{b}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    ids = {f.value["r"]: f.id for f in await graph.apending_fetches(config)}
+    await graph.ainvoke(Command(fetch={ids["A"]: "AA"}), config)
+    still = await graph.apending_fetches(config)
+    assert [f.value["r"] for f in still] == ["B"]
+    out = await graph.ainvoke(Command(fetch={ids["B"]: "BB"}), config)
+    assert out["result"] == "AA:BB"
+
+
+async def test_e2e_async_deadline_expiry(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def node(state):
+        try:
+            return {"result": fetch({"r": "x"}, deadline=0.001)}
+        except FetchError as e:
+            return {"result": f"exp:{e.status}"}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    time.sleep(0.05)
+    await graph.aexpire_fetches(config)
+    state = await graph.aget_state(config)
+    assert state.values["result"] == "exp:expired"
+
+
+async def test_e2e_async_fail_fetch(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def node(state):
+        return {"result": fetch({"r": "x"})}
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"result": ""}, config)
+    pending = await graph.apending_fetches(config)
+    with pytest.raises(FetchError) as exc:
+        await graph.afail_fetch(config, pending[0].id, "boom")
+    assert exc.value.status == "failed"
+
+
+async def test_e2e_async_multi_node(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    async def a(state):
+        return {"fetched": fetch({"resource": "profile"})}
+
+    async def b(state):
+        return {"result": f"hello {state['fetched']}"}
+
+    builder = StateGraph(MultiState)
+    builder.add_node("a", a)
+    builder.add_node("b", b)
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", END)
+    graph = builder.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.ainvoke({"fetched": "", "result": ""}, config)
+    pending = await graph.apending_fetches(config)
+    out = await graph.ainvoke(Command(fetch={pending[0].id: "Ada"}), config)
+    assert out["result"] == "hello Ada"
+
+
+

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5598,6 +5598,7 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                     {
                         "id": AnyStr(),
                         "value": "test",
+                        "kind": "human",
                     },
                 ],
                 "name": "graph",
@@ -5642,6 +5643,7 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                             {
                                 "id": AnyStr(),
                                 "value": "test",
+                                "kind": "human",
                             },
                         ),
                         "name": "graph",

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5598,7 +5598,6 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                     {
                         "id": AnyStr(),
                         "value": "test",
-                        "kind": "human",
                     },
                 ],
                 "name": "graph",
@@ -5643,7 +5642,6 @@ def test_falsy_return_from_task(sync_checkpointer: BaseCheckpointSaver):
                             {
                                 "id": AnyStr(),
                                 "value": "test",
-                                "kind": "human",
                             },
                         ),
                         "name": "graph",


### PR DESCRIPTION
# feat: `fetch()` — a native service-to-service data-dependency primitive

Closes #7700.

## Summary

Adds `fetch()`, a first-class primitive for **service-to-service (s2s) data dependencies** — a typed, bounded-SLA, always-resuming counterpart to `interrupt()`. Where `interrupt()` pauses for an *indeterminate human decision*, `fetch()` pauses for an *automated data dependency* the serving layer is expected to fulfill and resume within an SLA.

`fetch()` is a **sibling of `interrupt()`, not a flavor of it**: it has its own suspend signal, its own resolution path (by content-addressed id, never positional), and its own terminal-failure semantics. `interrupt()` is untouched.

```python

from langgraph.types import fetch

def node(state):

    # suspends the graph; the serving layer fulfills this by id and resumes

    data = fetch({"resource": "transactions", "user_id": "123"}, deadline=30.0)

    return {"result": data}

```

```python

# serving layer

for req in graph.pending_fetches(config):      # automated data dependencies

    value, source = data_layer.get(req.value)

    graph.fulfill(config, req.id, value, source=source)

```

## Motivation

Teams deploying agents as pure services need a pause/resume boundary without a human in the loop: a node hits a data dependency, the graph suspends durably, an external service provides the data, and execution resumes — within a bounded SLA. `interrupt()` is the wrong tool: its resume is indeterminate (may never happen), matching is positional, and it has no expiry or terminal-failure model. This PR splits that concern into a dedicated primitive, following the discussion on #7700.

## What's included

### Core primitive

- **`GraphFetch`** — a suspend signal that is a **sibling of `GraphInterrupt` under `GraphBubbleUp`** (not a subclass), so fetches never touch the human-interrupt resume path or the `__interrupt__` stream. No user-raiseable `NodeFetch` (that pattern is deprecated); users call `fetch()`.

- **`fetch(value, *, key=None, deadline=None, owner=None)`** and **`fetch_all(values, *, deadline=None)`** — declare one or many dependencies; `fetch_all` suspends once and supports **partial fulfillment** (already-fulfilled return immediately, outstanding ones re-suspend).

- **Content-addressed identity** — `id = hash(thread, ns, node, digest(request))`, resolved **by id**. This gives the reviewer invariants *by construction*: one result satisfies exactly one dependency; a changed request yields a new id (no stale replay); one value can't satisfy two fetches unless the caller shares a `key=` (opt-in fan-out).

- **Storage reuses existing machinery** — requests/results are checkpoint **writes** (`FETCH` / `FETCH_RESULT`), the same substrate as `INTERRUPT` / `RESUME`. No new channel, no checkpoint-format change.

### SLA / expiry & terminal outcomes

- **`FetchRequest`**: `id`, `value`, `deadline`, `created_at`, `owner`. Deadline is fixed once at first suspension and reused across re-execution.

- **`FetchResult`**: `id`, `value`, `status` (`fulfilled | expired | failed | cancelled`), `error`, `value_digest`, `resolved_at`, `source`.

- **`FetchError`** — raised **inside the node** on a terminal failure (expired/failed/cancelled), so the node can `try/except` or fail deterministically.

- **Deadline is authoritative**: a fulfillment arriving past the deadline is **rejected → `expired`** (never a silent success); a value fulfilled in time stays valid even if the graph resumes later.

- **Lazy expiry**: a resume past the deadline drives the fetch to terminal `expired` — the mechanism the background sweeper triggers.

### Serving-layer API (sync + async)

- `pending_fetches(config)` / `apending_fetches` — outstanding `FetchRequest`s (distinct from `task.interrupts`).

- `fulfill(config, id, value, *, source=None)` / `afulfill` — resolve one dependency by id and resume; optional `source` records provenance.

- `fail_fetch(config, id, error=None)` / `afail_fetch` — fail closed.

- `expire_fetches(config)` / `aexpire_fetches` — resume so past-deadline fetches self-resolve as `expired`.

- `cancel_fetches(config, ids)` / `acancel_fetches` — terminal `cancelled`.

- `resolved_fetches(config)` / `aresolved_fetches` — the provenance/audit trail (status, `value_digest`, `resolved_at`, `source`), walking checkpoint history.

- `start_fetch_sweeper()` / `stop_fetch_sweeper()` — opt-in background daemon (modeled on the store TTL sweeper) that expires idle graphs.

- `Command(fetch={id: value})` fulfillment; `PregelTask.fetches` surfaces pending requests.

### Provenance / audit

A `fetch()` is *cited evidence* — an assertion that a fact entered the agent's reasoning from outside. Its resolution binds the **point in time**, not just the value: `value_digest` (content hash), `resolved_at`, and `source` (actual origin, distinct from `owner` = expected fulfiller). This makes resolutions reproducible and drift-detectable, and keeps the `task.fetches` vs `task.interrupts` split meaningful for audit tooling (a dependency resolution vs a consent gate carry different compliance weight).

## How this addresses the issue discussion

- **@blah-mad / @urbantech** — dependency-boundary primitive (not a relabeled interrupt); explicit resume record (id, owner, created_at, deadline, value digest, terminal outcome); and their four regression invariants: (1) human `interrupt()` and `fetch()` coexist without cross-resuming, (2) checkpoint-resume preserves pending-fetch ownership, (3) one value can't satisfy two fetches unless explicitly fanned out, (4) expired fetches resume as terminal failure, not silent success. All covered and tested.

- **@zeweihan** — resolution binds point-in-time (`value_digest` + `resolved_at`), plus a result-side `source` and a queryable audit trail via `resolved_fetches()`.

## Backwards compatibility

Purely additive. `interrupt()` is unchanged. New reserved write-types, a new signal, and a new API surface; existing graphs behave identically. No checkpoint-format migration.

## Testing

- `tests/test_fetch.py` — unit + single-backend coverage (exception hierarchy, content-id determinism, suspend/fulfill-by-id, `fetch_all` partial fulfillment, deadline/expiry, late-fulfill rejection, `fail_fetch`, node-catches-`FetchError`, coexistence with `interrupt()`, sweeper).

- `tests/test_fetch_e2e.py` — end-to-end across **every checkpointer backend** (memory / sqlite / postgres) and **sync + async**: suspend/fulfill, partial, deadline expiry, fail, interrupt coexistence, multi-node downstream, streaming, **subgraph nesting**, **fetch inside a ToolNode tool**, and provenance/audit (`source`, `value_digest`, `resolved_at`, `resolved_fetches`).

Full `langgraph` suite green on memory/sqlite locally; postgres/redis variants run in CI.

## Deferred (follow-ups)

- **LangGraph Server REST surface** for `pending_fetches`/`fulfill` (separate repo).

- **Node-side provenance envelope** (`fetch(..., with_metadata=True)`) — only if a node needs to branch on staleness; audit needs are served by `resolved_fetches()`.

---

Credits: design feedback from @blah-mad, @urbantech, and @zeweihan on #7700.

