### PR TITLE
fix(sdk): unblock active subscribe iterators on stream close (#8429)

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -1618,51 +1618,58 @@ class AsyncThreadStream:
         """
         from langgraph_sdk.stream.subscription import matches_subscription
 
-        while not self._closed:
-            shared = self._shared_stream
-            if shared is None:
-                return
-            try:
-                async for event in self._dedup_iter(shared.events):
-                    if self._closed:
-                        break
-                    self._observe_event(event)
-                    for sub in list(self._subscriptions.values()):
-                        if matches_subscription(event, sub.params):
-                            sub.queue.put_nowait(event)
-                    # On root-terminal lifecycle, push the `None` sentinel
-                    # into all subscription queues so projection iterators
-                    # exit when the run ends naturally. Runs on the shared
-                    # SSE so the terminal is processed in seq order with
-                    # the projection events -- any in-flight values /
-                    # tools / messages events for this run are already
-                    # queued before None.
-                    if _is_root_terminal_lifecycle(event):
-                        self._signal_paused()
-            except Exception:
-                # Pump errored — fall through to error-handling/reconnect.
-                pass
-            if self._shared_stream is shared:
-                # No rotation happened; the stream genuinely ended. Check
-                # `shared.done` for a post-ready drop and, if so, attempt to
-                # reconnect with `since=<cursor>` so subscribers don't lose
-                # buffered events on a transient transport failure.
-                err = await shared.done
-                if (
-                    err is not None
-                    and not isinstance(err, asyncio.CancelledError)
-                    and not self._closed
-                ):
-                    with contextlib.suppress(Exception):
-                        await shared.close()
-                    if await self._reconnect_shared_stream():
-                        continue
-                break
-            # Rotation: loop again to pick up the new _shared_stream.
-
-        # Terminate consumers cleanly on shutdown / stream-end.
-        for sub in self._subscriptions.values():
-            sub.queue.put_nowait(None)
+        try:
+            while not self._closed:
+                shared = self._shared_stream
+                if shared is None:
+                    return
+                try:
+                    async for event in self._dedup_iter(shared.events):
+                        if self._closed:
+                            break
+                        self._observe_event(event)
+                        for sub in list(self._subscriptions.values()):
+                            if matches_subscription(event, sub.params):
+                                sub.queue.put_nowait(event)
+                        # On root-terminal lifecycle, push the `None` sentinel
+                        # into all subscription queues so projection iterators
+                        # exit when the run ends naturally. Runs on the shared
+                        # SSE so the terminal is processed in seq order with
+                        # the projection events -- any in-flight values /
+                        # tools / messages events for this run are already
+                        # queued before None.
+                        if _is_root_terminal_lifecycle(event):
+                            self._signal_paused()
+                except Exception:
+                    # Pump errored — fall through to error-handling/reconnect.
+                    pass
+                if self._shared_stream is shared:
+                    # No rotation happened; the stream genuinely ended. Check
+                    # `shared.done` for a post-ready drop and, if so, attempt to
+                    # reconnect with `since=<cursor>` so subscribers don't lose
+                    # buffered events on a transient transport failure.
+                    err = await shared.done
+                    if (
+                        err is not None
+                        and not isinstance(err, asyncio.CancelledError)
+                        and not self._closed
+                    ):
+                        with contextlib.suppress(Exception):
+                            await shared.close()
+                        if await self._reconnect_shared_stream():
+                            continue
+                    break
+                # Rotation: loop again to pick up the new _shared_stream.
+        finally:
+            for sub in list(self._subscriptions.values()):
+                try:
+                    sub.queue.put_nowait(None)
+                except asyncio.QueueFull:
+                    try:
+                        sub.queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        pass
+                    sub.queue.put_nowait(None)
 
     async def _reconnect_sleep(self, attempt: int) -> None:
         """Sleep with exponential backoff and jitter for reconnect attempt `attempt`."""

--- a/libs/sdk-py/tests/streaming/test_thread_stream.py
+++ b/libs/sdk-py/tests/streaming/test_thread_stream.py
@@ -1231,3 +1231,42 @@ async def test_interleave_projections_data_channel_scoped_to_root_namespace():
                     checkpoints.append(item)
     assert {"scope": "root"} in checkpoints
     assert {"scope": "child"} not in checkpoints
+@pytest.mark.asyncio
+async def test_close_unblocks_active_subscription():
+    class EndlessSSE(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            while True:
+                yield b": keepalive\n\n"
+                await asyncio.sleep(0.05)
+
+    async def serve_sse(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=EndlessSSE(),
+        )
+
+    async def consume(stream: AsyncThreadStream) -> None:
+        async for _ in stream.subscribe(["messages"]):
+            pass
+
+    transport = httpx.MockTransport(serve_sse)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as raw:
+        stream = AsyncThreadStream(
+            http=HttpClient(raw),
+            thread_id="thread-1",
+            assistant_id="agent",
+            explicit_thread_id=True,
+        )
+        async with stream:
+            consumer = asyncio.create_task(consume(stream))
+            # Wait only until consumer registers its subscription
+            while not stream._subscriptions:
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.1)
+
+        # Context closed — active consumer iterator must terminate now without timing out
+        await asyncio.wait_for(consumer, timeout=0.25)


### PR DESCRIPTION
Pull Request Description
Summary
Fixes #8429.

Resolves an issue where calling AsyncThreadStream.close() leaves active consumer iterators (stream.subscribe(...)) blocked indefinitely if the context exits while a consumer is awaiting sub.queue.get().

Cause of Bug
When AsyncThreadStream.close() cancels _fanout_task, Python raises an asyncio.CancelledError inside the running _fanout() coroutine at its nearest await point. Because execution aborts immediately upon cancellation, control bypasses the loop completion logic that normally delivers termination sentinels (None) to active subscriber queues. As a result, active consumer iterators suspended on await sub.queue.get() never receive an end-of-stream signal and wait indefinitely unless explicitly cancelled.

Key Changes
Guaranteed Sentinel Cleanup in _fanout(): Wrapped the main stream processing loop inside a try ... finally block.

Cancellation-Safe Delivery: On normal exit, unhandled exception, or task cancellation, the finally block iterates over self._subscriptions and safely pushes a None sentinel using put_nowait(None).

Queue Overflow Protection: Added fallback handling (QueueFull) to drop stale items if a queue is at capacity, ensuring the shutdown sentinel is always delivered.

Unit Test Coverage: Added a regression test in streaming/test_thread_stream.py (test_close_unblocks_active_subscription) to verify that consumer tasks unblock and exit cleanly upon stream closure within the expected timeout.

Verification
Test Command Executed:pytest tests/streaming/test_thread_stream.py -k test_close_unblocks_active_subscription

Result: 1 passed (0.11s) — verified locally that active iterators unblock immediately upon close() without timing out or raising unhandled exceptions.