### PR TITLE
fix(sdk-py): unblock subscribers on stream close

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -1291,8 +1291,7 @@ class AsyncThreadStream:
             return
         self._closed = True
         # Cancelling fanout skips its post-loop subscription sentinels.
-        for sub in self._subscriptions.values():
-            sub.queue.put_nowait(None)
+        self._signal_subscriptions_closed()
         for handle in self._open_handles:
             await handle.close()
         # Cancel _run_done so thread.output doesn't wait forever on close.
@@ -1315,6 +1314,16 @@ class AsyncThreadStream:
             await self._shared_stream.close()
         if self._transport is not None:
             await self._transport.close()
+
+    def _signal_subscriptions_closed(self) -> None:
+        """Enqueue a terminal sentinel without blocking on a saturated queue."""
+        for sub in list(self._subscriptions.values()):
+            try:
+                sub.queue.put_nowait(None)
+            except asyncio.QueueFull:
+                # Shutdown must not block on an inactive subscriber.
+                sub.queue.get_nowait()
+                sub.queue.put_nowait(None)
 
     def _register_subscription(self, params: SubscribeParams) -> _Subscription:
         """Allocate a subscription id and add it to the registry."""

--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -67,8 +67,23 @@ class _Subscription:
     id: int
     params: SubscribeParams
     queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    terminal_signaled: bool = False
     # Why: asyncio.Queue[Event | None] as a subscript in the field annotation
     # causes a type error with ty; bare asyncio.Queue is accepted.
+
+    def signal_terminal(self) -> None:
+        """Mark the subscription terminal without discarding buffered events."""
+        if self.terminal_signaled:
+            return
+        self.terminal_signaled = True
+        with contextlib.suppress(asyncio.QueueFull):
+            self.queue.put_nowait(None)
+
+    async def get(self) -> Event | None:
+        """Return the next event, or terminate after buffered events are drained."""
+        if self.terminal_signaled and self.queue.empty():
+            return None
+        return await self.queue.get()
 
 
 # All public protocol channels used by the raw `events`/`subscribe` surface.
@@ -365,7 +380,7 @@ class _ValuesProjection:
             state = await self._thread._fetch_state()
             yield state["values"]
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 for out in decoder.feed(item):
@@ -415,7 +430,7 @@ class _MessagesProjection:
             await self._thread._reconcile_stream(params)
             self._thread._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 for stream in decoder.feed(item):
@@ -934,7 +949,7 @@ class _SubgraphsProjection:
             await self._thread._reconcile_stream(params)
             self._thread._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 params_field = item.get("params") or {}
@@ -1065,7 +1080,7 @@ class _ToolCallsProjection:
             await self._thread._reconcile_stream(params)
             self._thread._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 for handle in decoder.feed(item):
@@ -1145,7 +1160,7 @@ class _ExtensionProjection:
             await self._thread._reconcile_stream(params)
             self._thread._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 for out in decoder.feed(item):
@@ -1316,14 +1331,9 @@ class AsyncThreadStream:
             await self._transport.close()
 
     def _signal_subscriptions_closed(self) -> None:
-        """Enqueue a terminal sentinel without blocking on a saturated queue."""
+        """Mark subscriptions terminal without discarding buffered events."""
         for sub in list(self._subscriptions.values()):
-            try:
-                sub.queue.put_nowait(None)
-            except asyncio.QueueFull:
-                # Shutdown must not block on an inactive subscriber.
-                sub.queue.get_nowait()
-                sub.queue.put_nowait(None)
+            sub.signal_terminal()
 
     def _register_subscription(self, params: SubscribeParams) -> _Subscription:
         """Allocate a subscription id and add it to the registry."""
@@ -1375,10 +1385,10 @@ class AsyncThreadStream:
     def _signal_paused(self) -> None:
         """Wake every active projection iterator on interrupt / run end.
 
-        Pushes the terminal sentinel (`None`) into every subscription
-        queue. Iterators see `None` and return; the shared SSE keeps
-        running so re-iteration after `run.respond(...)` registers a
-        fresh subscription and resumes.
+        Marks every subscription terminal and enqueues `None` when its queue
+        has capacity. A saturated queue drains its buffered events first, then
+        its terminal-aware reader returns; the shared SSE keeps running so
+        re-iteration after `run.respond(...)` registers a fresh subscription.
 
         `root_messages_inbox` is intentionally NOT signaled here: the
         subgraphs projection that populates it is responsible for
@@ -1387,11 +1397,7 @@ class AsyncThreadStream:
         sentinel. Signaling root_inbox here would race the redirection
         and could drop messages.
         """
-        # On a saturated queue the consumer is already behind; the iterator
-        # will still terminate when it drains to this point.
-        for sub in list(self._subscriptions.values()):
-            with contextlib.suppress(asyncio.QueueFull):
-                sub.queue.put_nowait(None)
+        self._signal_subscriptions_closed()
 
     def observe_applied_through_seq(self, seq: Any) -> None:
         """Advance the reconnect cursor from a command response meta sequence."""
@@ -1603,7 +1609,7 @@ class AsyncThreadStream:
             await self._reconcile_stream(params)
             self._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 yield item
@@ -1640,15 +1646,14 @@ class AsyncThreadStream:
                         break
                     self._observe_event(event)
                     for sub in list(self._subscriptions.values()):
-                        if matches_subscription(event, sub.params):
+                        if not sub.terminal_signaled and matches_subscription(
+                            event, sub.params
+                        ):
                             sub.queue.put_nowait(event)
-                    # On root-terminal lifecycle, push the `None` sentinel
-                    # into all subscription queues so projection iterators
-                    # exit when the run ends naturally. Runs on the shared
-                    # SSE so the terminal is processed in seq order with
-                    # the projection events -- any in-flight values /
-                    # tools / messages events for this run are already
-                    # queued before None.
+                    # On root-terminal lifecycle, mark all subscriptions
+                    # terminal so projection iterators exit after buffered
+                    # events. Runs on the shared SSE so the terminal is
+                    # processed in seq order with the projection events.
                     if _is_root_terminal_lifecycle(event):
                         self._signal_paused()
             except Exception:
@@ -1673,8 +1678,7 @@ class AsyncThreadStream:
             # Rotation: loop again to pick up the new _shared_stream.
 
         # Terminate consumers cleanly on shutdown / stream-end.
-        for sub in self._subscriptions.values():
-            sub.queue.put_nowait(None)
+        self._signal_subscriptions_closed()
 
     async def _reconnect_sleep(self, attempt: int) -> None:
         """Sleep with exponential backoff and jitter for reconnect attempt `attempt`."""

--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -1290,6 +1290,9 @@ class AsyncThreadStream:
         if self._closed:
             return
         self._closed = True
+        # Cancelling fanout skips its post-loop subscription sentinels.
+        for sub in self._subscriptions.values():
+            sub.queue.put_nowait(None)
         for handle in self._open_handles:
             await handle.close()
         # Cancel _run_done so thread.output doesn't wait forever on close.

--- a/libs/sdk-py/langgraph_sdk/stream/controller.py
+++ b/libs/sdk-py/langgraph_sdk/stream/controller.py
@@ -68,8 +68,23 @@ class _Subscription:
     id: int
     params: SubscribeParams
     queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    terminal_signaled: bool = False
     # Why: asyncio.Queue[Event | None] as a subscript in the field annotation
     # causes a type error with ty; bare asyncio.Queue is accepted.
+
+    def signal_terminal(self) -> None:
+        """Mark the subscription terminal without discarding buffered events."""
+        if self.terminal_signaled:
+            return
+        self.terminal_signaled = True
+        with contextlib.suppress(asyncio.QueueFull):
+            self.queue.put_nowait(None)
+
+    async def get(self) -> Event | None:
+        """Return the next event, or terminate after buffered events are drained."""
+        if self.terminal_signaled and self.queue.empty():
+            return None
+        return await self.queue.get()
 
 
 # ---------------------------------------------------------------------------
@@ -178,14 +193,9 @@ class StreamController:
             await asyncio.gather(*self._rotation_close_tasks, return_exceptions=True)
 
     def _signal_subscriptions_closed(self) -> None:
-        """Enqueue a terminal sentinel without blocking on a saturated queue."""
+        """Mark subscriptions terminal without discarding buffered events."""
         for sub in list(self._subscriptions.values()):
-            try:
-                sub.queue.put_nowait(None)
-            except asyncio.QueueFull:
-                # Shutdown must not block on an inactive subscriber.
-                sub.queue.get_nowait()
-                sub.queue.put_nowait(None)
+            sub.signal_terminal()
 
     # ------------------------------------------------------------------
     # Subscription internals
@@ -220,7 +230,7 @@ class StreamController:
             await self._reconcile_stream(params)
             self._ensure_fanout_running()
             while True:
-                item = await sub.queue.get()
+                item = await sub.get()
                 if item is None:
                     return
                 yield item
@@ -261,7 +271,9 @@ class StreamController:
                     if self._closed:
                         break
                     for sub in list(self._subscriptions.values()):
-                        if matches_subscription(event, sub.params):
+                        if not sub.terminal_signaled and matches_subscription(
+                            event, sub.params
+                        ):
                             sub.queue.put_nowait(event)
             except Exception as drop_err:
                 _logger.debug("transport drop in fanout: %r", drop_err)
@@ -282,8 +294,7 @@ class StreamController:
             # Rotation: loop again to pick up the new _shared_stream.
 
         # Terminate consumers cleanly on shutdown / stream-end.
-        for sub in self._subscriptions.values():
-            sub.queue.put_nowait(None)
+        self._signal_subscriptions_closed()
 
     async def _reconnect_sleep(self, attempt: int) -> None:
         """Sleep with exponential backoff and jitter for reconnect attempt *attempt*."""

--- a/libs/sdk-py/langgraph_sdk/stream/controller.py
+++ b/libs/sdk-py/langgraph_sdk/stream/controller.py
@@ -167,8 +167,7 @@ class StreamController:
             return
         self._closed = True
         # Cancelling fanout skips its post-loop subscription sentinels.
-        for sub in self._subscriptions.values():
-            sub.queue.put_nowait(None)
+        self._signal_subscriptions_closed()
         if self._fanout_task is not None:
             self._fanout_task.cancel()
             with contextlib.suppress(Exception, asyncio.CancelledError):
@@ -177,6 +176,16 @@ class StreamController:
             await self._shared_stream.close()
         if self._rotation_close_tasks:
             await asyncio.gather(*self._rotation_close_tasks, return_exceptions=True)
+
+    def _signal_subscriptions_closed(self) -> None:
+        """Enqueue a terminal sentinel without blocking on a saturated queue."""
+        for sub in list(self._subscriptions.values()):
+            try:
+                sub.queue.put_nowait(None)
+            except asyncio.QueueFull:
+                # Shutdown must not block on an inactive subscriber.
+                sub.queue.get_nowait()
+                sub.queue.put_nowait(None)
 
     # ------------------------------------------------------------------
     # Subscription internals

--- a/libs/sdk-py/langgraph_sdk/stream/controller.py
+++ b/libs/sdk-py/langgraph_sdk/stream/controller.py
@@ -166,6 +166,9 @@ class StreamController:
         if self._closed:
             return
         self._closed = True
+        # Cancelling fanout skips its post-loop subscription sentinels.
+        for sub in self._subscriptions.values():
+            sub.queue.put_nowait(None)
         if self._fanout_task is not None:
             self._fanout_task.cancel()
             with contextlib.suppress(Exception, asyncio.CancelledError):

--- a/libs/sdk-py/tests/streaming/test_shared_stream.py
+++ b/libs/sdk-py/tests/streaming/test_shared_stream.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from typing import Any, cast
 
 import httpx
+import pytest
 
 from langgraph_sdk._async.http import HttpClient
 from langgraph_sdk._async.stream import AsyncThreadStream
@@ -135,6 +136,31 @@ async def test_two_concurrent_subscribes_share_one_stream():
     assert len(fake.stream_request_bodies) == 2
 
 
+def _make_async_subscription_owner(
+    owner_kind: str,
+    raw: httpx.AsyncClient,
+    *,
+    max_queue_size: int,
+) -> Any:
+    if owner_kind == "thread":
+        return AsyncThreadStream(
+            http=HttpClient(raw),
+            thread_id="t-1",
+            assistant_id="agent",
+            explicit_thread_id=True,
+            max_queue_size=max_queue_size,
+        )
+
+    from unittest.mock import MagicMock
+
+    from langgraph_sdk.stream.transport.http import ProtocolSseTransport
+
+    return StreamController(
+        transport=MagicMock(spec=ProtocolSseTransport),
+        max_queue_size=max_queue_size,
+    )
+
+
 async def test_thread_stream_close_unblocks_active_subscription():
     """Exiting the public stream context terminates active subscribers."""
 
@@ -172,30 +198,91 @@ async def test_thread_stream_close_unblocks_active_subscription():
         await asyncio.wait_for(consumer, timeout=0.1)
 
 
-async def test_thread_stream_close_handles_saturated_subscription_queue():
-    """Explicit close prioritizes termination when a subscriber queue is full."""
+@pytest.mark.parametrize("owner_kind", ("thread", "controller"))
+async def test_close_drains_saturated_subscription_queue(monkeypatch, owner_kind):
+    """Explicit close preserves buffered events for both async implementations."""
+    from unittest.mock import AsyncMock
+
+    async with httpx.AsyncClient(base_url="http://test") as raw:
+        owner = _make_async_subscription_owner(
+            owner_kind,
+            raw,
+            max_queue_size=2,
+        )
+        monkeypatch.setattr(owner, "_reconcile_stream", AsyncMock())
+        monkeypatch.setattr(owner, "_ensure_fanout_running", lambda: None)
+
+        iterator = owner._subscription_iter({"channels": ["values"]})
+        first_event = asyncio.create_task(iterator.__anext__())
+        while not owner._subscriptions:
+            await asyncio.sleep(0)
+        saturated = next(iter(owner._subscriptions.values()))
+        saturated.queue.put_nowait(values_event(seq=1))
+        assert (await first_event)["seq"] == 1
+
+        saturated.queue.put_nowait(values_event(seq=2))
+        saturated.queue.put_nowait(values_event(seq=3))
+
+        await owner.close()
+        remaining = [event async for event in iterator]
+
+    assert [event["seq"] for event in remaining] == [2, 3]
+
+
+@pytest.mark.parametrize("owner_kind", ("thread", "controller"))
+async def test_normal_eof_drains_saturated_subscription_queue(owner_kind):
+    """Natural EOF preserves buffered events for both async implementations."""
+    async with httpx.AsyncClient(base_url="http://test") as raw:
+        owner = _make_async_subscription_owner(
+            owner_kind,
+            raw,
+            max_queue_size=1,
+        )
+        sub = owner._register_subscription({"channels": ["values"]})
+        sub.queue.put_nowait(values_event(seq=1))
+        owner._shared_stream, _ = _make_handle([])
+
+        owner._ensure_fanout_running()
+        assert owner._fanout_task is not None
+        await asyncio.wait_for(owner._fanout_task, timeout=0.1)
+
+    assert sub.terminal_signaled
+    event = await sub.get()
+    assert event is not None
+    assert event["seq"] == 1
+    assert await sub.get() is None
+
+
+async def test_signal_paused_drains_saturated_values_projection(monkeypatch):
+    """Run pause preserves buffered values before terminating the projection."""
+    from unittest.mock import AsyncMock, MagicMock
+
     async with httpx.AsyncClient(base_url="http://test") as raw:
         thread = AsyncThreadStream(
             http=HttpClient(raw),
             thread_id="t-1",
             assistant_id="agent",
             explicit_thread_id=True,
-            max_queue_size=2,
+            max_queue_size=1,
         )
-        saturated = thread._register_subscription({"channels": ["values"]})
-        buffered = thread._register_subscription({"channels": ["messages"]})
-        empty = thread._register_subscription({"channels": ["updates"]})
-        saturated.queue.put_nowait(values_event(seq=1))
-        saturated.queue.put_nowait(values_event(seq=2))
-        buffered.queue.put_nowait(values_event(seq=3))
+        thread._transport = MagicMock()
+        monkeypatch.setattr(thread, "_reconcile_stream", AsyncMock())
+        monkeypatch.setattr(thread, "_ensure_fanout_running", lambda: None)
+        monkeypatch.setattr(
+            thread,
+            "_fetch_state",
+            AsyncMock(return_value={"values": {"counter": 0}}),
+        )
 
-        await thread.close()
+        iterator = thread.values.__aiter__()
+        assert await iterator.__anext__() == {"counter": 0}
+        sub = next(iter(thread._subscriptions.values()))
+        sub.queue.put_nowait(values_event(seq=1, counter=1))
 
-    assert saturated.queue.get_nowait()["seq"] == 2
-    assert saturated.queue.get_nowait() is None
-    assert buffered.queue.get_nowait()["seq"] == 3
-    assert buffered.queue.get_nowait() is None
-    assert empty.queue.get_nowait() is None
+        thread._signal_paused()
+        remaining = [value async for value in iterator]
+
+    assert remaining == [{"counter": 1}]
 
 
 async def test_subscribe_does_not_leak_when_iterator_unconsumed():
@@ -306,70 +393,6 @@ def _make_handle(
     return EventStreamHandle(
         events=_aiter(), ready=ready, done=done, close=_close
     ), queue
-
-
-async def test_controller_close_unblocks_active_subscription():
-    """Closing the controller terminates consumers even before the first event."""
-    from unittest.mock import MagicMock
-
-    from langgraph_sdk.stream.transport.http import ProtocolSseTransport
-
-    loop = asyncio.get_running_loop()
-    ready: asyncio.Future[None] = loop.create_future()
-    done: asyncio.Future[BaseException | None] = loop.create_future()
-    ready.set_result(None)
-
-    async def _aiter():
-        await asyncio.Event().wait()
-        if False:
-            yield {}
-
-    async def _close() -> None:
-        if not done.done():
-            done.set_result(None)
-
-    handle = EventStreamHandle(
-        events=_aiter(),
-        ready=ready,
-        done=done,
-        close=_close,
-    )
-    transport = MagicMock(spec=ProtocolSseTransport)
-    transport.open_event_stream.return_value = handle
-
-    controller = StreamController(transport=transport)
-    sub = controller.register_subscription({"channels": ["values"]})
-    await controller.reconcile_stream({"channels": ["values"]})
-    controller.ensure_fanout_running()
-    await asyncio.sleep(0)
-
-    await controller.close()
-
-    assert await asyncio.wait_for(sub.queue.get(), timeout=0.1) is None
-
-
-async def test_controller_close_handles_saturated_subscription_queue():
-    """Controller close terminates every subscriber even if one queue is full."""
-    from unittest.mock import MagicMock
-
-    from langgraph_sdk.stream.transport.http import ProtocolSseTransport
-
-    transport = MagicMock(spec=ProtocolSseTransport)
-    controller = StreamController(transport=transport, max_queue_size=2)
-    saturated = controller.register_subscription({"channels": ["values"]})
-    buffered = controller.register_subscription({"channels": ["messages"]})
-    empty = controller.register_subscription({"channels": ["updates"]})
-    saturated.queue.put_nowait(values_event(seq=1))
-    saturated.queue.put_nowait(values_event(seq=2))
-    buffered.queue.put_nowait(values_event(seq=3))
-
-    await controller.close()
-
-    assert saturated.queue.get_nowait()["seq"] == 2
-    assert saturated.queue.get_nowait() is None
-    assert buffered.queue.get_nowait()["seq"] == 3
-    assert buffered.queue.get_nowait() is None
-    assert empty.queue.get_nowait() is None
 
 
 async def test_shared_stream_reconnects_with_since_after_transport_drop():

--- a/libs/sdk-py/tests/streaming/test_shared_stream.py
+++ b/libs/sdk-py/tests/streaming/test_shared_stream.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import httpx
 
 from langgraph_sdk._async.http import HttpClient
+from langgraph_sdk._async.stream import AsyncThreadStream
 from langgraph_sdk._async.threads import ThreadsClient
 from langgraph_sdk.stream.controller import StreamController
 from langgraph_sdk.stream.transport.http import EventStreamHandle
@@ -171,6 +172,32 @@ async def test_thread_stream_close_unblocks_active_subscription():
         await asyncio.wait_for(consumer, timeout=0.1)
 
 
+async def test_thread_stream_close_handles_saturated_subscription_queue():
+    """Explicit close prioritizes termination when a subscriber queue is full."""
+    async with httpx.AsyncClient(base_url="http://test") as raw:
+        thread = AsyncThreadStream(
+            http=HttpClient(raw),
+            thread_id="t-1",
+            assistant_id="agent",
+            explicit_thread_id=True,
+            max_queue_size=2,
+        )
+        saturated = thread._register_subscription({"channels": ["values"]})
+        buffered = thread._register_subscription({"channels": ["messages"]})
+        empty = thread._register_subscription({"channels": ["updates"]})
+        saturated.queue.put_nowait(values_event(seq=1))
+        saturated.queue.put_nowait(values_event(seq=2))
+        buffered.queue.put_nowait(values_event(seq=3))
+
+        await thread.close()
+
+    assert saturated.queue.get_nowait()["seq"] == 2
+    assert saturated.queue.get_nowait() is None
+    assert buffered.queue.get_nowait()["seq"] == 3
+    assert buffered.queue.get_nowait() is None
+    assert empty.queue.get_nowait() is None
+
+
 async def test_subscribe_does_not_leak_when_iterator_unconsumed():
     """Subscriptions register lazily on first __anext__, not at subscribe() call time.
 
@@ -319,6 +346,30 @@ async def test_controller_close_unblocks_active_subscription():
     await controller.close()
 
     assert await asyncio.wait_for(sub.queue.get(), timeout=0.1) is None
+
+
+async def test_controller_close_handles_saturated_subscription_queue():
+    """Controller close terminates every subscriber even if one queue is full."""
+    from unittest.mock import MagicMock
+
+    from langgraph_sdk.stream.transport.http import ProtocolSseTransport
+
+    transport = MagicMock(spec=ProtocolSseTransport)
+    controller = StreamController(transport=transport, max_queue_size=2)
+    saturated = controller.register_subscription({"channels": ["values"]})
+    buffered = controller.register_subscription({"channels": ["messages"]})
+    empty = controller.register_subscription({"channels": ["updates"]})
+    saturated.queue.put_nowait(values_event(seq=1))
+    saturated.queue.put_nowait(values_event(seq=2))
+    buffered.queue.put_nowait(values_event(seq=3))
+
+    await controller.close()
+
+    assert saturated.queue.get_nowait()["seq"] == 2
+    assert saturated.queue.get_nowait() is None
+    assert buffered.queue.get_nowait()["seq"] == 3
+    assert buffered.queue.get_nowait() is None
+    assert empty.queue.get_nowait() is None
 
 
 async def test_shared_stream_reconnects_with_since_after_transport_drop():

--- a/libs/sdk-py/tests/streaming/test_shared_stream.py
+++ b/libs/sdk-py/tests/streaming/test_shared_stream.py
@@ -134,6 +134,43 @@ async def test_two_concurrent_subscribes_share_one_stream():
     assert len(fake.stream_request_bodies) == 2
 
 
+async def test_thread_stream_close_unblocks_active_subscription():
+    """Exiting the public stream context terminates active subscribers."""
+
+    class EndlessSSE(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            while True:
+                yield b": keepalive\n\n"
+                await asyncio.sleep(0.01)
+
+    async def serve_sse(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=EndlessSSE(),
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(serve_sse),
+        base_url="http://test",
+    ) as raw:
+        threads = ThreadsClient(HttpClient(raw))
+        async with threads.stream(
+            thread_id="t-1",
+            assistant_id="agent",
+        ) as thread:
+
+            async def drain() -> None:
+                async for _ in thread.subscribe(["messages"]):
+                    pass
+
+            consumer = asyncio.create_task(drain())
+            while not thread._subscriptions:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(consumer, timeout=0.1)
+
+
 async def test_subscribe_does_not_leak_when_iterator_unconsumed():
     """Subscriptions register lazily on first __anext__, not at subscribe() call time.
 
@@ -242,6 +279,46 @@ def _make_handle(
     return EventStreamHandle(
         events=_aiter(), ready=ready, done=done, close=_close
     ), queue
+
+
+async def test_controller_close_unblocks_active_subscription():
+    """Closing the controller terminates consumers even before the first event."""
+    from unittest.mock import MagicMock
+
+    from langgraph_sdk.stream.transport.http import ProtocolSseTransport
+
+    loop = asyncio.get_running_loop()
+    ready: asyncio.Future[None] = loop.create_future()
+    done: asyncio.Future[BaseException | None] = loop.create_future()
+    ready.set_result(None)
+
+    async def _aiter():
+        await asyncio.Event().wait()
+        if False:
+            yield {}
+
+    async def _close() -> None:
+        if not done.done():
+            done.set_result(None)
+
+    handle = EventStreamHandle(
+        events=_aiter(),
+        ready=ready,
+        done=done,
+        close=_close,
+    )
+    transport = MagicMock(spec=ProtocolSseTransport)
+    transport.open_event_stream.return_value = handle
+
+    controller = StreamController(transport=transport)
+    sub = controller.register_subscription({"channels": ["values"]})
+    await controller.reconcile_stream({"channels": ["values"]})
+    controller.ensure_fanout_running()
+    await asyncio.sleep(0)
+
+    await controller.close()
+
+    assert await asyncio.wait_for(sub.queue.get(), timeout=0.1) is None
 
 
 async def test_shared_stream_reconnects_with_since_after_transport_drop():


### PR DESCRIPTION
Fixes #8429

## Summary

- mark active subscriptions terminal before fanout cancellation
- apply one termination path to explicit close, run pause, and natural EOF
- preserve buffered events when a bounded subscription queue is saturated
- cover both `AsyncThreadStream` and `StreamController`

## Why

`close()` cancels `_fanout_task`, so `CancelledError` bypasses the subscription
sentinel delivery after the fanout loop. Consumers waiting on an empty
subscription queue therefore remain blocked after the stream context exits.

The existing terminal sentinel also cannot be enqueued when a subscription
queue is full. This affects explicit close, natural fanout completion, and run
pause: `QueueFull` either escapes or the sentinel is silently lost.

Each async subscription now records terminal state separately from its bounded
queue. A sentinel still wakes an iterator already blocked on an empty queue.
When the queue is full, the iterator drains buffered events and then observes
the terminal state, so shutdown neither blocks nor drops an event.

## Why safe

- no public API changes
- no change to ordinary event overflow or transport backpressure policy
- terminal subscriptions stop accepting new fanout events
- empty, partially buffered, and saturated queues retain FIFO behavior

## Tests

- `make format`
- `make lint`
- `make test` (`499 passed, 55 deselected`)
