### PR TITLE
fix(sdk-py): unblock active subscriptions on AsyncThreadStream.close()

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/stream.py
+++ b/libs/sdk-py/langgraph_sdk/_async/stream.py
@@ -1304,6 +1304,12 @@ class AsyncThreadStream:
             await self._lifecycle_watcher_handle.close()
         self._fail_active_message_streams(asyncio.CancelledError())
         self._fail_active_tool_calls(asyncio.CancelledError())
+        # Push the terminal sentinel into active subscriptions BEFORE cancelling
+        # the fanout task: cancellation raises inside `_fanout()`, so its own
+        # sentinel loop never runs and iterators awaiting an empty queue would
+        # stay blocked. `SyncThreadStream.close()` already closes its controller
+        # first for the same reason.
+        self._signal_paused()
         if self._fanout_task is not None:
             self._fanout_task.cancel()
             with contextlib.suppress(Exception, asyncio.CancelledError):

--- a/libs/sdk-py/tests/streaming/test_thread_stream.py
+++ b/libs/sdk-py/tests/streaming/test_thread_stream.py
@@ -1231,3 +1231,44 @@ async def test_interleave_projections_data_channel_scoped_to_root_namespace():
                     checkpoints.append(item)
     assert {"scope": "root"} in checkpoints
     assert {"scope": "child"} not in checkpoints
+
+
+async def test_close_unblocks_active_subscription_iterator():
+    """`close()` must terminate iterators waiting on an empty subscription queue.
+
+    Cancelling the fanout task raises inside `_fanout()`, so its own terminal
+    sentinel loop never runs; without an explicit sentinel the consumer stays
+    suspended on `await sub.queue.get()`.
+    """
+
+    class EndlessSSE(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            while True:
+                yield b": keepalive\n\n"
+                await asyncio.sleep(0.05)
+
+    async def serve_sse(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=EndlessSSE(),
+        )
+
+    async def consume(stream: AsyncThreadStream) -> None:
+        async for _ in stream.subscribe(["messages"]):
+            pass
+
+    transport = httpx.MockTransport(serve_sse)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as raw:
+        stream = AsyncThreadStream(
+            http=HttpClient(raw),
+            thread_id="thread-1",
+            assistant_id="agent",
+        )
+        async with stream:
+            consumer = asyncio.create_task(consume(stream))
+            while not stream._subscriptions:
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(consumer, timeout=0.25)


### PR DESCRIPTION
Fixes #8429

`AsyncThreadStream.close()` cancelled the fanout task without first pushing the terminal sentinel into active subscriptions, so a consumer suspended on an empty subscription queue never terminated (cancellation raises inside `_fanout()` and skips its own sentinel loop). It now calls `_signal_paused()` before the cancel, matching `SyncThreadStream.close()`, which closes its controller first for the same reason.

Verified: the new `test_close_unblocks_active_subscription_iterator` reproduces the reported `TimeoutError` without the source change and passes with it (stash-verified); `pytest tests/streaming` is 372 passed, and `ruff check`/`ruff format --check` are clean on both changed files.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/
