### PR TITLE
fix(cli): keep .dockerignore negations in the deploy source archive

### DIFF
--- a/libs/cli/langgraph_cli/archive.py
+++ b/libs/cli/langgraph_cli/archive.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import click
 import pathspec
 
-from langgraph_cli._ignore import _build_ignore_spec
+from langgraph_cli._ignore import _build_dockerignore_negation_hints, _build_ignore_spec
 from langgraph_cli.config import Config, _assemble_local_deps
 
 _WARN_SIZE = 50 * 1024 * 1024  # 50 MB
@@ -35,16 +35,25 @@ def _add_directory(
 
     If arcname_prefix is None, files are added at the archive root.
     Paths matching ignore_spec are excluded.
+
+    A directory that matches ignore_spec is still walked if a `.dockerignore`
+    negation (`!pattern`) re-includes something underneath it, mirroring the
+    same directory-pruning override `uv_lock.py`'s Docker-context listing
+    uses (see `_NegatedDockerignoreHints`). Pruning by directory match alone
+    would stop `os.walk` before ever reaching the negated file below.
     """
+    negated_hints = _build_dockerignore_negation_hints(source_dir)
     for root, dirs, files in os.walk(source_dir):
         rel_root = os.path.relpath(root, source_dir).replace(os.sep, "/")
-        dirs[:] = [
-            d
-            for d in dirs
-            if not ignore_spec.match_file(
-                f"{rel_root}/{d}/" if rel_root != "." else f"{d}/"
-            )
-        ]
+        kept_dirs = []
+        for d in dirs:
+            rel_dir = f"{rel_root}/{d}" if rel_root != "." else d
+            excluded = ignore_spec.match_file(f"{rel_dir}/")
+            if not excluded or negated_hints.requires_dir_walk(
+                pathlib.PurePosixPath(rel_dir)
+            ):
+                kept_dirs.append(d)
+        dirs[:] = kept_dirs
         for f in files:
             full_path = os.path.join(root, f)
             rel = os.path.relpath(full_path, source_dir).replace(os.sep, "/")

--- a/libs/cli/tests/unit_tests/test_archive.py
+++ b/libs/cli/tests/unit_tests/test_archive.py
@@ -178,6 +178,36 @@ class TestAddDirectory:
         assert "main.py" in names
         assert "lib/util.py" not in names
 
+    def test_dockerignore_negation_inside_excluded_dir_is_included(self, tmp_path):
+        """A `!pattern` re-including a path under an otherwise-ignored directory
+        must still reach the archive, matching the same negation handling
+        `uv_lock.py`'s Docker-context listing applies. Naively pruning any
+        directory that matches an ignore pattern stops `os.walk` before it
+        ever reaches the negated file underneath.
+        """
+        project = tmp_path / "src"
+        project.mkdir()
+        (project / "app.py").write_text("print('hi')")
+        vendor = project / "vendor"
+        vendor.mkdir()
+        (vendor / "junk.txt").write_text("junk")
+        keep = vendor / "keep"
+        keep.mkdir()
+        (keep / "important.py").write_text("REQUIRED = True")
+        (project / ".dockerignore").write_text(
+            "vendor/\n!vendor/keep/\n!vendor/keep/**\n"
+        )
+        spec = _build_ignore_spec(project)
+
+        archive_path = tmp_path / "out.tar"
+        with tarfile.open(archive_path, "w") as tar:
+            _add_directory(tar, project, arcname_prefix=None, ignore_spec=spec)
+
+        with tarfile.open(archive_path, "r") as tar:
+            names = tar.getnames()
+        assert "vendor/keep/important.py" in names
+        assert "vendor/junk.txt" not in names
+
 
 # ---------------------------------------------------------------------------
 # create_archive (integration)


### PR DESCRIPTION
`_add_directory` pruned any directory matching the ignore spec, so `os.walk` never reached a file that a `!pattern` re-included underneath it — meaning `langgraph deploy` archives silently dropped files that local Docker builds keep. Reuses the `_NegatedDockerignoreHints` override `uv_lock.py` already applies, plus a regression test.

Fixes #8387