### PR TITLE
fix(checkpoint): serialize pathlib.PurePath and range in JsonPlusSerializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -33,6 +33,7 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),
+        ("builtins", "range"),
         ("collections", "deque"),
         # ip addresses
         ("ipaddress", "IPv4Address"),
@@ -45,10 +46,16 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("pathlib", "Path"),
         ("pathlib", "PosixPath"),
         ("pathlib", "WindowsPath"),
+        ("pathlib", "PurePath"),
+        ("pathlib", "PurePosixPath"),
+        ("pathlib", "PureWindowsPath"),
         # pathlib in Python 3.13+
         ("pathlib._local", "Path"),
         ("pathlib._local", "PosixPath"),
         ("pathlib._local", "WindowsPath"),
+        ("pathlib._local", "PurePath"),
+        ("pathlib._local", "PurePosixPath"),
+        ("pathlib._local", "PureWindowsPath"),
         # zoneinfo
         ("zoneinfo", "ZoneInfo"),
         # regex

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -350,11 +350,20 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 ),
             ),
         )
-    elif isinstance(obj, pathlib.Path):
+    elif isinstance(obj, pathlib.PurePath):
+        # PurePath covers both the pure variants and the concrete Path subclasses;
+        # every one is rebuilt from its parts by its own constructor.
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_POS_ARGS,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, obj.parts),
+            ),
+        )
+    elif isinstance(obj, range):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "range", (obj.start, obj.stop, obj.step)),
             ),
         )
     elif isinstance(obj, re.Pattern):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -333,6 +333,22 @@ def test_serde_jsonplus_bytes() -> None:
     assert serde.loads_typed(dumped) == some_bytes
 
 
+def test_serde_jsonplus_purepath_and_range() -> None:
+    serde = JsonPlusSerializer()
+
+    values: list[object] = [
+        pathlib.PurePosixPath("/foo/bar"),
+        pathlib.PureWindowsPath("C:/x/y"),
+        pathlib.Path("foo", "bar"),
+        range(0, 10, 2),
+        range(5),
+    ]
+    for value in values:
+        revived = serde.loads_typed(serde.dumps_typed(value))
+        assert revived == value
+        assert type(revived) is type(value)
+
+
 def test_lc2_json_safe_type_revives_without_allowlist() -> None:
     """Old 'json' blobs with lc=2 for safe types must revive without an explicit allowlist.
 


### PR DESCRIPTION
`JsonPlusSerializer` raised on `pathlib.PurePath` values and on `range`:

```python
s = JsonPlusSerializer()
s.dumps_typed(pathlib.PurePosixPath("/foo/bar"))  # unsupported
s.dumps_typed(range(0, 10, 2))                     # unsupported
```

The encoder only matched `pathlib.Path`, but a `PurePosixPath`/`PureWindowsPath`
is a `PurePath` and not a `Path`, so those instances fell through; `range` had no
handler at all.

Matching `pathlib.PurePath` covers the pure variants and the concrete `Path`
subclasses (all reconstruct from their `parts`), and `range` is encoded from its
`start`/`stop`/`step`. Both new names are added to `SAFE_MSGPACK_TYPES` so they
round-trip under strict deserialization too.

Added a round-trip test; the checkpoint serde suite passes and `ruff` is clean.

Closes #8350
Closes #8326
