### PR TITLE
fix(langgraph): infer edges from a Command goto typed as a Union of Literals

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -836,14 +836,25 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                                 rtn_origin = arg_origin
                                 break
 
-                    # Check if it's a Command type
-                    if (
-                        rtn_origin is Command
-                        and (rargs := get_args(rtn))
-                        and get_origin(rargs[0]) is Literal
-                        and (vals := get_args(rargs[0]))
-                    ):
-                        ends = vals
+                    # Check if it's a Command type. Its goto annotation may be a
+                    # Literal or a Union of Literals; both describe the same set
+                    # of destinations, e.g. Literal["a"] | Literal["b"] is
+                    # equivalent to Literal["a", "b"].
+                    if rtn_origin is Command and (rargs := get_args(rtn)):
+                        goto = rargs[0]
+                        goto_origin = get_origin(goto)
+                        if goto_origin is Literal:
+                            if vals := get_args(goto):
+                                ends = vals
+                        elif goto_origin is Union:
+                            vals = tuple(
+                                v
+                                for member in get_args(goto)
+                                if get_origin(member) is Literal
+                                for v in get_args(member)
+                            )
+                            if vals:
+                                ends = vals
         except (NameError, TypeError, StopIteration):
             pass
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5128,6 +5128,34 @@ def test_command_pydantic_dataclass() -> None:
         assert graph.invoke(State(foo="")) == {"foo": "foobar"}
 
 
+def test_command_union_of_literals_draws_edges() -> None:
+    """A Command goto annotated as a Union of Literals should infer the same
+    edges as a single Literal with all the constants."""
+
+    class State(TypedDict):
+        foo: str
+
+    A = Literal["a"]
+    B = Literal["b"]
+
+    def router(state: State) -> Command[A | B]:
+        return Command(goto="a")
+
+    def a(state: State) -> None: ...
+
+    def b(state: State) -> None: ...
+
+    builder = StateGraph(State)
+    builder.add_edge(START, "router")
+    builder.add_node("router", router)
+    builder.add_node("a", a)
+    builder.add_node("b", b)
+    mermaid = builder.compile().get_graph().draw_mermaid()
+
+    assert "router -.-> a;" in mermaid
+    assert "router -.-> b;" in mermaid
+
+
 def test_command_with_static_breakpoints(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
A node returning `Command[Literal["a"] | Literal["b"]]` produced no conditional
edges (so `draw_mermaid` omitted them), while the equivalent
`Command[Literal["a", "b"]]` worked:

```python
def router(state) -> Command[BILLING | TECH_SUPPORT]:  # each a Literal
    ...
```

Edge inference only matched `get_origin(goto) is Literal`. A union of Literals
has origin `Union`, so it fell through. A union of Literals describes the same
set of destinations as a single Literal with all the constants, so this flattens
the Literal members of a `Union` goto annotation into the destinations.

The single-`Literal` case is unchanged. Added a test asserting both edges are
drawn for a `Union`-of-`Literal` `Command` node; `ruff` is clean.

Closes #8369