### PR TITLE
fix(checkpoint): serialize fractions.Fraction and complex in JsonPlusSerializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -30,6 +30,8 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("uuid", "UUID"),
         # numeric
         ("decimal", "Decimal"),
+        ("fractions", "Fraction"),
+        ("builtins", "complex"),
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import decimal
+import fractions
 import importlib
 import json
 import logging
@@ -376,6 +377,20 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             EXT_CONSTRUCTOR_SINGLE_ARG,
             _msgpack_enc(
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
+    elif isinstance(obj, fractions.Fraction):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
+            ),
+        )
+    elif isinstance(obj, complex):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                ("builtins", "complex", (obj.real, obj.imag)),
             ),
         )
     elif isinstance(obj, (set, frozenset, deque)):

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -333,6 +333,23 @@ def test_serde_jsonplus_bytes() -> None:
     assert serde.loads_typed(dumped) == some_bytes
 
 
+def test_serde_jsonplus_fraction_and_complex() -> None:
+    import fractions
+
+    serde = JsonPlusSerializer()
+
+    values: list[object] = [
+        fractions.Fraction(3, 4),
+        fractions.Fraction(-7, 2),
+        complex(1, 2),
+        complex(-3.5, 0),
+    ]
+    for value in values:
+        revived = serde.loads_typed(serde.dumps_typed(value))
+        assert revived == value
+        assert type(revived) is type(value)
+
+
 def test_lc2_json_safe_type_revives_without_allowlist() -> None:
     """Old 'json' blobs with lc=2 for safe types must revive without an explicit allowlist.
 


### PR DESCRIPTION
`JsonPlusSerializer` supports `decimal.Decimal` but raised on `fractions.Fraction`
and `complex`:

```python
s = JsonPlusSerializer()
s.dumps_typed(fractions.Fraction(3, 4))  # unsupported
s.dumps_typed(complex(1, 2))             # unsupported
```

Neither had an encoder branch. `Fraction` is encoded from its `str()` and rebuilt
by its constructor (mirroring `Decimal`); `complex` is encoded from its `real`
and `imag` parts. Both names are added to `SAFE_MSGPACK_TYPES` so they round-trip
under strict deserialization too.

Added a round-trip test; the checkpoint serde suite passes and `ruff` is clean.

Closes #8185