### PR TITLE
fix(checkpoint-postgres): don't cache a None walk cursor before the target checkpoint is loaded

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -389,8 +389,15 @@ class BasePostgresSaver(BaseCheckpointSaver[str]):
         for i, ch in enumerate(channels):
             if ch in seeded:
                 continue
-            # First-time entry: cursor starts at the target's parent.
+            # First-time entry: cursor starts at the target's parent. If
+            # `target_id` itself hasn't been paged in yet, `parent_of` can't
+            # tell us its real parent — leave this channel uninitialized
+            # (skip it this round) rather than caching a `None` cursor that
+            # would be indistinguishable from "target has no parent" and
+            # would never be revisited on a later page.
             if ch not in walk_cursor_by_ch:
+                if target_id not in parent_of:
+                    continue
                 walk_cursor_by_ch[ch] = parent_of.get(target_id)
             cur_cid = walk_cursor_by_ch[ch]
             ch_chain = chain_by_ch[ch]

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -415,3 +415,75 @@ async def test_delta_channel_chain_reconstruction(saver_name: str) -> None:
         assert msgs[1].content == "reply-1"
         assert msgs[2].content == "there"
         assert msgs[3].content == "reply-3"
+
+
+@pytest.mark.parametrize("saver_name", ["base", "pool", "pipe"])
+async def test_delta_channel_history_across_pagination_pages(
+    monkeypatch, saver_name: str
+) -> None:
+    """Regression test: `get_delta_channel_history`'s stage-1 walk must find
+    a channel's seed even when the target checkpoint isn't loaded within the
+    first pagination page.
+
+    Previously, the walk cursor for a not-yet-loaded target was cached as
+    `None` (indistinguishable from "target has no parent") and never
+    revisited once the target's real row arrived on a later page, so the
+    channel silently hydrated as empty. Shrinking `_DELTA_PAGE_SIZE` to 1
+    forces multiple pagination pages without needing 1000+ real checkpoints.
+    """
+    pytest.importorskip(
+        "langgraph.channels.delta", reason="langgraph core not installed"
+    )
+
+    from typing import Annotated
+
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langgraph.channels.delta import DeltaChannel
+    from langgraph.graph import START, StateGraph
+    from langgraph.graph.message import _messages_delta_reducer
+    from typing_extensions import TypedDict
+
+    class State(TypedDict):
+        messages: Annotated[list, DeltaChannel(_messages_delta_reducer)]
+
+    def respond(state: State) -> dict:
+        n = len(state["messages"])
+        return {"messages": [AIMessage(content=f"reply-{n}", id=f"ai-{n}")]}
+
+    builder = StateGraph(State)
+    builder.add_node("respond", respond)
+    builder.add_edge(START, "respond")
+
+    async with _saver(saver_name) as saver:
+        graph = builder.compile(checkpointer=saver)
+        config = {"configurable": {"thread_id": "diff-channel-pagination-test-1"}}
+
+        checkpoint_ids: list[str] = []
+        for i in range(6):
+            await graph.ainvoke(
+                {"messages": [HumanMessage(content=f"msg-{i}", id=f"h{i}")]}, config
+            )
+            state = await graph.aget_state(config)
+            checkpoint_ids.append(state.config["configurable"]["checkpoint_id"])
+
+        # Ground truth: hydrate every checkpoint with the real (large) page
+        # size, where the target row is always within the first page.
+        expected_by_id: dict[str, list[str]] = {}
+        for cid in checkpoint_ids:
+            s = await graph.aget_state(
+                {"configurable": {**config["configurable"], "checkpoint_id": cid}}
+            )
+            expected_by_id[cid] = [m.content for m in s.values["messages"]]
+
+        # Force multiple stage-1 pagination pages, then re-hydrate an older
+        # checkpoint that won't be present in the first (size-1) page.
+        monkeypatch.setattr("langgraph.checkpoint.postgres.aio._DELTA_PAGE_SIZE", 1)
+        old_cid = checkpoint_ids[1]
+        s = await graph.aget_state(
+            {"configurable": {**config["configurable"], "checkpoint_id": old_cid}}
+        )
+        actual = [m.content for m in s.values["messages"]]
+        assert actual == expected_by_id[old_cid], (
+            f"expected {expected_by_id[old_cid]}, got {actual}"
+        )
+        assert len(actual) > 0


### PR DESCRIPTION
Fixes #8448.

### Bug

`BasePostgresSaver._try_advance_walks` initializes a `DeltaChannel`'s walk cursor exactly once, from `parent_of.get(target_id)`, guarded by `if ch not in walk_cursor_by_ch`. `get_delta_channel_history` pages the `checkpoints` table newest-first in chunks of `_DELTA_PAGE_SIZE` (1024), so on the first page `parent_of` only contains the newest 1024 rows.

If the target checkpoint (the one being hydrated — can be any checkpoint in the thread's history, not just the latest) isn't within that first page, `parent_of.get(target_id)` returns `None`, and the code caches `walk_cursor_by_ch[ch] = None` as if the target had no parent. On every later page the guard is now `False` (the key already exists), so the cursor is never re-derived once the target's real row — and real parent — actually loads. The walk stays stuck at `None`, the channel is never seeded, and `get_delta_channel_history` silently returns `{"writes": []}` with no `"seed"` for that channel.

Downstream, this means `get_state`/`update_state`/`get_state_history` against an older checkpoint hydrate a `DeltaChannel` (e.g. `messages`) as empty, even though the thread has real accumulated history — no exception, just silent data loss.

### Fix

Only derive the walk cursor once `target_id` has actually been observed in `parent_of`; otherwise leave the channel uninitialized for this page and retry once more of the chain has loaded:

```python
if ch not in walk_cursor_by_ch:
    if target_id not in parent_of:
        continue
    walk_cursor_by_ch[ch] = parent_of.get(target_id)
```

This affects both `PostgresSaver` and `AsyncPostgresSaver`, since both call the same shared static method on `BasePostgresSaver`.

### Test plan

- Added `test_delta_channel_history_across_pagination_pages` in `libs/checkpoint-postgres/tests/test_async.py`. It shrinks `_DELTA_PAGE_SIZE` to 1 (via monkeypatch) to force multiple pagination pages without needing 1000+ real checkpoints, then hydrates an older checkpoint and compares against ground truth computed with the real (large) page size.
- Verified the new test fails on the pre-fix code (`got []` instead of the real message history) and passes after the fix.
- `make format`, `make lint`, and the full `libs/checkpoint-postgres` test suite (both Postgres 15 and 16) pass.
