### PR TITLE
fix(langgraph): suppress handled concurrent errors on executor exit

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import time
+import weakref
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, ExitStack
 from contextvars import copy_context
 from types import TracebackType
 from typing import (
+    Any,
     Protocol,
     TypeVar,
     cast,
@@ -22,6 +24,10 @@ from langgraph.errors import GraphBubbleUp
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+SKIP_RERAISE_SET: weakref.WeakSet[
+    concurrent.futures.Future[Any] | asyncio.Future[Any]
+] = weakref.WeakSet()
 
 
 class Submit(Protocol[P, T]):
@@ -111,7 +117,7 @@ class BackgroundExecutor(AbstractContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     task.result()
@@ -202,7 +208,7 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     if exc := task.exception():

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -43,7 +43,7 @@ from langgraph._internal._typing import MISSING
 from langgraph.constants import TAG_HIDDEN
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
 from langgraph.pregel._algo import Call
-from langgraph.pregel._executor import Submit
+from langgraph.pregel._executor import SKIP_RERAISE_SET, Submit
 from langgraph.pregel._retry import arun_with_retry, run_with_retry
 from langgraph.types import (
     CachePolicy,
@@ -65,10 +65,6 @@ EXCLUDED_FRAME_FNAMES = (
     "langchain_core/runnables/config.py",
     "concurrent/futures/thread.py",
     "concurrent/futures/_base.py",
-)
-
-SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
-    weakref.WeakSet()
 )
 
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9649,6 +9649,33 @@ async def test_graph_error_handler_async_runtime_info() -> None:
     assert isinstance(captured["from_node_error"], BaseException)
 
 
+async def test_graph_error_handler_handles_failure_concurrent() -> None:
+    class State(TypedDict):
+        results: Annotated[list[str], operator.add]
+
+    async def failing_node(state: State) -> State:
+        raise RuntimeError("boom")
+
+    async def sibling_node(state: State) -> State:
+        return {"results": ["sibling"]}
+
+    async def err_handler(state: State) -> State:
+        return {"results": ["handled"]}
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing", failing_node, error_handler=err_handler)
+        .add_node("sibling", sibling_node)
+        .add_edge(START, "failing")
+        .add_edge(START, "sibling")
+        .compile()
+    )
+
+    result = await graph.ainvoke({"results": []})
+
+    assert set(result["results"]) == {"handled", "sibling"}
+
+
 @NEEDS_CONTEXTVARS
 async def test_graph_error_handler_does_not_swallow_interrupt_concurrent() -> None:
     """When a graph error handler is configured and a node calls interrupt()

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2194,6 +2194,33 @@ def test_graph_error_handler_error_context_survives_checkpoint_resume():
     assert isinstance(captured["from_node_error"], BaseException)
 
 
+def test_graph_error_handler_handles_failure_concurrent():
+    class State(TypedDict):
+        results: Annotated[list[str], operator.add]
+
+    def failing_node(state: State) -> State:
+        raise RuntimeError("boom")
+
+    def sibling_node(state: State) -> State:
+        return {"results": ["sibling"]}
+
+    def err_handler(state: State) -> State:
+        return {"results": ["handled"]}
+
+    graph = (
+        StateGraph(State)
+        .add_node("failing", failing_node, error_handler=err_handler)
+        .add_node("sibling", sibling_node)
+        .add_edge(START, "failing")
+        .add_edge(START, "sibling")
+        .compile()
+    )
+
+    result = graph.invoke({"results": []})
+
+    assert set(result["results"]) == {"handled", "sibling"}
+
+
 def test_graph_error_handler_does_not_swallow_interrupt_concurrent():
     """When a graph error handler is configured and a node calls interrupt()
     concurrently with other nodes, the interrupt must still be raised — not


### PR DESCRIPTION
## Summary

When multiple graph nodes run in the same superstep, a node-level `error_handler` can handle one node's exception while a sibling continues successfully. The runner already marks the handled future so it is excluded from panic handling, but the background executor still re-raised that future during context-manager shutdown.

This change shares the runner's handled-future suppression set with both sync and async background executors, so handled exceptions are not raised a second time on exit. Unhandled exceptions and control-flow signals keep their existing behavior.

## Tests

- Added synchronous concurrent error-handler regression coverage.
- Added asynchronous concurrent error-handler regression coverage.
- `NO_DOCKER=true make format`
- `NO_DOCKER=true make lint`
- `NO_DOCKER=true make test` — 1970 passed, 4 skipped.
