### PR TITLE
ci: preserve dependency bounds in Dependabot uv updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -284,3 +284,20 @@ updates:
           - "*"
         update-types:
           - "major"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/libs/sdk-py/integration"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,16 @@ updates:
     directory: "/libs/checkpoint"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -38,6 +48,16 @@ updates:
     directory: "/libs/checkpoint-conformance"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -55,6 +75,16 @@ updates:
     directory: "/libs/checkpoint-postgres"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -72,6 +102,16 @@ updates:
     directory: "/libs/checkpoint-sqlite"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -89,6 +129,16 @@ updates:
     directory: "/libs/cli"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -106,6 +156,16 @@ updates:
     directory: "/libs/langgraph"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -123,6 +183,16 @@ updates:
     directory: "/libs/prebuilt"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:
@@ -140,6 +210,16 @@ updates:
     directory: "/libs/sdk-py"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langgraph"
+      - dependency-name: "langgraph-cli"
+      - dependency-name: "langgraph-sdk"
+      - dependency-name: "langgraph-prebuilt"
+      - dependency-name: "langgraph-checkpoint"
+      - dependency-name: "langgraph-checkpoint-postgres"
+      - dependency-name: "langgraph-checkpoint-sqlite"
+      - dependency-name: "langgraph-checkpoint-conformance"
     groups:
       minor-and-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -266,3 +266,21 @@ updates:
           - "*"
         update-types:
           - "major"
+
+  # CI builds this maintained integration image and Compose stack.
+  - package-ecosystem: "docker"
+    directory: "/libs/sdk-py/integration"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary

- Configure each maintained `uv` Dependabot root to increase compatible manifest bounds while updating lockfiles.
- Ignore coordinated same-repository `langgraph*` packages so Dependabot does not separate their release updates.
- Add Docker and Docker Compose coverage for the maintained `libs/sdk-py/integration` image and Compose stack exercised by CI.
- Keep the existing dependency roots, monthly schedule, and update groups unchanged.

## Test Plan

- [x] Parse `.github/dependabot.yml` with Ruby YAML.
- [x] Run `git diff --check`.
- [x] Inspect the diff to confirm it only changes `.github/dependabot.yml`.

Made by [Open SWE](https://openswe.vercel.app/agents/07e36bb8-9f01-5052-a372-62c956123951)
