### PR TITLE
fix: synchronize pipeline before reading results in setup() (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -96,6 +96,9 @@ class AsyncPostgresSaver(BasePostgresSaver):
         """
         async with self._cursor() as cur:
             await cur.execute(self.MIGRATIONS[0])
+            # If using pipeline, sync to ensure results are available
+            if self.pipe:
+                await self.pipe.sync()
             results = await cur.execute(
                 "SELECT v FROM checkpoint_migrations ORDER BY v DESC LIMIT 1"
             )


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver` with `pipeline=True`, the `setup()` method fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This happens because within an `AsyncPipeline`, commands are queued and not immediately sent to the server. When setup tries to fetch results (e.g., `await cur.execute(...)` followed by `fetchone()`), the pipeline may not have flushed, leading to race conditions and SSL disconnections.

## Fix
Added a call to `await self.pipe.sync()` after executing the first migration in `setup()` when a pipeline is active. This ensures that the migration is fully applied before attempting to read the checkpoint_migrations version. The sync flushes the pipeline and blocks until the server confirms completion, preventing the SSL error.

Closes #5675