### PR TITLE
fix(docs): add redirect for JavaScript LangGraph reference

### DIFF
--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -273,6 +273,7 @@
   "/how-tos/persistence-functional": "https://docs.langchain.com/oss/python/langgraph/add-memory",
   "/how-tos/react-agent-from-scratch-functional": "https://docs.langchain.com/oss/python/langgraph/workflows-agents",
   "/reference": "https://reference.langchain.com/python/langgraph/",
+  "/reference/javascript/langchain-langgraph": "https://langchain-ai.github.io/langgraphjs/reference/index.html",
   "/troubleshooting/errors": "https://docs.langchain.com/oss/python/langgraph/common-errors",
   "/tutorials/chatbot-simulation-evaluation/agent-simulation-evaluation": "https://docs.langchain.com/oss/python/langgraph/overview",
   "/tutorials/chatbot-simulation-evaluation/langsmith-agent-simulation-evaluation": "https://docs.langchain.com/oss/python/langgraph/overview",


### PR DESCRIPTION
Fixes #8456

## Problem
The JavaScript LangGraph API reference page at https://reference.langchain.com/javascript/langchain-langgraph returns a 404 error. This occurs when users navigate to the LangChain Reference website, select JavaScript, and try to access the LangGraph documentation.

## Root Cause
The redirects configuration in docs/redirects.json was missing an entry for the JavaScript LangGraph reference path. While Python LangGraph references were properly configured, the JavaScript equivalent was not.

## Solution
Added a redirect entry in docs/redirects.json to map:
- From: /reference/javascript/langchain-langgraph
- To: https://langchain-ai.github.io/langgraphjs/reference/index.html

This ensures users are properly redirected to the correct JavaScript LangGraph API documentation hosted on the langgraphjs GitHub Pages site.

## Changes
- Modified: docs/redirects.json (added 1 redirect entry)

## Verification
The redirect follows the existing pattern used for other reference redirects in the file and points to the official LangGraph.js documentation site as confirmed by web search.

## Impact
- No breaking changes
- No dependencies modified
- Fixes broken documentation link for JavaScript developers
- Improves developer experience for LangGraph.js users