### PR TITLE
release(langgraph): 1.2.10

### DIFF
--- a/libs/langgraph/pyproject.toml
+++ b/libs/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph"
-version = "1.2.9"
+version = "1.2.10"
 description = "Building stateful, multi-actor applications with LLMs"
 authors = []
 requires-python = ">=3.10"

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.9"
+version = "1.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.9"
+version = "1.2.10"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.9"
+version = "1.2.10"
 source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## Summary

Releases `langgraph` 1.2.10.

Bumps the package version `1.2.9` -> `1.2.10` and propagates it into the `langgraph`, `prebuilt`, and `sdk-py` lockfiles. No dependency floor or source changes.

Picks up the changes landed since 1.2.9: #8389 (typed v3 `stream_events` return and native projections), #8362 (`trace_policy` on `add_node`), #8402 and #8403 (`TracePolicy` tag drop, then revert).

## Changes

- Update `libs/langgraph/pyproject.toml` to version `1.2.10`.
- Update the editable `langgraph` package entries in `libs/langgraph/uv.lock`, `libs/prebuilt/uv.lock`, and `libs/sdk-py/uv.lock`.
