### PR TITLE
fix(checkpoint): restore tuple members when deserializing set/frozenset

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -534,6 +534,19 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         raise TypeError(f"Object of type {obj.__class__.__name__} is not serializable")
 
 
+def _restore_hashable(obj: Any) -> Any:
+    """Recursively convert decoded lists back into tuples.
+
+    msgpack has no tuple type, so tuples are encoded as arrays and decode as
+    lists. Members of a `set` / `frozenset` must be hashable, so their list
+    members (which were originally tuples) are restored to tuples here before
+    the container is reconstructed.
+    """
+    if isinstance(obj, list):
+        return tuple(_restore_hashable(el) for el in obj)
+    return obj
+
+
 def _send_from_args(args: Sequence[Any]) -> Any:
     # ya we have a cyclic import here ¯\_(ツ)_/¯
     from langgraph.types import Send  # type: ignore
@@ -648,7 +661,13 @@ def _create_msgpack_ext_hook(
                     # it would be validated upon construction.
                     return tup[2]
                 # module, name, arg
-                return getattr(importlib.import_module(tup[0]), tup[1])(tup[2])
+                cls = getattr(importlib.import_module(tup[0]), tup[1])
+                arg = tup[2]
+                if isinstance(cls, type) and issubclass(cls, (set, frozenset)):
+                    # set/frozenset members must be hashable; tuples decode as
+                    # (unhashable) lists, so restore them before reconstructing.
+                    arg = [_restore_hashable(el) for el in arg]
+                return cls(arg)
             except Exception:
                 return None
         elif code == EXT_CONSTRUCTOR_POS_ARGS:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -205,6 +205,25 @@ def test_serde_jsonplus() -> None:
     assert serde.loads_typed(serde.dumps_typed(surrogates)) == surrogates
 
 
+def test_serde_jsonplus_set_of_tuples() -> None:
+    """Sets and frozensets containing tuples must round-trip.
+
+    msgpack has no tuple type, so tuple members decode as lists, which are
+    unhashable. Without special handling, reconstructing the set raises and the
+    value is silently lost. See regression for the ``{(1, 2), (3, 4)}`` case.
+    """
+    serde = JsonPlusSerializer()
+    values: list[set | frozenset] = [
+        {(1, 2), (3, 4)},
+        frozenset({(1, 2), (3, 4)}),
+        {(1, (2, 3))},  # nested tuples
+        {("a", "b"), ("c",)},  # tuples of strings
+        {1, (2, 3), "x"},  # mixed hashable members
+    ]
+    for value in values:
+        assert serde.loads_typed(serde.dumps_typed(value)) == value
+
+
 def test_serde_jsonplus_json_mode() -> None:
     uid = uuid.UUID(int=1)
     deque_instance = deque([1, 2, 3])


### PR DESCRIPTION
Fixes #8388

A `set`/`frozenset` whose members are tuples silently deserialized to `None` through `JsonPlusSerializer`: msgpack decodes the tuple members as lists, which are unhashable, so reconstructing the set raised a `TypeError` that got swallowed by the ext hook's blanket `except`. This restores tuple members before rebuilding a `set`/`frozenset` so values like `{(1, 2), (3, 4)}` round-trip correctly.

`deque` is intentionally left unchanged, since it accepts list members.

**How verified:** added a regression test in `test_jsonplus.py` (plain, nested, and mixed tuple members); `make format`, `make lint`, and the checkpoint serde/store unit tests pass locally.