### PR TITLE
fix(sdk-py): declare missing parameters on runs @overload stubs

### DIFF
--- a/libs/sdk-py/langgraph_sdk/_async/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_async/runs.py
@@ -99,6 +99,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v1"] = "v1",
     ) -> AsyncIterator[StreamPart]: ...
 
@@ -131,6 +132,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v2"],
     ) -> AsyncIterator[StreamPartV2]: ...
 
@@ -147,6 +149,7 @@ class RunsClient:
         stream_resumable: bool = False,
         metadata: Mapping[str, Any] | None = None,
         config: Config | None = None,
+        context: Context | None = None,
         checkpoint_during: bool | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -160,6 +163,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v1"] = "v1",
     ) -> AsyncIterator[StreamPart]: ...
 
@@ -176,6 +180,7 @@ class RunsClient:
         stream_resumable: bool = False,
         metadata: Mapping[str, Any] | None = None,
         config: Config | None = None,
+        context: Context | None = None,
         checkpoint_during: bool | None = None,
         interrupt_before: All | Sequence[str] | None = None,
         interrupt_after: All | Sequence[str] | None = None,
@@ -189,6 +194,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v2"],
     ) -> AsyncIterator[StreamPartV2]: ...
 
@@ -385,6 +391,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> Run: ...
 
     @overload
@@ -414,6 +421,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> Run: ...
 
     async def create(
@@ -647,6 +655,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     @overload
@@ -673,6 +682,7 @@ class RunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     async def wait(

--- a/libs/sdk-py/langgraph_sdk/_sync/runs.py
+++ b/libs/sdk-py/langgraph_sdk/_sync/runs.py
@@ -80,6 +80,7 @@ class SyncRunsClient:
         command: Command | None = None,
         stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
+        stream_resumable: bool = False,
         metadata: Mapping[str, Any] | None = None,
         config: Config | None = None,
         context: Context | None = None,
@@ -98,6 +99,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v1"] = "v1",
     ) -> Iterator[StreamPart]: ...
 
@@ -111,6 +113,7 @@ class SyncRunsClient:
         command: Command | None = None,
         stream_mode: StreamMode | Sequence[StreamMode] = "values",
         stream_subgraphs: bool = False,
+        stream_resumable: bool = False,
         metadata: Mapping[str, Any] | None = None,
         config: Config | None = None,
         context: Context | None = None,
@@ -129,6 +132,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v2"],
     ) -> Iterator[StreamPartV2]: ...
 
@@ -159,6 +163,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v1"] = "v1",
     ) -> Iterator[StreamPart]: ...
 
@@ -189,6 +194,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
         version: Literal["v2"],
     ) -> Iterator[StreamPartV2]: ...
 
@@ -380,6 +386,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> Run: ...
 
     @overload
@@ -409,6 +416,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> Run: ...
 
     def create(
@@ -642,6 +650,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     @overload
@@ -668,6 +677,7 @@ class SyncRunsClient:
         headers: Mapping[str, str] | None = None,
         params: QueryParamTypes | None = None,
         on_run_created: Callable[[RunCreateMetadata], None] | None = None,
+        durability: Durability | None = None,
     ) -> builtins.list[dict] | dict[str, Any]: ...
 
     def wait(

--- a/libs/sdk-py/tests/test_api_parity.py
+++ b/libs/sdk-py/tests/test_api_parity.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import ast
 import inspect
+import pathlib
 import re
 
 import pytest
 
+import langgraph_sdk
 from langgraph_sdk.client import (
     AssistantsClient,
     CronClient,
@@ -128,3 +131,170 @@ def test_sync_api_matches_async(async_cls, sync_cls):
             f"Return annotation mismatch for {async_cls.__name__}.{name}: "
             f"async={a_ret}, sync={s_ret}"
         )
+
+
+# The tests above compare implementation signatures, which is what
+# `inspect.signature` resolves to. Type checkers never see those: for a method
+# with `@overload` stubs they consider only the stubs, so a parameter missing
+# from the stubs is unusable in typed code even though it works at runtime. The
+# tests below therefore read the stubs themselves.
+#
+# The stubs are parsed with `ast` rather than `typing.get_overloads` because the
+# latter needs Python 3.11 and this package supports 3.10.
+
+_SDK_DIR = pathlib.Path(langgraph_sdk.__file__).parent
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+# Modules under _async/ and _sync/ that declare @overload stubs.
+OVERLOADED_MODULES = ("assistants", "runs", "threads")
+
+# Runs parameters that are deliberately restricted to one `thread_id` variant,
+# and so are legitimately absent from the other variant's stubs.
+# `checkpoint`/`checkpoint_id`/`multitask_strategy` act on a thread the caller
+# supplies, so they cannot apply to a stateless run; `on_completion` decides the
+# fate of the thread the server creates for a stateless run, so it cannot apply
+# when the caller supplies the thread.
+STATEFUL_ONLY_PARAMS = frozenset({"checkpoint", "checkpoint_id", "multitask_strategy"})
+STATELESS_ONLY_PARAMS = frozenset({"on_completion"})
+
+
+def _parse_client_module(kind: str, module: str) -> ast.Module:
+    return ast.parse((_SDK_DIR / kind / f"{module}.py").read_text())
+
+
+def _is_overload(fn: FunctionNode) -> bool:
+    for dec in fn.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "overload":
+            return True
+        if isinstance(dec, ast.Attribute) and dec.attr == "overload":
+            return True
+    return False
+
+
+def _params(fn: FunctionNode) -> set[str]:
+    args = fn.args
+    return {
+        arg.arg
+        for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs)
+        if arg.arg != "self"
+    }
+
+
+def _thread_variant(fn: FunctionNode) -> str:
+    """Report which kind of run a stub describes, per its `thread_id` type."""
+    for arg in (*fn.args.posonlyargs, *fn.args.args):
+        if arg.arg == "thread_id":
+            annotation = arg.annotation
+            if isinstance(annotation, ast.Constant) and annotation.value is None:
+                return "stateless"
+    return "stateful"
+
+
+def _overload_groups(
+    tree: ast.Module,
+) -> dict[tuple[str, str], tuple[list[FunctionNode], FunctionNode]]:
+    """Map (class, method) to its overload stubs and its implementation."""
+    groups: dict[tuple[str, str], tuple[list[FunctionNode], FunctionNode]] = {}
+    for cls in [node for node in tree.body if isinstance(node, ast.ClassDef)]:
+        defs: dict[str, list[FunctionNode]] = {}
+        for fn in cls.body:
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                defs.setdefault(fn.name, []).append(fn)
+        for name, fns in defs.items():
+            stubs = [fn for fn in fns if _is_overload(fn)]
+            impls = [fn for fn in fns if not _is_overload(fn)]
+            if not stubs:
+                continue
+            assert len(impls) == 1, (
+                f"{cls.name}.{name} has {len(impls)} implementations, expected 1"
+            )
+            groups[(cls.name, name)] = (stubs, impls[0])
+    return groups
+
+
+@pytest.mark.parametrize("kind", ["_async", "_sync"])
+@pytest.mark.parametrize("module", OVERLOADED_MODULES)
+def test_overload_stubs_cover_the_implementation(kind: str, module: str) -> None:
+    """Every parameter must be reachable through at least one stub."""
+    groups = _overload_groups(_parse_client_module(kind, module))
+    assert groups, f"no overloaded methods found in {kind}/{module}.py"
+
+    for (cls_name, method), (stubs, impl) in groups.items():
+        impl_params = _params(impl)
+        declared: set[str] = set()
+        for stub in stubs:
+            stub_params = _params(stub)
+            assert stub_params <= impl_params, (
+                f"{cls_name}.{method} has an @overload stub declaring parameters "
+                f"the implementation does not accept: "
+                f"{sorted(stub_params - impl_params)}"
+            )
+            declared |= stub_params
+        assert declared == impl_params, (
+            f"{cls_name}.{method} accepts parameters that no @overload stub "
+            f"declares, so type checkers reject them even though they work at "
+            f"runtime: {sorted(impl_params - declared)}"
+        )
+
+
+@pytest.mark.parametrize("module", OVERLOADED_MODULES)
+def test_overload_stubs_match_between_sync_and_async(module: str) -> None:
+    """The hand-maintained sync stubs must mirror the async ones."""
+    async_groups = _overload_groups(_parse_client_module("_async", module))
+    sync_groups = _overload_groups(_parse_client_module("_sync", module))
+
+    def keyed(groups: dict) -> dict:
+        return {
+            (cls_name.removeprefix("Sync"), method): value
+            for (cls_name, method), value in groups.items()
+        }
+
+    async_by_key = keyed(async_groups)
+    sync_by_key = keyed(sync_groups)
+    assert async_by_key.keys() == sync_by_key.keys(), (
+        f"Overloaded methods differ in {module}.py: "
+        f"async-only={sorted(async_by_key.keys() - sync_by_key.keys())}, "
+        f"sync-only={sorted(sync_by_key.keys() - async_by_key.keys())}"
+    )
+
+    for (cls_name, method), (async_stubs, _) in async_by_key.items():
+        sync_stubs, _ = sync_by_key[(cls_name, method)]
+        assert len(async_stubs) == len(sync_stubs), (
+            f"{cls_name}.{method} has {len(async_stubs)} async stubs but "
+            f"{len(sync_stubs)} sync stubs"
+        )
+        paired = zip(async_stubs, sync_stubs, strict=True)
+        for index, (async_stub, sync_stub) in enumerate(paired):
+            async_params = _params(async_stub)
+            sync_params = _params(sync_stub)
+            assert async_params == sync_params, (
+                f"Overload {index} of {cls_name}.{method} differs between the "
+                f"async and sync clients: "
+                f"async-only={sorted(async_params - sync_params)}, "
+                f"sync-only={sorted(sync_params - async_params)}"
+            )
+
+
+@pytest.mark.parametrize("kind", ["_async", "_sync"])
+def test_runs_overload_stubs_match_their_thread_variant(kind: str) -> None:
+    """Each runs stub must declare exactly what its `thread_id` variant allows."""
+    groups = _overload_groups(_parse_client_module(kind, "runs"))
+
+    for (cls_name, method), (stubs, impl) in groups.items():
+        impl_params = _params(impl)
+        for stub in stubs:
+            variant = _thread_variant(stub)
+            omitted = (
+                STATEFUL_ONLY_PARAMS
+                if variant == "stateless"
+                else STATELESS_ONLY_PARAMS
+            )
+            expected = impl_params - omitted
+            actual = _params(stub)
+            assert actual == expected, (
+                f"The {variant} @overload stub for {cls_name}.{method} has "
+                f"drifted from the implementation: "
+                f"missing={sorted(expected - actual)}, "
+                f"unexpected={sorted(actual - expected)}"
+            )


### PR DESCRIPTION
Closes #8442

## Problem

`RunsClient` and `SyncRunsClient` declare `stream`, `create` and `wait` with `@overload`.
A type checker resolves calls against the stubs only and never sees the implementation signature, so any parameter the implementation accepts but the stubs omit is rejected in typed code even though it works at runtime.

Three gaps had accumulated:

| Parameter | Missing from |
| --- | --- |
| `durability` | all 16 stubs, in both clients, across all three methods |
| `stream_resumable` | the sync stateful `stream` stubs (present in the async ones) |
| `context` | the async stateless `stream` stubs (present in the sync ones) |

`durability` is the most user-visible of the three: the implementations accept it, document it, and warn that `checkpoint_during` is deprecated in its favour, so the SDK steers users toward a parameter its own stubs reject.

The other two point in opposite directions, which is what identifies this as drift between two hand-maintained files rather than intentional divergence.

## Why CI did not catch it

`tests/test_api_parity.py` does guard sync/async parity, but it reads `inspect.signature`, which resolves to the implementation and is structurally blind to the stubs.
`make lint` runs `ty`, which does not currently flag unknown keyword arguments.
pyright, which most users get through Pylance, flags every case.

## Fix

Added the missing parameters to the affected stubs, copying each declaration from the implementation and keeping it in the same position.
Deliberate omissions are untouched: stateless stubs still exclude `checkpoint`/`checkpoint_id`/`multitask_strategy`, and stateful stubs still exclude `on_completion`.

Added three checks over the stubs themselves, parsed with `ast` because `typing.get_overloads` needs Python 3.11 and this package supports 3.10:

- `test_overload_stubs_cover_the_implementation`: every implementation parameter is reachable through at least one stub, and no stub invents one.
- `test_overload_stubs_match_between_sync_and_async`: the hand-maintained sync stubs mirror the async ones, stub for stub.
- `test_runs_overload_stubs_match_their_thread_variant`: each runs stub declares exactly what its `thread_id` variant allows, per two documented constants.

All three fail on the current stubs and pass after the fix.
They also cover `assistants.py` and `threads.py`, which are clean today.

## One note on the reported repro

Four of the five errors in the issue are genuine and are fixed here.
The fifth looks like a false positive but is not:

```python
await ac.runs.wait("thread", "asst", on_completion="delete")
```

`on_completion` decides the fate of the thread the server creates for a stateless run, so it is meaningless when the caller supplies `thread_id`.
It appears in all six stateless stubs and in none of the six stateful ones, consistently across both clients, so that omission is a deliberate invariant rather than drift, and the issue text itself lists it as correct.
pyright is right to reject that call, so this PR leaves it rejected, and `test_runs_overload_stubs_match_their_thread_variant` now locks the invariant in so it cannot be "fixed" by accident later.

## Verification

- The issue's `repro.py` under pyright 1.1.411: 5 errors before, 1 after, that one being the `on_completion` call above.
- No new pyright diagnostics in the two modified modules (18 pre-existing, unchanged).
- Each of the three new tests confirmed to fail on the unfixed stubs, naming the exact missing parameters.
- `make format`, `make lint` and `make test` clean in `libs/sdk-py` (504 passed).

Thanks to @anuragpaul602-netizen for the report, which pinpointed all three gaps and the reason CI missed them.
They mentioned in the issue that they have a fix ready as well, so please take whichever is more useful.
