### PR TITLE
fix(langgraph): hydrate DeltaChannels when reading a subgraph's state

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1148,6 +1148,7 @@ class Pregel(
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
+        saver: BaseCheckpointSaver | None = None,
     ) -> StateSnapshot:
         if not saved:
             return StateSnapshot(
@@ -1169,7 +1170,14 @@ class Pregel(
         channels, managed = channels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
+            # A subgraph from `get_subgraphs()` was compiled WITHOUT a
+            # checkpointer — the caller resolved one from
+            # `CONFIG_KEY_CHECKPOINTER` and passes it here. Without it,
+            # `DeltaChannel`s have no saver to replay their ancestor writes
+            # and hydrate EMPTY, silently.
+            saver=saver
+            if isinstance(saver, BaseCheckpointSaver)
+            else self.checkpointer
             if isinstance(self.checkpointer, BaseCheckpointSaver)
             else None,
             config=saved.config,
@@ -1271,6 +1279,7 @@ class Pregel(
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
+        saver: BaseCheckpointSaver | None = None,
     ) -> StateSnapshot:
         if not saved:
             return StateSnapshot(
@@ -1292,7 +1301,14 @@ class Pregel(
         channels, managed = await achannels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
+            # A subgraph from `get_subgraphs()` was compiled WITHOUT a
+            # checkpointer — the caller resolved one from
+            # `CONFIG_KEY_CHECKPOINTER` and passes it here. Without it,
+            # `DeltaChannel`s have no saver to replay their ancestor writes
+            # and hydrate EMPTY, silently.
+            saver=saver
+            if isinstance(saver, BaseCheckpointSaver)
+            else self.checkpointer
             if isinstance(self.checkpointer, BaseCheckpointSaver)
             else None,
             config=saved.config,
@@ -1431,6 +1447,7 @@ class Pregel(
             saved,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
+            saver=checkpointer,
         )
 
     async def aget_state(
@@ -1475,6 +1492,7 @@ class Pregel(
             saved,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
+            saver=checkpointer,
         )
 
     def get_state_history(
@@ -1527,7 +1545,7 @@ class Pregel(
             checkpointer.list(config, before=before, limit=limit, filter=filter)
         ):
             yield self._prepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     async def aget_state_history(
@@ -1584,7 +1602,7 @@ class Pregel(
             )
         ]:
             yield await self._aprepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     def bulk_update_state(

--- a/libs/langgraph/tests/test_delta_channel_subgraph_read.py
+++ b/libs/langgraph/tests/test_delta_channel_subgraph_read.py
@@ -1,0 +1,132 @@
+"""Reading a nested subgraph's state must hydrate its `DeltaChannel`s.
+
+A subgraph obtained through `get_subgraphs()` was compiled WITHOUT a
+checkpointer — the parent supplies one via `CONFIG_KEY_CHECKPOINTER` when
+reading. `_prepare_state_snapshot` used to hydrate channels with
+`self.checkpointer` only, so for a nested subgraph the saver was `None`.
+
+`channels_from_checkpoint` needs that saver to replay a `DeltaChannel`'s
+ancestor writes; without it the channel falls through to
+`from_checkpoint(MISSING)` and hydrates EMPTY. No error is raised, so a caller
+reading a subgraph's history simply sees an empty channel and cannot tell it
+from a subgraph that genuinely never wrote one.
+
+Regular (non-delta) channels are unaffected, which is what makes the bug easy to
+miss: only reducer channels stored as deltas — `messages` on any agent that
+opts into delta storage — come back empty.
+"""
+
+from typing import Annotated, Any
+
+import pytest
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from typing_extensions import TypedDict
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import _messages_delta_reducer
+
+pytestmark = pytest.mark.anyio
+
+
+class ChildState(TypedDict, total=False):
+    messages: Annotated[list[AnyMessage], DeltaChannel(_messages_delta_reducer)]
+    plain: str
+
+
+class ParentState(TypedDict, total=False):
+    messages: Annotated[list[AnyMessage], DeltaChannel(_messages_delta_reducer)]
+    plain: str
+    done: bool
+
+
+def _build() -> Any:
+    """Parent graph with one compiled subgraph node writing across two supersteps."""
+    child = StateGraph(ChildState)
+    child.add_node("first", lambda s: {"messages": [HumanMessage("one")], "plain": "p"})
+    child.add_node("second", lambda s: {"messages": [AIMessage("two")]})
+    child.add_edge(START, "first")
+    child.add_edge("first", "second")
+    child.add_edge("second", END)
+
+    parent = StateGraph(ParentState)
+    parent.add_node("child", child.compile())
+    parent.add_node("finish", lambda s: {"done": True})
+    parent.add_edge(START, "child")
+    parent.add_edge("child", "finish")
+    parent.add_edge("finish", END)
+    return parent
+
+
+def _child_namespace(app: Any, config: dict) -> str:
+    """The child's `checkpoint_ns`, discovered the way a client would."""
+    for snapshot in app.get_state_history(config):
+        for task in snapshot.tasks:
+            if task.name == "child" and isinstance(task.state, dict):
+                return task.state["configurable"]["checkpoint_ns"]
+    raise AssertionError("child namespace not found in the parent's tasks")
+
+
+def test_subgraph_history_hydrates_delta_channel() -> None:
+    app = _build().compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    child_ns = _child_namespace(app, config)
+    child_config = {"configurable": {"thread_id": "1", "checkpoint_ns": child_ns}}
+
+    best: list[AnyMessage] = []
+    for snapshot in app.get_state_history(child_config):
+        messages = snapshot.values.get("messages") or []
+        if len(messages) > len(best):
+            best = messages
+
+    assert [m.content for m in best] == ["one", "two"]
+
+
+def test_subgraph_get_state_hydrates_delta_channel() -> None:
+    app = _build().compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    child_ns = _child_namespace(app, config)
+    values = app.get_state(
+        {"configurable": {"thread_id": "1", "checkpoint_ns": child_ns}}
+    ).values
+    assert [m.content for m in values.get("messages") or []] == ["one", "two"]
+    # A non-delta channel in the same namespace was never affected — it is the
+    # contrast that makes the delta-only nature of the bug explicit.
+    assert values.get("plain") == "p"
+
+
+async def test_subgraph_ahistory_hydrates_delta_channel() -> None:
+    app = _build().compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    await app.ainvoke({}, config)
+
+    child_ns = None
+    async for snapshot in app.aget_state_history(config):
+        for task in snapshot.tasks:
+            if task.name == "child" and isinstance(task.state, dict):
+                child_ns = task.state["configurable"]["checkpoint_ns"]
+    assert child_ns is not None
+
+    best: list[AnyMessage] = []
+    async for snapshot in app.aget_state_history(
+        {"configurable": {"thread_id": "1", "checkpoint_ns": child_ns}}
+    ):
+        messages = snapshot.values.get("messages") or []
+        if len(messages) > len(best):
+            best = messages
+
+    assert [m.content for m in best] == ["one", "two"]
+
+
+def test_root_history_still_hydrates_delta_channel() -> None:
+    """Control: the root graph has its own checkpointer and always worked."""
+    app = _build().compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+    values = app.get_state(config).values
+    assert [m.content for m in values.get("messages") or []] == ["one", "two"]


### PR DESCRIPTION
Fixes #8470

## Problem

Reading a **nested subgraph's** state returns every `DeltaChannel` **empty**, with no error.

`messages` on an agent that opts into delta storage is the common case, so a client walking `get_state_history` over a subgraph namespace sees an empty transcript — and cannot distinguish it from a subgraph that genuinely never wrote one. Non-delta channels in the same namespace hydrate fine, which is what makes this easy to miss.

Minimal repro (fails on `main`):

```python
class ChildState(TypedDict, total=False):
    messages: Annotated[list[AnyMessage], DeltaChannel(_messages_delta_reducer)]

parent.add_node("child", child.compile())
app = parent.compile(checkpointer=InMemorySaver())
app.invoke({}, {"configurable": {"thread_id": "1"}})

# parent namespace → ['one', 'two']   ✅
# child  namespace → []               ❌
```

## Cause

A subgraph obtained through `get_subgraphs()` was compiled **without** a checkpointer — the parent supplies one via `CONFIG_KEY_CHECKPOINTER` at read time, exactly as the public readers already resolve it:

```python
checkpointer = ensure_config(config)[CONF].get(CONFIG_KEY_CHECKPOINTER, self.checkpointer)
```

But `_prepare_state_snapshot` then hydrated channels using `self.checkpointer` **alone**, so `saver` was `None` for any nested subgraph:

```python
saver=self.checkpointer if isinstance(self.checkpointer, BaseCheckpointSaver) else None,
```

`channels_from_checkpoint` needs that saver to call `get_delta_channel_history` and replay a `DeltaChannel`'s ancestor writes. Without it the channel falls through to `from_checkpoint(MISSING)` → empty:

```python
if delta_channels and saver is not None and config is not None:
    histories = saver.get_delta_channel_history(...)
...
ch = spec.from_checkpoint(checkpoint["channel_values"].get(k, MISSING))
```

Reading it back out of the config isn't possible either: `get_state_history` passes `checkpoint_tuple.config` — the checkpointer's *stored* config, which never carries `CONFIG_KEY_CHECKPOINTER`. So this PR passes the already-resolved saver explicitly instead.

## Change

`_prepare_state_snapshot` / `_aprepare_state_snapshot` take an optional `saver`, preferred over `self.checkpointer`; the four callers (`get_state`, `aget_state`, `get_state_history`, `aget_state_history`) hand over the checkpointer they already resolved. +26/−4.

The two **execution-path** `channels_from_checkpoint` call sites are deliberately untouched — this is scoped to the read path, where the bug is observable.

## Tests

`tests/test_delta_channel_subgraph_read.py`: subgraph history, subgraph `get_state`, the async history path, and a root-graph control.

The three subgraph tests **fail on main** (`assert [] == ['one', 'two']`) and pass with this change; the control passes either way — verified by reverting the fix and re-running.

Full suite, before and after, same machine:

| | passed | failed | errors |
|---|---|---|---|
| main | 2001 | 9 | 1460 |
| this PR | **2005** | 9 | 1460 |

The failure/error set is **byte-for-byte identical** (`diff` of the sorted `FAILED`/`ERROR` lines is empty) — all pre-existing, all requiring postgres/redis/sqlite_aes services not running locally. The only delta is `+4 passed`: the new tests. `ruff format` and `ruff check` clean.

## How this was found

Building a run-inspection UI on `POST /threads/{id}/history`. Every nested deep agent reported an empty `messages` channel while its tasks had demonstrably run many model turns and tool calls — and the message blobs were sitting in `checkpoint_blobs` the whole time (1452 kB for one namespace). Plain agents, whose `messages` is a `BinaryOperatorAggregate` rather than a `DeltaChannel`, were unaffected.