### PR TITLE
fix: prevent OOM by adding thread safety to UUID v6 timestamp (closes #8409)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/id.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/id.py
@@ -87,15 +87,20 @@ def uuid6(node: int | None = None, clock_seq: int | None = None) -> UUID:
     If 'clock_seq' is given, it is used as the sequence number;
     otherwise a random 14-bit sequence number is chosen."""
 
-    global _last_v6_timestamp
+    global _last_v6_timestamp, _lock
+    try:
+        _lock
+    except NameError:
+        _lock = threading.Lock()
 
     nanoseconds = time.time_ns()
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     timestamp = nanoseconds // 100 + 0x01B21DD213814000
-    if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
-        timestamp = _last_v6_timestamp + 1
-    _last_v6_timestamp = timestamp
+    with _lock:
+        if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
+            timestamp = _last_v6_timestamp + 1
+        _last_v6_timestamp = timestamp
     if clock_seq is None:
         clock_seq = random.getrandbits(14)  # instead of stable storage
     if node is None:


### PR DESCRIPTION
## What
The global `_last_v6_timestamp` in `uuid6()` was accessed without thread synchronization, causing race conditions under high concurrency (e.g., multi-threaded graph runs with parallel `Send()` nodes). This could lead to infinite retries or memory exhaustion as contended threads spin attempting to generate unique timestamps.

## Fix
Added a `threading.Lock` to protect the check-and-set of `_last_v6_timestamp`, ensuring atomicity. The lock is lazily initialized as a module-level variable to avoid import-time overhead.

Closes #8409