### PR TITLE
Warn when nodes return undeclared graph schema keys

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1439,10 +1439,22 @@ class CompiledStateGraph(
             output_keys = list(self.builder.channels) + [
                 k for k, v in self.builder.managed.items()
             ]
+        
 
         def _get_updates(
             input: None | dict | Any,
         ) -> Sequence[tuple[str, Any]] | None:
+            # check for undeclared key returned by node 
+            dropped = set(input) - set(output_keys)
+            if dropped:
+                warnings.warn(
+                    (
+                        f"Node '{key}' returned keys that are not present in the graph schema: "
+                        f"{sorted(dropped)}. "
+                        "These keys will be ignored."
+                    ),
+                    UserWarning)
+
             if input is None:
                 return None
             elif isinstance(input, dict):

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -10,6 +10,7 @@ from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel
 from typing_extensions import NotRequired, Required, TypedDict
 
+from langgraph.graph import START, END, StateGraph
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.graph.state import (
@@ -371,3 +372,59 @@ def test_is_field_channel() -> None:
     # No channel cases
     assert _is_field_channel(int) is None
     assert _is_field_channel(Annotated[int, "just_metadata"]) is None
+
+
+def test_warn_on_undeclared_output_keys():
+    class State(TypedDict):
+        x: int
+
+    def node(state):
+        return {
+            "x": 1,
+            "undeclared_key": "hello",
+        }
+
+    builder = StateGraph(State)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+
+    graph = builder.compile()
+    with pytest.warns(
+    UserWarning,
+    match=r"Node 'n'.*undeclared_key",
+    ):
+        result = graph.invoke({"x": 0})
+
+    assert result == {"x": 1}
+
+def test_output_schema_key_does_not_warn():
+    class State(TypedDict):
+        x: int
+
+    class Output(TypedDict):
+        x: int
+        undeclared_key: str
+
+    def node(state):
+        return {
+            "x": 1,
+            "undeclared_key": "hello",
+        }
+
+    builder = StateGraph(State, output_schema=Output)
+    builder.add_node("n", node)
+    builder.add_edge(START, "n")
+    builder.add_edge("n", END)
+
+    graph = builder.compile()
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        result = graph.invoke({"x": 0})
+
+    assert len(record) == 0
+    assert result == {
+        "x": 1,
+        "undeclared_key": "hello",
+    }


### PR DESCRIPTION
Fixes #8320

Emit a `UserWarning` when a node returns keys that are not declared in the graph schema while preserving the existing behavior of ignoring those keys. Also adds regression tests covering both undeclared keys and keys declared in `output_schema`.