### PR TITLE
fix(langgraph): don't replay an abandoned branch into a DeltaChannel fork

### DIFF
--- a/libs/langgraph/langgraph/pregel/_checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/_checkpoint.py
@@ -81,7 +81,10 @@ def get_updated_channels_from_tasks(
 def get_delta_channels_from_all_channels(
     channels: Mapping[str, BaseChannel],
 ) -> set[str]:
-    """DeltaChannels to snapshot on the first update_state of a fresh thread."""
+    """Every available DeltaChannel — the set to snapshot when no ancestor walk
+    can reconstruct them: the first update_state of a fresh thread (no
+    ancestors at all) and the first checkpoint of a fork (whose base holds the
+    abandoned branch's writes)."""
     return {
         k
         for k, ch in channels.items()
@@ -122,14 +125,24 @@ def create_checkpoint_plan_for_update_state_api(
     parents: dict[str, Any],
     saved_metadata: Mapping[str, Any] | None,
     is_fresh_thread: bool,
+    is_fork: bool = False,
 ) -> tuple[set[str], dict[str, Any]]:
-    """Return ``(channels_to_snapshot, metadata)`` for an update_state head."""
+    """Return `(channels_to_snapshot, metadata)` for an update_state head.
+
+    `is_fork` (the update was addressed at an explicit checkpoint) forces a
+    full snapshot for the same reason `is_fresh_thread` does: the ancestor
+    walk cannot reconstruct this head. The base a fork branches off keeps the
+    pending writes of the branch being abandoned, and nothing records which
+    child consumed which write, so the walk would replay them here too.
+    Snapshotting terminates it at this checkpoint. Every delta channel
+    snapshots, so no counters carry over.
+    """
     metadata: dict[str, Any] = {
         "source": "update",
         "step": step,
         "parents": parents,
     }
-    if is_fresh_thread:
+    if is_fresh_thread or is_fork:
         return get_delta_channels_from_all_channels(channels), metadata
 
     new_counters = create_metadata_for_update_state_api(
@@ -179,9 +192,11 @@ def create_checkpoint(
             ch = channels[k]
             if k in channels_to_snapshot:
                 # Callers force a full snapshot blob here: exit mode when a
-                # delta channel reaches its snapshot cadence, and update_state
-                # on a fresh thread (no ancestor to replay writes from). The
-                # manual version-bump below only applies to the exit-mode case.
+                # delta channel reaches its snapshot cadence, update_state on a
+                # fresh thread (no ancestor to replay writes from), and a fork
+                # (whose base holds writes belonging to the abandoned branch).
+                # The manual version-bump below only applies to the exit-mode
+                # case.
                 #
                 # In exit mode, the snapshot decision is deferred to exit
                 # time (intermediate steps have do_checkpoint=False). The

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -222,10 +222,24 @@ class PregelLoop:
     # under the saver's `ORDER BY task_id, idx` sorting.
     _exit_delta_writes: list[tuple[int, str, str, Any]] | None = None
 
-    # Delta channels that saw an Overwrite since the last checkpoint. These
-    # channels must snapshot after live update applies overwrite semantics so
-    # sparse replay starts from the same post-overwrite value.
-    _delta_channels_with_overwrite: set[str]
+    # Delta channels that must snapshot at the next checkpoint, whatever their
+    # cadence counters say. Two sources:
+    # * an Overwrite arrived since the last checkpoint — snapshot after live
+    #   update applied overwrite semantics, so sparse replay starts from the
+    #   same post-overwrite value;
+    # * this run forked off an explicitly addressed checkpoint — see
+    #   `_delta_channels_awaiting_fork_snapshot`.
+    _delta_channels_forced_snapshot: set[str]
+
+    # Delta channels still owed a fork snapshot, when this run was launched
+    # against an explicitly addressed checkpoint (time travel / fork). That
+    # base keeps the pending writes of the branch the fork abandons, and
+    # nothing records which child consumed which write, so the ancestor walk
+    # would replay them into this branch as well. Snapshotting terminates the
+    # walk inside the fork instead of at the shared parent. Names drop out as
+    # they are snapshotted; a channel with no value yet has nothing to
+    # snapshot, so it waits for the superstep that gives it one.
+    _delta_channels_awaiting_fork_snapshot: set[str]
 
     # The checkpoint_config that points at the parent loaded at `__enter__`
     # (or the synthetic-empty checkpoint, on first run). We capture it
@@ -313,6 +327,14 @@ class PregelLoop:
         self.manager = manager
         self.is_nested = CONFIG_KEY_TASK_ID in self.config.get(CONF, {})
         self.is_replaying = CONFIG_KEY_CHECKPOINT_ID in config[CONF]
+        # Checks the value, not just key presence like `is_replaying` above:
+        # subgraph task configs always carry an explicit `None` here, and only
+        # a real id means the caller addressed one specific checkpoint.
+        self._delta_channels_awaiting_fork_snapshot = (
+            {k for k, s in specs.items() if isinstance(s, DeltaChannel)}
+            if config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)
+            else set()
+        )
         self._migrate_checkpoint = migrate_checkpoint
         self.trigger_to_nodes = trigger_to_nodes
         self.retry_policy = retry_policy
@@ -683,7 +705,7 @@ class PregelLoop:
     def after_tick(self) -> None:
         # finish superstep
         writes = [w for t in self.tasks.values() for w in t.writes]
-        self._delta_channels_with_overwrite.update(
+        self._delta_channels_forced_snapshot.update(
             ch
             for ch, v in writes
             if isinstance(self.specs.get(ch), DeltaChannel) and _get_overwrite(v)[0]
@@ -991,7 +1013,7 @@ class PregelLoop:
                 manager=None,
                 updated_channels=updated_channels,
             )
-            self._delta_channels_with_overwrite.update(
+            self._delta_channels_forced_snapshot.update(
                 c
                 for c, v in input_writes
                 if isinstance(self.specs.get(c), DeltaChannel) and _get_overwrite(v)[0]
@@ -1133,10 +1155,21 @@ class PregelLoop:
         do_checkpoint = self._checkpointer_put_after_previous is not None and (
             exiting or self.durability != "exit"
         )
+        # fork: make this checkpoint self-contained, so the ancestor walk stops
+        # inside the fork instead of reaching the base this run forked off and
+        # collecting the abandoned branch's writes from it. Resolved here (not
+        # in `_first`) so channels that only got a value this superstep are
+        # covered too.
+        if self._delta_channels_awaiting_fork_snapshot:
+            self._delta_channels_forced_snapshot.update(
+                k
+                for k in self._delta_channels_awaiting_fork_snapshot
+                if (ch := self.channels.get(k)) is not None and ch.is_available()
+            )
         # create new checkpoint
         channels_to_snapshot = (
             delta_channels_to_snapshot(self.channels, new_counters)
-            | self._delta_channels_with_overwrite
+            | self._delta_channels_forced_snapshot
             if do_checkpoint
             else set()
         )
@@ -1154,7 +1187,13 @@ class PregelLoop:
         for k in channels_to_snapshot:
             new_counters[k] = (0, 0)
         if do_checkpoint:
-            self._delta_channels_with_overwrite.difference_update(channels_to_snapshot)
+            self._delta_channels_forced_snapshot.difference_update(channels_to_snapshot)
+            # `create_checkpoint` drops a requested snapshot for a channel with
+            # no version in this checkpoint yet (nothing was ever written to it
+            # on this branch), so keep asking until the blob really landed.
+            self._delta_channels_awaiting_fork_snapshot.difference_update(
+                self.checkpoint["channel_values"]
+            )
         non_zero = {k: v for k, v in new_counters.items() if v != (0, 0)}
         if non_zero:
             self.checkpoint_metadata["counters_since_delta_snapshot"] = non_zero
@@ -1239,7 +1278,7 @@ class PregelLoop:
         )
         channels_to_snapshot = (
             delta_channels_to_snapshot(self.channels, counters)
-            | self._delta_channels_with_overwrite
+            | self._delta_channels_forced_snapshot
         )
 
         pending = [
@@ -1684,7 +1723,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         )
         self._delta_write_futs = []
         self._error_handler_write_futs = []
-        self._delta_channels_with_overwrite = set()
+        self._delta_channels_forced_snapshot = set()
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None
         )
@@ -1942,7 +1981,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         )
         self._delta_write_futs = []
         self._error_handler_write_futs = []
-        self._delta_channels_with_overwrite = set()
+        self._delta_channels_forced_snapshot = set()
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None
         )

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2020,6 +2020,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
+                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
                 )
             )
             checkpoint = create_checkpoint(
@@ -2480,6 +2481,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
+                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
                 )
             )
             checkpoint = create_checkpoint(

--- a/libs/langgraph/tests/test_delta_channel_fork.py
+++ b/libs/langgraph/tests/test_delta_channel_fork.py
@@ -1,0 +1,200 @@
+"""Forking a thread must not replay the abandoned branch into the fork.
+
+Regression suite for #8443. Addressing an older checkpoint creates a fork: the
+shared base ends up with two children, and it keeps the `checkpoint_writes` of
+the branch the fork abandons. Nothing in the stored data records which child
+consumed which write, so the `DeltaChannel` ancestor walk used to collect the
+abandoned branch's writes as well.
+
+Every graph here carries a `DeltaChannel` and a plain reducer channel fed the
+same values. `full` channels store complete `channel_values` and need no
+replay, so the plain channel is the oracle: after a fork the two must agree.
+
+Coverage: fork by `invoke` with new input (sync/async, all durabilities) and
+fork by `update_state` (sync/async).
+"""
+
+from collections.abc import Sequence
+from operator import add
+from typing import Annotated, Any
+
+import pytest
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from typing_extensions import TypedDict
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph import START, StateGraph
+from langgraph.types import Durability
+
+pytestmark = pytest.mark.anyio
+
+
+def _append(current: list | None, writes: Sequence[Any]) -> list:
+    out = list(current or [])
+    for write in writes:
+        out.extend(write if isinstance(write, list) else [write])
+    return out
+
+
+class State(TypedDict):
+    delta: Annotated[list, DeltaChannel(_append, snapshot_frequency=1000)]
+    plain: Annotated[list, add]
+
+
+def _build(checkpointer: BaseCheckpointSaver, tag: str) -> Any:
+    """Graph whose single node appends `f"{tag}-out"` to both channels."""
+
+    def node(state: State) -> dict:
+        return {"delta": [f"{tag}-out"], "plain": [f"{tag}-out"]}
+
+    builder = StateGraph(State)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.set_finish_point("node")
+    return builder.compile(checkpointer=checkpointer)
+
+
+def _both(value: str) -> dict:
+    return {"delta": [value], "plain": [value]}
+
+
+def _fork_config(config: dict, snapshot: Any) -> dict:
+    return {
+        "configurable": {
+            **config["configurable"],
+            "checkpoint_ns": "",
+            "checkpoint_id": snapshot.config["configurable"]["checkpoint_id"],
+        }
+    }
+
+
+def test_fork_with_new_input_ignores_abandoned_writes(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    config = {"configurable": {"thread_id": "1"}}
+    _build(sync_checkpointer, "first").invoke(
+        _both("in-1"), config, durability=durability
+    )
+    graph = _build(sync_checkpointer, "second")
+    graph.invoke(_both("in-2"), config, durability=durability)
+
+    # deepest checkpoint of the second run that predates its input: the base a
+    # fork branches off, and the only one still holding "in-2" as a write.
+    base = next(
+        snapshot
+        for snapshot in graph.get_state_history(config)
+        if "in-2" not in snapshot.values["plain"]
+    )
+    fork_config = _fork_config(config, base)
+    _build(sync_checkpointer, "third").invoke(
+        _both("in-3"), fork_config, durability=durability
+    )
+
+    values = graph.get_state(config).values
+    assert values["plain"] == ["in-1", "first-out", "in-3", "third-out"]
+    assert values["delta"] == values["plain"]
+
+
+async def test_afork_with_new_input_ignores_abandoned_writes(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    config = {"configurable": {"thread_id": "1"}}
+    await _build(async_checkpointer, "first").ainvoke(
+        _both("in-1"), config, durability=durability
+    )
+    graph = _build(async_checkpointer, "second")
+    await graph.ainvoke(_both("in-2"), config, durability=durability)
+
+    base = None
+    async for snapshot in graph.aget_state_history(config):
+        if "in-2" not in snapshot.values["plain"]:
+            base = snapshot
+            break
+    assert base is not None
+    await _build(async_checkpointer, "third").ainvoke(
+        _both("in-3"), _fork_config(config, base), durability=durability
+    )
+
+    values = (await graph.aget_state(config)).values
+    assert values["plain"] == ["in-1", "first-out", "in-3", "third-out"]
+    assert values["delta"] == values["plain"]
+
+
+def test_fork_from_thread_root_ignores_abandoned_writes(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Fork off the checkpoint that predates the thread's first input.
+
+    The delta channel has no version there, so the fork's own first checkpoint
+    cannot carry a snapshot blob — the walk has to be terminated by the first
+    checkpoint that can.
+    """
+    config = {"configurable": {"thread_id": "1"}}
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_both("in-1"), config, durability=durability)
+
+    root = list(graph.get_state_history(config))[-1]
+    assert root.values["plain"] == []
+    _build(sync_checkpointer, "second").invoke(
+        _both("in-2"), _fork_config(config, root), durability=durability
+    )
+
+    values = graph.get_state(config).values
+    assert values["plain"] == ["in-2", "second-out"]
+    assert values["delta"] == values["plain"]
+
+
+def test_update_state_fork_ignores_abandoned_writes(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    config = {"configurable": {"thread_id": "1"}}
+    _build(sync_checkpointer, "first").invoke(_both("in-1"), config)
+    graph = _build(sync_checkpointer, "second")
+    graph.invoke(_both("in-2"), config)
+
+    base = next(
+        snapshot
+        for snapshot in graph.get_state_history(config)
+        if "in-2" not in snapshot.values["plain"]
+    )
+    forked = graph.update_state(_fork_config(config, base), _both("patched"))
+
+    values = graph.get_state(forked).values
+    assert values["plain"] == ["in-1", "first-out", "patched"]
+    assert values["delta"] == values["plain"]
+
+
+async def test_aupdate_state_fork_ignores_abandoned_writes(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    config = {"configurable": {"thread_id": "1"}}
+    await _build(async_checkpointer, "first").ainvoke(_both("in-1"), config)
+    graph = _build(async_checkpointer, "second")
+    await graph.ainvoke(_both("in-2"), config)
+
+    base = None
+    async for snapshot in graph.aget_state_history(config):
+        if "in-2" not in snapshot.values["plain"]:
+            base = snapshot
+            break
+    assert base is not None
+    forked = await graph.aupdate_state(_fork_config(config, base), _both("patched"))
+
+    values = (await graph.aget_state(forked)).values
+    assert values["plain"] == ["in-1", "first-out", "patched"]
+    assert values["delta"] == values["plain"]
+
+
+def test_no_fork_leaves_snapshot_cadence_untouched(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """A run without an addressed checkpoint must not force extra snapshots."""
+    config = {"configurable": {"thread_id": "1"}}
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_both("in-1"), config)
+    graph.invoke(_both("in-2"), config)
+
+    for snapshot in graph.get_state_history(config):
+        stored = sync_checkpointer.get_tuple(snapshot.config)
+        assert stored is not None
+        assert "delta" not in stored.checkpoint["channel_values"]


### PR DESCRIPTION
Fixes #8443

## Problem

Addressing an older checkpoint creates a fork: the shared base ends up with two children, and it keeps the `checkpoint_writes` of the branch the fork abandons. Nothing in the stored data records which child consumed which write, so the `DeltaChannel` ancestor walk in `get_delta_channel_history` collects the abandoned branch's writes too.

Live execution is correct — only the reconstruction after a reload is wrong:

```
fork base: ['in-1', 'first-out']
fork returns:  ['in-1', 'first-out', 'in-3', 'third-out']   # correct
reload gives:  ['in-1', 'first-out', 'in-2', 'in-3', 'third-out']
                                      ^^^^^^ belongs to the branch the fork replaced
```

`full` channels are unaffected: their checkpoints carry complete `channel_values` and need no replay. In a graph carrying both, the plain channel is right and the delta channel is not — which is what the new tests assert against.

This is not one saver's slip. `InMemorySaver`, the base walk (used by SQLite) and `PostgresSaver`'s paged-SQL override all reproduce it, because write-to-child ownership simply is not recorded.

## Fix

Write side, so no saver changes are needed. A run launched against an explicitly addressed checkpoint forces every `DeltaChannel` to snapshot into its first checkpoint, which terminates the walk inside the fork instead of at the shared parent. This mirrors the existing force-snapshot for `Overwrite` writes, which exists for the same reason — the set that carried those channels now carries both cases, hence its rename to `_delta_channels_forced_snapshot`.

* `_loop.py` — queue every delta channel for a forced snapshot when `configurable.checkpoint_id` names a real checkpoint. Resolved in `_put_checkpoint` rather than `_first` so channels that only get a value later in the run are covered. Checks the value, not key presence like `is_replaying`, because subgraph task configs always carry an explicit `None` there.
* `_checkpoint.py` — `create_checkpoint_plan_for_update_state_api(..., is_fork=True)` forces the same full snapshot for `update_state` against an older checkpoint, for the same reason `is_fresh_thread` already does.
* `main.py` — pass `is_fork` from both `bulk_update_state` paths.

A channel with no value at the fork base cannot carry a snapshot blob yet (`create_checkpoint` skips channels absent from `channel_versions`), so it stays queued until the first superstep that gives it one — otherwise forking off the checkpoint that predates a thread's first input would still leak.

Cost is one snapshot per explicitly addressed run, not per superstep. Runs without an addressed checkpoint are untouched: the queue is empty and nothing else changes.

## Tests

`tests/test_delta_channel_fork.py`, parametrized over the standard checkpointer fixtures (memory / sqlite / sqlite_aes / postgres in CI) and, for the run paths, over all three durabilities:

* fork by `invoke` with new input, sync and async
* fork off the checkpoint that predates the thread's first input (the deferred-snapshot path)
* fork by `update_state` / `aupdate_state`
* a guard that a run without an addressed checkpoint still writes no snapshot blobs, so the normal `snapshot_frequency` cadence is unchanged

29 of the 32 cases fail on `main` and all 32 pass with the fix; the 3 that pass either way are the cadence guard.

`make format` / `make lint` clean. Full `libs/langgraph` suite: 1994 passed, with 5 failures that reproduce identically on unpatched `main` (`test_imp_nested`, `test_async_streaming_with_functional_api`, `test_replay_creates_branch_preserving_old_checkpoints` — order/timing flakes on Windows, none of them delta-channel tests).

## Not covered

`update_state` persists its writes against the addressed checkpoint, so on a fork those writes also become visible to the *abandoned* branch's reads. That is the mirror of this bug rather than this bug, it predates this change, and fixing it means moving where those writes are stored — which would change task-result attribution in `get_state_history`. Left alone here; happy to open a separate issue for it.
