### PR TITLE
fix: Ensure AsyncPipeline is synced before closing in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -83,7 +83,10 @@ class AsyncPostgresSaver(BasePostgresSaver):
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                    try:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
+                    finally:
+                        await pipe.sync()
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
AsyncPostgresSaver fails with 'SSL connection has been closed unexpectedly' when used with psycopg AsyncPipeline. This occurs because the pipeline's pending commands are not flushed before the connection is closed, leading to connection errors.

## Fix
Added a `finally` block in `from_conn_string` to call `await pipe.sync()` when the pipeline context exits, ensuring all queued commands are sent and the connection is properly settled.

Closes #5675