### PR TITLE
fix(prebuilt): correct GraphRecusionError typo in create_react_agent docstring

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -437,7 +437,7 @@ def create_react_agent(
                 If `remaining_steps` is less than 2 and tool calls are present in the response,
                 the react agent will return a final AI Message with
                 the content "Sorry, need more steps to process this request.".
-                No `GraphRecusionError` will be raised in this case.
+                No `GraphRecursionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
         checkpointer: An optional checkpoint saver object. This is used for persisting


### PR DESCRIPTION
Fixes #8130

## Summary
Correct a typo in the `create_react_agent` docstring: `GraphRecusionError` → `GraphRecursionError`.

The corrected name matches the real class exported from `langgraph.errors` (`langgraph/errors.py:67`), so the docstring now references a class that actually exists.

## Change
```diff
-                No `GraphRecusionError` will be raised in this case.
+                No `GraphRecursionError` will be raised in this case.
```

A grep over the repo confirms:
- Old typo `GraphRecusionError`: 0 occurrences
- Corrected `GraphRecursionError`: matches the real class