### PR TITLE
fix: warn when node returns keys not declared in state schema

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1446,6 +1446,14 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
+                dropped = set(input.keys()) - set(output_keys)
+                if dropped:
+                    warnings.warn(
+                        f"Node '{key}' returned keys {dropped} not declared in the state schema. "
+                        f"These keys will be dropped.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:


### PR DESCRIPTION
## Problem

Fixes #8320

When a LangGraph node returns a dictionary containing keys not declared in the graph's state TypedDict, those keys are silently discarded with no warning, error, or log message. This makes debugging extremely confusing when a developer adds a new field to a node's return value but forgets to update the state schema.

## Root Cause

In CompiledStateGraph.attach_node(), the inner _get_updates function filters node output against output_keys (derived from the state schema) using a list comprehension that simply skips undeclared keys:



There is no else branch, no warning, no logging - the undeclared keys vanish without a trace.

## Solution

Added a warnings.warn() call in _get_updates that fires when dropped keys are detected:



This is a minimal, non-breaking change that surfaces the issue to developers without changing existing behavior.

## Changes

- libs/langgraph/langgraph/graph/state.py: Added warning in _get_updates when undeclared keys are detected
- import warnings was already present in the file
