### PR TITLE
fix(prebuilt): stop ExecutionInfo/ServerInfo import from breaking on older langgraph

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -87,11 +87,23 @@ from langgraph._internal._runnable import RunnableCallable
 from langgraph.errors import GraphBubbleUp
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.pregel._tools import _tool_call_writer
-from langgraph.runtime import ExecutionInfo, ServerInfo  # noqa: TC002
 from langgraph.store.base import BaseStore  # noqa: TC002
 from langgraph.types import Command, Send, StreamWriter
 from pydantic import BaseModel, ValidationError
 from typing_extensions import TypeVar, Unpack
+
+# langgraph-prebuilt intentionally declares no version-pinned dependency on
+# core langgraph (one would create a dependency cycle: langgraph depends on
+# langgraph-prebuilt). ExecutionInfo/ServerInfo are recent additions to
+# langgraph.runtime, so an older, otherwise-compatible core langgraph may not
+# have them yet. Fall back to `Any` rather than fail the whole module import
+# (GH #7404) -- ToolRuntime's fields still need a real type for Pydantic to
+# build tool args_schema, so `TYPE_CHECKING`-only import is not an option.
+try:
+    from langgraph.runtime import ExecutionInfo, ServerInfo
+except ImportError:
+    ExecutionInfo = Any  # type: ignore[assignment,misc]
+    ServerInfo = Any  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -811,8 +823,13 @@ class ToolNode(RunnableCallable):
                 store=runtime.store,
                 stream_writer=runtime.stream_writer,
                 tools=list(self.tools_by_name.values()),
-                execution_info=runtime.execution_info,
-                server_info=runtime.server_info,
+                # getattr (not attribute access): langgraph-prebuilt intentionally
+                # has no hard version dependency on core langgraph (it would create
+                # a dependency cycle, since langgraph depends on langgraph-prebuilt).
+                # A `Runtime` from an older langgraph that predates these fields
+                # must degrade to None rather than raise AttributeError.
+                execution_info=getattr(runtime, "execution_info", None),
+                server_info=getattr(runtime, "server_info", None),
             )
             tool_runtimes.append(tool_runtime)
 
@@ -846,8 +863,13 @@ class ToolNode(RunnableCallable):
                 store=runtime.store,
                 stream_writer=runtime.stream_writer,
                 tools=list(self.tools_by_name.values()),
-                execution_info=runtime.execution_info,
-                server_info=runtime.server_info,
+                # getattr (not attribute access): langgraph-prebuilt intentionally
+                # has no hard version dependency on core langgraph (it would create
+                # a dependency cycle, since langgraph depends on langgraph-prebuilt).
+                # A `Runtime` from an older langgraph that predates these fields
+                # must degrade to None rather than raise AttributeError.
+                execution_info=getattr(runtime, "execution_info", None),
+                server_info=getattr(runtime, "server_info", None),
             )
             tool_runtimes.append(tool_runtime)
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2143,6 +2143,52 @@ async def test_tool_runtime_forwards_execution_info_server_info_and_tools_async(
     ]
 
 
+class _PreExecutionInfoRuntime:
+    """Stand-in for a `Runtime` from a langgraph-core release older than the
+    one that added `execution_info`/`server_info` (see langgraph.runtime.Runtime).
+
+    Plain object with only the older attributes, so accessing a missing one
+    raises `AttributeError` instead of a Mock auto-vivifying it.
+    """
+
+    def __init__(self) -> None:
+        self.store = None
+        self.context = None
+        self.stream_writer = lambda *args, **kwargs: None
+
+
+def test_tool_runtime_tolerates_runtime_without_execution_info() -> None:
+    """ToolNode must not crash against a core langgraph old enough that
+    `Runtime` predates `execution_info`/`server_info` (GH #7404): the two
+    fields should degrade to `None` rather than raise `AttributeError`.
+    """
+    captured: dict = {}
+
+    @dec_tool
+    def info_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that captures runtime info."""
+        captured["execution_info"] = runtime.execution_info
+        captured["server_info"] = runtime.server_info
+        return "ok"
+
+    node = ToolNode([info_tool])
+    tool_call = {
+        "name": "info_tool",
+        "args": {"x": 1},
+        "id": "call-1",
+        "type": "tool_call",
+    }
+    msg = AIMessage("", tool_calls=[tool_call])
+    config: RunnableConfig = {
+        "configurable": {"__pregel_runtime": _PreExecutionInfoRuntime()}
+    }
+    result = node.invoke({"messages": [msg]}, config=config)
+
+    assert result["messages"][-1].content == "ok"
+    assert captured["execution_info"] is None
+    assert captured["server_info"] is None
+
+
 # --- InjectedToolArg security tests ---
 
 


### PR DESCRIPTION
## Problem

`langgraph-prebuilt` declares no version-pinned dependency on core `langgraph`
in its `pyproject.toml` (only `langgraph-checkpoint` and `langchain-core`).
This is intentional: `langgraph` itself depends on `langgraph-prebuilt`
(`langgraph-prebuilt>=1.1.0,<1.2.0`), so adding a reverse pin would create a
dependency cycle.

`ExecutionInfo` and `ServerInfo` were added to `langgraph.runtime` in a
relatively recent core release (first in tags `1.1.3`/`1.1.5`; both are used
together as of `tool_node.py`'s `ToolRuntime` starting with commit 39288e611,
PR #7363). Because `tool_node.py` imports them at module level with no
version guard, `from langgraph.prebuilt import ToolNode` raises `ImportError`
for anyone running an older, otherwise-compatible core `langgraph` — exactly
the failure in #7404 (`ImportError: cannot import name 'ServerInfo' from
'langgraph.runtime'`).

## Fix

- Wrap the `langgraph.runtime` import in `try`/`except ImportError`, falling
  back to `Any` for both names on failure.

  I first tried moving the import into the existing `TYPE_CHECKING` block
  (the file already has `from __future__ import annotations`, so eager
  evaluation of the annotations themselves isn't the issue). That breaks
  `test_tool_runtime_forwards_execution_info_server_info_and_tools` and two
  others with `PydanticUserError: ... is not fully defined` — any tool
  function with a `runtime: ToolRuntime` parameter needs Pydantic to build a
  full `args_schema`, which requires resolving every field on `ToolRuntime`
  (including `execution_info`/`server_info`) to a real type at conversion
  time, not just a string annotation. So the import has to stay real; only
  the failure mode when it's unavailable needed to change.

- At both `ToolRuntime` construction sites (sync `_func` and async `_afunc`),
  read `execution_info`/`server_info` off the injected `Runtime` via
  `getattr(runtime, "...", None)` instead of direct attribute access. Fixing
  only the import would trade the current top-level `ImportError` for an
  `AttributeError` the first time a tool actually runs against an old-enough
  `Runtime` that predates these fields — same underlying version-skew
  problem, just deferred to first tool invocation instead of package import.

- Added `test_tool_runtime_tolerates_runtime_without_execution_info`, using a
  plain object with only the pre-existing `Runtime` attributes (not `Mock`,
  which auto-vivifies any attribute you access) to actually exercise the
  "older core langgraph" code path.

## Testing

- `uv run pytest tests/` in `libs/prebuilt`: 225 passed, 3 skipped (no
  regressions).
- `uv run ruff check` / `ruff format --check` / `ty check` on the changed
  files: clean.

Fixes #7404