### PR TITLE
docs(examples): document ChatOpenAI base_url for multi-model gateways

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,18 @@ The examples previously found here have been moved to the consolidated LangChain
 ## 📖 Documentation
 
 For up-to-date LangGraph examples, tutorials, and guides, see the [LangGraph Docs](https://docs.langchain.com/oss/python/langgraph/overview). Get started with the [LangGraph Quickstart](https://docs.langchain.com/oss/python/langgraph/quickstart).
+
+
+## OpenAI-compatible multi-model gateways
+
+Several examples use `langchain_openai.ChatOpenAI`. The same client works with any OpenAI-compatible endpoint via `base_url` (or `OPENAI_API_BASE` / `OPENAI_BASE_URL`), for example a multi-model gateway like [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`:
+
+```python
+from langchain_openai import ChatOpenAI
+
+model = ChatOpenAI(
+    model="gpt-4o-mini",
+    base_url="https://api.daoxe.com/v1",
+    api_key="...",
+)
+```

--- a/libs/cli/examples/graphs/agent.py
+++ b/libs/cli/examples/graphs/agent.py
@@ -12,6 +12,8 @@ from langgraph.runtime import Runtime
 tools = [TavilySearchResults(max_results=1)]
 
 model_anth = ChatAnthropic(temperature=0, model_name="claude-3-sonnet-20240229")
+# ChatOpenAI accepts base_url for any OpenAI-compatible multi-model gateway, e.g. DaoXE:
+# model_oai = ChatOpenAI(temperature=0, base_url="https://api.daoxe.com/v1", api_key="...")
 model_oai = ChatOpenAI(temperature=0)
 
 model_anth = model_anth.bind_tools(tools)


### PR DESCRIPTION
## Summary

Several examples use `langchain_openai.ChatOpenAI`, which already supports `base_url` for OpenAI-compatible endpoints. That capability was not called out in the examples.

This PR documents the pattern with [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete multi-model gateway example:
- Comment in `libs/cli/examples/graphs/agent.py`
- Short section in `examples/README.md`

Docs/examples only — no runtime behavior changes.

## Test plan

- [ ] Example still imports and runs with default ChatOpenAI()
- [ ] base_url / api_key names match langchain-openai
- [ ] README section is optional guidance only