### PR TITLE
fix: warn when node returns keys not declared in state schema

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1446,6 +1446,14 @@ class CompiledStateGraph(
             if input is None:
                 return None
             elif isinstance(input, dict):
+                dropped = [k for k in input if k not in output_keys]
+                if dropped:
+                    warnings.warn(
+                        f"Node '{key}' returned keys {dropped} that are not "
+                        f"declared in the graph state schema and will be dropped. "
+                        f"Add them to the state schema to persist them.",
+                        stacklevel=2,
+                    )
                 return [(k, v) for k, v in input.items() if k in output_keys]
             elif isinstance(input, Command):
                 if input.graph == Command.PARENT:


### PR DESCRIPTION
## Problem

Fixes #8320

When a LangGraph node returns a dictionary containing keys not declared in the graph's state schema, those keys are silently discarded with no warning, error, or log message. This makes debugging extremely confusing when a developer adds a new field to a node's return value but forgets to update the state schema.

## Root Cause

In `CompiledStateGraph.attach_node()`, the inner `_get_updates` function filters node output against `output_keys` (derived from the state schema):

```python
elif isinstance(input, dict):
    return [(k, v) for k, v in input.items() if k in output_keys]
```

This list comprehension silently skips any key not in `output_keys` with no diagnostic output.

## Solution

Detect dropped keys and emit a `warnings.warn()` so developers are immediately informed which keys were lost and why:

```python
elif isinstance(input, dict):
    dropped = [k for k in input if k not in output_keys]
    if dropped:
        warnings.warn(
            f"Node '{key}' returned keys {dropped} that are not "
            f"declared in the graph state schema and will be dropped. "
            f"Add them to the state schema to persist them.",
            stacklevel=2,
        )
    return [(k, v) for k, v in input.items() if k in output_keys]
```

This is a minimal, non-breaking change:
- Behavior is unchanged (keys are still dropped as before)
- No new exceptions raised, so existing workflows are unaffected
- The warning uses `stacklevel=2` to point at the caller
- Only fires when there are actually dropped keys (no noise for valid graphs)

## Testing

- Verified the warning fires when a node returns undeclared keys
- Verified no warning for graphs where all returned keys are declared
- Verified graph execution results are unchanged
