### PR TITLE
docs: fix broken why-langgraph link in llms.txt

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@ LangGraph documentation has moved to docs.langchain.com.
 ## Overview
 
 - [LangGraph Overview](https://docs.langchain.com/oss/python/langgraph/overview): Introduction to LangGraph, a library for building stateful, multi-actor applications with LLMs.
-- [Why LangGraph?](https://docs.langchain.com/oss/python/langgraph/why-langgraph): Motivation for LangGraph and its key features.
+- [Why LangGraph?](https://docs.langchain.com/oss/python/langgraph/overview#core-benefits): Motivation for LangGraph and its key features.
 
 ## Core Concepts
 


### PR DESCRIPTION
The `why-langgraph` entry in `docs/llms.txt` points to `https://docs.langchain.com/oss/python/langgraph/why-langgraph`, which returns 404. The page content was merged into the overview page under the "Core benefits" section, so this updates the link to `https://docs.langchain.com/oss/python/langgraph/overview#core-benefits`.

Verified all 14 links in the file resolve successfully after the change.

Fixes #8509