### PR TITLE
fix: Add thread lock to uuid6 generation (closes #8409)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/id.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/id.py
@@ -93,9 +93,10 @@ def uuid6(node: int | None = None, clock_seq: int | None = None) -> UUID:
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     timestamp = nanoseconds // 100 + 0x01B21DD213814000
-    if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
-        timestamp = _last_v6_timestamp + 1
-    _last_v6_timestamp = timestamp
+    with _lock:
+        if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
+            timestamp = _last_v6_timestamp + 1
+        _last_v6_timestamp = timestamp
     if clock_seq is None:
         clock_seq = random.getrandbits(14)  # instead of stable storage
     if node is None:


### PR DESCRIPTION
## What
The `uuid6` function in `langgraph/checkpoint/base/id.py` uses a global variable `_last_v6_timestamp` to ensure monotonically increasing timestamps, but it does so without synchronization. In multi-threaded environments (e.g., concurrent thread runs in langgraph-api), this can lead to race conditions where multiple threads read and write the timestamp concurrently, potentially producing duplicate or corrupted UUIDs. This can cause downstream issues such as OOM in services like OpenTelemetry that rely on unique, ordered IDs.

## Fix
Introduce a module-level `threading.Lock` and acquire it around the read-modify-write of `_last_v6_timestamp`. This ensures atomic increments and prevents race conditions, preserving UUID correctness under high concurrency.

Closes #8409