### PR TITLE
fix(langgraph): hydrate delta channels with the caller-resolved checkpointer

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1148,6 +1148,7 @@ class Pregel(
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
+        saver: BaseCheckpointSaver | None = None,
     ) -> StateSnapshot:
         if not saved:
             return StateSnapshot(
@@ -1161,6 +1162,16 @@ class Pregel(
                 interrupts=(),
             )
 
+        # prefer the saver resolved by the caller: a subgraph is compiled without
+        # a checkpointer of its own, the parent supplies one via
+        # CONFIG_KEY_CHECKPOINTER at read time
+        if not isinstance(saver, BaseCheckpointSaver):
+            saver = (
+                self.checkpointer
+                if isinstance(self.checkpointer, BaseCheckpointSaver)
+                else None
+            )
+
         # migrate checkpoint if needed
         self._migrate_checkpoint(saved.checkpoint)
 
@@ -1169,9 +1180,7 @@ class Pregel(
         channels, managed = channels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
-            if isinstance(self.checkpointer, BaseCheckpointSaver)
-            else None,
+            saver=saver,
             config=saved.config,
         )
         # tasks for this checkpoint
@@ -1271,6 +1280,7 @@ class Pregel(
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
+        saver: BaseCheckpointSaver | None = None,
     ) -> StateSnapshot:
         if not saved:
             return StateSnapshot(
@@ -1284,6 +1294,16 @@ class Pregel(
                 interrupts=(),
             )
 
+        # prefer the saver resolved by the caller: a subgraph is compiled without
+        # a checkpointer of its own, the parent supplies one via
+        # CONFIG_KEY_CHECKPOINTER at read time
+        if not isinstance(saver, BaseCheckpointSaver):
+            saver = (
+                self.checkpointer
+                if isinstance(self.checkpointer, BaseCheckpointSaver)
+                else None
+            )
+
         # migrate checkpoint if needed
         self._migrate_checkpoint(saved.checkpoint)
 
@@ -1292,9 +1312,7 @@ class Pregel(
         channels, managed = await achannels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
-            if isinstance(self.checkpointer, BaseCheckpointSaver)
-            else None,
+            saver=saver,
             config=saved.config,
         )
         # tasks for this checkpoint
@@ -1431,6 +1449,7 @@ class Pregel(
             saved,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
+            saver=checkpointer,
         )
 
     async def aget_state(
@@ -1475,6 +1494,7 @@ class Pregel(
             saved,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
+            saver=checkpointer,
         )
 
     def get_state_history(
@@ -1527,7 +1547,7 @@ class Pregel(
             checkpointer.list(config, before=before, limit=limit, filter=filter)
         ):
             yield self._prepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     async def aget_state_history(
@@ -1584,7 +1604,7 @@ class Pregel(
             )
         ]:
             yield await self._aprepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     def bulk_update_state(
@@ -1666,9 +1686,8 @@ class Pregel(
             channels, managed = channels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
-                if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
+                saver=checkpointer
+                if saved is not None and isinstance(checkpointer, BaseCheckpointSaver)
                 else None,
                 config=saved.config if saved is not None else None,
             )
@@ -2132,9 +2151,8 @@ class Pregel(
             channels, managed = await achannels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
-                if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
+                saver=checkpointer
+                if saved is not None and isinstance(checkpointer, BaseCheckpointSaver)
                 else None,
                 config=saved.config if saved is not None else None,
             )

--- a/libs/langgraph/tests/test_delta_channel_subgraph_read.py
+++ b/libs/langgraph/tests/test_delta_channel_subgraph_read.py
@@ -1,0 +1,160 @@
+"""Tests for reading/updating a nested subgraph's `DeltaChannel` state.
+
+A subgraph is compiled without a checkpointer of its own — the parent supplies
+one via `CONFIG_KEY_CHECKPOINTER` at read time. The public readers resolve it
+from the config, so they must hand it to `channels_from_checkpoint`: without a
+saver a `DeltaChannel` that needs an ancestor walk hydrates empty (and silently,
+since `from_checkpoint(MISSING)` is a valid empty channel).
+
+Coverage:
+
+* nested-subgraph `get_state` / `aget_state` and `get_state_history` /
+  `aget_state_history` hydrate delta channels
+* root-graph control (owns its checkpointer) still hydrates
+* nested-subgraph `update_state` / `aupdate_state` accumulate onto the replayed
+  state rather than onto an empty one
+"""
+
+from typing import Annotated, Any
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from typing_extensions import TypedDict
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph import START, StateGraph
+from langgraph.graph.message import _messages_delta_reducer
+
+pytestmark = pytest.mark.anyio
+
+
+def _build_graph(
+    checkpointer: InMemorySaver,
+    *,
+    freq: int = 1000,
+) -> Any:
+    """Parent graph with a single `child` subgraph writing two messages."""
+    channel = DeltaChannel(_messages_delta_reducer, snapshot_frequency=freq)
+    # Functional TypedDict form: class form can't reference `channel` (a
+    # local variable) inside Annotated due to forward-ref evaluation rules.
+    State = TypedDict("State", {"messages": Annotated[list, channel]})  # type: ignore[call-overload]  # noqa: UP013
+
+    def one(state: dict) -> dict:
+        return {"messages": [AIMessage(content="one", id="ai1")]}
+
+    def two(state: dict) -> dict:
+        return {"messages": [AIMessage(content="two", id="ai2")]}
+
+    child = StateGraph(State)
+    child.add_node("one", one)
+    child.add_node("two", two)
+    child.add_edge(START, "one")
+    child.add_edge("one", "two")
+    child.set_finish_point("two")
+
+    parent = StateGraph(State)
+    parent.add_node("child", child.compile())
+    parent.add_edge(START, "child")
+    parent.set_finish_point("child")
+    return parent.compile(checkpointer=checkpointer)
+
+
+def _child_config(graph: Any, config: dict) -> dict:
+    """Config addressing the `child` task's own checkpoint namespace."""
+    ns = next(
+        task.state["configurable"]["checkpoint_ns"]
+        for snapshot in graph.get_state_history(config)
+        for task in snapshot.tasks
+        if task.name == "child" and isinstance(task.state, dict)
+    )
+    return {
+        "configurable": {
+            "thread_id": config["configurable"]["thread_id"],
+            "checkpoint_ns": ns,
+        }
+    }
+
+
+def _contents(values: dict) -> list[str]:
+    return [m.content for m in values["messages"]]
+
+
+def test_subgraph_get_state_delta_channel() -> None:
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "sub-get-state"}}
+    graph.invoke({"messages": []}, config)
+
+    assert _contents(graph.get_state(config).values) == ["one", "two"]
+    child_state = graph.get_state(_child_config(graph, config))
+    assert _contents(child_state.values) == ["one", "two"]
+
+
+def test_subgraph_get_state_history_delta_channel() -> None:
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "sub-history"}}
+    graph.invoke({"messages": []}, config)
+
+    history = list(graph.get_state_history(_child_config(graph, config)))
+    # newest first: after `two`, after `one`, before either ran
+    assert [_contents(s.values) for s in history[:2]] == [["one", "two"], ["one"]]
+
+
+async def test_subgraph_aget_state_delta_channel() -> None:
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "sub-aget-state"}}
+    await graph.ainvoke({"messages": []}, config)
+
+    child_state = await graph.aget_state(_child_config(graph, config))
+    assert _contents(child_state.values) == ["one", "two"]
+
+
+async def test_subgraph_aget_state_history_delta_channel() -> None:
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "sub-ahistory"}}
+    await graph.ainvoke({"messages": []}, config)
+
+    history = [s async for s in graph.aget_state_history(_child_config(graph, config))]
+    assert [_contents(s.values) for s in history[:2]] == [["one", "two"], ["one"]]
+
+
+def test_root_graph_get_state_delta_channel() -> None:
+    """Control: a graph that owns its checkpointer was never affected."""
+    graph = _build_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "root"}}
+    graph.invoke({"messages": []}, config)
+
+    assert _contents(graph.get_state(config).values) == ["one", "two"]
+    history = list(graph.get_state_history(config))
+    assert _contents(history[0].values) == ["one", "two"]
+
+
+def test_subgraph_update_state_delta_channel() -> None:
+    """A forced snapshot must be built from the replayed state, not an empty one."""
+    graph = _build_graph(InMemorySaver(), freq=3)
+    config = {"configurable": {"thread_id": "sub-update"}}
+    graph.invoke({"messages": []}, config)
+    child_config = _child_config(graph, config)
+
+    expected = ["one", "two"]
+    for i in range(3):
+        graph.update_state(
+            child_config, {"messages": [AIMessage(content=f"u{i}", id=f"u{i}")]}
+        )
+        expected.append(f"u{i}")
+        assert _contents(graph.get_state(child_config).values) == expected
+
+
+async def test_subgraph_aupdate_state_delta_channel() -> None:
+    graph = _build_graph(InMemorySaver(), freq=3)
+    config = {"configurable": {"thread_id": "sub-aupdate"}}
+    await graph.ainvoke({"messages": []}, config)
+    child_config = _child_config(graph, config)
+
+    expected = ["one", "two"]
+    for i in range(3):
+        await graph.aupdate_state(
+            child_config, {"messages": [AIMessage(content=f"u{i}", id=f"u{i}")]}
+        )
+        expected.append(f"u{i}")
+        assert _contents((await graph.aget_state(child_config)).values) == expected


### PR DESCRIPTION
# fix(langgraph): hydrate delta channels with the caller-resolved checkpointer

Fixes #8470

## Root cause

A `DeltaChannel` is usually *not* stored in `checkpoint["channel_values"]` — only
every Nth checkpoint carries a `_DeltaSnapshot` seed, and the value in between is
reconstructed by walking ancestors and replaying `checkpoint_writes`. That walk is
`saver.get_delta_channel_history(...)`, so `channels_from_checkpoint` needs a saver;
without one it silently falls through to `spec.from_checkpoint(MISSING)`, which is a
perfectly valid *empty* channel (`libs/langgraph/langgraph/pregel/_checkpoint.py:260-275`).

A subgraph is compiled without a checkpointer of its own — the parent hands one down
via `CONFIG_KEY_CHECKPOINTER` at read time, which is exactly what the public readers
resolve (`main.py:1396-1402` etc.). But `_prepare_state_snapshot` /
`_aprepare_state_snapshot` ignored that resolved value and hydrated with
`self.checkpointer`, which is `None` for any subgraph obtained from `get_subgraphs()`:

```python
# main.py:1169 (before)
channels, managed = channels_from_checkpoint(
    self.channels,
    saved.checkpoint,
    saver=self.checkpointer if isinstance(self.checkpointer, BaseCheckpointSaver) else None,
    config=saved.config,
)
```

Recovering it inside `_prepare_state_snapshot` isn't possible: `get_state_history`
passes `checkpoint_tuple.config`, the checkpointer's *stored* config, which never
carries `CONFIG_KEY_CHECKPOINTER`.

Result: `get_state`, `aget_state`, `get_state_history` and `aget_state_history` on a
nested subgraph namespace report every `DeltaChannel` as empty, with no error — and
non-delta channels in the same namespace hydrate correctly, so the payload looks
healthy.

**Same bug, write path.** `bulk_update_state` / `abulk_update_state` (which back
`update_state` / `aupdate_state`) contain the identical expression at `main.py:1666`
and `main.py:2152`. That one is destructive rather than merely misleading: when the
update pushes the channel to its `snapshot_frequency`, `create_checkpoint` writes a
`_DeltaSnapshot` built from the empty-hydrated channel, so the accumulated history is
lost *on disk*, not just in the response. Reproduced below; it is fixed here too
because it is the same root cause and the same expression — flagging it explicitly
since it is beyond the literal wording of the issue.

## Fix

`libs/langgraph/langgraph/pregel/main.py`, read path only for behaviour changes:

- `_prepare_state_snapshot` / `_aprepare_state_snapshot` take a new optional `saver`
  argument and prefer it over `self.checkpointer`, falling back to the old behaviour
  when it isn't a `BaseCheckpointSaver` (so any other caller is unaffected).
- The four public readers pass the checkpointer they already resolved from the config.
- `bulk_update_state` / `abulk_update_state` use their local resolved `checkpointer`
  instead of `self.checkpointer` in the same `channels_from_checkpoint` call.

No new resolution logic and no new config plumbing — the value was already computed a
few lines above every call site. A graph that owns its checkpointer resolves to the
same object it did before, so there is no behaviour change there.

## Testing

New file `libs/langgraph/tests/test_delta_channel_subgraph_read.py` (7 tests):
nested-subgraph `get_state` / `aget_state`, `get_state_history` /
`aget_state_history`, `update_state` / `aupdate_state`, plus a root-graph control.

```
$ cd libs/langgraph && TEST=tests/test_delta_channel_subgraph_read.py make test
7 passed
```

Against unmodified `langgraph/pregel/main.py` (fix stashed, tests kept):

```
6 failed, 1 passed
FAILED test_subgraph_get_state_delta_channel        - assert [] == ['one', 'two']
FAILED test_subgraph_get_state_history_delta_channel
FAILED test_subgraph_aget_state_delta_channel
FAILED test_subgraph_aget_state_history_delta_channel
FAILED test_subgraph_update_state_delta_channel
FAILED test_subgraph_aupdate_state_delta_channel
PASSED test_root_graph_get_state_delta_channel      # control, never affected
```

With only the read-path hunks applied, the two `update_state` tests still fail — both
halves of the change are load-bearing.

Full library suite:

```
$ cd libs/langgraph && NO_DOCKER=true uv run pytest tests/ -q -p no:randomly
1975 passed, 4 skipped in 154.59s
```

```
$ cd libs/langgraph && make format && make lint
149 files left unchanged / All checks passed (ruff, ruff format, isort, ty)
```

Issue repro, before → after:

```
child : {'msgs': []}                      →  {'msgs': ['a1', 'b1', 'b2']}
hist  : [{}, {}, {}, {}] all empty        →  [['a1','b1','b2'], ['a1'], [], []]
```

## Notes for reviewer

- **Scope.** The issue reports the read path; the write-path hunks
  (`bulk_update_state` / `abulk_update_state`) are the same root cause and the same
  expression, and cause silent data loss on disk. Happy to split them into a separate
  PR if you'd rather keep this one strictly to the four readers — the read fix stands
  alone.
- `_prepare_state_snapshot` still passes `self.checkpointer` to `prepare_next_tasks`
  (`main.py:1189`). I left that alone deliberately: it only seeds task configs for
  would-be execution, subgraph task states are resolved separately via `recurse`, and
  it is not needed for the bug. Worth a maintainer's opinion on whether it should be
  made consistent.
- `tests/test_pregel.py::test_stream_subgraphs_during_execution` is timing-flaky on
  this machine (`FloatBetween(0.0, 0.1)` assertions around `time.sleep`); it fails at
  the same rate with and without this change — 5 isolated runs each, both sides mixed
  pass/fail — and passed in the clean full-suite run above. Unrelated to this change,
  which touches no streaming code.
- New param is `saver`, keyword-passed at all four call sites and defaulted to `None`,
  so it does not disturb the existing positional `recurse` / `apply_pending_writes`
  arguments.

---
This contribution was developed with AI assistance (Claude Code). I reviewed the change and the test results before submitting.