### PR TITLE
test(checkpoint): make Redis availability probe cheap on Windows

### DIFF
--- a/libs/checkpoint/tests/test_redis_cache.py
+++ b/libs/checkpoint/tests/test_redis_cache.py
@@ -4,23 +4,45 @@ import time
 
 import pytest
 import redis
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 from langgraph.cache.base import FullKey
 from langgraph.cache.redis import RedisCache
 
 
+@pytest.fixture(scope="session")
+def redis_available() -> bool:
+    """Probe once per session whether a local Redis is reachable.
+
+    The probe disables redis-py's retry policy, which otherwise reattempts a
+    failed connection ten times with backoff. On Windows a refused loopback
+    connection takes ~2s per address family (`::1` then `127.0.0.1`) rather
+    than returning immediately, so the default policy turns an unavailable
+    Redis into a ~49s wait — paid again for every test in the class.
+    """
+    client = redis.Redis(host="localhost", port=6379, retry=Retry(NoBackoff(), 0))
+    try:
+        client.ping()
+    except redis.RedisError:
+        # Both ConnectionError and TimeoutError mean "not usable here".
+        return False
+    else:
+        return True
+    finally:
+        client.close()
+
+
 class TestRedisCache:
     @pytest.fixture(autouse=True)
-    def setup(self) -> None:
+    def setup(self, redis_available: bool) -> None:
         """Set up test Redis client and cache."""
+        if not redis_available:
+            pytest.skip("Redis server not available")
+
         self.client = redis.Redis(
             host="localhost", port=6379, db=0, decode_responses=False
         )
-        try:
-            self.client.ping()
-        except redis.ConnectionError:
-            pytest.skip("Redis server not available")
-
         self.cache: RedisCache = RedisCache(self.client, prefix="test:cache:")
 
         # Clean up before each test


### PR DESCRIPTION
Fixes #5029

On Windows the `libs/checkpoint` suite times out because the Redis test fixture's availability probe takes ~49s to decide Redis is absent, and being function-scoped it runs once per test. This moves the probe to a session-scoped fixture with redis-py's retry policy disabled, taking the full suite from a 600s timeout to 156 passed / 17 skipped in 9.93s.

Scope note: this only clears the blocker that stalled the earlier Windows CI attempts — the `windows-latest` job itself still needs adding, so #5029 probably wants to stay open rather than auto-close on merge.

How I verified: Windows 11, Python 3.12, redis-py 8.0.1, no Redis running. `test_redis_cache.py` goes from exceeding 180s to 16 skipped in 4.75s; full suite 156 passed, 17 skipped in 9.93s. `uv run ruff format --check` and `uv run ruff check` both pass (`make` isn't available on Windows by default, which is itself relevant to the CI job).

One gotcha for anyone else on this: `redis.TimeoutError` is not a subclass of `redis.ConnectionError`, so lowering `socket_connect_timeout` below Windows' ~2s loopback refusal converts the 16 skips into 16 errors. Measurements are in #5029.
