### PR TITLE
docs: fix 404 link to Why LangGraph in llms.txt

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,7 +5,7 @@ LangGraph documentation has moved to docs.langchain.com.
 ## Overview
 
 - [LangGraph Overview](https://docs.langchain.com/oss/python/langgraph/overview): Introduction to LangGraph, a library for building stateful, multi-actor applications with LLMs.
-- [Why LangGraph?](https://docs.langchain.com/oss/python/langgraph/why-langgraph): Motivation for LangGraph and its key features.
+- [Why LangGraph?](https://docs.langchain.com/oss/python/langgraph/overview): Motivation for LangGraph and its key features.
 
 ## Core Concepts
 


### PR DESCRIPTION
# What does this PR do?

Fixes the 404 link for the "Why LangGraph?" entry in `docs/llms.txt`.

The entry pointed to `https://docs.langchain.com/oss/python/langgraph/why-langgraph`, which returns 404. According to `docs/redirects.json`, the `/concepts/why-langgraph` path redirects to the LangGraph overview page, so this PR points the entry to `https://docs.langchain.com/oss/python/langgraph/overview` instead.

Fixes #8509