### PR TITLE
fix(checkpoint): default LANGGRAPH_STRICT_MSGPACK to true

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -1,15 +1,17 @@
 """Msgpack deserialization safety controls.
 
-Set ``LANGGRAPH_STRICT_MSGPACK=true`` to restrict checkpoint deserialization
-to the types listed in ``SAFE_MSGPACK_TYPES``.  Without this, any Python
-callable stored in checkpoint data will be imported and executed on load.
+``LANGGRAPH_STRICT_MSGPACK`` defaults to true, restricting checkpoint
+deserialization to the types listed in ``SAFE_MSGPACK_TYPES``.
+Set ``LANGGRAPH_STRICT_MSGPACK=false`` to opt out (permissive mode).
+When disabled, any Python callable stored in checkpoint data will be
+imported and executed on load.
 """
 
 import os
 from collections.abc import Iterable
 from typing import cast
 
-STRICT_MSGPACK_ENABLED = os.getenv("LANGGRAPH_STRICT_MSGPACK", "false").lower() in (
+STRICT_MSGPACK_ENABLED = os.getenv("LANGGRAPH_STRICT_MSGPACK", "true").lower() in (
     "1",
     "true",
     "yes",


### PR DESCRIPTION
Fixes #8522

## Summary
- Defaults `LANGGRAPH_STRICT_MSGPACK` to **true** so msgpack constructor allowlisting is secure-by-default after [GHSA-g48c-2wqr-h844](https://github.com/langchain-ai/langgraph/security/advisories/GHSA-g48c-2wqr-h844).
- Operators who need the previous permissive behavior can set `LANGGRAPH_STRICT_MSGPACK=false` or use an explicit allowlist.
- Test conftest override left as-is so the suite can still exercise non-strict paths.

## Test plan
- [ ] CI on this PR
- [ ] Confirm apps with custom checkpoint types document opt-out / allowlist