### PR TITLE
test(checkpoint-postgres,checkpoint-sqlite): run the conformance suite

### DIFF
--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -32,6 +32,7 @@ test = [
   "pytest-mock",
   "psycopg[binary]",
   "langgraph-checkpoint",
+  "langgraph-checkpoint-conformance",
   "pytest-watcher",
 ]
 lint = [
@@ -49,6 +50,7 @@ default-groups = ['dev']
 
 [tool.uv.sources]
 langgraph-checkpoint = { path = "../checkpoint", editable = true }
+langgraph-checkpoint-conformance = { path = "../checkpoint-conformance", editable = true }
 
 [tool.hatch.build.targets.wheel]
 include = ["langgraph"]

--- a/libs/checkpoint-postgres/tests/test_conformance_delta.py
+++ b/libs/checkpoint-postgres/tests/test_conformance_delta.py
@@ -1,0 +1,37 @@
+"""Run delta-channel conformance capabilities against AsyncPostgresSaver."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import DEFAULT_URI
+
+pytest.importorskip(
+    "langgraph.checkpoint.conformance",
+    reason="langgraph-checkpoint-conformance not installed",
+)
+
+
+@pytest.mark.asyncio
+async def test_delta_channel_conformance():
+    from langgraph.checkpoint.conformance import validate
+    from langgraph.checkpoint.conformance.initializer import checkpointer_test
+
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+    @checkpointer_test(name="AsyncPostgresSaver")
+    async def postgres_saver():
+        async with AsyncPostgresSaver.from_conn_string(DEFAULT_URI) as saver:
+            await saver.setup()
+            yield saver
+
+    report = await validate(
+        postgres_saver,
+        capabilities={
+            "delta_channel_history",
+        },
+    )
+    for cap, result in report.results.items():
+        if result.passed is False:
+            details = "\n".join(result.failures or [])
+            pytest.fail(f"Capability {cap} failed:\n{details}")

--- a/libs/checkpoint-postgres/tests/test_conformance_delta.py
+++ b/libs/checkpoint-postgres/tests/test_conformance_delta.py
@@ -3,22 +3,15 @@
 from __future__ import annotations
 
 import pytest
+from langgraph.checkpoint.conformance import validate
+from langgraph.checkpoint.conformance.initializer import checkpointer_test
 
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from tests.conftest import DEFAULT_URI
-
-pytest.importorskip(
-    "langgraph.checkpoint.conformance",
-    reason="langgraph-checkpoint-conformance not installed",
-)
 
 
 @pytest.mark.asyncio
 async def test_delta_channel_conformance():
-    from langgraph.checkpoint.conformance import validate
-    from langgraph.checkpoint.conformance.initializer import checkpointer_test
-
-    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-
     @checkpointer_test(name="AsyncPostgresSaver")
     async def postgres_saver():
         async with AsyncPostgresSaver.from_conn_string(DEFAULT_URI) as saver:

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -159,7 +159,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -323,6 +323,33 @@ test = [
 ]
 
 [[package]]
+name = "langgraph-checkpoint-conformance"
+version = "0.0.2"
+source = { editable = "../checkpoint-conformance" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "langgraph-checkpoint", editable = "../checkpoint" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+lint = [
+    { name = "ruff" },
+    { name = "ty" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[[package]]
 name = "langgraph-checkpoint-postgres"
 version = "3.1.1"
 source = { editable = "." }
@@ -338,6 +365,7 @@ dev = [
     { name = "anyio" },
     { name = "codespell" },
     { name = "langgraph-checkpoint" },
+    { name = "langgraph-checkpoint-conformance" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -354,6 +382,7 @@ lint = [
 test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint" },
+    { name = "langgraph-checkpoint-conformance" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -374,6 +403,7 @@ dev = [
     { name = "anyio" },
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -390,6 +420,7 @@ lint = [
 test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },

--- a/libs/checkpoint-sqlite/pyproject.toml
+++ b/libs/checkpoint-sqlite/pyproject.toml
@@ -30,6 +30,7 @@ test = [
   "pytest-mock",
   "pytest-watcher",
   "langgraph-checkpoint",
+  "langgraph-checkpoint-conformance",
   "pytest-retry>=1.7.0",
 ]
 lint = [
@@ -47,6 +48,7 @@ default-groups = ['dev']
 
 [tool.uv.sources]
 langgraph-checkpoint = { path = "../checkpoint", editable = true }
+langgraph-checkpoint-conformance = { path = "../checkpoint-conformance", editable = true }
 
 [tool.hatch.build.targets.wheel]
 include = ["langgraph"]

--- a/libs/checkpoint-sqlite/tests/test_conformance_delta.py
+++ b/libs/checkpoint-sqlite/tests/test_conformance_delta.py
@@ -8,11 +8,6 @@ from langgraph.checkpoint.conformance.initializer import checkpointer_test
 
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
-from langgraph.checkpoint.conformance import validate
-from langgraph.checkpoint.conformance.initializer import checkpointer_test
-
-from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-
 
 @pytest.mark.asyncio
 async def test_delta_channel_conformance():

--- a/libs/checkpoint-sqlite/tests/test_conformance_delta.py
+++ b/libs/checkpoint-sqlite/tests/test_conformance_delta.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from langgraph.checkpoint.conformance import validate
+from langgraph.checkpoint.conformance.initializer import checkpointer_test
 
-pytest.importorskip(
-    "langgraph.checkpoint.conformance",
-    reason="langgraph-checkpoint-conformance not installed",
-)
-pytest.importorskip("aiosqlite", reason="aiosqlite not installed")
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from langgraph.checkpoint.conformance import validate
 from langgraph.checkpoint.conformance.initializer import checkpointer_test

--- a/libs/checkpoint-sqlite/uv.lock
+++ b/libs/checkpoint-sqlite/uv.lock
@@ -168,7 +168,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -332,6 +332,33 @@ test = [
 ]
 
 [[package]]
+name = "langgraph-checkpoint-conformance"
+version = "0.0.2"
+source = { editable = "../checkpoint-conformance" }
+dependencies = [
+    { name = "langgraph-checkpoint" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "langgraph-checkpoint", editable = "../checkpoint" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+lint = [
+    { name = "ruff" },
+    { name = "ty" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[[package]]
 name = "langgraph-checkpoint-sqlite"
 version = "3.1.1"
 source = { editable = "." }
@@ -345,6 +372,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint" },
+    { name = "langgraph-checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -360,6 +388,7 @@ lint = [
 ]
 test = [
     { name = "langgraph-checkpoint" },
+    { name = "langgraph-checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -378,6 +407,7 @@ requires-dist = [
 dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -393,6 +423,7 @@ lint = [
 ]
 test = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1692,6 +1692,7 @@ dev = [
     { name = "anyio" },
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1708,6 +1709,7 @@ lint = [
 test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1736,6 +1738,7 @@ requires-dist = [
 dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -1751,6 +1754,7 @@ lint = [
 ]
 test = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -168,7 +168,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -439,6 +439,7 @@ dev = [
     { name = "anyio" },
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -455,6 +456,7 @@ lint = [
 test = [
     { name = "anyio" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -483,6 +485,7 @@ requires-dist = [
 dev = [
     { name = "codespell" },
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -498,6 +501,7 @@ lint = [
 ]
 test = [
     { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-conformance", editable = "../checkpoint-conformance" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },


### PR DESCRIPTION
Depends on #8535

`libs/checkpoint-conformance/tests/` only validates `InMemorySaver`. `checkpoint-sqlite` has had a `test_conformance_delta.py` for a while, but it guards on `importorskip("langgraph.checkpoint.conformance")` and the package was never in its test environment — so it has been skipping silently every run. `checkpoint-postgres` had no runner at all.

Net effect: the shared checkpointer contract was effectively unenforced everywhere except in-memory.

### Change

Adds `langgraph-checkpoint-conformance` to the `test` dependency group of both packages, with a path source like the existing `langgraph-checkpoint` entry. That alone is what makes sqlite's runner start executing. Postgres gets the equivalent runner.

Both pass the `delta_channel_history` capability.

### Why it's stacked

Against `main`'s Postgres, the new runner fails:

```
Capability delta_channel_history failed:
  test_history_migration_plain_value_as_seed
```

That is exactly the bug #8535 fixes, and it had been failing unnoticed precisely because nothing ran the suite there. So this is based on that branch rather than `main` — the diff here is the one conformance commit, and it will retarget once #8535 lands.

Reasonable to read that as the change justifying itself: the first thing turning the suite on did was catch a real bug that had been sitting in `main`.

### Verified

`checkpoint-postgres` 270 passed on PG 15 and 16, `checkpoint-sqlite` 118 passed, lint and `ty` clean in both. The `uv.lock` updates are the conformance package entry only.

### Note

The sync `PostgresSaver` and `SqliteSaver` aren't covered — the conformance harness reports every capability as `detected=False` for them, so only the async savers are exercised. Pre-existing and not addressed here, but worth knowing the coverage isn't total.
