### PR TITLE
fix(langgraph): hydrate subgraph delta channels with the caller-resolved saver

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1146,9 +1146,26 @@ class Pregel(
         self,
         config: RunnableConfig,
         saved: CheckpointTuple | None,
+        *,
+        saver: BaseCheckpointSaver | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
     ) -> StateSnapshot:
+        """Assemble a `StateSnapshot` from a saved checkpoint.
+
+        Args:
+            config: Config identifying the checkpoint being read.
+            saved: The checkpoint tuple to render, or `None` for an empty snapshot.
+            saver: Checkpointer to read with, as resolved by the caller from
+                `CONFIG_KEY_CHECKPOINTER` before falling back to `self.checkpointer`.
+                Required rather than defaulted because `self.checkpointer` is `None`
+                for a subgraph — it borrows the parent's saver through the config —
+                and a `DeltaChannel` silently hydrates empty without one.
+            recurse: When set, resolve subgraph task states with this checkpointer
+                instead of returning a config that merely signals they exist.
+            apply_pending_writes: Apply this checkpoint's pending writes to the
+                returned values.
+        """
         if not saved:
             return StateSnapshot(
                 values={},
@@ -1169,9 +1186,7 @@ class Pregel(
         channels, managed = channels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
-            if isinstance(self.checkpointer, BaseCheckpointSaver)
-            else None,
+            saver=saver,
             config=saved.config,
         )
         # tasks for this checkpoint
@@ -1269,9 +1284,12 @@ class Pregel(
         self,
         config: RunnableConfig,
         saved: CheckpointTuple | None,
+        *,
+        saver: BaseCheckpointSaver | None,
         recurse: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
     ) -> StateSnapshot:
+        """Async version of `_prepare_state_snapshot`. See docstring there."""
         if not saved:
             return StateSnapshot(
                 values={},
@@ -1292,9 +1310,7 @@ class Pregel(
         channels, managed = await achannels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
-            if isinstance(self.checkpointer, BaseCheckpointSaver)
-            else None,
+            saver=saver,
             config=saved.config,
         )
         # tasks for this checkpoint
@@ -1429,6 +1445,7 @@ class Pregel(
         return self._prepare_state_snapshot(
             config,
             saved,
+            saver=checkpointer,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
         )
@@ -1473,6 +1490,7 @@ class Pregel(
         return await self._aprepare_state_snapshot(
             config,
             saved,
+            saver=checkpointer,
             recurse=checkpointer if subgraphs else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
         )
@@ -1527,7 +1545,7 @@ class Pregel(
             checkpointer.list(config, before=before, limit=limit, filter=filter)
         ):
             yield self._prepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     async def aget_state_history(
@@ -1584,7 +1602,7 @@ class Pregel(
             )
         ]:
             yield await self._aprepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config, checkpoint_tuple, saver=checkpointer
             )
 
     def bulk_update_state(
@@ -1666,10 +1684,7 @@ class Pregel(
             channels, managed = channels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
-                if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
-                else None,
+                saver=checkpointer if saved is not None else None,
                 config=saved.config if saved is not None else None,
             )
             values, as_node = updates[0][:2]
@@ -2132,10 +2147,7 @@ class Pregel(
             channels, managed = await achannels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
-                if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
-                else None,
+                saver=checkpointer if saved is not None else None,
                 config=saved.config if saved is not None else None,
             )
             values, as_node = updates[0][:2]

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1159,7 +1159,7 @@ class Pregel(
             saver: Checkpointer to read with, as resolved by the caller from
                 `CONFIG_KEY_CHECKPOINTER` before falling back to `self.checkpointer`.
                 Required rather than defaulted because `self.checkpointer` is `None`
-                for a subgraph — it borrows the parent's saver through the config —
+                for a subgraph, which borrows the parent's saver through the config,
                 and a `DeltaChannel` silently hydrates empty without one.
             recurse: When set, resolve subgraph task states with this checkpointer
                 instead of returning a config that merely signals they exist.

--- a/libs/langgraph/tests/test_delta_channel_subgraph.py
+++ b/libs/langgraph/tests/test_delta_channel_subgraph.py
@@ -2,7 +2,7 @@
 
 Regression suite for #8470.
 
-A subgraph is compiled without a checkpointer of its own — the parent lends it
+A subgraph is compiled without a checkpointer of its own. The parent lends it
 one through `CONFIG_KEY_CHECKPOINTER` at read time. `DeltaChannel` stores no
 value in `channel_values`, so hydrating it requires that saver to walk ancestors
 and replay their writes. Reading with `self.checkpointer` instead of the
@@ -286,3 +286,43 @@ def test_root_graph_update_state_preserves_delta_channel_history() -> None:
     app.update_state(config, {"msgs": ["manual"]})
 
     assert app.get_state(config).values == {"msgs": ["a1", "b1", "b2", "manual"]}
+
+
+def test_stateless_subgraph_persists_nothing() -> None:
+    """A `checkpointer=False` subgraph opts out of persistence entirely.
+
+    Its state is unavailable by design, and passing the caller's saver must not
+    start surfacing state for a subgraph that asked not to be checkpointed.
+    """
+    child = _child_builder(snapshot_frequency=1000).compile(checkpointer=False)
+    builder = StateGraph(child.builder.state_schema)
+    builder.add_node("child", child)
+    builder.add_edge(START, "child")
+    builder.add_edge("child", END)
+    app = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    subgraph_namespaces = [
+        task.state["configurable"]["checkpoint_ns"]
+        for snapshot in app.get_state_history(config)
+        for task in snapshot.tasks
+        if task.name == "child" and isinstance(task.state, dict)
+    ]
+
+    assert subgraph_namespaces == []
+    assert app.get_state(config).values == {"msgs": ["a1", "b1", "b2"]}
+
+
+def test_completed_subgraph_exposes_no_task_state() -> None:
+    """`subgraphs=True` surfaces task state only while a task is pending.
+
+    Once the subgraph has finished there is no task to attach state to, for every
+    channel type alike. This is subgraph behaviour rather than delta replay, and
+    the fix leaves it untouched.
+    """
+    app = _build_nested_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    assert app.get_state(config, subgraphs=True).tasks == ()

--- a/libs/langgraph/tests/test_delta_channel_subgraph.py
+++ b/libs/langgraph/tests/test_delta_channel_subgraph.py
@@ -1,0 +1,288 @@
+"""Tests for reading and updating a subgraph's `DeltaChannel` state.
+
+Regression suite for #8470.
+
+A subgraph is compiled without a checkpointer of its own — the parent lends it
+one through `CONFIG_KEY_CHECKPOINTER` at read time. `DeltaChannel` stores no
+value in `channel_values`, so hydrating it requires that saver to walk ancestors
+and replay their writes. Reading with `self.checkpointer` instead of the
+caller-resolved saver leaves a subgraph with none, and the channel falls through
+to `from_checkpoint(MISSING)`: an empty value, indistinguishable from a channel
+that was never written and raising nothing.
+
+Coverage:
+
+* `get_state` / `aget_state` and `get_state_history` / `aget_state_history` on a
+  subgraph namespace, at one and two levels of nesting
+* `get_state(subgraphs=True)` task states, the surface a human-in-the-loop client
+  reads while a subgraph sits interrupted
+* `update_state` / `aupdate_state`, which persist the hydrated value as a
+  snapshot blob and so turn an empty hydration into permanent data loss
+* root-graph controls, which own their checkpointer and were never affected
+"""
+
+from typing import Annotated, Any
+
+import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+from typing_extensions import TypedDict
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import interrupt
+
+pytestmark = pytest.mark.anyio
+
+
+def _extend(state: list | None, writes: list[Any]) -> list:
+    """Batching-invariant list reducer: flattens each write batch onto the state."""
+    out = list(state or [])
+    for write in writes:
+        out.extend(write if isinstance(write, list) else [write])
+    return out
+
+
+def _child_builder(*, snapshot_frequency: int) -> StateGraph:
+    """Two-node graph writing `["a1"]` then `["b1", "b2"]` to a `DeltaChannel`."""
+
+    class State(TypedDict, total=False):
+        msgs: Annotated[
+            list, DeltaChannel(_extend, snapshot_frequency=snapshot_frequency)
+        ]
+
+    builder = StateGraph(State)
+    builder.add_node("a", lambda state: {"msgs": ["a1"]})
+    builder.add_node("b", lambda state: {"msgs": ["b1", "b2"]})
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", END)
+    return builder
+
+
+def _wrap(inner: StateGraph, *, node_name: str) -> StateGraph:
+    """Nest `inner` as a single node, sharing its state schema."""
+    builder = StateGraph(inner.state_schema)
+    builder.add_node(node_name, inner.compile())
+    builder.add_edge(START, node_name)
+    builder.add_edge(node_name, END)
+    return builder
+
+
+def _build_nested_graph(
+    checkpointer: InMemorySaver,
+    *,
+    snapshot_frequency: int = 1000,
+    depth: int = 1,
+) -> Any:
+    """Compile a graph whose `child` node is a subgraph nested `depth` levels deep."""
+    graph = _child_builder(snapshot_frequency=snapshot_frequency)
+    for _ in range(depth):
+        graph = _wrap(graph, node_name="child")
+    return graph.compile(checkpointer=checkpointer)
+
+
+def _namespaced(config: dict, namespace: str) -> dict:
+    return {"configurable": {**config["configurable"], "checkpoint_ns": namespace}}
+
+
+def _subgraph_namespace(app: Any, config: dict, *, depth: int = 1) -> str:
+    """Resolve the `child` namespace `depth` levels down, as a client would.
+
+    Each snapshot's tasks carry `{name, state: {"configurable": {"checkpoint_ns"}}}`,
+    and passing that namespace back is the documented way to read a subgraph's own
+    supersteps.
+    """
+    namespace = ""
+    for level in range(depth):
+        scoped = _namespaced(config, namespace) if namespace else config
+        namespace = next(
+            (
+                task.state["configurable"]["checkpoint_ns"]
+                for snapshot in app.get_state_history(scoped)
+                for task in snapshot.tasks
+                if task.name == "child" and isinstance(task.state, dict)
+            ),
+            "",
+        )
+        assert namespace, f"no `child` subgraph task at nesting level {level}"
+    return namespace
+
+
+# ---------------------------------------------------------------------------
+# Reading a subgraph's state
+# ---------------------------------------------------------------------------
+
+
+def test_subgraph_get_state_replays_delta_channel() -> None:
+    app = _build_nested_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+
+    assert app.get_state(config).values == {"msgs": ["a1", "b1", "b2"]}
+    assert app.get_state(_namespaced(config, namespace)).values == {
+        "msgs": ["a1", "b1", "b2"]
+    }
+
+
+async def test_subgraph_aget_state_replays_delta_channel() -> None:
+    app = _build_nested_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    await app.ainvoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+
+    assert (await app.aget_state(_namespaced(config, namespace))).values == {
+        "msgs": ["a1", "b1", "b2"]
+    }
+
+
+def test_subgraph_get_state_history_replays_delta_channel() -> None:
+    app = _build_nested_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+    values = [
+        snapshot.values
+        for snapshot in app.get_state_history(_namespaced(config, namespace))
+    ]
+
+    # newest first: after `b`, after `a`, then the two supersteps preceding any write
+    assert values == [
+        {"msgs": ["a1", "b1", "b2"]},
+        {"msgs": ["a1"]},
+        {"msgs": []},
+        {"msgs": []},
+    ]
+
+
+async def test_subgraph_aget_state_history_replays_delta_channel() -> None:
+    app = _build_nested_graph(InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    await app.ainvoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+    values = [
+        snapshot.values
+        async for snapshot in app.aget_state_history(_namespaced(config, namespace))
+    ]
+
+    assert values == [
+        {"msgs": ["a1", "b1", "b2"]},
+        {"msgs": ["a1"]},
+        {"msgs": []},
+        {"msgs": []},
+    ]
+
+
+def test_doubly_nested_subgraph_get_state_replays_delta_channel() -> None:
+    app = _build_nested_graph(InMemorySaver(), depth=2)
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    namespace = _subgraph_namespace(app, config, depth=2)
+
+    assert app.get_state(_namespaced(config, namespace)).values == {
+        "msgs": ["a1", "b1", "b2"]
+    }
+
+
+def test_interrupted_subgraph_task_state_replays_delta_channel() -> None:
+    """`get_state(subgraphs=True)` resolves task states through a separate
+    recursion; it reads the paused subgraph a human-in-the-loop client is shown."""
+
+    class State(TypedDict, total=False):
+        msgs: Annotated[list, DeltaChannel(_extend)]
+
+    def pause(state: State) -> dict:
+        interrupt("pause")
+        return {"msgs": ["b1"]}
+
+    child = StateGraph(State)
+    child.add_node("a", lambda state: {"msgs": ["a1", "a2"]})
+    child.add_node("b", pause)
+    child.add_edge(START, "a")
+    child.add_edge("a", "b")
+    child.add_edge("b", END)
+
+    app = _wrap(child, node_name="child").compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    task_values = [
+        task.state.values
+        for task in app.get_state(config, subgraphs=True).tasks
+        if task.name == "child"
+    ]
+
+    assert task_values == [{"msgs": ["a1", "a2"]}]
+
+
+# ---------------------------------------------------------------------------
+# Updating a subgraph's state
+# ---------------------------------------------------------------------------
+
+
+def test_subgraph_update_state_preserves_delta_channel_history() -> None:
+    """`update_state` persists the hydrated channel, so an empty hydration is
+    written to disk rather than merely returned.
+
+    `snapshot_frequency=2` is what makes that observable: this update reaches the
+    cadence and forces a `_DeltaSnapshot` blob built from the hydrated value. At
+    the default frequency nothing is written and the loss stays latent, so the
+    assertion below would hold either way.
+    """
+    app = _build_nested_graph(InMemorySaver(), snapshot_frequency=2)
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+    child_config = _namespaced(config, namespace)
+    app.update_state(child_config, {"msgs": ["manual"]})
+
+    assert app.get_state(child_config).values == {"msgs": ["a1", "b1", "b2", "manual"]}
+
+
+async def test_subgraph_aupdate_state_preserves_delta_channel_history() -> None:
+    app = _build_nested_graph(InMemorySaver(), snapshot_frequency=2)
+    config = {"configurable": {"thread_id": "1"}}
+    await app.ainvoke({}, config)
+
+    namespace = _subgraph_namespace(app, config)
+    child_config = _namespaced(config, namespace)
+    await app.aupdate_state(child_config, {"msgs": ["manual"]})
+
+    assert (await app.aget_state(child_config)).values == {
+        "msgs": ["a1", "b1", "b2", "manual"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Controls: a graph owning its checkpointer resolves the same saver as before
+# ---------------------------------------------------------------------------
+
+
+def test_root_graph_get_state_replays_delta_channel() -> None:
+    app = _child_builder(snapshot_frequency=1000).compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    assert app.get_state(config).values == {"msgs": ["a1", "b1", "b2"]}
+    assert [snapshot.values for snapshot in app.get_state_history(config)] == [
+        {"msgs": ["a1", "b1", "b2"]},
+        {"msgs": ["a1"]},
+        {"msgs": []},
+        {"msgs": []},
+    ]
+
+
+def test_root_graph_update_state_preserves_delta_channel_history() -> None:
+    app = _child_builder(snapshot_frequency=2).compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "1"}}
+    app.invoke({}, config)
+
+    app.update_state(config, {"msgs": ["manual"]})
+
+    assert app.get_state(config).values == {"msgs": ["a1", "b1", "b2", "manual"]}


### PR DESCRIPTION
Fixes langchain-ai/langgraph#8470

Reported by @gururafiki, with a self-contained `InMemorySaver` repro and the observation that non-delta channels in the same namespace hydrate fine, which is what makes the failure silent.

`_prepare_state_snapshot` re-derived the saver from `self.checkpointer`, which is `None` for a subgraph, so every `DeltaChannel` in a nested subgraph hydrated empty on read, silently.

### Why the old resolution was wrong

A `DeltaChannel` stores no value in `channel_values`, so reconstructing it means walking ancestors and replaying their writes, which needs a saver. A subgraph has none of its own: it borrows the parent's through `CONFIG_KEY_CHECKPOINTER` at read time, exactly as the four public readers already resolve it a few lines above the call.

`_prepare_state_snapshot` ignored that and went back to `self.checkpointer`. With no saver the walk never ran, and the channel fell through to `from_checkpoint(MISSING)`: an empty value, indistinguishable from a channel that was never written, raising nothing. Non-delta channels in the same namespace hydrate fine, so the payload looks healthy.

Recovering it inside the function isn't possible: `get_state_history` passes `checkpoint_tuple.config`, the checkpointer's *stored* config, which never carries a live saver. The caller is the only place the resolved saver exists, so the caller has to pass it.

### How I verified it

`tests/test_delta_channel_subgraph.py` adds 12 tests. **8 fail on main, 4 pass.** The 4 that pass are controls for modes that stay unchanged (the two root-graph cases, a stateless subgraph, a completed subgraph). The 8 failures, by surface:

<!-- linear:table-colwidths:400,400 -->
| surface | on main |
| -- | -- |
| `get_state` / `aget_state` on a subgraph ns | `{'msgs': []}` |
| `get_state_history` / `aget_state_history` | every snapshot empty |
| two levels of nesting | `{'msgs': []}` |
| `get_state(subgraphs=True)` task state, subgraph interrupted | `{'msgs': []}` |
| `update_state` / `aupdate_state` | `['manual']`, prior history destroyed |

Tests use `InMemorySaver`: the defect is in `Pregel`'s saver resolution rather than in any checkpointer implementation, so the storage backend is irrelevant to the reproduction.

Full suite `1968 -> 1980 passed, 4 skipped`, exactly the 12 new tests. `make format`, `lint_package`, `lint_tests` clean; `check_sdk_methods.py` passes.

### Two things worth a closer look in review

**1. This fixes a write path as well as a read path, and both are load-bearing.** `bulk_update_state` / `abulk_update_state` carried the same expression, and that half is worse than a misleading read: when the update reaches the channel's snapshot cadence, `create_checkpoint` persists a `_DeltaSnapshot` built from the empty-hydrated channel, losing history **on disk**. I checked whether it could be split: reverting only the two `bulk_update_state` hunks leaves `test_subgraph_update_state_preserves_delta_channel_history` and its async twin failing while the other 10 pass. Splitting would ship a fix that still corrupts history on write.

The write-path tests use `snapshot_frequency=2`, which is what makes the update reach the cadence and force a snapshot blob. At the default 1000 nothing is written, the loss stays latent, and the assertion would hold either way.

**2.** `prepare_next_tasks` **in the same two methods still receives** `self.checkpointer`**, and I left it.** It is inert on the read path: `_algo.py:915` builds the task config as `checkpointer or configurable.get(CONFIG_KEY_CHECKPOINTER)`, so a subgraph's `None` already falls back to the config value, and `PregelTask` carries no `config` field, so that config never reaches a reader. Changing it would be cosmetic, but I'll make it symmetric if you'd rather not leave two different expressions side by side.

### Note on the signature

`saver` is a **required** keyword argument rather than a defaulted one. A silent fallback is what caused this bug, and both methods are private with no other callers, so there is nothing to stay compatible with. `recurse` stays defaulted because `None` is meaningful there (do not resolve subgraph task states); for `saver`, `None` is only ever a bug.

Net -6 lines of logic: passing an already-narrowed saver removes the `isinstance` dance at every site.
