### PR TITLE
fix(langgraph): don't replay an abandoned branch into a DeltaChannel fork

### DIFF
--- a/libs/langgraph/langgraph/pregel/_checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/_checkpoint.py
@@ -81,7 +81,13 @@ def get_updated_channels_from_tasks(
 def get_delta_channels_from_all_channels(
     channels: Mapping[str, BaseChannel],
 ) -> set[str]:
-    """DeltaChannels to snapshot on the first update_state of a fresh thread."""
+    """Every available DeltaChannel.
+
+    The set to snapshot whenever no ancestor walk can reconstruct these
+    channels: the first update_state of a fresh thread (no ancestors at all),
+    and the first checkpoint of a fork (whose base also holds the writes of the
+    branch the fork abandons).
+    """
     return {
         k
         for k, ch in channels.items()
@@ -122,14 +128,24 @@ def create_checkpoint_plan_for_update_state_api(
     parents: dict[str, Any],
     saved_metadata: Mapping[str, Any] | None,
     is_fresh_thread: bool,
+    is_fork: bool,
 ) -> tuple[set[str], dict[str, Any]]:
-    """Return ``(channels_to_snapshot, metadata)`` for an update_state head."""
+    """Return ``(channels_to_snapshot, metadata)`` for an update_state head.
+
+    ``is_fork`` (the update was addressed at an explicit checkpoint) forces a
+    full snapshot for the same reason ``is_fresh_thread`` does: the ancestor
+    walk cannot reconstruct this head. The base a fork branches off keeps the
+    pending writes of the branch being abandoned, and nothing records which
+    child consumed which write, so the walk would replay them here too.
+    Snapshotting terminates the walk at this checkpoint. Every delta channel
+    snapshots, so no counters carry over.
+    """
     metadata: dict[str, Any] = {
         "source": "update",
         "step": step,
         "parents": parents,
     }
-    if is_fresh_thread:
+    if is_fresh_thread or is_fork:
         return get_delta_channels_from_all_channels(channels), metadata
 
     new_counters = create_metadata_for_update_state_api(
@@ -179,9 +195,11 @@ def create_checkpoint(
             ch = channels[k]
             if k in channels_to_snapshot:
                 # Callers force a full snapshot blob here: exit mode when a
-                # delta channel reaches its snapshot cadence, and update_state
-                # on a fresh thread (no ancestor to replay writes from). The
-                # manual version-bump below only applies to the exit-mode case.
+                # delta channel reaches its snapshot cadence, update_state on
+                # a fresh thread (no ancestor to replay writes from), and a
+                # fork (whose base also holds the abandoned branch's writes).
+                # The manual version-bump below only applies to the exit-mode
+                # case.
                 #
                 # In exit mode, the snapshot decision is deferred to exit
                 # time (intermediate steps have do_checkpoint=False). The

--- a/libs/langgraph/langgraph/pregel/_checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/_checkpoint.py
@@ -162,6 +162,41 @@ def create_checkpoint_plan_for_update_state_api(
     return channels_to_snapshot, metadata
 
 
+def create_fork_checkpoint(
+    checkpoint: Checkpoint,
+    channels: Mapping[str, BaseChannel],
+    step: int,
+    *,
+    is_fork: bool,
+    get_next_version: GetNextVersion,
+) -> Checkpoint:
+    """``create_checkpoint`` for an update_state path that bypasses the plan.
+
+    The ``as_node`` INPUT and END paths write the fork's first checkpoint and
+    return before ``create_checkpoint_plan_for_update_state_api`` runs. Left
+    without a snapshot that checkpoint does not seal the fork, and the next
+    superstep reconstructs its delta channels by walking through the shared
+    base, picking up the abandoned branch's writes and then baking them into
+    whatever it snapshots. Sealing has to happen on the fork's *first*
+    checkpoint, which is this one.
+
+    ``get_next_version`` is required for the same reason exit mode needs it:
+    these paths apply writes to the input channel, not to the delta channel,
+    so nothing bumps the delta channel's version and ``put`` would drop the
+    blob as not-a-new-version. Callers must derive ``new_versions`` from the
+    returned checkpoint rather than the one they passed in.
+    """
+    if not is_fork:
+        return create_checkpoint(checkpoint, channels, step)
+    return create_checkpoint(
+        checkpoint,
+        channels,
+        step,
+        get_next_version=get_next_version,
+        channels_to_snapshot=get_delta_channels_from_all_channels(channels),
+    )
+
+
 def create_checkpoint(
     checkpoint: Checkpoint,
     channels: Mapping[str, BaseChannel] | None,

--- a/libs/langgraph/langgraph/pregel/_checkpoint.py
+++ b/libs/langgraph/langgraph/pregel/_checkpoint.py
@@ -80,6 +80,8 @@ def get_updated_channels_from_tasks(
 
 def get_delta_channels_from_all_channels(
     channels: Mapping[str, BaseChannel],
+    *,
+    include_unavailable: bool = False,
 ) -> set[str]:
     """Every available DeltaChannel.
 
@@ -91,7 +93,7 @@ def get_delta_channels_from_all_channels(
     return {
         k
         for k, ch in channels.items()
-        if isinstance(ch, DeltaChannel) and ch.is_available()
+        if isinstance(ch, DeltaChannel) and (include_unavailable or ch.is_available())
     }
 
 
@@ -146,7 +148,9 @@ def create_checkpoint_plan_for_update_state_api(
         "parents": parents,
     }
     if is_fresh_thread or is_fork:
-        return get_delta_channels_from_all_channels(channels), metadata
+        return get_delta_channels_from_all_channels(
+            channels, include_unavailable=is_fork
+        ), metadata
 
     new_counters = create_metadata_for_update_state_api(
         channels,
@@ -193,7 +197,9 @@ def create_fork_checkpoint(
         channels,
         step,
         get_next_version=get_next_version,
-        channels_to_snapshot=get_delta_channels_from_all_channels(channels),
+        channels_to_snapshot=get_delta_channels_from_all_channels(
+            channels, include_unavailable=True
+        ),
     )
 
 
@@ -225,9 +231,20 @@ def create_checkpoint(
         values = {}
         channel_versions = dict(checkpoint["channel_versions"])
         for k in channels:
-            if k not in channel_versions:
-                continue
             ch = channels[k]
+            if k not in channel_versions:
+                # Nothing was ever written to this channel on this branch, so
+                # it has no version and `put` would drop any blob stored for
+                # it. A *forced* snapshot still has to land: it is the only
+                # thing that stops the ancestor walk running past this
+                # checkpoint into a fork base that holds another branch's
+                # writes. Mint a first version so the blob survives.
+                if k in channels_to_snapshot and get_next_version is not None:
+                    channel_versions[k] = get_next_version(None, None)
+                    values[k] = _DeltaSnapshot(
+                        ch.get() if ch.is_available() else ch.typ()
+                    )
+                continue
             if k in channels_to_snapshot:
                 # Callers force a full snapshot blob here: exit mode when a
                 # delta channel reaches its snapshot cadence, update_state on

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -222,10 +222,32 @@ class PregelLoop:
     # under the saver's `ORDER BY task_id, idx` sorting.
     _exit_delta_writes: list[tuple[int, str, str, Any]] | None = None
 
-    # Delta channels that saw an Overwrite since the last checkpoint. These
-    # channels must snapshot after live update applies overwrite semantics so
-    # sparse replay starts from the same post-overwrite value.
-    _delta_channels_with_overwrite: set[str]
+    # Delta channels that must snapshot at the next checkpoint, whatever their
+    # cadence counters say. Two sources:
+    # * an Overwrite arrived since the last checkpoint, so the snapshot has to
+    #   happen after live update applied overwrite semantics and sparse replay
+    #   starts from the same post-overwrite value;
+    # * this run forked off an explicitly addressed checkpoint, see
+    #   `_delta_channels_awaiting_fork_snapshot`.
+    _delta_channels_forced_snapshot: set[str]
+
+    # Delta channels still owed a fork snapshot, when this run was launched
+    # against an explicitly addressed checkpoint (time travel / fork). That
+    # base keeps the pending writes of the branch the fork abandons, and
+    # nothing records which child consumed which write, so the ancestor walk
+    # would replay them into this branch too. Snapshotting terminates the walk
+    # inside the fork instead of at the shared base. Names drop out once the
+    # blob has landed; a channel with no value yet has nothing to snapshot, so
+    # it waits for the superstep that gives it one.
+    #
+    # The trigger is deliberately coarse: any addressed checkpoint, not only
+    # one that turns out to have abandoned writes on it. Which writes belong to
+    # which child is exactly what is not recorded, so a narrower test would
+    # have to trust the base's `pending_writes` to be complete, and a saver
+    # that leaves them out would silently go back to leaking. Snapshotting when
+    # it was not needed costs one blob per addressed run; not snapshotting when
+    # it was needed is silent corruption.
+    _delta_channels_awaiting_fork_snapshot: set[str]
 
     # The checkpoint_config that points at the parent loaded at `__enter__`
     # (or the synthetic-empty checkpoint, on first run). We capture it
@@ -368,6 +390,16 @@ class PregelLoop:
             tuple(cast(str, self.config[CONF][CONFIG_KEY_CHECKPOINT_NS]).split(NS_SEP))
             if self.config[CONF].get(CONFIG_KEY_CHECKPOINT_NS)
             else ()
+        )
+        # Checks the value, not just key presence like `is_replaying` above:
+        # subgraph task configs always carry an explicit `None` here, and only
+        # a real id means the caller addressed one specific checkpoint. Read
+        # off `checkpoint_config` so subgraphs resolved through a checkpoint
+        # map during time travel are covered too, matching `__enter__`.
+        self._delta_channels_awaiting_fork_snapshot = (
+            {k for k, spec in specs.items() if isinstance(spec, DeltaChannel)}
+            if self.checkpoint_config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)
+            else set()
         )
         self.prev_checkpoint_config = None
         runtime = self.config[CONF].get(CONFIG_KEY_RUNTIME)
@@ -683,7 +715,7 @@ class PregelLoop:
     def after_tick(self) -> None:
         # finish superstep
         writes = [w for t in self.tasks.values() for w in t.writes]
-        self._delta_channels_with_overwrite.update(
+        self._delta_channels_forced_snapshot.update(
             ch
             for ch, v in writes
             if isinstance(self.specs.get(ch), DeltaChannel) and _get_overwrite(v)[0]
@@ -991,7 +1023,7 @@ class PregelLoop:
                 manager=None,
                 updated_channels=updated_channels,
             )
-            self._delta_channels_with_overwrite.update(
+            self._delta_channels_forced_snapshot.update(
                 c
                 for c, v in input_writes
                 if isinstance(self.specs.get(c), DeltaChannel) and _get_overwrite(v)[0]
@@ -1133,10 +1165,21 @@ class PregelLoop:
         do_checkpoint = self._checkpointer_put_after_previous is not None and (
             exiting or self.durability != "exit"
         )
+        # Fork: make this checkpoint self-contained, so the ancestor walk stops
+        # inside the fork instead of reaching the base this run forked off and
+        # collecting the abandoned branch's writes from it. Resolved here
+        # rather than in `_first` so channels that only got a value this
+        # superstep are covered too.
+        if self._delta_channels_awaiting_fork_snapshot:
+            self._delta_channels_forced_snapshot.update(
+                k
+                for k in self._delta_channels_awaiting_fork_snapshot
+                if (ch := self.channels.get(k)) is not None and ch.is_available()
+            )
         # create new checkpoint
         channels_to_snapshot = (
             delta_channels_to_snapshot(self.channels, new_counters)
-            | self._delta_channels_with_overwrite
+            | self._delta_channels_forced_snapshot
             if do_checkpoint
             else set()
         )
@@ -1154,7 +1197,13 @@ class PregelLoop:
         for k in channels_to_snapshot:
             new_counters[k] = (0, 0)
         if do_checkpoint:
-            self._delta_channels_with_overwrite.difference_update(channels_to_snapshot)
+            self._delta_channels_forced_snapshot.difference_update(channels_to_snapshot)
+            # `create_checkpoint` drops a requested snapshot for a channel with
+            # no version in this checkpoint yet (nothing was ever written to it
+            # on this branch), so keep asking until the blob really landed.
+            self._delta_channels_awaiting_fork_snapshot.difference_update(
+                self.checkpoint["channel_values"]
+            )
         non_zero = {k: v for k, v in new_counters.items() if v != (0, 0)}
         if non_zero:
             self.checkpoint_metadata["counters_since_delta_snapshot"] = non_zero
@@ -1239,7 +1288,7 @@ class PregelLoop:
         )
         channels_to_snapshot = (
             delta_channels_to_snapshot(self.channels, counters)
-            | self._delta_channels_with_overwrite
+            | self._delta_channels_forced_snapshot
         )
 
         pending = [
@@ -1684,7 +1733,7 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         )
         self._delta_write_futs = []
         self._error_handler_write_futs = []
-        self._delta_channels_with_overwrite = set()
+        self._delta_channels_forced_snapshot = set()
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None
         )
@@ -1942,7 +1991,7 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         )
         self._delta_write_futs = []
         self._error_handler_write_futs = []
-        self._delta_channels_with_overwrite = set()
+        self._delta_channels_forced_snapshot = set()
         self._exit_delta_writes = (
             [] if self.durability == "exit" and self.checkpointer is not None else None
         )

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1174,7 +1174,7 @@ class PregelLoop:
             self._delta_channels_forced_snapshot.update(
                 k
                 for k in self._delta_channels_awaiting_fork_snapshot
-                if (ch := self.channels.get(k)) is not None and ch.is_available()
+                if k in self.channels
             )
         # create new checkpoint
         channels_to_snapshot = (

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1638,7 +1638,10 @@ class Pregel(
                 raise ValueError(f"Subgraph {recast} not found")
 
         def perform_superstep(
-            input_config: RunnableConfig, updates: Sequence[StateUpdate]
+            input_config: RunnableConfig,
+            updates: Sequence[StateUpdate],
+            *,
+            is_fork: bool,
         ) -> RunnableConfig:
             # get last checkpoint
             config = ensure_config(self.config, input_config)
@@ -1873,6 +1876,9 @@ class Pregel(
                     return perform_superstep(
                         patch_checkpoint_map(next_config, saved.metadata),
                         [item for lst in user_group_by.values() for item in lst],
+                        # The checkpoint just written clears tasks and carries
+                        # no delta snapshot, so a fork is still unsealed here.
+                        is_fork=is_fork,
                     )
 
                 return patch_checkpoint_map(next_config, saved.metadata)
@@ -2020,7 +2026,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
-                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
+                    is_fork=is_fork,
                 )
             )
             checkpoint = create_checkpoint(
@@ -2050,8 +2056,16 @@ class Pregel(
         current_config = patch_configurable(
             config, {CONFIG_KEY_THREAD_ID: str(config[CONF][CONFIG_KEY_THREAD_ID])}
         )
+        # Only the first superstep can fork. `perform_superstep` returns the
+        # config of the checkpoint it just wrote and the loop feeds that back
+        # in, so from the second superstep on the incoming config always names
+        # a checkpoint whether or not the caller addressed one.
+        is_fork = bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID))
         for superstep in supersteps:
-            current_config = perform_superstep(current_config, superstep)
+            current_config = perform_superstep(
+                current_config, superstep, is_fork=is_fork
+            )
+            is_fork = False
         return current_config
 
     async def abulk_update_state(
@@ -2105,7 +2119,10 @@ class Pregel(
                 raise ValueError(f"Subgraph {recast} not found")
 
         async def aperform_superstep(
-            input_config: RunnableConfig, updates: Sequence[StateUpdate]
+            input_config: RunnableConfig,
+            updates: Sequence[StateUpdate],
+            *,
+            is_fork: bool,
         ) -> RunnableConfig:
             # get last checkpoint
             config = ensure_config(self.config, input_config)
@@ -2336,6 +2353,9 @@ class Pregel(
                     return await aperform_superstep(
                         patch_checkpoint_map(next_config, saved.metadata),
                         [item for lst in user_group_by.values() for item in lst],
+                        # The checkpoint just written clears tasks and carries
+                        # no delta snapshot, so a fork is still unsealed here.
+                        is_fork=is_fork,
                     )
 
                 return patch_checkpoint_map(
@@ -2481,7 +2501,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
-                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
+                    is_fork=is_fork,
                 )
             )
             checkpoint = create_checkpoint(
@@ -2510,8 +2530,16 @@ class Pregel(
         current_config = patch_configurable(
             config, {CONFIG_KEY_THREAD_ID: str(config[CONF][CONFIG_KEY_THREAD_ID])}
         )
+        # Only the first superstep can fork. `aperform_superstep` returns the
+        # config of the checkpoint it just wrote and the loop feeds that back
+        # in, so from the second superstep on the incoming config always names
+        # a checkpoint whether or not the caller addressed one.
+        is_fork = bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID))
         for superstep in supersteps:
-            current_config = await aperform_superstep(current_config, superstep)
+            current_config = await aperform_superstep(
+                current_config, superstep, is_fork=is_fork
+            )
+            is_fork = False
         return current_config
 
     def update_state(

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -108,6 +108,7 @@ from langgraph.callbacks import (
     get_sync_graph_callback_manager_for_config,
 )
 from langgraph.channels.base import BaseChannel
+from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.topic import Topic
 from langgraph.config import get_config
 from langgraph.constants import END
@@ -133,6 +134,7 @@ from langgraph.pregel._checkpoint import (
     copy_checkpoint,
     create_checkpoint,
     create_checkpoint_plan_for_update_state_api,
+    create_fork_checkpoint,
     empty_checkpoint,
     get_updated_channels_from_tasks,
 )
@@ -1637,6 +1639,19 @@ class Pregel(
             else:
                 raise ValueError(f"Subgraph {recast} not found")
 
+        # Delta channels still owed a fork snapshot. Mirrors
+        # `_delta_channels_awaiting_fork_snapshot` in `_loop.py`: a fork is only
+        # sealed once a checkpoint actually carries the blob. Several superstep
+        # paths (`as_node` of INPUT, END or `__copy__`) write a checkpoint and
+        # return before reaching the plan, so a flag cleared after the first
+        # superstep would leave the branch unsealed and the next superstep would
+        # reconstruct through the shared base.
+        fork_pending: set[str] = (
+            {k for k, v in self.channels.items() if isinstance(v, DeltaChannel)}
+            if config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)
+            else set()
+        )
+
         def perform_superstep(
             input_config: RunnableConfig,
             updates: Sequence[StateUpdate],
@@ -1729,9 +1744,17 @@ class Pregel(
                         self.trigger_to_nodes,
                     )
                 # save checkpoint
+                next_checkpoint = create_fork_checkpoint(
+                    checkpoint,
+                    channels,
+                    step,
+                    is_fork=is_fork,
+                    get_next_version=checkpointer.get_next_version,
+                )
+                fork_pending.difference_update(next_checkpoint["channel_values"])
                 next_config = checkpointer.put(
                     checkpoint_config,
-                    create_checkpoint(checkpoint, channels, step),
+                    next_checkpoint,
                     {
                         "source": "update",
                         "step": step + 1,
@@ -1739,7 +1762,7 @@ class Pregel(
                     },
                     get_new_channel_versions(
                         checkpoint_previous_versions,
-                        checkpoint["channel_versions"],
+                        next_checkpoint["channel_versions"],
                     ),
                 )
                 return patch_checkpoint_map(
@@ -1768,9 +1791,17 @@ class Pregel(
                         if saved and saved.metadata.get("step") is not None
                         else -1
                     )
+                    next_checkpoint = create_fork_checkpoint(
+                        checkpoint,
+                        channels,
+                        next_step,
+                        is_fork=is_fork,
+                        get_next_version=checkpointer.get_next_version,
+                    )
+                    fork_pending.difference_update(next_checkpoint["channel_values"])
                     next_config = checkpointer.put(
                         checkpoint_config,
-                        create_checkpoint(checkpoint, channels, next_step),
+                        next_checkpoint,
                         {
                             "source": "input",
                             "step": next_step,
@@ -1780,7 +1811,7 @@ class Pregel(
                         },
                         get_new_channel_versions(
                             checkpoint_previous_versions,
-                            checkpoint["channel_versions"],
+                            next_checkpoint["channel_versions"],
                         ),
                     )
 
@@ -2039,6 +2070,8 @@ class Pregel(
                 else None,
                 channels_to_snapshot=channels_to_snapshot,
             )
+            if is_fork:
+                fork_pending.difference_update(checkpoint["channel_values"])
             next_config = checkpointer.put(
                 checkpoint_config,
                 checkpoint,
@@ -2056,16 +2089,14 @@ class Pregel(
         current_config = patch_configurable(
             config, {CONFIG_KEY_THREAD_ID: str(config[CONF][CONFIG_KEY_THREAD_ID])}
         )
-        # Only the first superstep can fork. `perform_superstep` returns the
-        # config of the checkpoint it just wrote and the loop feeds that back
-        # in, so from the second superstep on the incoming config always names
-        # a checkpoint whether or not the caller addressed one.
-        is_fork = bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID))
+        # The flag cannot be derived from `current_config`: `perform_superstep`
+        # returns the config of the checkpoint it just wrote and the loop feeds
+        # that back in, so from the second superstep on it always names a
+        # checkpoint whether or not the caller addressed one.
         for superstep in supersteps:
             current_config = perform_superstep(
-                current_config, superstep, is_fork=is_fork
+                current_config, superstep, is_fork=bool(fork_pending)
             )
-            is_fork = False
         return current_config
 
     async def abulk_update_state(
@@ -2117,6 +2148,19 @@ class Pregel(
                 )
             else:
                 raise ValueError(f"Subgraph {recast} not found")
+
+        # Delta channels still owed a fork snapshot. Mirrors
+        # `_delta_channels_awaiting_fork_snapshot` in `_loop.py`: a fork is only
+        # sealed once a checkpoint actually carries the blob. Several superstep
+        # paths (`as_node` of INPUT, END or `__copy__`) write a checkpoint and
+        # return before reaching the plan, so a flag cleared after the first
+        # superstep would leave the branch unsealed and the next superstep would
+        # reconstruct through the shared base.
+        fork_pending: set[str] = (
+            {k for k, v in self.channels.items() if isinstance(v, DeltaChannel)}
+            if config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)
+            else set()
+        )
 
         async def aperform_superstep(
             input_config: RunnableConfig,
@@ -2208,16 +2252,25 @@ class Pregel(
                         self.trigger_to_nodes,
                     )
                 # save checkpoint
+                next_checkpoint = create_fork_checkpoint(
+                    checkpoint,
+                    channels,
+                    step,
+                    is_fork=is_fork,
+                    get_next_version=checkpointer.get_next_version,
+                )
+                fork_pending.difference_update(next_checkpoint["channel_values"])
                 next_config = await checkpointer.aput(
                     checkpoint_config,
-                    create_checkpoint(checkpoint, channels, step),
+                    next_checkpoint,
                     {
                         "source": "update",
                         "step": step + 1,
                         "parents": saved.metadata.get("parents", {}) if saved else {},
                     },
                     get_new_channel_versions(
-                        checkpoint_previous_versions, checkpoint["channel_versions"]
+                        checkpoint_previous_versions,
+                        next_checkpoint["channel_versions"],
                     ),
                 )
                 return patch_checkpoint_map(
@@ -2246,9 +2299,17 @@ class Pregel(
                         if saved and saved.metadata.get("step") is not None
                         else -1
                     )
+                    next_checkpoint = create_fork_checkpoint(
+                        checkpoint,
+                        channels,
+                        next_step,
+                        is_fork=is_fork,
+                        get_next_version=checkpointer.get_next_version,
+                    )
+                    fork_pending.difference_update(next_checkpoint["channel_values"])
                     next_config = await checkpointer.aput(
                         checkpoint_config,
-                        create_checkpoint(checkpoint, channels, next_step),
+                        next_checkpoint,
                         {
                             "source": "input",
                             "step": next_step,
@@ -2258,7 +2319,7 @@ class Pregel(
                         },
                         get_new_channel_versions(
                             checkpoint_previous_versions,
-                            checkpoint["channel_versions"],
+                            next_checkpoint["channel_versions"],
                         ),
                     )
 
@@ -2514,6 +2575,8 @@ class Pregel(
                 else None,
                 channels_to_snapshot=channels_to_snapshot,
             )
+            if is_fork:
+                fork_pending.difference_update(checkpoint["channel_values"])
             next_config = await checkpointer.aput(
                 checkpoint_config,
                 checkpoint,
@@ -2530,16 +2593,14 @@ class Pregel(
         current_config = patch_configurable(
             config, {CONFIG_KEY_THREAD_ID: str(config[CONF][CONFIG_KEY_THREAD_ID])}
         )
-        # Only the first superstep can fork. `aperform_superstep` returns the
-        # config of the checkpoint it just wrote and the loop feeds that back
-        # in, so from the second superstep on the incoming config always names
-        # a checkpoint whether or not the caller addressed one.
-        is_fork = bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID))
+        # The flag cannot be derived from `current_config`: `aperform_superstep`
+        # returns the config of the checkpoint it just wrote and the loop feeds
+        # that back in, so from the second superstep on it always names a
+        # checkpoint whether or not the caller addressed one.
         for superstep in supersteps:
             current_config = await aperform_superstep(
-                current_config, superstep, is_fork=is_fork
+                current_config, superstep, is_fork=bool(fork_pending)
             )
-            is_fork = False
         return current_config
 
     def update_state(

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2020,6 +2020,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
+                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
                 )
             )
             checkpoint = create_checkpoint(
@@ -2480,6 +2481,7 @@ class Pregel(
                     parents=saved.metadata.get("parents", {}) if saved else {},
                     saved_metadata=saved.metadata if saved else None,
                     is_fresh_thread=saved is None,
+                    is_fork=bool(config[CONF].get(CONFIG_KEY_CHECKPOINT_ID)),
                 )
             )
             checkpoint = create_checkpoint(

--- a/libs/langgraph/tests/memory_assert.py
+++ b/libs/langgraph/tests/memory_assert.py
@@ -86,11 +86,19 @@ class MemorySaverAssertImmutable(InMemorySaver):
                 )
                 == saved
             ), config["configurable"]["checkpoint_ns"]
-        self.storage_for_copies[thread_id][checkpoint_ns][checkpoint["id"]] = (
-            self.serde.dumps_typed(checkpoint)
-        )
         # call super to write checkpoint
-        return super().put(config, checkpoint, metadata, new_versions)
+        next_config = super().put(config, checkpoint, metadata, new_versions)
+        # Record the checkpoint as the saver reads it back, not the object it
+        # was handed. `channel_values` are stored per (channel, version), so a
+        # channel a step did not write is refilled from the blob its inherited
+        # version still points at. A `DeltaChannel` omits its value except at a
+        # snapshot, which makes the two representations differ for reasons that
+        # are not mutation. Comparing read-back against read-back still catches
+        # a checkpoint whose stored data actually changed.
+        self.storage_for_copies[thread_id][checkpoint_ns][checkpoint["id"]] = (
+            self.serde.dumps_typed(super().get(next_config))
+        )
+        return next_config
 
 
 class MemorySaverNoPending(InMemorySaver):

--- a/libs/langgraph/tests/test_delta_channel_fork.py
+++ b/libs/langgraph/tests/test_delta_channel_fork.py
@@ -12,7 +12,8 @@ replay, so the plain channel is the oracle: after a fork the two must agree.
 
 Coverage: fork by ``invoke`` with new input (sync/async, all durabilities),
 fork off the checkpoint that predates the thread's first input (sync/async),
-fork by ``update_state`` / ``aupdate_state``, and guards that neither an
+fork by ``update_state`` / ``aupdate_state``, fork before the delta channel
+ever had a value, and guards that neither an
 unaddressed run nor an unaddressed multi-superstep ``bulk_update_state``
 departs from the normal ``snapshot_frequency`` cadence.
 """
@@ -46,6 +47,9 @@ def _append(current: list | None, writes: Sequence[Any]) -> list:
 class _State(TypedDict):
     log: Annotated[list, DeltaChannel(_append, snapshot_frequency=1000)]
     plain: Annotated[list, add]
+    # Written only by the tests that fork before `log` ever has a value, so the
+    # fork advances without touching the delta channel.
+    other: Annotated[list, add]
 
 
 def _build(checkpointer: BaseCheckpointSaver, tag: str) -> Any:
@@ -57,6 +61,19 @@ def _build(checkpointer: BaseCheckpointSaver, tag: str) -> Any:
 
     def node(state: _State) -> dict:
         return {"log": [f"{tag}-out"], "plain": [f"{tag}-out"]}
+
+    builder = StateGraph(_State)
+    builder.add_node("n", node)
+    builder.set_entry_point("n")
+    builder.set_finish_point("n")
+    return builder.compile(checkpointer=checkpointer)
+
+
+def _build_without_delta_writes(checkpointer: BaseCheckpointSaver, tag: str) -> Any:
+    """Compile a graph whose node writes only ``other``, never the delta channel."""
+
+    def node(state: _State) -> dict:
+        return {"other": [f"{tag}-other"]}
 
     builder = StateGraph(_State)
     builder.add_node("n", node)
@@ -255,6 +272,81 @@ def test_unaddressed_run_keeps_snapshot_cadence(
     graph.invoke(_input("in-2"), config, durability=durability)
 
     assert not _snapshotted_checkpoints(sync_checkpointer, config)
+
+
+def test_fork_before_first_value_when_fork_never_writes_the_channel(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Seal the fork even when the channel has no value to snapshot.
+
+    Forking before ``log`` was ever written leaves nothing to copy into the
+    fork's first checkpoint, so without a minted version and an empty blob the
+    boundary goes unrecorded and the walk runs into the base. The fork here
+    never writes ``log`` at all, so no later superstep can seal it either.
+    """
+    config = _thread("t")
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_input("in-1"), config, durability=durability)
+
+    root = list(graph.get_state_history(config))[-1]
+    assert root.values["log"] == []
+
+    _build_without_delta_writes(sync_checkpointer, "third").invoke(
+        {"other": ["in-9"]}, _at(config, root), durability=durability
+    )
+
+    state = graph.get_state(config)
+    _assert_fork_is_clean(state, "in-1")
+    assert state.values["log"] == []
+
+
+async def test_afork_before_first_value_when_fork_never_writes_the_channel(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Async twin of ``test_fork_before_first_value_when_fork_never_writes_the_channel``."""
+    config = _thread("t")
+    graph = _build(async_checkpointer, "first")
+    await graph.ainvoke(_input("in-1"), config, durability=durability)
+
+    root = [snapshot async for snapshot in graph.aget_state_history(config)][-1]
+    assert root.values["log"] == []
+
+    await _build_without_delta_writes(async_checkpointer, "third").ainvoke(
+        {"other": ["in-9"]}, _at(config, root), durability=durability
+    )
+
+    state = await graph.aget_state(config)
+    _assert_fork_is_clean(state, "in-1")
+    assert state.values["log"] == []
+
+
+def test_fork_before_first_value_by_bulk_update(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """The fork's first superstep touches another key, the delta key comes later.
+
+    The first checkpoint has to seal the boundary on its own. Deferring until
+    the superstep that finally writes ``log`` is too late, because that
+    superstep reconstructs through the unsealed checkpoint first.
+    """
+    config = _thread("t")
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_input("in-1"), config)
+
+    root = list(graph.get_state_history(config))[-1]
+    assert root.values["log"] == []
+
+    forked = graph.bulk_update_state(
+        _at(config, root),
+        [
+            [StateUpdate({"other": ["s1"]}, "n")],
+            [StateUpdate(_input("s2"), "n")],
+        ],
+    )
+
+    state = graph.get_state(forked)
+    _assert_fork_is_clean(state, "in-1")
+    assert state.values["log"] == ["s2"]
 
 
 @pytest.mark.parametrize("first_as_node", [INPUT, END, "__copy__"])

--- a/libs/langgraph/tests/test_delta_channel_fork.py
+++ b/libs/langgraph/tests/test_delta_channel_fork.py
@@ -1,0 +1,248 @@
+"""Forking a thread must not replay the abandoned branch into the fork.
+
+Regression suite for #8443. Addressing an older checkpoint creates a fork: the
+shared base ends up with two children, and it keeps the ``checkpoint_writes``
+of the branch the fork abandons. Nothing in the stored data records which child
+consumed which write, so the ``DeltaChannel`` ancestor walk used to collect the
+abandoned branch's writes as well.
+
+Every graph here carries a ``DeltaChannel`` and a plain reducer channel fed the
+same values. ``full`` channels store complete ``channel_values`` and need no
+replay, so the plain channel is the oracle: after a fork the two must agree.
+
+Coverage: fork by ``invoke`` with new input (sync/async, all durabilities),
+fork off the checkpoint that predates the thread's first input, fork by
+``update_state`` / ``aupdate_state``, and a guard that an unaddressed run still
+follows the normal ``snapshot_frequency`` cadence.
+"""
+
+from collections.abc import Sequence
+from operator import add
+from typing import Annotated, Any
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+from typing_extensions import TypedDict
+
+from langgraph.channels.delta import DeltaChannel
+from langgraph.graph import StateGraph
+from langgraph.types import Durability, StateSnapshot
+
+pytestmark = pytest.mark.anyio
+
+
+def _append(current: list | None, writes: Sequence[Any]) -> list:
+    """DeltaChannel reducer: extend the list with every batched write."""
+    out = list(current or [])
+    for write in writes:
+        out.extend(write if isinstance(write, list) else [write])
+    return out
+
+
+class _State(TypedDict):
+    log: Annotated[list, DeltaChannel(_append, snapshot_frequency=1000)]
+    plain: Annotated[list, add]
+
+
+def _build(checkpointer: BaseCheckpointSaver, tag: str) -> Any:
+    """Compile a one-node graph whose node appends ``{tag}-out`` to both channels.
+
+    ``snapshot_frequency=1000`` keeps the cadence from masking the bug: without
+    a forced snapshot the fork's ancestor walk always runs past the fork base.
+    """
+
+    def node(state: _State) -> dict:
+        return {"log": [f"{tag}-out"], "plain": [f"{tag}-out"]}
+
+    builder = StateGraph(_State)
+    builder.add_node("n", node)
+    builder.set_entry_point("n")
+    builder.set_finish_point("n")
+    return builder.compile(checkpointer=checkpointer)
+
+
+def _thread(thread_id: str) -> RunnableConfig:
+    return {"configurable": {"thread_id": thread_id}}
+
+
+def _at(config: RunnableConfig, snapshot: StateSnapshot) -> RunnableConfig:
+    """Config addressing one specific checkpoint of ``config``'s thread."""
+    return {
+        "configurable": {
+            **config["configurable"],
+            "checkpoint_ns": "",
+            "checkpoint_id": snapshot.config["configurable"]["checkpoint_id"],
+        }
+    }
+
+
+def _input(marker: str) -> dict:
+    return {"log": [marker], "plain": [marker]}
+
+
+def _assert_fork_is_clean(state: StateSnapshot, abandoned: str) -> None:
+    """The delta channel must match the plain channel and drop ``abandoned``."""
+    assert state.values["log"] == state.values["plain"], (
+        f"delta channel diverged from the plain channel: "
+        f"{state.values['log']} != {state.values['plain']}"
+    )
+    assert abandoned not in state.values["log"], (
+        f"{abandoned!r} belongs to the branch the fork replaced, "
+        f"but was replayed into {state.values['log']}"
+    )
+
+
+def test_fork_by_invoke(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    config = _thread("t")
+    _build(sync_checkpointer, "first").invoke(
+        _input("in-1"), config, durability=durability
+    )
+    graph = _build(sync_checkpointer, "second")
+    graph.invoke(_input("in-2"), config, durability=durability)
+
+    # The last checkpoint that predates "in-2" entering state: forking here
+    # abandons the "in-2" branch, whose writes still hang off this checkpoint.
+    base = next(
+        snapshot
+        for snapshot in graph.get_state_history(config)
+        if "in-2" not in snapshot.values["log"]
+    )
+    _build(sync_checkpointer, "third").invoke(
+        _input("in-3"), _at(config, base), durability=durability
+    )
+
+    state = graph.get_state(config)
+    _assert_fork_is_clean(state, "in-2")
+    assert state.values["log"] == [*base.values["log"], "in-3", "third-out"]
+
+
+async def test_afork_by_invoke(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    config = _thread("t")
+    await _build(async_checkpointer, "first").ainvoke(
+        _input("in-1"), config, durability=durability
+    )
+    graph = _build(async_checkpointer, "second")
+    await graph.ainvoke(_input("in-2"), config, durability=durability)
+
+    base = await anext(
+        snapshot
+        async for snapshot in graph.aget_state_history(config)
+        if "in-2" not in snapshot.values["log"]
+    )
+    await _build(async_checkpointer, "third").ainvoke(
+        _input("in-3"), _at(config, base), durability=durability
+    )
+
+    state = await graph.aget_state(config)
+    _assert_fork_is_clean(state, "in-2")
+    assert state.values["log"] == [*base.values["log"], "in-3", "third-out"]
+
+
+def test_fork_off_checkpoint_before_first_input(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Fork off the root checkpoint, which predates any value for ``log``.
+
+    ``create_checkpoint`` drops a requested snapshot for a channel absent from
+    ``channel_versions``, so the fork's own first checkpoint cannot carry the
+    blob. The request has to stay queued until a superstep gives the channel a
+    value, otherwise the root's ``in-1`` write still leaks into the fork.
+    """
+    config = _thread("t")
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_input("in-1"), config, durability=durability)
+
+    root = list(graph.get_state_history(config))[-1]
+    assert root.values["log"] == []
+
+    _build(sync_checkpointer, "third").invoke(
+        _input("in-9"), _at(config, root), durability=durability
+    )
+
+    state = graph.get_state(config)
+    _assert_fork_is_clean(state, "in-1")
+    assert state.values["log"] == ["in-9", "third-out"]
+
+
+async def test_afork_off_checkpoint_before_first_input(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Async twin of ``test_fork_off_checkpoint_before_first_input``."""
+    config = _thread("t")
+    graph = _build(async_checkpointer, "first")
+    await graph.ainvoke(_input("in-1"), config, durability=durability)
+
+    root = [snapshot async for snapshot in graph.aget_state_history(config)][-1]
+    assert root.values["log"] == []
+
+    await _build(async_checkpointer, "third").ainvoke(
+        _input("in-9"), _at(config, root), durability=durability
+    )
+
+    state = await graph.aget_state(config)
+    _assert_fork_is_clean(state, "in-1")
+    assert state.values["log"] == ["in-9", "third-out"]
+
+
+def test_fork_by_update_state(sync_checkpointer: BaseCheckpointSaver) -> None:
+    config = _thread("t")
+    _build(sync_checkpointer, "first").invoke(_input("in-1"), config)
+    graph = _build(sync_checkpointer, "second")
+    graph.invoke(_input("in-2"), config)
+
+    base = next(
+        snapshot
+        for snapshot in graph.get_state_history(config)
+        if "in-2" not in snapshot.values["log"]
+    )
+    forked = graph.update_state(_at(config, base), _input("patched"))
+
+    state = graph.get_state(forked)
+    _assert_fork_is_clean(state, "in-2")
+    assert state.values["log"] == [*base.values["log"], "patched"]
+
+
+async def test_afork_by_update_state(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    config = _thread("t")
+    await _build(async_checkpointer, "first").ainvoke(_input("in-1"), config)
+    graph = _build(async_checkpointer, "second")
+    await graph.ainvoke(_input("in-2"), config)
+
+    base = await anext(
+        snapshot
+        async for snapshot in graph.aget_state_history(config)
+        if "in-2" not in snapshot.values["log"]
+    )
+    forked = await graph.aupdate_state(_at(config, base), _input("patched"))
+
+    state = await graph.aget_state(forked)
+    _assert_fork_is_clean(state, "in-2")
+    assert state.values["log"] == [*base.values["log"], "patched"]
+
+
+def test_unaddressed_run_keeps_snapshot_cadence(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """A run with no explicitly addressed checkpoint writes no snapshot blob.
+
+    Guards the cost of the fix: the forced snapshot is one per addressed run,
+    not a change to the normal ``snapshot_frequency`` cadence.
+    """
+    config = _thread("t")
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_input("in-1"), config, durability=durability)
+    graph.invoke(_input("in-2"), config, durability=durability)
+
+    assert not [
+        tuple_.config["configurable"]["checkpoint_id"]
+        for tuple_ in sync_checkpointer.list(config)
+        if isinstance(tuple_.checkpoint["channel_values"].get("log"), _DeltaSnapshot)
+    ]

--- a/libs/langgraph/tests/test_delta_channel_fork.py
+++ b/libs/langgraph/tests/test_delta_channel_fork.py
@@ -11,9 +11,10 @@ same values. ``full`` channels store complete ``channel_values`` and need no
 replay, so the plain channel is the oracle: after a fork the two must agree.
 
 Coverage: fork by ``invoke`` with new input (sync/async, all durabilities),
-fork off the checkpoint that predates the thread's first input, fork by
-``update_state`` / ``aupdate_state``, and a guard that an unaddressed run still
-follows the normal ``snapshot_frequency`` cadence.
+fork off the checkpoint that predates the thread's first input (sync/async),
+fork by ``update_state`` / ``aupdate_state``, and guards that neither an
+unaddressed run nor an unaddressed multi-superstep ``bulk_update_state``
+departs from the normal ``snapshot_frequency`` cadence.
 """
 
 from collections.abc import Sequence
@@ -28,7 +29,7 @@ from typing_extensions import TypedDict
 
 from langgraph.channels.delta import DeltaChannel
 from langgraph.graph import StateGraph
-from langgraph.types import Durability, StateSnapshot
+from langgraph.types import Durability, StateSnapshot, StateUpdate
 
 pytestmark = pytest.mark.anyio
 
@@ -80,6 +81,17 @@ def _at(config: RunnableConfig, snapshot: StateSnapshot) -> RunnableConfig:
 
 def _input(marker: str) -> dict:
     return {"log": [marker], "plain": [marker]}
+
+
+def _snapshotted_checkpoints(
+    checkpointer: BaseCheckpointSaver, config: RunnableConfig
+) -> list[str]:
+    """Ids of this thread's checkpoints carrying a ``log`` snapshot blob."""
+    return [
+        tuple_.config["configurable"]["checkpoint_id"]
+        for tuple_ in checkpointer.list(config)
+        if isinstance(tuple_.checkpoint["channel_values"].get("log"), _DeltaSnapshot)
+    ]
 
 
 def _assert_fork_is_clean(state: StateSnapshot, abandoned: str) -> None:
@@ -241,8 +253,27 @@ def test_unaddressed_run_keeps_snapshot_cadence(
     graph.invoke(_input("in-1"), config, durability=durability)
     graph.invoke(_input("in-2"), config, durability=durability)
 
-    assert not [
-        tuple_.config["configurable"]["checkpoint_id"]
-        for tuple_ in sync_checkpointer.list(config)
-        if isinstance(tuple_.checkpoint["channel_values"].get("log"), _DeltaSnapshot)
-    ]
+    assert not _snapshotted_checkpoints(sync_checkpointer, config)
+
+
+def test_unaddressed_bulk_update_keeps_snapshot_cadence(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """A multi-superstep ``bulk_update_state`` forks at most once, at the head.
+
+    ``perform_superstep`` returns the config of the checkpoint it just wrote
+    and the driver feeds that back in, so every superstep after the first
+    receives a config naming a checkpoint even when the caller addressed none.
+    Deriving the fork flag from that config snapshots the whole growing value
+    once per superstep.
+    """
+    config = _thread("t")
+    graph = _build(sync_checkpointer, "first")
+    graph.invoke(_input("in-1"), config)
+
+    graph.bulk_update_state(
+        config,
+        [[StateUpdate(_input(f"u{i}"), "n")] for i in range(4)],
+    )
+
+    assert not _snapshotted_checkpoints(sync_checkpointer, config)

--- a/libs/langgraph/tests/test_delta_channel_fork.py
+++ b/libs/langgraph/tests/test_delta_channel_fork.py
@@ -27,8 +27,9 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from typing_extensions import TypedDict
 
+from langgraph._internal._constants import INPUT
 from langgraph.channels.delta import DeltaChannel
-from langgraph.graph import StateGraph
+from langgraph.graph import END, StateGraph
 from langgraph.types import Durability, StateSnapshot, StateUpdate
 
 pytestmark = pytest.mark.anyio
@@ -254,6 +255,48 @@ def test_unaddressed_run_keeps_snapshot_cadence(
     graph.invoke(_input("in-2"), config, durability=durability)
 
     assert not _snapshotted_checkpoints(sync_checkpointer, config)
+
+
+@pytest.mark.parametrize("first_as_node", [INPUT, END, "__copy__"])
+def test_fork_by_bulk_update_whose_first_superstep_skips_the_plan(
+    sync_checkpointer: BaseCheckpointSaver, first_as_node: str
+) -> None:
+    """The fork must be sealed by whichever checkpoint the fork writes first.
+
+    ``as_node`` of INPUT, END or ``__copy__`` writes a checkpoint and returns
+    before ``create_checkpoint_plan_for_update_state_api`` runs. If that
+    checkpoint carries no snapshot the branch is still unsealed, so the next
+    superstep reconstructs through the shared base, picks up the abandoned
+    writes, and bakes them into whatever it snapshots. Sealing later is too
+    late: by then the in-memory value is already wrong.
+    """
+    config = _thread("t")
+    _build(sync_checkpointer, "first").invoke(_input("in-1"), config)
+    graph = _build(sync_checkpointer, "second")
+    graph.invoke(_input("in-2"), config)
+
+    base = next(
+        snapshot
+        for snapshot in graph.get_state_history(config)
+        if "in-2" not in snapshot.values["log"]
+    )
+    first = (
+        StateUpdate(_input("first-step"), first_as_node)
+        if first_as_node == INPUT
+        else StateUpdate(None, first_as_node)
+    )
+    forked = graph.bulk_update_state(
+        _at(config, base),
+        [[first], [StateUpdate(_input("second-step"), "n")]],
+    )
+
+    state = graph.get_state(forked)
+    # END legitimately absorbs the base's already-run task writes, so "in-2"
+    # belongs there; the plain channel is the oracle for which is which.
+    assert state.values["log"] == state.values["plain"], (
+        f"delta channel diverged from the plain channel: "
+        f"{state.values['log']} != {state.values['plain']}"
+    )
 
 
 def test_unaddressed_bulk_update_keeps_snapshot_cadence(


### PR DESCRIPTION
Fixes #8443

## Problem

Addressing an older checkpoint creates a fork: the shared base ends up with two children, and it keeps the `checkpoint_writes` of the branch the fork abandons. Nothing in the stored data records which child consumed which write, so the `DeltaChannel` ancestor walk in `get_delta_channel_history` collects the abandoned branch's writes too.

Live execution is correct. Only the reconstruction after a reload is wrong:

```
fork base:     ['in-1', 'first-out']
fork returns:  ['in-1', 'first-out', 'in-3', 'third-out']            # correct
reload gives:  ['in-1', 'first-out', 'in-2', 'in-3', 'third-out']
                                     ^^^^^^ belongs to the branch the fork replaced
```

`full` channels are unaffected: their checkpoints carry complete `channel_values` and need no replay. In a graph carrying both, the plain channel is right and the delta channel is not, which is what the new tests assert against.

This is not one saver's slip. The new test file fails on every backend on `main`: `memory`, `memory_migrate_sends`, `sqlite`, `sqlite_aes`, `sqlite_aio`, and `postgres` in all three pool modes, sync and async. `InMemorySaver`, the base walk used by SQLite, and `PostgresSaver`'s paged-SQL override are each wrong independently, because write-to-child ownership simply is not recorded.

## Fix

Write side, so no saver changes are needed. A run launched against an explicitly addressed checkpoint forces every `DeltaChannel` to snapshot into its first checkpoint, which terminates the walk inside the fork instead of at the shared base. This mirrors the existing force-snapshot for `Overwrite` writes, which exists for the same reason; the set that carried those channels now carries both cases, hence its rename to `_delta_channels_forced_snapshot`.

* `_loop.py`: queue every delta channel for a forced snapshot when the addressed `checkpoint_id` names a real checkpoint. Read off `checkpoint_config` rather than `config`, so a subgraph resolved through a checkpoint map during time travel is covered too, matching what `__enter__` already does to decide the same question. Checks the value, not key presence like `is_replaying`, because subgraph task configs always carry an explicit `None` there. Drained in `_put_checkpoint` rather than `_first`, so channels that only get a value later in the run are covered.
* `_checkpoint.py`: `create_checkpoint_plan_for_update_state_api(..., is_fork=True)` forces the same full snapshot for `update_state` against an older checkpoint, for the same reason `is_fresh_thread` already does. `main.py` reads this off `config`, not `checkpoint_config`, because there `checkpoint_config` has already been merged with the loaded checkpoint's own id and would be truthy on every call.
* `main.py`: pass `is_fork` through both `bulk_update_state` paths. Two details there are load-bearing. The flag cannot be read off the per-superstep config, because `perform_superstep` returns the config of the checkpoint it just wrote and the driver feeds that back in, so from the second superstep on it always names a checkpoint whether the caller addressed one or not. And the fork has to be sealed by whichever checkpoint the fork writes *first*: the `as_node` INPUT and END paths write one and return before reaching the plan, so `create_fork_checkpoint` snapshots there too. Sealing later is too late, because by then the next superstep has already reconstructed a wrong in-memory value through the shared base and would just bake it into the snapshot. `fork_pending` tracks what is still owed, mirroring `_delta_channels_awaiting_fork_snapshot` in `_loop.py`.

`create_fork_checkpoint` passes `get_next_version` for the same reason exit mode does: those paths apply writes to the input channel rather than the delta channel, so nothing bumps the delta channel's version and `put` would drop the blob as not-a-new-version. Their `new_versions` is therefore derived from the returned checkpoint rather than the one passed in.

A channel with no value at the fork base cannot carry a snapshot blob yet (`create_checkpoint` skips channels absent from `channel_versions`), so it stays queued until the first superstep that gives it one. Without that, forking off the checkpoint that predates a thread's first input still leaks.

### Cost, and why the trigger is coarse

One snapshot per addressed run, not per superstep. Measured on a six-node graph: the forked run writes 8 checkpoints and exactly 1 snapshot blob. Runs with no addressed checkpoint are untouched, and `test_unaddressed_run_keeps_snapshot_cadence` guards that.

The trigger fires on any truthy `checkpoint_id`, including a caller that addresses the thread's *latest* checkpoint for optimistic concurrency rather than to fork. That caller pays one snapshot per run. I considered narrowing it to "the addressed checkpoint has pending writes for this delta channel", which is where the leak actually comes from and would make that case free, and decided against it for two reasons: it would depend on `CheckpointTuple.pending_writes` being complete, so a saver that leaves them out goes back to leaking silently; and addressing the latest checkpoint genuinely does fork when that checkpoint carries pending writes from an interrupted run. Snapshotting when it was not needed costs a blob; not snapshotting when it was needed is silent corruption. Happy to trade that off differently if you'd rather.

## Tests

`tests/test_delta_channel_fork.py`, parametrized over the shared `sync_checkpointer` / `async_checkpointer` fixtures and, for the run paths, over all three durabilities. Every graph carries a `DeltaChannel` and a plain reducer channel fed the same values, so the plain channel is the oracle: after a fork the two must agree.

* fork by `invoke` with new input, sync and async
* fork off the checkpoint that predates the thread's first input, sync and async (the deferred-snapshot path)
* fork by `update_state` / `aupdate_state`
* fork by `bulk_update_state` whose first superstep is `as_node` INPUT, END or `__copy__`, each of which skips the plan
* cadence guards that neither an unaddressed run nor an unaddressed multi-superstep `bulk_update_state` writes a snapshot blob

**91 of 133 cases fail on `main`, all 133 pass with the fix.** Of the 42 that pass either way, 21 are the cadence guards and the rest are the END and `__copy__` variants, which turn out not to leak: END legitimately absorbs the base's already-run task writes, so the delta and plain channels agree there. They are kept because the oracle is what distinguishes that from a leak, and because both paths now go through the same sealing code.

`make format`, `make lint_package`, `make lint_tests` clean. Full `libs/langgraph` suite against Docker postgres and redis: 3601 passed, 2 failed, both `tests/test_remote_graph.py` connection errors that reproduce identically on unpatched `main` (they need the dev server, which I did not start).

## Not covered

`update_state` persists its writes against the addressed checkpoint, so on a fork those writes also become visible to the *abandoned* branch's reads. Verified on this branch: after forking with `update_state`, re-reading the abandoned head returns `['in-1', 'first-out', 'patched', 'in-2', 'second-out']` while its plain channel correctly returns `['in-1', 'first-out', 'in-2', 'second-out']`. That is the mirror of this bug rather than this bug, and it predates this change.

It is left out here because it is a separate change, not because it is hard: @AnnaSuSu has it written and verified on top of this branch, and it is worth saying that **it is blocked on this PR rather than merely adjacent to it.** The fix moves those writes onto the checkpoint `update_state` creates, which is where the INPUT and PUSH writes in `bulk_update_state` already go. That only works if the new checkpoint carries a snapshot blob, because `get_delta_channel_history` starts its walk at `target_tuple.parent_config` and so never collects a checkpoint's own writes for itself. `create_fork_checkpoint` is what now guarantees the blob. Reproduced locally, deferring the `channel_writes` loop past the `put` and targeting `next_config if is_fork else checkpoint_config`:

```
                                fork sees "patched"   sibling clean   plain update_state
main @658541c + move             FAIL                  pass            FAIL
this branch + move, conditional  pass                  pass            pass
this branch + move, uncondit'l   pass                  pass            FAIL
```

On `main` the fork loses the update that created it. The third row is why the move has to be conditional on the fork flag this PR already threads through.

**A delta channel with no value at the fork base, that the fork does not write in the same superstep, is still not sealed.** `create_checkpoint` skips channels absent from `channel_versions` and `get()` raises on an unavailable channel, so there is no blob to write and the fork boundary goes unrecorded. Two verified cases, both on this branch:

```
fork the root checkpoint, fork never writes the delta channel
   delta: ['in-1']          plain: []      <- oracle
bulk_update_state fork at root, delta key only in the second superstep
   delta: ['in-1', 's2']    plain: ['s2']  <- oracle
```

This is narrower than the bug being fixed (on `main` every fork leaks) but it is the same class. Closing it needs the fork boundary represented in the first persisted checkpoint even when the channel has no value, which means either a sentinel for "empty as of here" in the checkpoint format, or synthesising a `channel_versions` entry for a never-written channel, which reaches into `versions_seen` and task triggering. That felt like a call for a maintainer rather than something to fold in here. Happy to take either direction in this PR or a follow-up.

Threads already forked before this change keep the state they have. The ownership information was never recorded, so there is nothing to recover from at read time.

Thanks to @AnnaSuSu for the report, the minimal reproduction, and for working out that ownership is unrecoverable at read time and proposing the force-snapshot approach taken here, and to @UditDewan for the implementation in #8476, including the case where a channel has no value at the fork base and so cannot carry the blob until a later superstep. Both are credited as co-authors on the commit.
