### PR TITLE
docs: fix multiple interrupts error URL

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -916,7 +916,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8950,7 +8950,7 @@ def test_null_resume_disallowed_with_multiple_interrupts(
     }
     with pytest.raises(
         RuntimeError,
-        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.",
+        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.*interrupts#handling-multiple-interrupts",
     ):
         graph.invoke(Command(resume="singular resume"), config=config)
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9391,7 +9391,7 @@ async def test_null_resume_disallowed_with_multiple_interrupts(
     }
     with pytest.raises(
         RuntimeError,
-        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.",
+        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.*interrupts#handling-multiple-interrupts",
     ):
         await graph.ainvoke(Command(resume="singular resume"), config=config)
 


### PR DESCRIPTION
## Summary
- update the RuntimeError docs URL for multiple pending interrupts to the current interrupts page anchor
- tighten sync and async tests to assert the corrected URL fragment

Closes #7686.

## Testing
- UV_CACHE_DIR=/Users/aadya/Downloads/ruby-portfolio/.uv-cache NO_DOCKER=true uv run pytest tests/test_pregel.py::test_null_resume_disallowed_with_multiple_interrupts tests/test_pregel_async.py::test_null_resume_disallowed_with_multiple_interrupts
- UV_CACHE_DIR=/Users/aadya/Downloads/ruby-portfolio/.uv-cache uv run ruff check langgraph/pregel/_loop.py tests/test_pregel.py tests/test_pregel_async.py