### PR TITLE
fix: make uuid6 thread-safe to prevent race condition under concurrency (closes #8409)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/id.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/id.py
@@ -93,9 +93,10 @@ def uuid6(node: int | None = None, clock_seq: int | None = None) -> UUID:
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     timestamp = nanoseconds // 100 + 0x01B21DD213814000
-    if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
-        timestamp = _last_v6_timestamp + 1
-    _last_v6_timestamp = timestamp
+    with _lock:
+        if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
+            timestamp = _last_v6_timestamp + 1
+        _last_v6_timestamp = timestamp
     if clock_seq is None:
         clock_seq = random.getrandbits(14)  # instead of stable storage
     if node is None:


### PR DESCRIPTION
## What
- The `uuid6` function uses a global `_last_v6_timestamp` without synchronization.
- Under high concurrency (e.g., multiple thread runs and high fanout), this race can produce duplicate timestamps and corrupt UUIDs.
- This can lead to unexpected behavior in systems relying on unique IDs, potentially contributing to OOM in downstream components like OpenTelemetry exporters.

## Fix
- Add a module-level `threading.Lock` to protect read/write of `_last_v6_timestamp`.
- Ensure atomic check-and-update to guarantee unique, monotonically increasing timestamps even under concurrent calls.
- This preserves the function's API and ensures thread safety with minimal overhead.

Closes #8409