### PR TITLE
fix: Disable AsyncPipeline for SSL connections to prevent connection drops (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -81,6 +81,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
         async with await AsyncConnection.connect(
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
+            # Avoid pipeline when SSL is used, as it's known to cause connection drops
+            if pipeline and conn.info.ssl_in_use:
+                import warnings
+                warnings.warn("AsyncPipeline is not recommended with SSL connections. Disabling pipeline.",
+                             RuntimeWarning, stacklevel=2)
+                pipeline = False
             if pipeline:
                 async with conn.pipeline() as pipe:
                     yield cls(conn=conn, pipe=pipe, serde=serde)


### PR DESCRIPTION
## What
Users using `AsyncPostgresSaver` with `pipeline=True` and an SSL-enabled Postgres connection (e.g., Supabase) consistently encounter `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. This is due to known instability of psycopg's `AsyncPipeline` over SSL connections.

## Fix
In `from_conn_string`, detect if the connection is using SSL and if `pipeline=True`, automatically disable pipeline mode and emit a warning. This prevents the error while preserving functionality for non-SSL connections.

## Changes
- Check `conn.info.ssl_in_use` before enabling pipeline
- Add a runtime warning when disabling pipeline

Closes #5675