### PR TITLE
fix(checkpoint-sqlite): call setup() in adelete_thread before accessing DB

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -608,6 +608,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             None
         """
+        await self.setup()
         async with self.lock, self.conn.cursor() as cur:
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,16 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_adelete_thread_on_fresh_connection(self) -> None:
+        """Regression test for adelete_thread failing on an uninitialized database.
+
+        Every other public async method in AsyncSqliteSaver calls setup() before
+        touching the DB; adelete_thread() was missing that call and raised
+        sqlite3.OperationalError ("no such table: checkpoints") when invoked
+        before any other method on a brand-new connection.
+        """
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            # Must not raise OperationalError even though no other method has
+            # been called on this saver instance yet.
+            await saver.adelete_thread("nonexistent-thread")


### PR DESCRIPTION
## Summary

`AsyncSqliteSaver.adelete_thread()` raises `sqlite3.OperationalError: no such table: checkpoints` when called as the first operation on a fresh connection (e.g. `AsyncSqliteSaver.from_conn_string(":memory:")`).

Every other public async method in the class — `aget_tuple`, `alist`, `aput`, `aput_writes`, `aget_delta_channel_history` — calls `await self.setup()` before the first DB access to ensure the tables exist. `adelete_thread` was the only method missing that call, going straight to `self.conn.cursor()`.

**Root cause:** `await self.setup()` was never added when `adelete_thread` was implemented.

**Fix:** Add `await self.setup()` as the first line of `adelete_thread`, matching every sibling method.

**Regression test:** `test_adelete_thread_on_fresh_connection` — creates an `AsyncSqliteSaver.from_conn_string(":memory:")`, then calls `adelete_thread("nonexistent-thread")` as the *first* operation (no other method called before it). Must complete without raising `OperationalError`.

Fixes #8549

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.