### PR TITLE
fix: update multiple-interrupts documentation URL

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -916,7 +916,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
## Summary

- Update the obsolete multiple-interrupts documentation URL in the RuntimeError to the current `interrupts#handling-multiple-interrupts` anchor.
- This addresses langchain-ai/langgraph#7686.

## Verification

- Artifact normalized and validated with `git apply --check --recount` (with `--unidiff-zero` for the zero-context hunk), then applied with matching recount flags.
- `git diff --check` passed.
- local verification not run; relying on upstream CI (fresh worktree has no installed dependencies).
