### PR TITLE
fix(checkpoint-sqlite): release lock before yielding history

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -463,6 +463,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             self.conn.execute(query, params) as cur,
             self.conn.cursor() as wcur,
         ):
+            checkpoints: list[CheckpointTuple] = []
             async for (
                 thread_id,
                 checkpoint_ns,
@@ -476,35 +477,39 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                     "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
                     (thread_id, checkpoint_ns, checkpoint_id),
                 )
-                yield CheckpointTuple(
-                    {
-                        "configurable": {
-                            "thread_id": thread_id,
-                            "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": checkpoint_id,
-                        }
-                    },
-                    self.serde.loads_typed((type, checkpoint)),
-                    cast(
-                        CheckpointMetadata,
-                        (json.loads(metadata) if metadata is not None else {}),
-                    ),
-                    (
+                checkpoints.append(
+                    CheckpointTuple(
                         {
                             "configurable": {
                                 "thread_id": thread_id,
                                 "checkpoint_ns": checkpoint_ns,
-                                "checkpoint_id": parent_checkpoint_id,
+                                "checkpoint_id": checkpoint_id,
                             }
-                        }
-                        if parent_checkpoint_id
-                        else None
-                    ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        async for task_id, channel, type, value in wcur
-                    ],
+                        },
+                        self.serde.loads_typed((type, checkpoint)),
+                        cast(
+                            CheckpointMetadata,
+                            (json.loads(metadata) if metadata is not None else {}),
+                        ),
+                        (
+                            {
+                                "configurable": {
+                                    "thread_id": thread_id,
+                                    "checkpoint_ns": checkpoint_ns,
+                                    "checkpoint_id": parent_checkpoint_id,
+                                }
+                            }
+                            if parent_checkpoint_id
+                            else None
+                        ),
+                        [
+                            (task_id, channel, self.serde.loads_typed((type, value)))
+                            async for task_id, channel, type, value in wcur
+                        ],
+                    )
                 )
+        for checkpoint in checkpoints:
+            yield checkpoint
 
     async def aput(
         self,


### PR DESCRIPTION
## Summary

Materialize and deserialize `AsyncSqliteSaver.alist` results while holding the SQLite lock, then yield the completed tuples after releasing it. This prevents a paused async-generator consumer from blocking checkpoint writes.

## Issue

Closes #8558

## Verification

- `git apply --check --recount --unidiff-zero` passed.
- `git apply --recount --unidiff-zero` applied cleanly.
- `git diff --check` passed.
- local verification not run; relying on upstream CI.
