### PR TITLE
release(checkpoint): 4.2.0

### DIFF
--- a/libs/checkpoint-conformance/uv.lock
+++ b/libs/checkpoint-conformance/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -276,7 +276,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/checkpoint-sqlite/uv.lock
+++ b/libs/checkpoint-sqlite/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 description = "Library with base interfaces for LangGraph checkpoint savers."
 authors = []
 requires-python = ">=3.10"

--- a/libs/checkpoint/uv.lock
+++ b/libs/checkpoint/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1622,7 +1622,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -369,7 +369,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/sdk-py/uv.lock
+++ b/libs/sdk-py/uv.lock
@@ -382,7 +382,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
+version = "4.2.0"
 source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Version bump only. No library code changes in this PR.

Unreleased since `checkpoint==4.1.1`:

- #8526 - collect writes at plain-value seed in delta channel history
- #8354 - add opt-in `TTLConfig.omit_expired` to skip expired rows on read

Minor rather than patch because #8354 adds a new public `TTLConfig` key. Note that the checkpoint-postgres half of #8354 already shipped in `checkpointpostgres==3.1.1`, so the currently released Postgres saver honors an option that no released `langgraph-checkpoint` declares. This closes that gap.

`langgraph-checkpoint-postgres` 3.1.2 (#8535) follows once this is live on PyPI.