### PR TITLE
release(checkpoint-postgres): 3.1.2

### DIFF
--- a/libs/checkpoint-postgres/pyproject.toml
+++ b/libs/checkpoint-postgres/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.1"
+version = "3.1.2"
 description = "Library with a Postgres implementation of LangGraph checkpoint saver."
 authors = []
 requires-python = ">=3.10"

--- a/libs/checkpoint-postgres/uv.lock
+++ b/libs/checkpoint-postgres/uv.lock
@@ -351,7 +351,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "langgraph-checkpoint" },

--- a/libs/langgraph/uv.lock
+++ b/libs/langgraph/uv.lock
@@ -1670,7 +1670,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "../checkpoint-postgres" }
 dependencies = [
     { name = "langgraph-checkpoint" },

--- a/libs/prebuilt/uv.lock
+++ b/libs/prebuilt/uv.lock
@@ -417,7 +417,7 @@ test = [
 
 [[package]]
 name = "langgraph-checkpoint-postgres"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "../checkpoint-postgres" }
 dependencies = [
     { name = "langgraph-checkpoint" },


### PR DESCRIPTION
Version bump only. No library code changes in this PR.

Unreleased since `checkpointpostgres==3.1.1`:

- #8535 - find plain-value seeds when walking delta history

Follows `checkpoint==4.2.0`, which is already live on PyPI. No dependency change needed here, since `langgraph-checkpoint>=4.1.0,<5.0.0` already admits 4.2.0.