### PR TITLE
fix: release AsyncSqliteSaver history lock before yielding

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -463,6 +463,11 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
             self.conn.execute(query, params) as cur,
             self.conn.cursor() as wcur,
         ):
+            # Materialize all matching checkpoints while holding the lock, so
+            # the lock is released before yielding to the caller. Holding the
+            # lock across a yield lets a paused consumer block aput() and any
+            # other lock-guarded operation (langgraph-ai/langgraph#8558).
+            results: list[CheckpointTuple] = []
             async for (
                 thread_id,
                 checkpoint_ns,
@@ -476,35 +481,41 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
                     "SELECT task_id, channel, type, value FROM writes WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? ORDER BY task_id, idx",
                     (thread_id, checkpoint_ns, checkpoint_id),
                 )
-                yield CheckpointTuple(
-                    {
-                        "configurable": {
-                            "thread_id": thread_id,
-                            "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": checkpoint_id,
-                        }
-                    },
-                    self.serde.loads_typed((type, checkpoint)),
-                    cast(
-                        CheckpointMetadata,
-                        (json.loads(metadata) if metadata is not None else {}),
-                    ),
-                    (
+                results.append(
+                    CheckpointTuple(
                         {
                             "configurable": {
                                 "thread_id": thread_id,
                                 "checkpoint_ns": checkpoint_ns,
-                                "checkpoint_id": parent_checkpoint_id,
+                                "checkpoint_id": checkpoint_id,
                             }
-                        }
-                        if parent_checkpoint_id
-                        else None
-                    ),
-                    [
-                        (task_id, channel, self.serde.loads_typed((type, value)))
-                        async for task_id, channel, type, value in wcur
-                    ],
+                        },
+                        self.serde.loads_typed((type, checkpoint)),
+                        cast(
+                            CheckpointMetadata,
+                            (json.loads(metadata) if metadata is not None else {}),
+                        ),
+                        (
+                            {
+                                "configurable": {
+                                    "thread_id": thread_id,
+                                    "checkpoint_ns": checkpoint_ns,
+                                    "checkpoint_id": parent_checkpoint_id,
+                                }
+                            }
+                            if parent_checkpoint_id
+                            else None
+                        ),
+                        [
+                            (task_id, channel, self.serde.loads_typed((type, value)))
+                            async for task_id, channel, type, value in wcur
+                        ],
+                    )
                 )
+        # Yield only after the lock has been released, so a paused consumer
+        # does not block other saver operations.
+        for result in results:
+            yield result
 
     async def aput(
         self,

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pytest
@@ -188,3 +189,32 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_alist_paused_consumer_does_not_block_aput(self) -> None:
+        """A paused ``alist`` consumer must not block checkpoint writes.
+
+        Regression test for https://github.com/langchain-ai/langgraph/issues/8558:
+        ``alist`` held ``self.lock`` across the async generator ``yield``,
+        so a consumer that paused after receiving a checkpoint blocked
+        ``aput`` (and any other lock-guarded operation) until it resumed.
+        """
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            await saver.aput(self.config_1, self.chkpnt_1, self.metadata_1, {})
+            await saver.aput(self.config_2, self.chkpnt_2, self.metadata_2, {})
+
+            iterator = saver.alist(None)
+            # Consume exactly one checkpoint, then pause the consumer. The
+            # lock must already be released before control returns here.
+            first = await anext(iterator)
+            assert first is not None
+
+            # If the lock were still held, this write would hang forever;
+            # bound it so a regression reports as a failure, not a deadlock.
+            await asyncio.wait_for(
+                saver.aput(self.config_3, self.chkpnt_3, self.metadata_3, {}),
+                timeout=10,
+            )
+            await iterator.aclose()
+
+            stored = await saver.aget_tuple(self.config_3)
+            assert stored is not None


### PR DESCRIPTION
local verification not run; relying on upstream CI