### PR TITLE
fix: update multiple-interrupts documentation URL

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -916,7 +916,7 @@ class PregelLoop:
                     if len(self._pending_interrupts()) > 1:
                         raise RuntimeError(
                             "When there are multiple pending interrupts, you must specify the interrupt id when resuming. "
-                            "Docs: https://docs.langchain.com/oss/python/langgraph/add-human-in-the-loop#resume-multiple-interrupts-with-one-invocation."
+                            "Docs: https://docs.langchain.com/oss/python/langgraph/interrupts#handling-multiple-interrupts."
                         )
 
             writes: defaultdict[str, list[tuple[str, Any]]] = defaultdict(list)


### PR DESCRIPTION
Fixes #7686

Updates the stale RuntimeError documentation link for multiple pending interrupts to the current working page.

local verification not run; relying on upstream CI