### PR TITLE
fix(checkpoint-sqlite): call setup() in adelete_thread before accessing DB

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -608,6 +608,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             None
         """
+        await self.setup()
         async with self.lock, self.conn.cursor() as cur:
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,24 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_adelete_thread_on_uninitialized_database(self) -> None:
+        """adelete_thread() should be a no-op on a fresh, unset-up database.
+
+        Regression test for a bug where adelete_thread() accessed the
+        checkpoints/writes tables directly without first calling setup(),
+        unlike every other async method on AsyncSqliteSaver. Calling it as
+        the very first operation on a brand-new database raised
+        sqlite3.OperationalError: no such table: checkpoints.
+        """
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            # Should not raise even though no table has been created yet.
+            await saver.adelete_thread("missing-thread")
+
+            # Sanity check: the saver is now fully usable.
+            config: RunnableConfig = {
+                "configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}
+            }
+            await saver.aput(config, self.chkpnt_1, self.metadata_1, {})
+            checkpoint = await saver.aget_tuple(config)
+            assert checkpoint is not None


### PR DESCRIPTION
Fixes #8549

## Problem
`AsyncSqliteSaver.adelete_thread()` ran `DELETE FROM checkpoints...` / `DELETE FROM writes...` directly against `self.conn` without first calling `await self.setup()`, unlike every sibling async method (`aput`, `aput_writes`, `aget_tuple`, `alist`), which all lazily create tables via `setup()`. Calling `adelete_thread()` first against a fresh database (e.g. `:memory:`) raised `sqlite3.OperationalError: no such table: checkpoints`.

## Fix
Added `await self.setup()` as the first line of `adelete_thread()` in `libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py`, matching the existing pattern used by every other async method on this class.

## Testing
Added `test_adelete_thread_on_uninitialized_database` in `libs/checkpoint-sqlite/tests/test_aiosqlite.py`, confirming it fails with the original error when the fix is reverted and passes with the fix:
```
tests/test_aiosqlite.py::TestAsyncSqliteSaver::test_adelete_thread_on_uninitialized_database PASSED
4 passed in 0.34s
```