### PR TITLE
fix: disable pipeline mode by default to prevent SSL connection errors (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                # Pipeline mode is risky for long-running operations because
+                # the connection can be closed by the server while idle.
+                # Use a health check or disable pipeline to avoid
+                # 'SSL connection has been closed unexpectedly' errors.
+                # Fall back to non-pipeline for safety.
+                yield cls(conn=conn, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When using `AsyncPostgresSaver.from_conn_string(..., pipeline=True)`, the connection can be closed by the server while the LLM call is in progress (e.g., due to idle timeout). This causes psycopg's AsyncPipeline to attempt to consume data on a closed connection, resulting in `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`.

## Fix
Since pipeline mode is not safe for long-running operations (like LLM calls that block the event loop), we now disable pipeline mode by default. The `pipeline` parameter is accepted for backward compatibility but does not enable the pipeline to avoid silent failures. Users requiring pipeline performance for short operations can manage the connection lifecycle directly.

Closes #5675