### PR TITLE
Fix AsyncSqliteSaver.adelete_thread missing setup() call

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -608,6 +608,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             None
         """
+        await self.setup()
         async with self.lock, self.conn.cursor() as cur:
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,38 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_adelete_thread_without_prior_setup(self) -> None:
+        """Test that adelete_thread calls setup() internally.
+
+        Regression test for https://github.com/langchain-ai/langgraph/issues/8549.
+        Previously, adelete_thread did not call await self.setup() before executing
+        SQL, causing a crash if the database tables had not been created yet.
+        """
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            # Call adelete_thread without calling setup() first.
+            # This should NOT raise an error (previously would fail with
+            # "no such table: checkpoints").
+            await saver.adelete_thread("nonexistent-thread")
+
+            # Verify the tables were created and the call succeeded
+            # by inserting and then deleting a checkpoint
+            config: RunnableConfig = {
+                "configurable": {
+                    "thread_id": "test-thread",
+                    "checkpoint_ns": "",
+                }
+            }
+            checkpoint = empty_checkpoint()
+            await saver.aput(config, checkpoint, {}, {})
+
+            # Verify checkpoint exists
+            result = await saver.aget_tuple(config)
+            assert result is not None
+
+            # Delete the thread
+            await saver.adelete_thread("test-thread")
+
+            # Verify checkpoint was deleted
+            result = await saver.aget_tuple(config)
+            assert result is None


### PR DESCRIPTION
## Summary

Fixes #8549

In `libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py`, the `adelete_thread` method was missing `await self.setup()` before executing SQL queries. All other async methods in the `AsyncSqliteSaver` class (`aget_tuple`, `alist`, `aput`, `aput_writes`, `aget_delta_channel_history`) call `await self.setup()` as their first operation to ensure the database tables exist, but `adelete_thread` was missing this call.

This caused a crash with a "no such table: checkpoints" error if `adelete_thread` was called before any other method that triggers `setup()`.

## Changes

- **`libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py`**: Added `await self.setup()` as the first line of the `adelete_thread` method body, matching the pattern used by all other async methods.
- **`libs/checkpoint-sqlite/tests/test_aiosqlite.py`**: Added `test_adelete_thread_without_prior_setup` regression test that creates an `AsyncSqliteSaver` and calls `adelete_thread` without calling `setup()` first, verifying it does not crash.