### PR TITLE
fix(langgraph): reject scalar resume when multiple interrupts are pending in one subgraph task

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -818,29 +818,33 @@ class PregelLoop:
     def _pending_interrupts(self) -> set[str]:
         """Return the set of interrupt ids that are pending without corresponding resume values."""
         # mapping of task ids to interrupt ids
-        pending_interrupts: dict[str, str] = {}
+        pending_interrupts: dict[str, set[str]] = {}
 
         # set of resume task ids
         pending_resumes: set[str] = set()
 
         for task_id, write_type, value in self.checkpoint_pending_writes:
             if write_type == INTERRUPT:
-                # interrupts is always a list, but there should only be one element
-                pending_interrupts[task_id] = value[0].id
+                # A task may hold multiple pending interrupts: a subgraph with
+                # parallel interrupting branches collapses into a single write.
+                pending_interrupts[task_id] = {i.id for i in value}
             elif write_type == RESUME:
                 pending_resumes.add(task_id)
 
+        # Resuming a task resolves all of its pending interrupts (task-level dedup).
         resumed_interrupt_ids = {
-            pending_interrupts[task_id]
+            iid
             for task_id in pending_resumes
             if task_id in pending_interrupts
+            for iid in pending_interrupts[task_id]
         }
 
         # Keep only interrupts whose interrupt_id is not resumed
         hanging_interrupts: set[str] = {
-            interrupt_id
-            for interrupt_id in pending_interrupts.values()
-            if interrupt_id not in resumed_interrupt_ids
+            iid
+            for ids in pending_interrupts.values()
+            for iid in ids
+            if iid not in resumed_interrupt_ids
         }
 
         return hanging_interrupts

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -8951,6 +8951,51 @@ def test_null_resume_disallowed_with_multiple_interrupts(
     }
 
 
+def test_null_resume_disallowed_with_multiple_interrupts_in_subgraph() -> None:
+    class State(TypedDict):
+        answers: Annotated[list[str], operator.add]
+
+    def ask_left(state: State) -> State:
+        return {"answers": [f"left={interrupt('left')}"]}
+
+    def ask_right(state: State) -> State:
+        return {"answers": [f"right={interrupt('right')}"]}
+
+    child = (
+        StateGraph(State)
+        .add_node("ask_left", ask_left)
+        .add_node("ask_right", ask_right)
+        .add_edge(START, "ask_left")
+        .add_edge(START, "ask_right")
+        .compile()
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("child", child)
+        .add_edge(START, "child")
+        .compile(checkpointer=InMemorySaver())
+    )
+
+    config = {"configurable": {"thread_id": str(uuid.uuid4())}}
+    first = graph.invoke({"answers": []}, config)
+    assert len(first["__interrupt__"]) == 2
+
+    with pytest.raises(
+        RuntimeError,
+        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.",
+    ):
+        graph.invoke(Command(resume="ambiguous"), config)
+
+    resume_map = {
+        i.id: f"resume for {i.value}" for i in graph.get_state(config).interrupts
+    }
+    assert graph.invoke(Command(resume=resume_map), config)["answers"] == [
+        "left=resume for left",
+        "right=resume for right",
+    ]
+
+
 def test_interrupt_stream_mode_values(sync_checkpointer: BaseCheckpointSaver):
     """Test that interrupts are surfaced on 'values' stream mode"""
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -9390,6 +9390,52 @@ async def test_null_resume_disallowed_with_multiple_interrupts(
     }
 
 
+async def test_null_resume_disallowed_with_multiple_interrupts_in_subgraph() -> None:
+    class State(TypedDict):
+        answers: Annotated[list[str], operator.add]
+
+    async def ask_left(state: State) -> State:
+        return {"answers": [f"left={interrupt('left')}"]}
+
+    async def ask_right(state: State) -> State:
+        return {"answers": [f"right={interrupt('right')}"]}
+
+    child = (
+        StateGraph(State)
+        .add_node("ask_left", ask_left)
+        .add_node("ask_right", ask_right)
+        .add_edge(START, "ask_left")
+        .add_edge(START, "ask_right")
+        .compile()
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("child", child)
+        .add_edge(START, "child")
+        .compile(checkpointer=InMemorySaver())
+    )
+
+    config = {"configurable": {"thread_id": str(uuid.uuid4())}}
+    first = await graph.ainvoke({"answers": []}, config)
+    assert len(first["__interrupt__"]) == 2
+
+    with pytest.raises(
+        RuntimeError,
+        match="When there are multiple pending interrupts, you must specify the interrupt id when resuming.",
+    ):
+        await graph.ainvoke(Command(resume="ambiguous"), config)
+
+    resume_map = {
+        i.id: f"resume for {i.value}"
+        for i in (await graph.aget_state(config)).interrupts
+    }
+    assert (await graph.ainvoke(Command(resume=resume_map), config))["answers"] == [
+        "left=resume for left",
+        "right=resume for right",
+    ]
+
+
 async def test_astream_waiter_cleanup_on_cancel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #8579

`Command(resume=<scalar>)` was accepted when two interrupts are pending
inside a single subgraph task, because `_pending_interrupts()` records
only `value[0].id` per task write. This change collects every interrupt
id in each task's `INTERRUPT` write (retaining the existing task-level
dedup for resolved writes), so the multiple-pending-interrupt guard
raises the expected `RuntimeError` and a resume map is required.

### Tests
- Regression test in `tests/test_pregel.py` and async variant in
  `tests/test_pregel_async.py` (fails on main, passes with the fix,
  across memory/sqlite/sqlite_aes).