### PR TITLE
docs(checkpoint-postgres): clarify ssl vs sslmode connection-string parameter

### DIFF
--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -53,6 +53,17 @@ For full documentation, see the [API reference](https://reference.langchain.com/
 >     # TypeError: tuple indices must be integers or slices, not str
 > ```
 
+> [!IMPORTANT]
+> `psycopg` and `asyncpg` use different query parameter names for TLS. If your connection string was built for `asyncpg` (for example, reused from an existing SQLAlchemy async engine URL), it uses `ssl` (e.g. `ssl=require`); `psycopg`, which `PostgresSaver` and `AsyncPostgresSaver` are built on, expects `sslmode` instead (e.g. `sslmode=require`). Passing the `asyncpg`-style parameter raises `psycopg.ProgrammingError: invalid URI query parameter: "ssl"` rather than connecting.
+>
+> ```python
+> # ❌ asyncpg-style query parameter — psycopg rejects this
+> DB_URI = "postgresql://user:pass@host:5432/db?ssl=require"
+>
+> # ✅ psycopg-style query parameter
+> DB_URI = "postgresql://user:pass@host:5432/db?sslmode=require"
+> ```
+
 ```python
 from langgraph.checkpoint.postgres import PostgresSaver
 


### PR DESCRIPTION
## Summary

`PostgresSaver`/`AsyncPostgresSaver` are built on `psycopg`, which expects the libpq `sslmode` query parameter (e.g. `sslmode=require`). If a connection string was instead built for `asyncpg` — for example reused from an existing SQLAlchemy async engine URL, a common setup in apps that already talk to Postgres before adding LangGraph checkpointing — it uses `ssl` instead (e.g. `ssl=require`). Passing that string straight into `from_conn_string` fails with:

```
psycopg.ProgrammingError: invalid URI query parameter: "ssl"
```

which doesn't name the actual fix. I hit this directly while wiring `AsyncPostgresSaver` into a FastAPI/SQLAlchemy app and lost time tracing it back to the parameter-name mismatch between the two drivers.

This adds one `[!IMPORTANT]` callout to `libs/checkpoint-postgres/README.md`, styled the same as the existing `autocommit`/`row_factory` callout directly above it, with a short explanation and a ❌/✅ before-and-after snippet.

Docs only — no code changes.

## Test plan

- [x] Reproduced the exact `psycopg.ProgrammingError: invalid URI query parameter: "ssl"` locally against the installed `psycopg` version to confirm the failure mode described.
- [x] Ran `markdownlint-cli2` against the edited file; the only reported issue (`MD028/no-blanks-blockquote`) already exists identically elsewhere in the same file prior to this change, so this PR doesn't introduce a new lint state.
- N/A automated tests — documentation-only change.