### PR TITLE
fix(langgraph): restore UntrackedValue input to Send tasks on resume

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -364,6 +364,7 @@ def prepare_next_tasks(
     updated_channels: set[str] | None = None,
     retry_policy: Sequence[RetryPolicy] = (),
     cache_policy: Literal[None] = None,
+    runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, PregelTask]: ...
 
 
@@ -386,6 +387,7 @@ def prepare_next_tasks(
     updated_channels: set[str] | None = None,
     retry_policy: Sequence[RetryPolicy] = (),
     cache_policy: CachePolicy | None = None,
+    runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, PregelExecutableTask]: ...
 
 
@@ -407,6 +409,7 @@ def prepare_next_tasks(
     updated_channels: set[str] | None = None,
     retry_policy: Sequence[RetryPolicy] = (),
     cache_policy: CachePolicy | None = None,
+    runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, PregelTask] | dict[str, PregelExecutableTask]:
     """Prepare the set of tasks that will make up the next Pregel step.
 
@@ -462,6 +465,7 @@ def prepare_next_tasks(
                 input_cache=input_cache,
                 cache_policy=cache_policy,
                 retry_policy=retry_policy,
+                runtime_untracked_values=runtime_untracked_values,
             ):
                 tasks.append(task)
 
@@ -508,6 +512,7 @@ def prepare_next_tasks(
             input_cache=input_cache,
             cache_policy=cache_policy,
             retry_policy=retry_policy,
+            runtime_untracked_values=runtime_untracked_values,
         ):
             tasks.append(task)
     return {t.id: t for t in tasks}
@@ -542,6 +547,7 @@ def prepare_single_task(
     input_cache: dict[INPUT_CACHE_KEY_TYPE, Any] | None = None,
     cache_policy: CachePolicy | None = None,
     retry_policy: Sequence[RetryPolicy] = (),
+    runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
 ) -> None | PregelTask | PregelExecutableTask:
     """Prepares a single task for the next Pregel step, given a task path, which
     uniquely identifies a PUSH or PULL task within the graph."""
@@ -592,6 +598,7 @@ def prepare_single_task(
             retry_policy=retry_policy,
             parent_ns=parent_ns,
             task_id_func=task_id_func,
+            runtime_untracked_values=runtime_untracked_values,
         )
 
     elif task_path[0] == PULL:
@@ -957,6 +964,7 @@ def prepare_push_task_send(
     parent_ns: str,
     task_id_func: _TaskIDFn,
     processes: Mapping[str, PregelNode],
+    runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
 ) -> PregelTask | PregelExecutableTask | None:
     if len(task_path) == 2:
         # SEND tasks, executed in superstep n+1
@@ -973,6 +981,15 @@ def prepare_push_task_send(
                 f"Ignoring invalid packet type {type(packet)} in pending sends"
             )
             return
+        if runtime_untracked_values is not None and any(
+            isinstance(channels.get(k), UntrackedValue) for k in channels
+        ):
+            retained_values = runtime_untracked_values.get(
+                config.get(CONF, {}).get(CONFIG_KEY_THREAD_ID), {}
+            )
+            packet = rehydrate_untracked_values_in_send(
+                packet, channels, retained_values
+            )
 
         if packet.node not in processes:
             logger.warning(f"Ignoring unknown node name {packet.node} in pending sends")
@@ -1439,13 +1456,19 @@ class LazyAtomicCounter:
         return self._counter()
 
 
+_UNTRACKED_VALUE_MARKER = "__langgraph_untracked_value__"
+
+
 def sanitize_untracked_values_in_send(
     packet: Send, channels: Mapping[str, BaseChannel]
 ) -> Send:
-    """Pop any values belonging to UntrackedValue channels in Send.arg for safe checkpointing.
+    """Replace any values belonging to UntrackedValue channels in Send.arg with a stable marker.
 
     Send is often called with state to be passed to the dest node, which may contain
-    UntrackedValues at the top level. Send is not typed and arg may be a nested dict."""
+    UntrackedValues at the top level. Send is not typed and arg may be a nested dict.
+    The marker keeps the key present in the checkpoint (the value is not
+    msgpack-serializable) so the task can be rehydrated with the original value on
+    resume; see `rehydrate_untracked_values_in_send`."""
 
     if not isinstance(packet.arg, dict):
         # Command
@@ -1453,8 +1476,43 @@ def sanitize_untracked_values_in_send(
 
     # top level keys should be the channel names
     sanitized_arg = {
-        k: v
+        k: _UNTRACKED_VALUE_MARKER if isinstance(channels.get(k), UntrackedValue) else v
         for k, v in packet.arg.items()
-        if not isinstance(channels.get(k), UntrackedValue)
     }
     return Send(node=packet.node, arg=sanitized_arg, timeout=packet.timeout)
+
+
+def rehydrate_untracked_values_in_send(
+    packet: Send,
+    channels: Mapping[str, BaseChannel],
+    retained_values: Mapping[str, Any],
+) -> Send:
+    """Restore untracked values in a Send.arg from values retained in-process at write time.
+
+    Replaces the marker left by `sanitize_untracked_values_in_send` with the value that
+    was retained when the Send was persisted, so a resumed task receives the same input
+    it was first scheduled with. Keys without a retained value (e.g. a cold resume from a
+    checkpoint written by another process) are deleted, matching the previous behavior.
+    Nested dicts are not touched, matching the sanitizer's top-level-only scope."""
+
+    if not isinstance(packet.arg, dict):
+        # Command
+        return packet
+    if not any(isinstance(channels.get(k), UntrackedValue) for k in packet.arg):
+        return packet
+    arg = dict(packet.arg)
+    for k in list(arg):
+        if arg[k] == _UNTRACKED_VALUE_MARKER and isinstance(
+            channels.get(k), UntrackedValue
+        ):
+            if (retained := retained_values.get(k, MISSING)) is not MISSING:
+                arg[k] = retained
+            else:
+                # cold resume: no retained value for this channel, degrade to
+                # the pre-fix behavior of dropping the key
+                logger.warning(
+                    f"Dropping untracked value for channel {k} in Send to {packet.node}: "
+                    "no value was retained in-process when the task was scheduled"
+                )
+                del arg[k]
+    return Send(node=packet.node, arg=arg, timeout=packet.timeout)

--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import binascii
 import concurrent.futures
+import threading
 from collections import defaultdict, deque
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import (
@@ -294,6 +295,8 @@ class PregelLoop:
         retry_policy: Sequence[RetryPolicy] = (),
         cache_policy: CachePolicy | None = None,
         has_graph_lifecycle_callbacks: bool = False,
+        runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
+        runtime_untracked_values_lock: threading.Lock | None = None,
     ) -> None:
         self.stream = stream
         self.config = config
@@ -320,6 +323,17 @@ class PregelLoop:
         self.durability = durability
         self._has_graph_lifecycle_callbacks = has_graph_lifecycle_callbacks
         self._graph_lifecycle_events = deque()
+        # in-process retention of top-level UntrackedValue channel values from
+        # Send args, keyed by thread id, so a resumed task receives the same
+        # input it was first scheduled with (see issue #8582). Never persisted.
+        self._runtime_untracked_values = (
+            runtime_untracked_values if runtime_untracked_values is not None else {}
+        )
+        self._runtime_untracked_values_lock = (
+            runtime_untracked_values_lock
+            if runtime_untracked_values_lock is not None
+            else threading.Lock()
+        )
         if self.stream is not None and CONFIG_KEY_STREAM in config[CONF]:
             self.stream = DuplexStream(self.stream, config[CONF][CONFIG_KEY_STREAM])
         scratchpad: PregelScratchpad | None = config[CONF].get(CONFIG_KEY_SCRATCHPAD)
@@ -412,6 +426,32 @@ class PregelLoop:
             return None
         return self._graph_lifecycle_events.popleft()
 
+    def _retain_untracked_values_in_send(self, v: Send) -> Send:
+        """Retain top-level UntrackedValue channel values from a Send arg in-process
+        and return the Send sanitized for checkpointing.
+
+        The retained values are keyed by thread id so a resumed task can restore its
+        original input; they are never written to the checkpoint. Called from
+        `put_writes` (background executor threads) and `_put_checkpoint`, so map
+        access is guarded by a lock.
+        Known limitation: retention is keyed per (thread, channel), so only a single
+        value is kept per channel per thread (last write wins) when two Sends in the
+        same step carry different values for the same UntrackedValue channel."""
+        if not isinstance(v.arg, dict):
+            return sanitize_untracked_values_in_send(v, self.channels)
+        if thread_id := self.config.get(CONF, {}).get(CONFIG_KEY_THREAD_ID):
+            retained = {
+                k: val
+                for k, val in v.arg.items()
+                if isinstance(self.channels.get(k), UntrackedValue)
+            }
+            if retained:
+                with self._runtime_untracked_values_lock:
+                    self._runtime_untracked_values.setdefault(thread_id, {}).update(
+                        retained
+                    )
+        return sanitize_untracked_values_in_send(v, self.channels)
+
     def put_writes(self, task_id: str, writes: WritesT) -> None:
         """Put writes for a task, to be read by the next tick."""
         if not writes:
@@ -443,8 +483,9 @@ class PregelLoop:
             # we do not persist untracked values in checkpoints
             writes_to_save = [
                 # sanitize UntrackedValues that are nested within Send packets
+                # while retaining the original values in-process for resume
                 (
-                    (c, sanitize_untracked_values_in_send(v, self.channels))
+                    (c, self._retain_untracked_values_in_send(v))
                     if c == TASKS and isinstance(v, Send)
                     else (c, v)
                 )
@@ -626,6 +667,7 @@ class PregelLoop:
             updated_channels=self.updated_channels,
             retry_policy=self.retry_policy,
             cache_policy=self.cache_policy,
+            runtime_untracked_values=self._runtime_untracked_values,
         )
 
         # produce debug output
@@ -870,6 +912,12 @@ class PregelLoop:
                 ),
             )
         )
+
+        if not is_resuming and (thread_id := configurable.get(CONFIG_KEY_THREAD_ID)):
+            # fresh run: drop any values retained from a previous run so stale
+            # in-process untracked values cannot leak across runs
+            with self._runtime_untracked_values_lock:
+                self._runtime_untracked_values.pop(thread_id, None)
 
         # When replaying from a specific checkpoint, drop cached RESUME
         # writes so that interrupt() calls re-fire instead of returning
@@ -1165,7 +1213,7 @@ class PregelLoop:
             isinstance(channel, UntrackedValue) for channel in self.channels.values()
         ):
             sanitized_tasks = [
-                sanitize_untracked_values_in_send(value, self.channels)
+                self._retain_untracked_values_in_send(value)
                 if isinstance(value, Send)
                 else value
                 for value in self.checkpoint["channel_values"][TASKS]
@@ -1490,6 +1538,8 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
         retry_policy: Sequence[RetryPolicy] = (),
         cache_policy: CachePolicy | None = None,
         has_graph_lifecycle_callbacks: bool = False,
+        runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
+        runtime_untracked_values_lock: threading.Lock | None = None,
     ) -> None:
         super().__init__(
             input,
@@ -1512,6 +1562,8 @@ class SyncPregelLoop(PregelLoop, AbstractContextManager):
             cache_policy=cache_policy,
             durability=durability,
             has_graph_lifecycle_callbacks=has_graph_lifecycle_callbacks,
+            runtime_untracked_values=runtime_untracked_values,
+            runtime_untracked_values_lock=runtime_untracked_values_lock,
         )
         self.stack = ExitStack()
         if checkpointer:
@@ -1743,6 +1795,8 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
         retry_policy: Sequence[RetryPolicy] = (),
         cache_policy: CachePolicy | None = None,
         has_graph_lifecycle_callbacks: bool = False,
+        runtime_untracked_values: dict[str, dict[str, Any]] | None = None,
+        runtime_untracked_values_lock: threading.Lock | None = None,
     ) -> None:
         super().__init__(
             input,
@@ -1765,6 +1819,8 @@ class AsyncPregelLoop(PregelLoop, AbstractAsyncContextManager):
             cache_policy=cache_policy,
             durability=durability,
             has_graph_lifecycle_callbacks=has_graph_lifecycle_callbacks,
+            runtime_untracked_values=runtime_untracked_values,
+            runtime_untracked_values_lock=runtime_untracked_values_lock,
         )
         self.stack = AsyncExitStack()
         if checkpointer:

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -5,6 +5,7 @@ import concurrent
 import concurrent.futures
 import contextlib
 import queue
+import threading
 import warnings
 import weakref
 from collections import defaultdict, deque
@@ -832,6 +833,11 @@ class Pregel(
             stream_transformers or ()
         )
         self._serde_allowlist: set[tuple[str, ...]] | None = None
+        # in-process retention of top-level UntrackedValue channel values from
+        # Send args, keyed by thread id, so a resumed task receives the same
+        # input it was first scheduled with (see issue #8582). Never persisted.
+        self._runtime_untracked_values: dict[str, dict[str, Any]] = {}
+        self._runtime_untracked_values_lock = threading.Lock()
         if auto_validate:
             self.validate()
 
@@ -2917,6 +2923,8 @@ class Pregel(
                 retry_policy=self.retry_policy,
                 cache_policy=self.cache_policy,
                 has_graph_lifecycle_callbacks=bool(graph_callback_manager.handlers),
+                runtime_untracked_values=self._runtime_untracked_values,
+                runtime_untracked_values_lock=self._runtime_untracked_values_lock,
             ) as loop:
                 emit_graph_lifecycle_events(loop)
                 # create runner
@@ -3371,6 +3379,8 @@ class Pregel(
                 retry_policy=self.retry_policy,
                 cache_policy=self.cache_policy,
                 has_graph_lifecycle_callbacks=bool(graph_callback_manager.handlers),
+                runtime_untracked_values=self._runtime_untracked_values,
+                runtime_untracked_values_lock=self._runtime_untracked_values_lock,
             ) as loop:
                 await aemit_graph_lifecycle_events(loop)
                 # create runner

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -54,7 +54,7 @@ from pytest_mock import MockerFixture
 from syrupy import SnapshotAssertion
 from typing_extensions import NotRequired, TypedDict
 
-from langgraph._internal._constants import CONFIG_KEY_NODE_FINISHED, ERROR, PULL
+from langgraph._internal._constants import CONFIG_KEY_NODE_FINISHED, ERROR, PULL, TASKS
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.ephemeral_value import EphemeralValue
@@ -9259,6 +9259,94 @@ def test_send_with_untracked_value_overlapping_keys(
     state = app.get_state(config)
     assert "session_resource" not in state.values
     assert state.values.get("dictionary") == {"session_resource": "legal_value"}
+
+
+def test_send_with_untracked_value_resume(
+    sync_checkpointer: BaseCheckpointSaver, durability: Durability
+):
+    """Test that a failed Send task whose arg contains an UntrackedValue
+    receives the same input when resumed from a checkpoint.
+
+    Regression test for langgraph issue #8582: the UntrackedValue was stripped
+    from the persisted Send arg, so a resumed task could not reconstruct its
+    original input. The value must be retained in-process across the resume
+    without ever being written to the checkpoint.
+
+    Known limitation: retention is keyed by (thread id, channel key), so if two
+    Sends in the same step carry different values for the same UntrackedValue
+    channel, the last write wins and both resumed tasks would receive that value."""
+
+    class RuntimeResource:
+        def __init__(self, name: str):
+            self.name = name
+
+    class State(TypedDict):
+        messages: Annotated[list[str], operator.add]
+        resource: Annotated[RuntimeResource, UntrackedValue]
+
+    attempts = 0
+    seen: list[RuntimeResource] = []
+
+    def setup_node(state: State) -> State:
+        return {"messages": ["setup"], "resource": RuntimeResource("runtime-secret")}
+
+    def send_to_worker(state: State):
+        return [Send("worker", state)]
+
+    def worker(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        resource = state.get("resource")
+        assert resource is not None, "resource was lost on resume"
+        seen.append(resource)
+        if attempts == 1:
+            raise ValueError("intentional-worker-failure")
+        return {"messages": [f"used {resource.name}"]}
+
+    def contains_runtime_resource(obj: Any) -> bool:
+        if isinstance(obj, RuntimeResource):
+            return True
+        if isinstance(obj, dict):
+            return any(contains_runtime_resource(v) for v in obj.values())
+        if isinstance(obj, (list, tuple)):
+            return any(contains_runtime_resource(v) for v in obj)
+        return False
+
+    graph = StateGraph(State)
+    graph.add_node("setup", setup_node)
+    graph.add_node("worker", worker)
+    graph.add_edge(START, "setup")
+    graph.add_conditional_edges("setup", send_to_worker)
+
+    app = graph.compile(checkpointer=sync_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+    with pytest.raises(ValueError, match="intentional-worker-failure"):
+        app.invoke({}, config, durability=durability)
+
+    assert attempts == 1
+    first_seen = seen[0]
+
+    # UntrackedValue must never be persisted: the checkpointed Send arg is
+    # sanitized (the value replaced, never written as-is). Some checkpointer
+    # variants return a legacy v3 checkpoint where sends live in a top-level
+    # `pending_sends` list instead of the TASKS channel, so scan both.
+    checkpoint = sync_checkpointer.get_tuple(config).checkpoint
+    assert "resource" not in checkpoint["channel_values"]
+    assert not contains_runtime_resource(checkpoint["channel_values"].get(TASKS, []))
+    assert not contains_runtime_resource(checkpoint.get("pending_sends", []))
+    pending_writes = sync_checkpointer.get_tuple(config).pending_writes
+    for _, channel, write in pending_writes:
+        assert not contains_runtime_resource(write)
+
+    snapshot = app.get_state(config)
+    assert snapshot.next == ("worker",)
+    assert "resource" not in snapshot.values
+
+    # Resuming retries the failed task with the SAME resource instance.
+    result = app.invoke(None, config, durability=durability)
+    assert attempts == 2
+    assert seen[1] is first_seen
+    assert result["messages"] == ["setup", "used runtime-secret"]
 
 
 @pytest.mark.parametrize("as_json", [False, True])

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -54,12 +54,13 @@ from pytest_mock import MockerFixture
 from syrupy import SnapshotAssertion
 from typing_extensions import NotRequired, TypedDict
 
-from langgraph._internal._constants import CONFIG_KEY_NODE_FINISHED, ERROR, PULL
+from langgraph._internal._constants import CONFIG_KEY_NODE_FINISHED, ERROR, PULL, TASKS
 from langgraph._internal._queue import AsyncQueue
 from langgraph.channels.binop import BinaryOperatorAggregate
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
 from langgraph.channels.topic import Topic
+from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import (
     GraphRecursionError,
     InvalidUpdateError,
@@ -2878,6 +2879,94 @@ async def test_send_dedupe_on_resume(
             parent_config=history[1].config
         )
         assert history[1] == expected_history[2]._replace(parent_config=None)
+
+
+async def test_send_with_untracked_value_resume(
+    async_checkpointer: BaseCheckpointSaver, durability: Durability
+) -> None:
+    """Test that a failed Send task whose arg contains an UntrackedValue
+    receives the same input when resumed from a checkpoint.
+
+    Regression test for langgraph issue #8582: the UntrackedValue was stripped
+    from the persisted Send arg, so a resumed task could not reconstruct its
+    original input. The value must be retained in-process across the resume
+    without ever being written to the checkpoint.
+
+    Known limitation: retention is keyed by (thread id, channel key), so if two
+    Sends in the same step carry different values for the same UntrackedValue
+    channel, the last write wins and both resumed tasks would receive that value."""
+
+    class RuntimeResource:
+        def __init__(self, name: str):
+            self.name = name
+
+    class State(TypedDict):
+        messages: Annotated[list[str], operator.add]
+        resource: Annotated[RuntimeResource, UntrackedValue]
+
+    attempts = 0
+    seen: list[RuntimeResource] = []
+
+    def setup_node(state: State) -> State:
+        return {"messages": ["setup"], "resource": RuntimeResource("runtime-secret")}
+
+    def send_to_worker(state: State):
+        return [Send("worker", state)]
+
+    def worker(state: State) -> State:
+        nonlocal attempts
+        attempts += 1
+        resource = state.get("resource")
+        assert resource is not None, "resource was lost on resume"
+        seen.append(resource)
+        if attempts == 1:
+            raise ValueError("intentional-worker-failure")
+        return {"messages": [f"used {resource.name}"]}
+
+    def contains_runtime_resource(obj: Any) -> bool:
+        if isinstance(obj, RuntimeResource):
+            return True
+        if isinstance(obj, dict):
+            return any(contains_runtime_resource(v) for v in obj.values())
+        if isinstance(obj, (list, tuple)):
+            return any(contains_runtime_resource(v) for v in obj)
+        return False
+
+    graph = StateGraph(State)
+    graph.add_node("setup", setup_node)
+    graph.add_node("worker", worker)
+    graph.add_edge(START, "setup")
+    graph.add_conditional_edges("setup", send_to_worker)
+
+    app = graph.compile(checkpointer=async_checkpointer)
+    config = {"configurable": {"thread_id": "1"}}
+    with pytest.raises(ValueError, match="intentional-worker-failure"):
+        await app.ainvoke({}, config, durability=durability)
+
+    assert attempts == 1
+    first_seen = seen[0]
+
+    # UntrackedValue must never be persisted: the checkpointed Send arg is
+    # sanitized (the value replaced, never written as-is). Some checkpointer
+    # variants return a legacy v3 checkpoint where sends live in a top-level
+    # `pending_sends` list instead of the TASKS channel, so scan both.
+    checkpoint_tuple = await async_checkpointer.aget_tuple(config)
+    checkpoint = checkpoint_tuple.checkpoint
+    assert "resource" not in checkpoint["channel_values"]
+    assert not contains_runtime_resource(checkpoint["channel_values"].get(TASKS, []))
+    assert not contains_runtime_resource(checkpoint.get("pending_sends", []))
+    for _, channel, write in checkpoint_tuple.pending_writes:
+        assert not contains_runtime_resource(write)
+
+    snapshot = await app.aget_state(config)
+    assert snapshot.next == ("worker",)
+    assert "resource" not in snapshot.values
+
+    # Resuming retries the failed task with the SAME resource instance.
+    result = await app.ainvoke(None, config, durability=durability)
+    assert attempts == 2
+    assert seen[1] is first_seen
+    assert result["messages"] == ["setup", "used runtime-secret"]
 
 
 async def test_send_react_interrupt(async_checkpointer: BaseCheckpointSaver) -> None:


### PR DESCRIPTION
Fixes #8582

Send tasks whose arg contains an `UntrackedValue` lost that key when the task was checkpointed, so a failed task was resumed with structurally different input. The sanitizer now keeps a stable marker in the persisted Send and retains the original values in-process (never written to the checkpoint), restoring the original input when the task is retried in the same process.

- Verified with `make format`, `make lint`, and `make test` locally.