### PR TITLE
fix: flush pipeline before checkpoint operations (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -94,6 +94,8 @@ class AsyncPostgresSaver(BasePostgresSaver):
         already exist and runs database migrations. It MUST be called directly by the user
         the first time checkpointer is used.
         """
+        if self.pipe:
+            await self.pipe.sync()
         async with self._cursor() as cur:
             await cur.execute(self.MIGRATIONS[0])
             results = await cur.execute(
@@ -113,7 +115,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
                 await cur.execute(
                     "INSERT INTO checkpoint_migrations (v) VALUES (%s)", (v,)
                 )
-        if self.pipe:
+            await self.pipe.sync() if self.pipe else None
             await self.pipe.sync()
 
     async def alist(


### PR DESCRIPTION
## What

AsyncPostgresSaver fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when using `pipeline=True`. This happens because the pipeline is left in an inconsistent state when an exception occurs during graph execution (e.g., LLM call failure), causing subsequent operations to be sent corrupted.

## Fix

Added explicit `pipe.sync()` calls before critical operations (e.g., `setup()`) to ensure the pipeline is flushed and in a consistent state. This prevents the SSL connection from being closed unexpectedly.

Closes #5675