### PR TITLE
fix(checkpoint-sqlite): roll back failed store batches instead of partial commit

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
@@ -241,7 +241,11 @@ class AsyncSqliteStore(AsyncBatchedBaseStore, BaseSqliteStore):
             async with self.conn.cursor() as cur:
                 try:
                     yield cur
-                finally:
+                except BaseException:
+                    if transaction:
+                        await self.conn.execute("ROLLBACK")
+                    raise
+                else:
                     if transaction:
                         await self.conn.execute("COMMIT")
 

--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -1052,9 +1052,14 @@ class SqliteStore(BaseSqliteStore, BaseStore):
             cur = self.conn.cursor()
             try:
                 yield cur
-            finally:
+            except BaseException:
+                if transaction:
+                    self.conn.execute("ROLLBACK")
+                raise
+            else:
                 if transaction:
                     self.conn.execute("COMMIT")
+            finally:
                 cur.close()
 
     def setup(self) -> None:

--- a/libs/checkpoint-sqlite/tests/test_async_store.py
+++ b/libs/checkpoint-sqlite/tests/test_async_store.py
@@ -745,3 +745,43 @@ async def test_async_namespace_segment_boundary(store: AsyncSqliteStore) -> None
     assert set(await store.alist_namespaces(suffix=["alice"], limit=100)) == {
         ("uid", "users", "alice"),
     }
+
+
+async def test_abatch_rollback_on_error() -> None:
+    """A failed abatch must not partially commit earlier mutations.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/8590.
+    A GetOp that refreshes the TTL, followed by a PutOp whose value cannot be
+    serialized, must not persist the TTL refresh when the batch raises.
+    """
+    original_expiration = "2000-01-01 00:00:00"
+
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:",
+        ttl={"default_ttl": 10, "refresh_on_read": True},
+    ) as store:
+        await store.setup()
+        await store.aput(("test",), "key", {"value": "original"})
+        await store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (original_expiration, "test", "key"),
+        )
+
+        with pytest.raises(TypeError):
+            await store.abatch(
+                [
+                    GetOp(("test",), "key", refresh_ttl=True),
+                    PutOp(("test",), "invalid", {"value": object()}),
+                ]
+            )
+
+        expires_at = (
+            await (
+                await store.conn.execute(
+                    "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+                    ("test", "key"),
+                )
+            ).fetchone()
+        )[0]
+
+        assert expires_at == original_expiration

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -1435,3 +1435,39 @@ def test_list_namespaces_metacharacter_labels(store: SqliteStore) -> None:
         assert set(store.list_namespaces(prefix=[label, "child"], limit=100)) == {
             (label, "child"),
         }
+
+
+def test_batch_rollback_on_error() -> None:
+    """A failed batch must not partially commit earlier mutations.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/8590.
+    A GetOp that refreshes the TTL, followed by a PutOp whose value cannot be
+    serialized, must not persist the TTL refresh when the batch raises.
+    """
+    original_expiration = "2000-01-01 00:00:00"
+
+    with SqliteStore.from_conn_string(
+        ":memory:",
+        ttl={"default_ttl": 10, "refresh_on_read": True},
+    ) as store:
+        store.setup()
+        store.put(("test",), "key", {"value": "original"})
+        store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (original_expiration, "test", "key"),
+        )
+
+        with pytest.raises(TypeError):
+            store.batch(
+                [
+                    GetOp(("test",), "key", refresh_ttl=True),
+                    PutOp(("test",), "invalid", {"value": object()}),
+                ]
+            )
+
+        expires_at = store.conn.execute(
+            "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+            ("test", "key"),
+        ).fetchone()[0]
+
+        assert expires_at == original_expiration


### PR DESCRIPTION
Fixes #8590.

## Problem

`SqliteStore.batch()` / `AsyncSqliteStore.abatch()` can partially persist changes when a later operation in the same batch raises.

Both SQLite store `_cursor()` context managers execute `COMMIT` in a `finally` block:

- `libs/checkpoint-sqlite/langgraph/store/sqlite/base.py`
- `libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py`

As a result, earlier mutations are committed even when control exits the context because of an exception (or, in the async path, cancellation). One observable case: a TTL refresh performed by a `GetOp` is persisted even when a later `PutOp` fails to serialize its value (raising `TypeError`).

## Fix

Both context managers now commit only on normal exit and roll back on any `BaseException` (which also covers asyncio cancellation) before re-raising:

- on normal exit: `COMMIT`;
- on any `BaseException`: `ROLLBACK`, then re-raise the original exception.

This makes each `batch()`/`abatch()` call atomic: a failed batch leaves the database unchanged.

## Tests (TDD)

RED (both fail on `main`):

- `tests/test_store.py::test_batch_rollback_on_error` — runs a batch of `GetOp(..., refresh_ttl=True)` followed by a `PutOp` whose value is not serializable (`object()`), then asserts the TTL refresh was not committed. On `main` the refresh is persisted, so the assertion fails.
- `tests/test_async_store.py::test_abatch_rollback_on_error` — the equivalent `AsyncSqliteStore.abatch()` regression test, failing on `main` for the same reason.

GREEN (all pass after the fix):

- The two regression tests above, plus the full `libs/checkpoint-sqlite` test suite.

No changeset is required for this package.