### PR TITLE
fix(checkpoint-sqlite): stop TTL sweeper when from_conn_string context exits

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
@@ -140,7 +140,14 @@ class AsyncSqliteStore(AsyncBatchedBaseStore, BaseSqliteStore):
             An AsyncSqliteStore instance wrapped in an async context manager.
         """
         async with aiosqlite.connect(conn_string, isolation_level=None) as conn:
-            yield cls(conn, index=index, ttl=ttl)
+            store = cls(conn, index=index, ttl=ttl)
+            try:
+                yield store
+            finally:
+                # The sweeper task holds a reference to the store and may wake up
+                # to sweep against `conn`. Stop it before the connection is closed
+                # so no background worker outlives the context that owns it.
+                await store.stop_ttl_sweeper()
 
     async def setup(self) -> None:
         """Set up the store database.
@@ -351,12 +358,10 @@ class AsyncSqliteStore(AsyncBatchedBaseStore, BaseSqliteStore):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        # Ensure the TTL sweeper task is stopped when exiting the context
-        if hasattr(self, "_ttl_sweeper_task") and self._ttl_sweeper_task is not None:
-            # Set the event to signal the task to stop
-            self._ttl_stop_event.set()
-            # We don't wait for the task to complete here to avoid blocking
-            # The task will clean up itself gracefully
+        # Ensure the TTL sweeper task is stopped when exiting the context.
+        # stop_ttl_sweeper() signals the task and awaits its completion so no
+        # background worker outlives the context that owns the connection.
+        await self.stop_ttl_sweeper()
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
         """Execute a batch of operations asynchronously.

--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -1032,7 +1032,14 @@ class SqliteStore(BaseSqliteStore, BaseStore):
             isolation_level=None,  # autocommit mode
         )
         try:
-            yield cls(conn, index=index, ttl=ttl)
+            store = cls(conn, index=index, ttl=ttl)
+            try:
+                yield store
+            finally:
+                # The sweeper thread closes over `store` and may wake up to sweep
+                # against `conn`. Stop it before the connection is closed so no
+                # background worker outlives the context that owns the connection.
+                store.stop_ttl_sweeper()
         finally:
             conn.close()
 

--- a/libs/checkpoint-sqlite/tests/test_ttl.py
+++ b/libs/checkpoint-sqlite/tests/test_ttl.py
@@ -427,3 +427,40 @@ async def test_async_asearch_refresh_ttl(temp_db_file: str) -> None:
         assert item1_final_check is None, (
             "Item1 should be gone after its refreshed TTL expired"
         )
+
+
+def test_ttl_sweeper_stops_on_context_exit(temp_db_file: str) -> None:
+    """The TTL sweeper thread must not outlive the from_conn_string context."""
+    ttl_config: TTLConfig = {
+        "default_ttl": 60,  # minutes; long enough to never fire during the test
+        "sweep_interval_minutes": 60,
+    }
+    with SqliteStore.from_conn_string(temp_db_file, ttl=ttl_config) as store:
+        store.setup()
+        future = store.start_ttl_sweeper()
+        thread = store._ttl_sweeper_thread
+        assert thread is not None and thread.is_alive()
+        assert not future.done()
+
+    # The connection-owning context has exited: its worker must be stopped.
+    assert thread is not None
+    assert not thread.is_alive()
+    assert future.done()
+
+
+@pytest.mark.asyncio
+async def test_async_ttl_sweeper_stops_on_context_exit(temp_db_file: str) -> None:
+    """The TTL sweeper task must not outlive the from_conn_string context."""
+    ttl_config: TTLConfig = {
+        "default_ttl": 60,  # minutes; long enough to never fire during the test
+        "sweep_interval_minutes": 60,
+    }
+    async with AsyncSqliteStore.from_conn_string(
+        temp_db_file, ttl=ttl_config
+    ) as store:
+        await store.setup()
+        task = await store.start_ttl_sweeper()
+        assert not task.done()
+
+    # The connection-owning context has exited: its worker must be finished.
+    assert task.done()


### PR DESCRIPTION
Fixes #8589.

## Problem

`SqliteStore.from_conn_string()` and `AsyncSqliteStore.from_conn_string()` own and close their SQLite connections, but neither helper stops a TTL sweeper started on the yielded store before closing that connection.

- **Sync store** (`libs/checkpoint-sqlite/langgraph/store/sqlite/base.py`): `start_ttl_sweeper()` spawns a daemon thread that is only stopped in `SqliteStore.__del__()`. Because the thread closes over the store, it keeps the store alive and prevents `__del__` from providing fallback cleanup. The thread can later wake and sweep against a connection its context manager has already closed.
- **Async store** (`libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py`): `from_conn_string()` never enters the yielded store's `__aexit__()`, so the stop event is never set and the sweeper task keeps running after the owning context exits. `AsyncSqliteStore.__aexit__()` only sets the event and does not await the task, so even direct `async with AsyncSqliteStore(...)` usage lets the worker outlive the context.

## Fix

- `base.py`: `from_conn_string()` keeps a reference to the yielded store and calls `stop_ttl_sweeper()` in `finally`, before the connection is closed.
- `aio.py`: `from_conn_string()` now `await`s `stop_ttl_sweeper()` in `finally` before the connection closes, and `__aexit__()` awaits `stop_ttl_sweeper()` instead of only setting the event.

Both paths now guarantee no background TTL worker outlives the context that owns the connection.

## Tests (TDD)

RED (both fail on `main`):

- `tests/test_ttl.py::test_ttl_sweeper_stops_on_context_exit` — starts a long-interval sync sweeper and asserts the thread is no longer alive and its future is done after the `from_conn_string` context exits. On `main` the thread is still alive.
- `tests/test_ttl.py::test_async_ttl_sweeper_stops_on_context_exit` — the equivalent `AsyncSqliteStore` regression test, failing on `main` because the task is still pending after the context exits.

GREEN (all pass after the fix): the two regression tests plus the full `libs/checkpoint-sqlite` test suite.