### PR TITLE
fix: resume at requested subgraph checkpoint on time travel

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -36,7 +36,7 @@ from langgraph.checkpoint.base import (
 from langgraph.store.base import BaseStore
 from typing_extensions import ParamSpec, Self
 
-from langgraph._internal._config import patch_configurable
+from langgraph._internal._config import patch_configurable, recast_checkpoint_ns
 from langgraph._internal._constants import (
     CONF,
     CONFIG_KEY_CHECKPOINT_ID,
@@ -356,6 +356,30 @@ class PregelLoop:
                     ][self.config[CONF][CONFIG_KEY_CHECKPOINT_NS]]
                 },
             )
+        elif CONFIG_KEY_CHECKPOINT_MAP in self.config[CONF] and (
+            checkpoint_ns := self.config[CONF].get(CONFIG_KEY_CHECKPOINT_NS, "")
+        ):
+            # Time-travel to a subgraph checkpoint: the eager parent fork
+            # (#7498) gave the parent a new checkpoint id, which derived a new
+            # subgraph task id and thus a brand-new, empty namespace. The
+            # checkpoint the caller asked for is still keyed under the
+            # pre-fork namespace in the checkpoint_map — resolve it via the
+            # stable (task-id-free) namespace so the subgraph resumes at the
+            # requested node instead of silently re-running from __start__.
+            checkpoint_map = self.config[CONF][CONFIG_KEY_CHECKPOINT_MAP]
+            stable_ns = recast_checkpoint_ns(checkpoint_ns)
+            for ns, checkpoint_id in checkpoint_map.items():
+                if recast_checkpoint_ns(ns) == stable_ns:
+                    self.checkpoint_config = patch_configurable(
+                        self.config,
+                        {
+                            CONFIG_KEY_CHECKPOINT_NS: ns,
+                            CONFIG_KEY_CHECKPOINT_ID: checkpoint_id,
+                        },
+                    )
+                    break
+            else:
+                self.checkpoint_config = self.config
         else:
             self.checkpoint_config = self.config
         if thread_id := self.checkpoint_config[CONF].get(CONFIG_KEY_THREAD_ID):

--- a/libs/langgraph/tests/test_time_travel_subgraph_replay.py
+++ b/libs/langgraph/tests/test_time_travel_subgraph_replay.py
@@ -1,0 +1,101 @@
+"""Regression tests for time travel into a subgraph checkpoint.
+
+When a client replays from a *subgraph* checkpoint (e.g. LangGraph Studio's
+"Re-run from here" against a node inside a subgraph), the config carries the
+subgraph's checkpoint id + namespace. The parent loop eagerly forks a new
+checkpoint (#7498) which changes the subgraph task id, so the replayed subgraph
+lands in a brand-new, empty namespace and the requested checkpoint is orphaned —
+the whole subgraph silently re-executes from __start__.
+
+See https://github.com/langchain-ai/langgraph/issues/8458
+"""
+
+import operator
+from typing import Annotated
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import interrupt
+from typing_extensions import TypedDict
+
+
+class State(TypedDict):
+    value: Annotated[list[str], operator.add]
+
+
+def test_subgraph_replay_from_mid_subgraph_checkpoint(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Replay from a checkpoint *inside* a subgraph (next node "c", before the
+    interrupt node "review") must resume at "c" and NOT re-run the nodes that
+    already executed ("a", "b").
+
+    Regression test for #8458: the eager parent fork checkpoint changes the
+    subgraph task id, orphaning the requested subgraph checkpoint and silently
+    re-running the whole subgraph from __start__.
+    """
+
+    ran: list[str] = []
+
+    def mk(name: str):
+        def fn(state: State) -> State:
+            ran.append(name)
+            return {"value": [name]}
+
+        fn.__name__ = name
+        return fn
+
+    def review(state: State) -> State:
+        ran.append("review")
+        answer = interrupt("approve?")
+        return {"value": [f"review:{answer}"]}
+
+    subgraph = (
+        StateGraph(State)
+        .add_node("a", mk("a"))
+        .add_node("b", mk("b"))
+        .add_node("c", mk("c"))
+        .add_node("review", review)
+        .add_edge(START, "a")
+        .add_edge("a", "b")
+        .add_edge("b", "c")
+        .add_edge("c", "review")
+        .add_edge("review", END)
+        .compile(checkpointer=True)
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("pre", mk("pre"))
+        .add_node("child", subgraph)
+        .add_edge(START, "pre")
+        .add_edge("pre", "child")
+        .add_edge("child", END)
+        .compile(checkpointer=sync_checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "1"}}
+    result = graph.invoke({"value": []}, config)
+    assert "__interrupt__" in result
+    assert result["__interrupt__"][0].value == "approve?"
+
+    # Find the subgraph checkpoint whose next node is "c" (a mid-subgraph
+    # checkpoint with no pending interrupt).
+    parent_state = graph.get_state(config, subgraphs=True)
+    ns_before = parent_state.tasks[0].state.config["configurable"]["checkpoint_ns"]
+    target = next(
+        h
+        for h in graph.get_state_history(
+            {"configurable": {"thread_id": "1", "checkpoint_ns": ns_before}}
+        )
+        if h.next == ("c",)
+    )
+
+    # "Re-run from here" — replay from the mid-subgraph checkpoint.
+    ran.clear()
+    replay = graph.invoke(None, target.config)
+    assert "__interrupt__" in replay
+    assert replay["__interrupt__"][0].value == "approve?"
+    # The subgraph must resume at "c": "a" and "b" must NOT re-run, and the
+    # parent's "pre" must not re-run either.
+    assert ran == ["c", "review"], f"expected ['c', 'review'], got {ran}"

--- a/libs/langgraph/tests/test_time_travel_subgraph_replay_async.py
+++ b/libs/langgraph/tests/test_time_travel_subgraph_replay_async.py
@@ -1,0 +1,93 @@
+"""Async regression tests for time travel into a subgraph checkpoint.
+
+Async counterpart of ``test_time_travel_subgraph_replay.py`` for #8458:
+replaying from a checkpoint *inside* a subgraph must resume at the selected
+node, not silently re-run the whole subgraph from __start__.
+"""
+
+import operator
+from typing import Annotated
+
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import interrupt
+
+pytestmark = pytest.mark.anyio
+
+
+class State(TypedDict):
+    value: Annotated[list[str], operator.add]
+
+
+async def test_subgraph_replay_from_mid_subgraph_checkpoint_async(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Replay from a checkpoint *inside* a subgraph (next node "c") must
+    resume at "c" and NOT re-run "a"/"b" (async variant).
+
+    Regression test for #8458.
+    """
+
+    ran: list[str] = []
+
+    def mk(name: str):
+        def fn(state: State) -> State:
+            ran.append(name)
+            return {"value": [name]}
+
+        fn.__name__ = name
+        return fn
+
+    async def review(state: State) -> State:
+        ran.append("review")
+        answer = interrupt("approve?")
+        return {"value": [f"review:{answer}"]}
+
+    subgraph = (
+        StateGraph(State)
+        .add_node("a", mk("a"))
+        .add_node("b", mk("b"))
+        .add_node("c", mk("c"))
+        .add_node("review", review)
+        .add_edge(START, "a")
+        .add_edge("a", "b")
+        .add_edge("b", "c")
+        .add_edge("c", "review")
+        .add_edge("review", END)
+        .compile(checkpointer=True)
+    )
+
+    graph = (
+        StateGraph(State)
+        .add_node("pre", mk("pre"))
+        .add_node("child", subgraph)
+        .add_edge(START, "pre")
+        .add_edge("pre", "child")
+        .add_edge("child", END)
+        .compile(checkpointer=async_checkpointer)
+    )
+
+    config = {"configurable": {"thread_id": "1"}}
+    result = await graph.ainvoke({"value": []}, config)
+    assert "__interrupt__" in result
+    assert result["__interrupt__"][0].value == "approve?"
+
+    parent_state = await graph.aget_state(config, subgraphs=True)
+    ns_before = parent_state.tasks[0].state.config["configurable"]["checkpoint_ns"]
+    target = None
+    async for h in graph.aget_state_history(
+        {"configurable": {"thread_id": "1", "checkpoint_ns": ns_before}}
+    ):
+        if h.next == ("c",):
+            target = h
+            break
+    assert target is not None, "expected a subgraph checkpoint with next == ('c',)"
+
+    ran.clear()
+    replay = await graph.ainvoke(None, target.config)
+    assert "__interrupt__" in replay
+    assert replay["__interrupt__"][0].value == "approve?"
+    assert ran == ["c", "review"], f"expected ['c', 'review'], got {ran}"


### PR DESCRIPTION
## Problem

Time travel to a checkpoint *inside* a subgraph (`invoke(None, config)` with the subgraph checkpoint's config, which is what LangGraph Studio's "Re-run from here" sends) silently re-executes the **whole subgraph from `__start__`** instead of resuming at the selected node. Regression introduced in 1.1.7 by #7498; broken on every release since, including current `main`. See #8458.

## Root cause

1. `PregelLoop._first` (`langgraph/pregel/_loop.py`) sees `is_time_traveling` and eagerly writes a parent fork checkpoint (added by #7498), giving the parent a **new checkpoint id**.
2. `prepare_next_tasks` (`langgraph/pregel/_algo.py`) derives subgraph task ids from the parent checkpoint id, so the subgraph task id changes.
3. `task_checkpoint_ns = "<node>:<task_id>"` — the subgraph runs in a brand-new, empty namespace. The checkpoint the caller explicitly asked for is orphaned, and the incoming `checkpoint_map` entry (keyed under the pre-fork namespace) is never consulted.
4. `ReplayState.get_checkpoint` (`langgraph/_internal/_replay.py`) lists the new namespace, finds nothing, and the subgraph starts from `__start__`.

## Fix

The eager parent fork from #7498 is kept (so #7498's interrupted-replay case stays fixed), but `PregelLoop.__init__` (`langgraph/pregel/_loop.py`) now resolves the requested subgraph checkpoint through the incoming `checkpoint_map` when the subgraph's namespace is not a direct key of it. Because the fork relocated the subgraph's task id, the caller's checkpoint is still keyed under the pre-fork namespace in the map; it is matched via the stable, task-id-free namespace (`recast_checkpoint_ns`) and loaded directly. The subgraph therefore resumes at the selected node instead of silently re-running from `__start__`.

Normal (non-time-travel) subgraph execution is unaffected — the new branch only fires when a stable-namespace match exists in the `checkpoint_map`, which never happens for fresh runs. Note that the forked subgraph executes in a new namespace (a consequence of the eager fork); the user-visible bug being fixed is the silent re-execution of the whole subgraph.

## Test

Adds sync + async regression tests (`tests/test_time_travel_subgraph_replay.py` and `tests/test_time_travel_subgraph_replay_async.py`) encoding the exact reproduction from #8458: a nested `StateGraph` (parent `pre → child → END`; child `a → b → c → review(interrupt)`). Each test replays from the subgraph checkpoint whose next node is `"c"` and asserts the subgraph runs `['c', 'review']` — not `['a', 'b', 'c', 'review']`. Both fail on pristine `main` (the regression) and pass with the fix.

Fixes #8458