### PR TITLE
fix(checkpoint-sqlite): roll back failed store batches

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/aio.py
@@ -241,7 +241,11 @@ class AsyncSqliteStore(AsyncBatchedBaseStore, BaseSqliteStore):
             async with self.conn.cursor() as cur:
                 try:
                     yield cur
-                finally:
+                except BaseException:
+                    if transaction:
+                        await self.conn.execute("ROLLBACK")
+                    raise
+                else:
                     if transaction:
                         await self.conn.execute("COMMIT")
 

--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -1052,9 +1052,14 @@ class SqliteStore(BaseSqliteStore, BaseStore):
             cur = self.conn.cursor()
             try:
                 yield cur
-            finally:
+            except BaseException:
+                if transaction:
+                    self.conn.execute("ROLLBACK")
+                raise
+            else:
                 if transaction:
                     self.conn.execute("COMMIT")
+            finally:
                 cur.close()
 
     def setup(self) -> None:

--- a/libs/checkpoint-sqlite/tests/test_async_store.py
+++ b/libs/checkpoint-sqlite/tests/test_async_store.py
@@ -745,3 +745,94 @@ async def test_async_namespace_segment_boundary(store: AsyncSqliteStore) -> None
     assert set(await store.alist_namespaces(suffix=["alice"], limit=100)) == {
         ("uid", "users", "alice"),
     }
+
+
+async def test_abatch_rollback_on_error() -> None:
+    """A failed abatch must not partially commit earlier mutations.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/8590.
+    A GetOp that refreshes the TTL, followed by a PutOp whose value cannot be
+    serialized, must not persist the TTL refresh when the batch raises.
+    """
+    original_expiration = "2000-01-01 00:00:00"
+
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:",
+        ttl={"default_ttl": 10, "refresh_on_read": True},
+    ) as store:
+        await store.setup()
+        await store.aput(("test",), "key", {"value": "original"})
+        await store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (original_expiration, "test", "key"),
+        )
+
+        with pytest.raises(TypeError):
+            await store.abatch(
+                [
+                    GetOp(("test",), "key", refresh_ttl=True),
+                    PutOp(("test",), "invalid", {"value": object()}),
+                ]
+            )
+
+        expires_at = (
+            await (
+                await store.conn.execute(
+                    "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+                    ("test", "key"),
+                )
+            ).fetchone()
+        )[0]
+
+        assert expires_at == original_expiration
+
+
+async def test_cursor_rollback_on_cancellation() -> None:
+    """Cancelling a store operation mid-transaction must roll back.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/8590.
+    CancelledError is a BaseException, so the async store's cursor context
+    manager must roll back instead of committing partial work when a task is
+    cancelled while inside the transaction.
+    """
+    original_expiration = "2000-01-01 00:00:00"
+
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:",
+        ttl={"default_ttl": 10, "refresh_on_read": True},
+    ) as store:
+        await store.setup()
+        await store.aput(("test",), "key", {"value": "original"})
+        await store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (original_expiration, "test", "key"),
+        )
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def mutate_then_wait_for_cancel() -> None:
+            async with store._cursor() as cur:
+                await cur.execute(
+                    "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+                    ("2099-01-01 00:00:00", "test", "key"),
+                )
+                entered.set()
+                await release.wait()
+
+        task = asyncio.create_task(mutate_then_wait_for_cancel())
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        expires_at = (
+            await (
+                await store.conn.execute(
+                    "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+                    ("test", "key"),
+                )
+            ).fetchone()
+        )[0]
+
+        assert expires_at == original_expiration

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -1435,3 +1435,39 @@ def test_list_namespaces_metacharacter_labels(store: SqliteStore) -> None:
         assert set(store.list_namespaces(prefix=[label, "child"], limit=100)) == {
             (label, "child"),
         }
+
+
+def test_batch_rollback_on_error() -> None:
+    """A failed batch must not partially commit earlier mutations.
+
+    Regression test for https://github.com/langchain-ai/langgraph/issues/8590.
+    A GetOp that refreshes the TTL, followed by a PutOp whose value cannot be
+    serialized, must not persist the TTL refresh when the batch raises.
+    """
+    original_expiration = "2000-01-01 00:00:00"
+
+    with SqliteStore.from_conn_string(
+        ":memory:",
+        ttl={"default_ttl": 10, "refresh_on_read": True},
+    ) as store:
+        store.setup()
+        store.put(("test",), "key", {"value": "original"})
+        store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (original_expiration, "test", "key"),
+        )
+
+        with pytest.raises(TypeError):
+            store.batch(
+                [
+                    GetOp(("test",), "key", refresh_ttl=True),
+                    PutOp(("test",), "invalid", {"value": object()}),
+                ]
+            )
+
+        expires_at = store.conn.execute(
+            "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+            ("test", "key"),
+        ).fetchone()[0]
+
+        assert expires_at == original_expiration


### PR DESCRIPTION
## Summary

Fixes #8590.

`SqliteStore.batch()` and `AsyncSqliteStore.abatch()` could partially commit earlier mutations when a later operation failed. The cursor context managers committed in `finally`, including after exceptions and async cancellation.

This change:

- commits only after normal completion;
- rolls back and re-raises on `BaseException`, including `asyncio.CancelledError`;
- keeps cursor cleanup in `finally`;
- adds synchronous and asynchronous regression coverage for failed batches and cancellation.

## Tests

- Baseline with the fix stashed: all three new regression tests failed, reproducing the partial commit.
- Fixed branch: all three regression tests passed.
- `uv run pytest tests/test_store.py tests/test_async_store.py` - 97 passed
- `uv run ruff check langgraph/store/sqlite/base.py langgraph/store/sqlite/aio.py tests/test_store.py tests/test_async_store.py`
- `uv run ruff format --check langgraph/store/sqlite/base.py langgraph/store/sqlite/aio.py tests/test_store.py tests/test_async_store.py`

The full checkpoint-sqlite library suite passed: 121 passed, 2 pre-existing skips.

## Scope

This is limited to SQLite store transaction boundaries. It doesn't change store APIs or operation ordering.