### PR TITLE
fix(cli): make analytics telemetry non-blocking

### DIFF
--- a/libs/cli/langgraph_cli/analytics.py
+++ b/libs/cli/langgraph_cli/analytics.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import platform
 import threading
-import urllib.error
 import urllib.request
 from typing import Any, TypedDict
 
@@ -15,6 +14,10 @@ from langgraph_cli.constants import (
     SUPABASE_URL,
 )
 from langgraph_cli.version import __version__
+
+# Telemetry is best-effort: bound the network request so a stalled endpoint can
+# never block a CLI command (see langchain-ai/langgraph#8074).
+ANALYTICS_URLOPEN_TIMEOUT = 3
 
 
 class LogData(TypedDict):
@@ -78,12 +81,22 @@ def log_data(data: LogData) -> None:
     )
 
     try:
-        urllib.request.urlopen(req)
-    except urllib.error.URLError:
+        urllib.request.urlopen(req, timeout=ANALYTICS_URLOPEN_TIMEOUT)
+    except Exception:
+        # Best-effort telemetry: never surface errors to the user and never let
+        # a failed request crash the background thread.
         pass
 
 
 def log_command(func):
+    """Log anonymous telemetry for a CLI command on a background daemon thread.
+
+    Telemetry is strictly best-effort: the worker thread is a daemon and the
+    HTTP request is time-bounded, so it can never delay or block CLI exit (see
+    langchain-ai/langgraph#8074). Set ``LANGGRAPH_CLI_NO_ANALYTICS=1`` to opt
+    out entirely.
+    """
+
     @functools.wraps(func)
     def decorator(*args, **kwargs):
         if os.getenv("LANGGRAPH_CLI_NO_ANALYTICS") == "1":
@@ -98,7 +111,7 @@ def log_command(func):
             "params": get_anonymized_params(kwargs, cli_command=func.__name__),
         }
 
-        background_thread = threading.Thread(target=log_data, args=(data,))
+        background_thread = threading.Thread(target=log_data, args=(data,), daemon=True)
         background_thread.start()
         return func(*args, **kwargs)
 

--- a/libs/cli/tests/unit_tests/test_analytics.py
+++ b/libs/cli/tests/unit_tests/test_analytics.py
@@ -1,0 +1,100 @@
+import urllib.error
+import urllib.request
+from unittest.mock import MagicMock, patch
+
+from langgraph_cli.analytics import (
+    ANALYTICS_URLOPEN_TIMEOUT,
+    LogData,
+    log_command,
+    log_data,
+)
+
+LOG_DATA: LogData = {
+    "os": "Darwin",
+    "os_version": "24.0.0",
+    "python_version": "3.13.0",
+    "cli_version": "0.4.31",
+    "cli_command": "fake_command",
+    "params": {},
+}
+
+
+def test_log_data_posts_payload_with_bounded_timeout():
+    """Telemetry requests must be time-bounded so a stalled network cannot
+    block the CLI (langchain-ai/langgraph#8074)."""
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        log_data(LOG_DATA)
+
+    mock_urlopen.assert_called_once()
+    req = mock_urlopen.call_args.args[0]
+    assert isinstance(req, urllib.request.Request)
+    assert req.full_url == "https://kzrlppojinpcyyaipxnb.supabase.co/rest/v1/logs"
+    assert req.method == "POST"
+    assert mock_urlopen.call_args.kwargs["timeout"] == ANALYTICS_URLOPEN_TIMEOUT
+
+
+def test_log_data_swallows_urlerror():
+    with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("boom")):
+        log_data(LOG_DATA)  # must not raise
+
+
+def test_log_data_swallows_timeout_error():
+    with patch("urllib.request.urlopen", side_effect=TimeoutError("timed out")):
+        log_data(LOG_DATA)  # must not raise
+
+
+def test_log_data_swallows_unexpected_errors():
+    """Telemetry is best-effort: any failure must be swallowed, never crash."""
+    with patch("urllib.request.urlopen", side_effect=RuntimeError("unexpected")):
+        log_data(LOG_DATA)  # must not raise
+
+
+def test_log_command_spawns_daemon_thread_and_returns_result():
+    """The telemetry worker must be a daemon thread so it cannot keep the
+    process alive after the command body has returned."""
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+
+        @log_command
+        def fake_command(param="x"):
+            return "ok"
+
+        result = fake_command(param="x")
+
+    assert result == "ok"
+    mock_thread.assert_called_once()
+    assert mock_thread.call_args.kwargs["daemon"] is True
+    mock_thread.return_value.start.assert_called_once()
+
+
+def test_log_command_opt_out_env_skips_telemetry(monkeypatch):
+    """LANGGRAPH_CLI_NO_ANALYTICS=1 must fully opt out of telemetry."""
+    monkeypatch.setenv("LANGGRAPH_CLI_NO_ANALYTICS", "1")
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+
+        @log_command
+        def fake_command(param="x"):
+            return "ok"
+
+        result = fake_command(param="x")
+
+    assert result == "ok"
+    mock_thread.assert_not_called()
+
+
+def test_log_command_calls_func_when_env_unset(monkeypatch):
+    """Without the opt-out env var, telemetry runs in the background and the
+    command still executes."""
+    monkeypatch.delenv("LANGGRAPH_CLI_NO_ANALYTICS", raising=False)
+    mock_thread = MagicMock()
+    with patch("threading.Thread", mock_thread):
+
+        @log_command
+        def fake_command(param="x"):
+            return "ok"
+
+        result = fake_command(param="x")
+
+    assert result == "ok"
+    mock_thread.assert_called_once()


### PR DESCRIPTION
## Summary

Best-effort CLI analytics could keep the process alive indefinitely when the telemetry endpoint stalled: the worker thread was non-daemon and `urlopen()` had no timeout.

This change:

- bounds the telemetry request with a 3-second timeout;
- runs the analytics worker as a daemon thread so telemetry can't delay CLI shutdown;
- swallows telemetry failures so analytics never changes the command result;
- preserves the `LANGGRAPH_CLI_NO_ANALYTICS=1` opt-out.

## Tests

- `uv run pytest tests/unit_tests/test_analytics.py` - 7 passed
- `uv run ruff check langgraph_cli/analytics.py tests/unit_tests/test_analytics.py`
- `uv run ruff format --check langgraph_cli/analytics.py tests/unit_tests/test_analytics.py`
- Baseline subprocess reproduction confirmed a stalled non-daemon analytics worker kept the process alive; the fixed branch exits promptly with the worker marked daemon.

The broader CLI unit suite was also run: 341 passed and 2 pre-existing Docker-environment tests failed on clean `main` as well.
