### PR TITLE
fix(pregel): suppress handled node errors in parallel/custom stream modes

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import time
+import weakref
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, ExitStack
 from contextvars import copy_context
@@ -22,6 +23,13 @@ from langgraph.errors import GraphBubbleUp
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+# Futures whose exceptions have already been routed elsewhere (e.g. to a node
+# error handler, or into a parent task via _call/_acall) and therefore must not
+# be re-raised when the executor exits.
+SKIP_RERAISE_SET: weakref.WeakSet[
+    concurrent.futures.Future | asyncio.Future
+] = weakref.WeakSet()
 
 
 class Submit(Protocol[P, T]):
@@ -111,7 +119,7 @@ class BackgroundExecutor(AbstractContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     task.result()
@@ -202,7 +210,7 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     if exc := task.exception():

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -43,7 +43,7 @@ from langgraph._internal._typing import MISSING
 from langgraph.constants import TAG_HIDDEN
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
 from langgraph.pregel._algo import Call
-from langgraph.pregel._executor import Submit
+from langgraph.pregel._executor import SKIP_RERAISE_SET, Submit
 from langgraph.pregel._retry import arun_with_retry, run_with_retry
 from langgraph.types import (
     CachePolicy,
@@ -65,10 +65,6 @@ EXCLUDED_FRAME_FNAMES = (
     "langchain_core/runnables/config.py",
     "concurrent/futures/thread.py",
     "concurrent/futures/_base.py",
-)
-
-SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
-    weakref.WeakSet()
 )
 
 

--- a/libs/langgraph/tests/test_error_handler_leak.py
+++ b/libs/langgraph/tests/test_error_handler_leak.py
@@ -1,0 +1,94 @@
+import asyncio
+
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.errors import NodeError
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
+
+
+class State(TypedDict, total=False):
+    x: str
+    y: str
+
+
+def _build_graph(parallel: bool):
+    handler_calls = {"count": 0}
+
+    def boom(state: State) -> State:
+        raise RuntimeError("test")
+
+    def sibling(state: State) -> State:
+        return {"y": "sibling"}
+
+    def handler(state: State, error: NodeError) -> Command:
+        handler_calls["count"] += 1
+        return Command(update={"x": "handled"}, goto=END)
+
+    builder = (
+        StateGraph(State)
+        .add_node("boom", boom, error_handler=handler)
+        .add_edge(START, "boom")
+    )
+    if parallel:
+        builder = builder.add_node("sibling", sibling).add_edge(START, "sibling")
+    return builder.compile(), handler_calls
+
+
+async def _collect(graph, **kwargs):
+    return [event async for event in graph.astream({}, **kwargs)]
+
+
+SYNC_CASES = [
+    pytest.param(
+        False,
+        lambda g: list(g.stream({}, stream_mode="custom")),
+        id="solo-custom",
+    ),
+    pytest.param(
+        False,
+        lambda g: list(g.stream({}, stream_mode="messages")),
+        id="solo-messages",
+    ),
+    pytest.param(
+        False,
+        lambda g: list(g.stream({}, stream_mode="values", subgraphs=True)),
+        id="solo-subgraphs",
+    ),
+    pytest.param(True, lambda g: g.invoke({}), id="parallel-invoke"),
+    pytest.param(
+        True,
+        lambda g: list(g.stream({}, stream_mode="values")),
+        id="parallel-values",
+    ),
+]
+
+ASYNC_CASES = [
+    pytest.param(
+        False,
+        lambda g: asyncio.run(_collect(g, stream_mode="custom")),
+        id="solo-astream-custom",
+    ),
+    pytest.param(
+        True,
+        lambda g: asyncio.run(g.ainvoke({})),
+        id="parallel-ainvoke",
+    ),
+]
+
+
+@pytest.mark.parametrize("parallel,run", SYNC_CASES)
+def test_error_handler_suppresses_node_error_sync(parallel, run) -> None:
+    graph, handler_calls = _build_graph(parallel)
+    # Must not raise: the error handler handled the node's exception.
+    run(graph)
+    assert handler_calls["count"] == 1
+
+
+@pytest.mark.parametrize("parallel,run", ASYNC_CASES)
+def test_error_handler_suppresses_node_error_async(parallel, run) -> None:
+    graph, handler_calls = _build_graph(parallel)
+    # Must not raise: the error handler handled the node's exception.
+    run(graph)
+    assert handler_calls["count"] == 1


### PR DESCRIPTION
Fixes #8608.

A node registered with `add_node(..., error_handler=...)` that raises still leaked the original exception out of the graph in several configurations: parallel nodes in the same superstep (plain `invoke`/`ainvoke`/`stream_mode="values"`), and solo-node `stream_mode="custom"`/`"messages"`/`subgraphs=True`.

Root cause: in those configurations the failing node runs through `BackgroundExecutor`/`AsyncBackgroundExecutor` (parallel tasks, or a stream waiter that disables the single-task fast path). The executor's `done()` callback deliberately leaves errored futures in its task dict, and `__exit__`/`__aexit__` later re-raises them via `task.result()`/`task.exception()` — even after `PregelRunner` routed the exception to the error handler and marked the future in `SKIP_RERAISE_SET`.

Fix: move `SKIP_RERAISE_SET` into `_executor.py` and have the executor skip re-raising any future in that set, matching the runner's existing panic/stop logic.

Adds a regression test (`test_error_handler_leak.py`) covering each failing configuration from the issue.