### PR TITLE
fix(cli): copy workspace member manifests into the uv export stage

### DIFF
--- a/libs/cli/langgraph_cli/uv_lock.py
+++ b/libs/cli/langgraph_cli/uv_lock.py
@@ -973,7 +973,11 @@ def python_config_to_docker_uv_lock(
     # `uv export --package` resolves a member by reading that member's own
     # manifest, so the root manifest names it but is not enough to find it. Only
     # the manifests are copied; member sources arrive later, per member.
-    for member_root in sorted(plan.all_workspace_roots - {plan.project_root}):
+    #
+    # Restricted to the closure rather than every member. Members outside it are
+    # not needed for the export, and copying them would reach for paths that
+    # `.dockerignore` may have removed from the build context.
+    for member_root in sorted(set(plan.container_roots) - {plan.project_root}):
         member_relative = pathlib.PurePosixPath(
             member_root.relative_to(plan.project_root).as_posix()
         )

--- a/libs/cli/langgraph_cli/uv_lock.py
+++ b/libs/cli/langgraph_cli/uv_lock.py
@@ -970,6 +970,19 @@ def python_config_to_docker_uv_lock(
             f"{uv_export_project_dir}/uv.lock",
         )
     )
+    # `uv export --package` resolves a member by reading that member's own
+    # manifest, so the root manifest names it but is not enough to find it. Only
+    # the manifests are copied; member sources arrive later, per member.
+    for member_root in sorted(plan.all_workspace_roots - {plan.project_root}):
+        member_relative = pathlib.PurePosixPath(
+            member_root.relative_to(plan.project_root).as_posix()
+        )
+        docker_plan.add_raw(
+            copy_from_project_root(
+                member_relative / "pyproject.toml",
+                f"{uv_export_project_dir}/{member_relative}/pyproject.toml",
+            )
+        )
     docker_plan.add_instruction("WORKDIR", uv_export_project_dir)
     docker_plan.add_instruction(
         "RUN",


### PR DESCRIPTION
`source.kind: "uv"` is broken for uv workspace members. Every such build fails at the export step:

```
error: The workspace does not have a member <name>
```

The export stage copies the workspace root's `pyproject.toml` and `uv.lock` into `/tmp/uv_export/project`, then runs `uv export --package <member>`. The root manifest only *names* its members; `uv` resolves `--package` by reading that member's own `pyproject.toml`, and nothing copied it.

This is already visible in CI. `uv-examples/monorepo` fails this way, and the `Build uv monorepo service` step in the integration job has been red.

## Fix

Copy each workspace member's manifest at its relative path, alongside the lockfile. Manifests only, since member sources are copied later, per member, by the existing install steps.

Single-package projects are unaffected: their only workspace root is the project root, so no extra `COPY` lines are emitted and the generated Dockerfile is byte-identical.

## Test Plan

- [x] `uv-examples/monorepo` builds, via `langgraph build` from `apps/agent` exactly as the integration job runs it. Previously failed at `uv export`.
- [x] `uv-examples/simple` still builds, and emits zero member-manifest copies, confirming no change for single-package projects.
- [x] Verified against a real 15-member workspace outside this repo: 20 member manifests copied, `uv export --package` resolves, image builds and the installed package imports.
- [x] `make lint` and `make test` clean, 349 passed.