### PR TITLE
fix(checkpoint): include state path in serialization error

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -268,6 +268,14 @@ class JsonPlusSerializer(SerializerProtocol):
             except ormsgpack.MsgpackEncodeError as exc:
                 if self.pickle_fallback:
                     return "pickle", pickle.dumps(obj)
+                # Re-raise with a JSONPath-style location so the user can
+                # find the offending value in deeply nested state without
+                # manual inspection. Regression for #8606.
+                path = _find_unsupported_path(obj)
+                if path:
+                    raise TypeError(
+                        f"{exc} (at {path})"
+                    ) from exc
                 raise exc
 
     def loads_typed(self, data: tuple[str, bytes]) -> Any:
@@ -858,6 +866,74 @@ _option = (
 
 def _msgpack_enc(data: Any) -> bytes:
     return ormsgpack.packb(data, default=_msgpack_default, option=_option)
+
+
+def _find_unsupported_path(
+    obj: Any,
+    *,
+    _path: str = "$",
+) -> str:
+    """Return a JSONPath-ish string pointing at the first value that
+    ormsgpack can't encode under the existing default/reviver hooks.
+
+    Walks dicts/lists/tuples/sets and dives into Pydantic v2 / dataclass
+    models to surface the path. Stops at the first leaf that raises, so
+    the error message stays actionable even on deeply nested state.
+
+    Returns the path string for the first leaf that the encoder can't
+    handle. Returns an empty string when no specific path can be pinned
+    down (e.g. the unsupported value lives behind a non-iterable opaque
+    container), so the caller can fall back to a generic message.
+    """
+    # ormsgpack's default hook handles the types it understands; everything
+    # else triggers MsgpackEncodeError. Try encoding this subtree; if it
+    # raises, recurse into the children until we find the leaf that
+    # actually trips the encoder.
+    try:
+        ormsgpack.packb(obj, default=_msgpack_default, option=_option)
+        return ""
+    except ormsgpack.MsgpackEncodeError:
+        pass
+
+    # Pydantic v2 model
+    if hasattr(type(obj), "model_fields"):
+        for name in type(obj).model_fields:
+            child = getattr(obj, name, None)
+            child_path = _find_unsupported_path(child, _path=f"{_path}.{name}")
+            if child_path:
+                return child_path
+        return ""
+
+    # dataclass
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        for field in dataclasses.fields(obj):
+            child = getattr(obj, field.name, None)
+            child_path = _find_unsupported_path(
+                child, _path=f"{_path}.{field.name}"
+            )
+            if child_path:
+                return child_path
+        return ""
+
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            key = (
+                str(k) if not isinstance(k, str) else k
+            )
+            child_path = _find_unsupported_path(v, _path=f'{_path}["{key}"]')
+            if child_path:
+                return child_path
+        return ""
+
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        for i, item in enumerate(obj):
+            child_path = _find_unsupported_path(item, _path=f"{_path}[{i}]")
+            if child_path:
+                return child_path
+        return ""
+
+    # Leaf — this is the unsupported value.
+    return _path
 
 
 def _normalize_allowlist(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -36,6 +36,7 @@ from langgraph.checkpoint.serde.jsonplus import (
     EXT_METHOD_SINGLE_ARG,
     InvalidModuleError,
     JsonPlusSerializer,
+    _find_unsupported_path,
     _msgpack_enc,
     _msgpack_ext_hook_to_json,
     _warned_blocked_types,
@@ -1230,3 +1231,73 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+# Regression for #8606.
+# When msgpack fails to encode the state, the resulting TypeError used
+# to name only the offending type. It now also includes the JSONPath-style
+# state path so the user can locate the failing value without manually
+# walking the state graph.
+class _UnserializableLeaf:
+    pass
+
+
+def test_unsupported_error_includes_top_level_path() -> None:
+    serde = JsonPlusSerializer()
+    obj = _UnserializableLeaf()
+
+    with pytest.raises(TypeError, match=r"\(at \$\)"):
+        serde.dumps_typed(obj)
+
+
+def test_unsupported_error_includes_dict_key_path() -> None:
+    serde = JsonPlusSerializer()
+    obj = {"ok": "value", "bad": _UnserializableLeaf()}
+
+    with pytest.raises(TypeError, match=r'\(at \$\["bad"\]\)'):
+        serde.dumps_typed(obj)
+
+
+def test_unsupported_error_includes_list_index_path() -> None:
+    serde = JsonPlusSerializer()
+    obj = ["ok", _UnserializableLeaf(), "also_ok"]
+
+    with pytest.raises(TypeError, match=r"\(at \$\[1\]\)"):
+        serde.dumps_typed(obj)
+
+
+def test_unsupported_error_includes_nested_path() -> None:
+    serde = JsonPlusSerializer()
+    obj = {
+        "outer": {
+            "level1": [
+                {"ok": 1},
+                {"level2": {"bad": _UnserializableLeaf()}},
+            ],
+        },
+    }
+
+    with pytest.raises(TypeError, match=r'\(at \$\["outer"\]\["level1"\]\[1\]\["level2"\]\["bad"\]\)'):
+        serde.dumps_typed(obj)
+
+
+def test_unsupported_error_includes_pydantic_field_path() -> None:
+    class _State(BaseModel):
+        model_config = {"arbitrary_types_allowed": True}
+
+        ok: str = "value"
+        bad: _UnserializableLeaf | None = None
+
+    serde = JsonPlusSerializer()
+    obj = _State(bad=_UnserializableLeaf())
+
+    with pytest.raises(TypeError, match=r"\(at \$\.bad\)"):
+        serde.dumps_typed(obj)
+
+
+def test_find_unsupported_path_primitive_passes() -> None:
+    # Primitives should encode cleanly and return an empty path.
+    assert _find_unsupported_path("hello") == ""
+    assert _find_unsupported_path(42) == ""
+    assert _find_unsupported_path(None) == ""
+    assert _find_unsupported_path({"a": 1, "b": [2, 3]}) == ""


### PR DESCRIPTION
Fixes #8606

When `JsonPlusSerializer.dumps_typed` can't encode a value with the default msgpack hook, the previous error message identified only the offending type, not where it sat in the graph state. For deeply nested state (dicts of Pydantic models, lists of dataclasses, etc.) users had to manually walk the state object to find the culprit — and the failure surfaces only at checkpoint time, well after the node that produced the bad value has finished logging.

After the new failure-only walk (`_find_unsupported_path`):
- Top-level value: `TypeError: ... (at $)`
- Dict key: `TypeError: ... (at $\"foo\"`)`
- List index: `TypeError: ... (at $[1])`
- Nested structures: `TypeError: ... (at $\"outer\"\.level1[1]\"level2\"\"bad\"`)`
- Pydantic v2 fields: `TypeError: ... (at $.bad)`

The walk dives into Pydantic v2 `model_fields`, dataclass fields, dicts, and sequences. It returns an empty string when no specific path can be pinned down (e.g. the unsupported value lives behind a non-iterable opaque container), in which case we re-raise the original `ormsgpack.MsgpackEncodeError` so callers can still see the bare type.

Adds six tests in `libs/checkpoint/tests/test_jsonplus.py`:
- top-level path,
- dict key path,
- list index path,
- deeply nested mixed structure,
- Pydantic v2 field path,
- primitives (negative case).

All 105 existing tests in the file still pass.