### PR TITLE
fix(langgraph): allow repeated compilation with default error handler

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1288,15 +1288,16 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         # Error-handler routing and cache_policy are only assigned to regular
         # nodes. Retry and timeout defaults also apply to error-handler nodes.
         defaults = self._node_defaults
+        nodes = dict(self.nodes)
         default_handler_name: str | None = None
         if defaults.error_handler is not None:
-            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+            if _DEFAULT_ERROR_HANDLER_NODE in nodes:
                 raise ValueError(
                     f"Auto-generated default error handler node "
                     f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
                 )
             default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
-            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
+            nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
                 coerce_to_runnable(
                     defaults.error_handler,  # type: ignore[arg-type]
                     name=default_handler_name,
@@ -1310,7 +1311,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
 
         # Apply builder defaults to node specs. Per-node values always win.
-        for spec in self.nodes.values():
+        for spec in nodes.values():
             # error_handler: regular nodes only — handlers must never
             # catch themselves or other handlers.
             if (
@@ -1339,7 +1340,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
 
         node_error_handler_map = {
             node_name: spec.error_handler_node
-            for node_name, spec in self.nodes.items()
+            for node_name, spec in nodes.items()
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
 
@@ -1371,7 +1372,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         compiled._serde_allowlist = serde_allowlist
 
         compiled.attach_node(START, None)
-        for key, node in self.nodes.items():
+        for key, node in nodes.items():
             compiled.attach_node(key, node)
 
         # Record output/state mappers for v2 stream coercion (pydantic/dataclass only)

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2347,6 +2347,30 @@ def test_set_node_defaults_error_handler_catches_all_nodes():
     assert "fail_b" in captured["nodes"]
 
 
+def test_set_node_defaults_error_handler_can_compile_builder_twice():
+    class State(TypedDict):
+        foo: str
+
+    def fail(state: State) -> State:
+        raise RuntimeError("boom")
+
+    def recover(state: State, error: NodeError) -> State:
+        return {"foo": f"handled: {error.error}"}
+
+    builder = (
+        StateGraph(State)
+        .set_node_defaults(error_handler=recover)
+        .add_node("fail", fail)
+        .add_edge(START, "fail")
+    )
+
+    first = builder.compile()
+    second = builder.compile()
+
+    assert first.invoke({"foo": "start"}) == {"foo": "handled: boom"}
+    assert second.invoke({"foo": "start"}) == {"foo": "handled: boom"}
+
+
 def test_set_node_defaults_error_handler_overridden_by_node_handler():
     class State(TypedDict):
         route: str


### PR DESCRIPTION
Fixes #8612

`StateGraph.compile()` currently writes the generated default error-handler node back into the builder, so compiling the same builder a second time raises a collision error. Keep compile-time node specs in a local mapping so repeated compilation remains independent while preserving the existing user-node collision check.

Added a regression test that compiles the same builder twice and invokes both compiled graphs to verify both recover through the default handler.

Verification:
- `pytest libs/langgraph/tests/test_retry.py -q` — 106 passed
- `pytest libs/langgraph/tests/test_retry.py -k 'set_node_defaults_error_handler' -q` — 7 passed
- `ruff format --check` on changed files — passed
- `ruff check` on changed files — passed
- `python -m py_compile libs/langgraph/langgraph/graph/state.py libs/langgraph/tests/test_retry.py` — passed
- `git diff --check` — passed

No breaking changes are expected.