### PR TITLE
docs(langgraph-prebuilt): fix typo GraphRecusionError -> GraphRecursionError

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
+++ b/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py
@@ -1,4 +1,4 @@
-import inspect
+﻿import inspect
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from typing import (
@@ -437,7 +437,7 @@ def create_react_agent(
                 If `remaining_steps` is less than 2 and tool calls are present in the response,
                 the react agent will return a final AI Message with
                 the content "Sorry, need more steps to process this request.".
-                No `GraphRecusionError` will be raised in this case.
+                No `GraphRecursionError` will be raised in this case.
 
         context_schema: An optional schema for runtime context.
         checkpointer: An optional checkpoint saver object. This is used for persisting


### PR DESCRIPTION
Fixes #8130

Fixed a typo in the `create_react_agent` docstring: `GraphRecusionError` → `GraphRecursionError`. No logic changes.

## How did you verify your code works?

This is a docstring-only text fix. Searched the entire repo with `grep -rn "GraphRecusionError"` — only one occurrence existed, now corrected.

## Social handles (optional)

LinkedIn: https://linkedin.com/in/astitvabajpai
