### PR TITLE
fix(checkpoint): widen Store.put()/aput() value type to Mapping[str, Any]

### DIFF
--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -12,7 +12,7 @@ Core types:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from typing import (
     Any,
@@ -473,7 +473,7 @@ class PutOp(NamedTuple):
         the full path would effectively be `"documents/user123/report1"`
     """
 
-    value: dict[str, Any] | None
+    value: Mapping[str, Any] | None
     """The data to store, or `None` to mark the item for deletion.
 
     The value must be a dictionary with string keys and JSON-serializable values.
@@ -857,7 +857,7 @@ class BaseStore(ABC):
         self,
         namespace: tuple[str, ...],
         key: str,
-        value: dict[str, Any],
+        value: Mapping[str, Any],
         index: Literal[False] | list[str] | None = None,
         *,
         ttl: float | None | NotProvided = NOT_PROVIDED,
@@ -1110,7 +1110,7 @@ class BaseStore(ABC):
         self,
         namespace: tuple[str, ...],
         key: str,
-        value: dict[str, Any],
+        value: Mapping[str, Any],
         index: Literal[False] | list[str] | None = None,
         *,
         ttl: float | None | NotProvided = NOT_PROVIDED,

--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -109,7 +109,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from importlib import util
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.embeddings import Embeddings
 
@@ -408,7 +408,7 @@ class InMemoryStore(BaseStore):
                 self._vectors[namespace].pop(key, None)
             else:
                 self._data[namespace][key] = Item(
-                    value=op.value,
+                    value=cast(dict, op.value),
                     key=key,
                     namespace=namespace,
                     created_at=datetime.now(timezone.utc),

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 from pytest_mock import MockerFixture
@@ -473,6 +473,7 @@ async def test_cannot_put_empty_namespace() -> None:
     assert (await store.asearch(("langgraph", "foo")))[0].value == doc
     await store.adelete(("langgraph", "foo"), "bar")
     assert (await store.aget(("langgraph", "foo"), "bar")) is None
+
     store.batch([PutOp(("langgraph", "foo"), "bar", doc)])
     assert store.get(("langgraph", "foo"), "bar").value == doc  # type: ignore[union-attr]
     assert store.search(("langgraph", "foo"))[0].value == doc
@@ -512,6 +513,30 @@ async def test_cannot_put_empty_namespace() -> None:
     assert (await async_store.asearch(("valid", "namespace")))[0].value == doc
     await async_store.adelete(("valid", "namespace"), "key")
     assert (await async_store.aget(("valid", "namespace"), "key")) is None
+
+
+class _Prefs(TypedDict):
+    theme: str
+
+
+async def test_put_accepts_typed_dict() -> None:
+    """A TypedDict is a Mapping[str, Any] but not a dict[str, Any] under a type
+    checker (it lacks arbitrary key add/remove), so `put`/`aput` must accept
+    `Mapping[str, Any]` rather than `dict[str, Any]` for this to type-check.
+    Runtime behavior was never broken -- this guards the type surface and the
+    resulting stored/retrieved value."""
+    store = InMemoryStore()
+    value: _Prefs = {"theme": "dark"}
+
+    store.put(("users", "123"), "prefs", value)
+    item = store.get(("users", "123"), "prefs")
+    assert item is not None
+    assert item.value == {"theme": "dark"}
+
+    await store.aput(("users", "456"), "prefs", value)
+    item = await store.aget(("users", "456"), "prefs")
+    assert item is not None
+    assert item.value == {"theme": "dark"}
 
 
 async def test_async_batch_store_deduplication(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Summary

Fixes #8616.

`BaseStore.put()`/`aput()` and `PutOp.value` are typed as `dict[str, Any]`, which rejects a well-formed `TypedDict` under mypy -- a `TypedDict` is not a `dict[str, Any]` (it lacks arbitrary key add/remove) -- even though the call works fine at runtime:

```python
class Prefs(TypedDict):
    theme: str

value: Prefs = {"theme": "dark"}
store.put(("users", "123"), "prefs", value)
# mypy: error: Argument 3 to "put" of "BaseStore" has incompatible type "Prefs"; expected "dict[str, Any]"
```

This widens `value` to `Mapping[str, Any]`, which both `dict` and `TypedDict` satisfy, per the fix proposed in the issue.

## Why this is safe

I traced every place `PutOp.value` / `Store.put value` flows to before touching anything, rather than widening the signature blind:

- `InMemoryStore._apply_put_ops` (`store/memory/__init__.py`) constructs `Item(value=op.value, ...)` directly. `Item.value` stays `dict[str, Any]` (out of scope -- `Item` is a *returned* value, not a caller input, so the original issue doesn't apply there). This one call site needed `cast(dict, op.value)` to keep type-checking clean.
- The Postgres and SQLite store backends (`checkpoint-postgres`, `checkpoint-sqlite`) don't override `put`/`aput` at all -- they only implement `batch`/`abatch`, and both already do `cast(dict, op.value)` at their own serialization call sites (`Jsonb(cast(dict, op.value))`, `orjson.dumps(cast(dict, op.value))`). Both needed **no changes**.
- `batch.py` (the batching wrapper) only forwards `PutOp` through, no direct field access.

So the fix is exactly two files: the type signatures in `store/base/__init__.py`, and one `cast` in `store/memory/__init__.py` to match the pattern the other two backends already use.

## Verification

- Added `test_put_accepts_typed_dict` to `tests/test_store.py`, exercising the issue's exact repro against both `put`/`get` and `aput`/`aget`.
- Confirmed the fix against **mypy** specifically, since that's what the issue was reported against (this repo's own CI uses `ty`, which doesn't flag this particular variance -- so a `ty`-only check would have missed it):
  - Before fix: `error: Argument 3 to "put" of "BaseStore" has incompatible type "Prefs"; expected "dict[str, Any]"  [arg-type]` (byte-for-byte the error from the issue)
  - After fix: `Success: no issues found in 1 source file`
- `uv run ty check langgraph tests`: all checks pass (both before and after -- confirms no regression from `ty`'s perspective either)
- `uv run pytest tests/`: **156 passed, 17 skipped** (17 skips are pre-existing, environment-gated -- e.g. real Redis)
- `uv run ruff check` / `ruff format --diff` / `ruff check --select I` / `codespell`: all clean

## Test plan

- [x] New regression test added and passing (`test_put_accepts_typed_dict`)
- [x] Full `libs/checkpoint` test suite passes with no regressions (156 passed, 17 pre-existing skips)
- [x] Reproduced the exact reported mypy error pre-fix, confirmed resolved post-fix
- [x] `ty check`, `ruff check`, `ruff format`, import sort, and `codespell` all clean