### PR TITLE
fix(langgraph): persist cancellation record under durability='exit'

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -1314,6 +1314,30 @@ class PregelLoop:
             if self._delta_write_futs is not None:
                 self._delta_write_futs.append(fut)
 
+    def _stage_cancelled_task_writes(self, exc_value: BaseException | None) -> None:
+        """Record cancellation for tasks that were cancelled mid-flight.
+
+        With durability "async"/"sync" the runner's `commit()` persists an ERROR
+        write for a cancelled task, so `get_state().tasks[...].error` reports the
+        cancellation. With durability "exit" that same `commit()` runs from a
+        done-callback that fires *after* this exit hook, by which point
+        `_put_pending_writes()` has already flushed; the write lands in
+        `checkpoint_pending_writes` too late and is never persisted.
+
+        Staging it here makes the three durability modes agree. Tasks that
+        already produced writes are skipped: they completed normally, and only
+        the still-running ones were actually cancelled.
+        """
+        if not isinstance(exc_value, asyncio.CancelledError):
+            return
+        if not hasattr(self, "tasks"):
+            return
+        written = {task_id for task_id, _, _ in self.checkpoint_pending_writes}
+        for task_id, task in self.tasks.items():
+            if task.writes or task_id in written:
+                continue
+            self.put_writes(task_id, [(ERROR, exc_value)])
+
     def _suppress_interrupt(
         self,
         exc_type: type[BaseException] | None,
@@ -1329,6 +1353,12 @@ class PregelLoop:
             # or a nested graph with checkpointer=True
             or all(NS_END not in part for part in self.checkpoint_ns)
         ):
+            # Stage the cancellation record before flushing: the cancelled
+            # task's own commit() runs from a done-callback that fires after
+            # this hook, so it would otherwise land in
+            # checkpoint_pending_writes after _put_pending_writes() has run
+            # and would never be persisted.
+            self._stage_cancelled_task_writes(exc_value)
             self._put_exit_delta_writes()
             self._put_checkpoint(self.checkpoint_metadata)
             self._put_pending_writes()

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -552,6 +552,67 @@ async def test_node_cancellation_on_external_cancel() -> None:
     assert inner_task_cancelled
 
 
+@pytest.mark.parametrize("durability", ["exit", "async", "sync"])
+async def test_cancellation_recorded_for_all_durability_modes(
+    durability: Durability,
+) -> None:
+    """Cancelling mid-superstep must durably record the cancellation of the task
+    that was still running, while preserving the writes of the task that
+    finished.
+
+    Regression test: with durability="exit" the cancelled task's ``commit()``
+    runs from a done-callback that fires *after* ``_suppress_interrupt`` has
+    already flushed pending writes, so the ERROR write was dropped and
+    ``get_state().tasks[...].error`` was None, unlike "async"/"sync".
+    """
+
+    class State(TypedDict):
+        steps: Annotated[list[str], operator.add]
+
+    async def fast(state: State) -> Any:
+        return {"steps": ["fast"]}
+
+    async def slow(state: State) -> Any:
+        await asyncio.sleep(5)
+        return {"steps": ["slow"]}
+
+    builder = StateGraph(State)
+    builder.add_node("fast", fast)
+    builder.add_node("slow", slow)
+    builder.add_edge(START, "fast")
+    builder.add_edge(START, "slow")
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": f"cancel-{durability}"}}
+
+    async def consume() -> None:
+        async for _ in graph.astream(
+            {"steps": []}, config, stream_mode="values", durability=durability
+        ):
+            pass
+
+    task = asyncio.create_task(consume())
+    # let `fast` finish and commit while `slow` is still sleeping
+    await asyncio.sleep(0.5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # allow the cancelled task's done-callback to run
+    await asyncio.sleep(0.5)
+
+    state = await graph.aget_state(config)
+    errors = {t.name: t.error for t in state.tasks}
+
+    # the cancellation of the in-flight task is durably recorded
+    assert errors.get("slow") is not None, (
+        f"cancellation not persisted for durability={durability!r}; tasks={errors}"
+    )
+    assert "CancelledError" in str(errors["slow"])
+    # the task that completed is not misreported as cancelled
+    assert errors.get("fast") is None
+    # and its committed work survives
+    assert state.values["steps"] == ["fast"]
+
+
 async def test_node_cancellation_on_other_node_exception() -> None:
     inner_task_cancelled = False
 


### PR DESCRIPTION
Fixes #5672

Cancelling a run mid-superstep does not persist the cancellation when `durability="exit"`, so `get_state().tasks[...].error` is `None` and callers cannot tell a task that was cancelled in flight from one that never started. `"async"` and `"sync"` both record it correctly.

## The inconsistency

Two nodes in one superstep, `p1` fast and `p2` slow; cancel while `p2` is still running:

```
durability=async   tasks=[('p1', None), ('p2', 'CancelledError()')]
durability=sync    tasks=[('p1', None), ('p2', 'CancelledError()')]
durability=exit    tasks=[('p1', None), ('p2', None)]     <-- cancellation lost
```

Deterministic across repeated trials.

## Root cause

`PregelRunner.commit()` appends `(ERROR, exception)` for a cancelled task (`_runner.py:579-583`), but it runs from a done-callback that fires *after* `AsyncPregelLoop.__aexit__` unwinds the stack. Instrumenting the call order:

```
durability=exit
  commit(task=p1, exc=None)
  _suppress_interrupt(enter, exc=CancelledError)
  _put_pending_writes(tasks=1, channels=['steps'])   <-- the only flush
  _suppress_interrupt(exit)
  commit(task=p2, exc=CancelledError)                <-- ERROR write arrives after
```

With `"async"`/`"sync"`, `put_writes()` forwards to the checkpointer immediately (`_loop.py:466`), so the record survives. With `"exit"`, writes are only flushed by `_put_pending_writes()` inside `_suppress_interrupt` (`_loop.py:1334`), which has already run, so the write lands in `checkpoint_pending_writes` too late and is never persisted.

## Fix

Stage the cancellation for still-running tasks before the exit flush. Tasks that already produced writes are skipped, so a completed node's work is untouched and is never misreported as cancelled.

## How I verified this

- New parametrized regression test over all three durability modes.
- **Mutation-checked**: removing only the new call makes the `exit` case fail while `async`/`sync` still pass, so the test measures the fix rather than decorating it.
- `tests/test_pregel_async.py`: 313 passed (310 on unmodified `main`, +3 new).
- Full suite: 2012 passed, 6 skipped, 0 failed (2009 on unmodified `main`). The 208 errors are byte-identical before and after and are postgres/redis fixtures I have no local service for.
- `ruff check` and `ruff format` clean.

## Scope

Deliberately narrow. It does not attempt the terminal-receipt / lineage contract discussed in the issue thread, and does not touch the Platform-side question of whether Agent Server awaits the loop's cancellation cleanup before publishing `interrupted`, which still looks Platform-owned.

Note on process: the issue is still unassigned despite several contributors asking. Happy to close this if you would rather assign it to someone already waiting, or to re-scope it, since the defect fixed here is narrower than the originally reported symptom (which I could not reproduce on current `main`; details in [my comment](https://github.com/langchain-ai/langgraph/issues/5672#issuecomment-5311786139)).
