### PR TITLE
fix(langgraph): restore deferred branch channels from bare value checkpoints

### DIFF
--- a/libs/langgraph/langgraph/channels/last_value.py
+++ b/libs/langgraph/langgraph/channels/last_value.py
@@ -116,7 +116,19 @@ class LastValueAfterFinish(
         empty = self.__class__(self.typ)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.value, empty.finished = checkpoint
+            if (
+                isinstance(checkpoint, (tuple, list))
+                and len(checkpoint) == 2
+                and isinstance(checkpoint[1], bool)
+            ):
+                empty.value, empty.finished = checkpoint
+            else:
+                # Tolerate a bare value checkpoint (e.g. written by a non-deferred
+                # channel such as EphemeralValue before the node's defer flag was
+                # flipped). Treat it as already finished so the pending node can
+                # still run when the thread resumes.
+                empty.value = checkpoint
+                empty.finished = True
         return empty
 
     def update(self, values: Sequence[Value | Any]) -> bool:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -66,6 +66,7 @@ from langgraph.errors import GraphRecursionError, InvalidUpdateError, ParentComm
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import MessagesState, _messages_delta_reducer, add_messages
+from langgraph.graph.state import CompiledStateGraph
 from langgraph.pregel import (
     NodeBuilder,
     Pregel,
@@ -2359,6 +2360,38 @@ def test_in_one_fan_out_state_graph_defer_node(
     assert [c for c in app_w_interrupt.stream(None, config, debug=1)] == [
         {"qa": {"answer": "doc1,doc2,doc3,doc4,doc5"}},
     ]
+
+
+def test_resume_after_flipping_defer_on_single_predecessor(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Regression test for #8629.
+
+    Toggling `defer` on a single-predecessor node between runs produces a
+    checkpoint whose branch channel has a different shape than the graph used to
+    resume the thread expects, crashing the resumed run with a TypeError.
+    """
+
+    class State(TypedDict):
+        messages: Annotated[list[str], operator.add]
+
+    def build(defer: bool) -> CompiledStateGraph:
+        builder = StateGraph(State)
+        builder.add_node("a", lambda state: {"messages": ["a"]})
+        builder.add_node("b", lambda state: {"messages": ["b"]}, defer=defer)
+        builder.add_edge(START, "a")
+        builder.add_edge("a", "b")
+        return builder.compile(checkpointer=sync_checkpointer, interrupt_before=["b"])
+
+    # pause with defer=False, resume with defer=True
+    config = {"configurable": {"thread_id": "1"}}
+    build(False).invoke({"messages": []}, config)
+    assert build(True).invoke(None, config) == {"messages": ["a", "b"]}
+
+    # pause with defer=True, resume with defer=False
+    config = {"configurable": {"thread_id": "2"}}
+    build(True).invoke({"messages": []}, config)
+    assert build(False).invoke(None, config) == {"messages": ["a", "b"]}
 
 
 def test_in_one_fan_out_state_graph_waiting_edge_via_branch(


### PR DESCRIPTION
Fixes #8629

## Problem

Toggling `defer` on a single-predecessor node between runs leaves every thread paused before that node unable to resume. The first run writes a bare value (from `EphemeralValue`) into the `branch:to:<node>` channel, but the resumed graph instantiates `LastValueAfterFinish`, whose `from_checkpoint` expects a `(value, finished)` pair:

```
TypeError: cannot unpack non-iterable NoneType object
  File "langgraph/channels/last_value.py", line 119, in from_checkpoint
    empty.value, empty.finished = checkpoint
```

## Root cause

`graph/state.py` picks the branch channel from the node's `defer` flag:

```python
self.channels[branch_channel] = (
    LastValueAfterFinish(Any) if node.defer else EphemeralValue(Any, guard=False)
)
```

The two channels checkpoint incompatible shapes: `EphemeralValue.checkpoint()` returns the bare value (`None` for a branch channel), while `LastValueAfterFinish.checkpoint()` returns `(value, finished)`. Flipping `defer` and redeploying therefore restores one shape into the other, and every paused thread crashes.

## Fix

`LastValueAfterFinish.from_checkpoint` now tolerates a bare value checkpoint and restores it as already finished, so the pending node still runs on resume. It accepts both `(value, finished)` tuples and lists (serializers like `JsonPlusSerializer` round-trip tuples as lists).

## Reproduction (from the issue)

```python
import operator
from typing import Annotated
from langgraph.checkpoint.memory import InMemorySaver
from langgraph.graph import START, StateGraph
from typing_extensions import TypedDict

class State(TypedDict):
    messages: Annotated[list[str], operator.add]

def build(defer: bool, saver: InMemorySaver):
    builder = StateGraph(State)
    builder.add_node('a', lambda state: {'messages': ['a']})
    builder.add_node('b', lambda state: {'messages': ['b']}, defer=defer)
    builder.add_edge(START, 'a')
    builder.add_edge('a', 'b')
    return builder.compile(checkpointer=saver, interrupt_before=['b'])

saver = InMemorySaver()
config = {'configurable': {'thread_id': '1'}}
build(False, saver).invoke({'messages': []}, config)
build(True, saver).invoke(None, config)  # TypeError before this fix
```

## Test plan

- Added `test_resume_after_flipping_defer_on_single_predecessor` (sync, all checkpointer params) covering both toggle directions.
- `pytest tests/test_pregel.py tests/test_channels.py` → 494 passed.
- `ruff check .` and `ruff format --diff` clean.

The fan-in counterpart (`NamedBarrierValue` / `NamedBarrierValueAfterFinish`) is tracked separately in #8618.