### PR TITLE
fix(langgraph): restore deferred fan-in barrier channels from bare checkpoints

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Generic
+from typing import Any, Generic
 
 from typing_extensions import Self
 
@@ -46,11 +46,23 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
     def checkpoint(self) -> set[Value]:
         return self.seen
 
-    def from_checkpoint(self, checkpoint: set[Value]) -> Self:
+    def from_checkpoint(
+        self, checkpoint: set[Value] | tuple[set[Value], bool] | Any
+    ) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            # a thread checkpointed while the target had defer=True hands us
+            # the NamedBarrierValueAfterFinish (seen, finished) pair; serde
+            # round-trips tuples as lists, so accept both shapes
+            if (
+                isinstance(checkpoint, (tuple, list))
+                and len(checkpoint) == 2
+                and isinstance(checkpoint[1], bool)
+            ):
+                empty.seen = checkpoint[0]
+            else:
+                empty.seen = checkpoint
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -124,11 +136,24 @@ class NamedBarrierValueAfterFinish(
     def checkpoint(self) -> tuple[set[Value], bool]:
         return (self.seen, self.finished)
 
-    def from_checkpoint(self, checkpoint: tuple[set[Value], bool]) -> Self:
+    def from_checkpoint(
+        self, checkpoint: tuple[set[Value], bool] | set[Value] | Any
+    ) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            if (
+                isinstance(checkpoint, (tuple, list))
+                and len(checkpoint) == 2
+                and isinstance(checkpoint[1], bool)
+            ):
+                empty.seen, empty.finished = checkpoint
+            else:
+                # a thread checkpointed while the target had no defer hands us
+                # the bare seen set; the barrier was already satisfied in that
+                # run, so mark it finished to fire the fan-in node on resume
+                empty.seen = checkpoint
+                empty.finished = True
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -66,6 +66,7 @@ from langgraph.errors import GraphRecursionError, InvalidUpdateError, ParentComm
 from langgraph.func import entrypoint, task
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.message import MessagesState, _messages_delta_reducer, add_messages
+from langgraph.graph.state import CompiledStateGraph
 from langgraph.pregel import (
     NodeBuilder,
     Pregel,
@@ -2359,6 +2360,41 @@ def test_in_one_fan_out_state_graph_defer_node(
     assert [c for c in app_w_interrupt.stream(None, config, debug=1)] == [
         {"qa": {"answer": "doc1,doc2,doc3,doc4,doc5"}},
     ]
+
+
+def test_resume_after_flipping_defer_on_fan_in_node(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Regression test for #8618.
+
+    Toggling `defer` on a fan-in node between runs produces a checkpoint whose
+    barrier channel has a different shape than the graph used to resume the
+    thread expects, silently corrupting the barrier so the fan-in node never
+    fires again on that thread (or raising a ValueError on restore).
+    """
+
+    class State(TypedDict):
+        messages: Annotated[list[str], operator.add]
+
+    def build(defer: bool) -> CompiledStateGraph:
+        builder = StateGraph(State)
+        builder.add_node("a1", lambda state: {"messages": ["a1"]})
+        builder.add_node("a2", lambda state: {"messages": ["a2"]})
+        builder.add_node("c", lambda state: {"messages": ["c"]}, defer=defer)
+        builder.add_edge(START, "a1")
+        builder.add_edge(START, "a2")
+        builder.add_edge(["a1", "a2"], "c")
+        return builder.compile(checkpointer=sync_checkpointer, interrupt_before=["c"])
+
+    # pause with defer=False, resume with defer=True
+    config = {"configurable": {"thread_id": "1"}}
+    build(False).invoke({"messages": []}, config)
+    assert build(True).invoke(None, config) == {"messages": ["a1", "a2", "c"]}
+
+    # pause with defer=True, resume with defer=False
+    config = {"configurable": {"thread_id": "2"}}
+    build(True).invoke({"messages": []}, config)
+    assert build(False).invoke(None, config) == {"messages": ["a1", "a2", "c"]}
 
 
 def test_in_one_fan_out_state_graph_waiting_edge_via_branch(

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -4062,6 +4062,41 @@ async def test_in_one_fan_out_state_graph_defer_node(
     ]
 
 
+async def test_resume_after_flipping_defer_on_fan_in_node(
+    async_checkpointer: BaseCheckpointSaver,
+) -> None:
+    """Regression test for #8618.
+
+    Toggling `defer` on a fan-in node between runs produces a checkpoint whose
+    barrier channel has a different shape than the graph used to resume the
+    thread expects, silently corrupting the barrier so the fan-in node never
+    fires again on that thread (or raising a ValueError on restore).
+    """
+
+    class State(TypedDict):
+        messages: Annotated[list[str], operator.add]
+
+    def build(defer: bool):
+        builder = StateGraph(State)
+        builder.add_node("a1", lambda state: {"messages": ["a1"]})
+        builder.add_node("a2", lambda state: {"messages": ["a2"]})
+        builder.add_node("c", lambda state: {"messages": ["c"]}, defer=defer)
+        builder.add_edge(START, "a1")
+        builder.add_edge(START, "a2")
+        builder.add_edge(["a1", "a2"], "c")
+        return builder.compile(checkpointer=async_checkpointer, interrupt_before=["c"])
+
+    # pause with defer=False, resume with defer=True
+    config = {"configurable": {"thread_id": "1"}}
+    await build(False).ainvoke({"messages": []}, config)
+    assert await build(True).ainvoke(None, config) == {"messages": ["a1", "a2", "c"]}
+
+    # pause with defer=True, resume with defer=False
+    config = {"configurable": {"thread_id": "2"}}
+    await build(True).ainvoke({"messages": []}, config)
+    assert await build(False).ainvoke(None, config) == {"messages": ["a1", "a2", "c"]}
+
+
 async def test_in_one_fan_out_state_graph_waiting_edge_via_branch(
     async_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
Fixes #8618

Restores deferred fan-in barrier channels correctly when `defer` is toggled between runs, so the fan-in node actually fires again on resume instead of silently never running (or crashing on restore).

- `NamedBarrierValue.from_checkpoint` now accepts the `(seen, finished)` pair written by `NamedBarrierValueAfterFinish` and extracts the seen set.
- `NamedBarrierValueAfterFinish.from_checkpoint` now accepts the bare seen set written by `NamedBarrierValue` and marks the barrier finished (it was already satisfied in the run that wrote the checkpoint), so the node fires on resume — restoring the set alone leaves `finished=False` and the node silently dead.
- Both accept tuples and lists, since checkpoint serde round-trips tuples as lists.

Regression tests added for both toggle directions, sync (`test_pregel.py`) and async (`test_pregel_async.py`).

Verified: `tests/test_pregel.py`, `tests/test_pregel_async.py`, `tests/test_channels.py` — 694 passed, 115 skipped; ruff check and format clean. (mypy blocked locally by a pre-existing `langgraph/types.py` stdlib-shadowing environment issue.)
