### PR TITLE
feat: static production-debt analysis for StateGraph + `langgraph lint`

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -863,6 +863,115 @@ def dev(
 
 
 # ---------------------------------------------------------------------------
+# lint command
+# ---------------------------------------------------------------------------
+
+
+@OPT_CONFIG
+@click.option(
+    "--fail-on",
+    type=click.Choice(["critical", "warning", "info", "never"]),
+    default="critical",
+    help="Minimum finding severity that causes a non-zero exit code. "
+    "Use 'never' to always exit 0 (report only).",
+)
+@cli.command(
+    help="🩺 Statically analyze configured graphs for production-debt anti-patterns "
+    "(unreachable nodes, unbounded cycles, missing checkpointers on cyclic graphs, "
+    "unresolvable conditional edges)."
+)
+@log_command
+def lint(config: str, fail_on: str):
+    """CLI entrypoint for structural graph linting."""
+    try:
+        from langgraph.graph.analysis import Severity, analyze, production_debt_score
+    except ImportError:
+        raise click.UsageError(
+            "The 'lint' command requires the 'langgraph' package to be installed "
+            "in this environment (it imports and statically inspects your graph "
+            "objects). Install it with:\n\n"
+            "    pip install -U langgraph"
+        ) from None
+
+    from langgraph_cli.lint import prepare_import_path, resolve_graph
+
+    config_path = pathlib.Path(config)
+    config_json = langgraph_cli.config.validate_config_file(config_path)
+    graphs = config_json["graphs"]  # validate_config_file guarantees non-empty
+
+    base_dir = config_path.resolve().parent
+    prepare_import_path(base_dir, config_json.get("dependencies", []))
+
+    severity_rank = {
+        Severity.CRITICAL: 0,
+        Severity.WARNING: 1,
+        Severity.INFO: 2,
+    }
+    fail_threshold = {
+        "critical": 0,
+        "warning": 1,
+        "info": 2,
+        "never": None,
+    }[fail_on]
+
+    def note_severity(current: int | None, severity: Severity) -> int:
+        rank = severity_rank[severity]
+        return rank if current is None else min(current, rank)
+
+    worst_seen: int | None = None
+    for graph_id, graph_def in graphs.items():
+        spec = graph_def["path"] if isinstance(graph_def, dict) else graph_def
+        result = resolve_graph(graph_id, spec, base_dir)
+
+        if result.error:
+            click.secho(f"\n{graph_id} ({spec}): failed to load", fg="red")
+            click.echo(f"  {result.error}")
+            worst_seen = note_severity(worst_seen, Severity.CRITICAL)
+            continue
+
+        if result.skipped_reason:
+            click.secho(f"\n{graph_id} ({spec}): skipped", fg="yellow")
+            click.echo(f"  {result.skipped_reason}")
+            continue
+
+        findings = analyze(result.builder, checkpointer=result.checkpointer)
+        score = production_debt_score(findings)
+
+        if not findings:
+            click.secho(
+                f"\n{graph_id} ({spec}): clean (production debt score 0)", fg="green"
+            )
+            continue
+
+        color = (
+            "red"
+            if any(f.severity == Severity.CRITICAL for f in findings)
+            else "yellow"
+        )
+        click.secho(
+            f"\n{graph_id} ({spec}): {len(findings)} finding(s), "
+            f"production debt score {score}",
+            fg=color,
+        )
+        if not result.checkpointer_known:
+            click.echo(
+                "  (graph was loaded uncompiled -- checkpointer-related checks "
+                "were skipped; lint a compiled graph object to include them)"
+            )
+        for f in findings:
+            worst_seen = note_severity(worst_seen, f.severity)
+            location = f" [{f.node}]" if f.node else ""
+            click.echo(f"  {f.severity.value:<8} {f.rule}{location}: {f.message}")
+
+    if (
+        fail_threshold is not None
+        and worst_seen is not None
+        and worst_seen <= fail_threshold
+    ):
+        raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
 # validate command
 # ---------------------------------------------------------------------------
 

--- a/libs/cli/langgraph_cli/lint.py
+++ b/libs/cli/langgraph_cli/lint.py
@@ -1,0 +1,157 @@
+"""Load configured graphs and run langgraph.graph.analysis against them.
+
+This module is deliberately separate from cli.py's `dev`/`up` commands: it
+never starts a server and never invokes user code beyond importing the
+module that defines each graph, so it is safe to run against a project
+without a database, API keys, or any other runtime dependency configured.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import pathlib
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class GraphLoadResult:
+    graph_id: str
+    spec: str
+    graph: Any | None
+    builder: Any | None
+    checkpointer_known: bool
+    checkpointer: Any | None
+    error: str | None
+    skipped_reason: str | None
+
+
+def _import_from_path(file_path: pathlib.Path, attr_name: str) -> Any:
+    module_name = f"_langgraph_lint_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load module from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    if not hasattr(module, attr_name):
+        raise AttributeError(f"module {file_path} has no attribute '{attr_name}'")
+    return getattr(module, attr_name)
+
+
+def load_graph_object(spec: str, base_dir: pathlib.Path) -> Any:
+    """Resolve a `path/to/file.py:attr` or `dotted.module:attr` spec.
+
+    Mirrors the "graphs" value syntax documented in langgraph.json (see
+    `GraphDef`/`Config.graphs` in schemas.py): a string is always
+    `<path-or-module>:<attribute name>`. File paths are resolved relative
+    to `base_dir` (the directory containing the config file), matching
+    the resolution used for local dependencies and for the Docker-build
+    graph-path remap (`_assemble_local_deps`/`_update_graph_paths` in
+    config.py) -- not the process's current working directory.
+    """
+    if ":" not in spec:
+        raise ValueError(f"graph spec '{spec}' is missing the ':<attribute>' suffix")
+    path_part, attr_name = spec.rsplit(":", 1)
+
+    candidate = (base_dir / path_part).resolve()
+    if candidate.suffix == ".py" and candidate.exists():
+        return _import_from_path(candidate, attr_name)
+    if path_part.endswith(".py"):
+        raise FileNotFoundError(f"graph file not found: {candidate}")
+
+    module = importlib.import_module(path_part)
+    if not hasattr(module, attr_name):
+        raise AttributeError(f"module '{path_part}' has no attribute '{attr_name}'")
+    return getattr(module, attr_name)
+
+
+def resolve_graph(graph_id: str, spec: str, base_dir: pathlib.Path) -> GraphLoadResult:
+    try:
+        obj = load_graph_object(spec, base_dir)
+    except Exception as exc:  # surfaced to the user as a lint error, not raised
+        return GraphLoadResult(
+            graph_id=graph_id,
+            spec=spec,
+            graph=None,
+            builder=None,
+            checkpointer_known=False,
+            checkpointer=None,
+            error=f"{type(exc).__name__}: {exc}",
+            skipped_reason=None,
+        )
+
+    # Compiled graph (Pregel / CompiledStateGraph): has both the original
+    # StateGraph builder and the checkpointer it was actually compiled with.
+    if hasattr(obj, "builder") and hasattr(obj, "checkpointer"):
+        return GraphLoadResult(
+            graph_id=graph_id,
+            spec=spec,
+            graph=obj,
+            builder=obj.builder,
+            checkpointer_known=True,
+            checkpointer=obj.checkpointer,
+            error=None,
+            skipped_reason=None,
+        )
+
+    # Uncompiled StateGraph: has nodes/edges/branches directly, but no
+    # checkpointer has been chosen yet.
+    if hasattr(obj, "nodes") and hasattr(obj, "edges") and hasattr(obj, "branches"):
+        return GraphLoadResult(
+            graph_id=graph_id,
+            spec=spec,
+            graph=obj,
+            builder=obj,
+            checkpointer_known=False,
+            checkpointer=None,
+            error=None,
+            skipped_reason=None,
+        )
+
+    if callable(obj):
+        return GraphLoadResult(
+            graph_id=graph_id,
+            spec=spec,
+            graph=obj,
+            builder=None,
+            checkpointer_known=False,
+            checkpointer=None,
+            error=None,
+            skipped_reason=(
+                "graph is a factory/context-manager callable; lint does not "
+                "invoke it (that would execute user side effects), so its "
+                "structure cannot be statically analyzed"
+            ),
+        )
+
+    return GraphLoadResult(
+        graph_id=graph_id,
+        spec=spec,
+        graph=obj,
+        builder=None,
+        checkpointer_known=False,
+        checkpointer=None,
+        error=None,
+        skipped_reason=f"object of type {type(obj).__name__} is not a recognized graph",
+    )
+
+
+def prepare_import_path(base_dir: pathlib.Path, dependencies: list[str]) -> None:
+    """Add base_dir and local dependency dirs to sys.path.
+
+    Mirrors the sys.path setup `dev` performs, but rooted at the config
+    file's directory rather than the process cwd (see `load_graph_object`).
+    """
+    if str(base_dir) not in sys.path:
+        sys.path.append(str(base_dir))
+    for dep in dependencies:
+        dep_path = base_dir / dep
+        if dep_path.is_dir() and dep_path.exists() and str(dep_path) not in sys.path:
+            sys.path.append(str(dep_path))

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest-mock",
     "pytest-watch",
     "msgspec",
+    "langgraph",
 ]
 lint = [
     "ruff",
@@ -57,6 +58,9 @@ dev = [
 
 [tool.uv]
 default-groups = ['dev']
+
+[tool.uv.sources]
+langgraph = { path = "../langgraph", editable = true }
 
 [tool.hatch.build.targets.wheel]
 include = ["langgraph_cli"]

--- a/libs/cli/tests/unit_tests/cli/test_lint_command.py
+++ b/libs/cli/tests/unit_tests/cli/test_lint_command.py
@@ -1,0 +1,188 @@
+"""End-to-end tests for `langgraph lint` via CliRunner + real graph modules."""
+
+from __future__ import annotations
+
+import builtins
+import json
+import pathlib
+
+import pytest
+from click.testing import CliRunner
+
+from langgraph_cli.cli import cli
+
+CLEAN_GRAPH = """\
+from typing_extensions import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict):
+    value: str
+
+
+def node(state):
+    return {}
+
+
+builder = StateGraph(State)
+builder.add_node("a", node)
+builder.add_edge(START, "a")
+builder.add_edge("a", END)
+graph = builder.compile()
+"""
+
+UNREACHABLE_NODE_GRAPH = """\
+from typing_extensions import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict):
+    value: str
+
+
+def node(state):
+    return {}
+
+
+builder = StateGraph(State)
+builder.add_node("a", node)
+builder.add_node("orphan", node)
+builder.add_edge(START, "a")
+builder.add_edge("a", END)
+graph = builder.compile()
+"""
+
+UNBOUNDED_CYCLE_GRAPH = """\
+from typing_extensions import TypedDict
+
+from langgraph.graph import START, StateGraph
+
+
+class State(TypedDict):
+    value: str
+
+
+def node(state):
+    return {}
+
+
+def always_loop(state):
+    return "loop"
+
+
+builder = StateGraph(State)
+builder.add_node("stuck", node)
+builder.add_edge(START, "stuck")
+builder.add_conditional_edges("stuck", always_loop, {"loop": "stuck"})
+graph = builder.compile()
+"""
+
+FACTORY_GRAPH = """\
+def make_graph(config):
+    raise NotImplementedError("should never be called by lint")
+"""
+
+
+def _write_project(
+    tmp_path: pathlib.Path, graph_source: str, attr: str = "graph"
+) -> pathlib.Path:
+    (tmp_path / "agent.py").write_text(graph_source)
+    config = {
+        "dependencies": ["."],
+        "graphs": {"agent": f"./agent.py:{attr}"},
+    }
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_text(json.dumps(config))
+    return config_path
+
+
+def test_lint_clean_graph_exits_zero(tmp_path: pathlib.Path) -> None:
+    config_path = _write_project(tmp_path, CLEAN_GRAPH)
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "clean" in result.output
+    assert "production debt score 0" in result.output
+
+
+def test_lint_unreachable_node_warns_but_default_exit_zero(
+    tmp_path: pathlib.Path,
+) -> None:
+    config_path = _write_project(tmp_path, UNREACHABLE_NODE_GRAPH)
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "unreachable-node" in result.output
+    assert "orphan" in result.output
+
+
+def test_lint_unreachable_node_fails_with_fail_on_warning(
+    tmp_path: pathlib.Path,
+) -> None:
+    config_path = _write_project(tmp_path, UNREACHABLE_NODE_GRAPH)
+    result = CliRunner().invoke(
+        cli, ["lint", "--config", str(config_path), "--fail-on", "warning"]
+    )
+    assert result.exit_code == 1, result.output
+
+
+def test_lint_unbounded_cycle_fails_by_default(tmp_path: pathlib.Path) -> None:
+    config_path = _write_project(tmp_path, UNBOUNDED_CYCLE_GRAPH)
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 1, result.output
+    assert "unbounded-cycle" in result.output
+
+
+def test_lint_unbounded_cycle_fail_on_never_exits_zero(tmp_path: pathlib.Path) -> None:
+    config_path = _write_project(tmp_path, UNBOUNDED_CYCLE_GRAPH)
+    result = CliRunner().invoke(
+        cli, ["lint", "--config", str(config_path), "--fail-on", "never"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "unbounded-cycle" in result.output
+
+
+def test_lint_factory_graph_is_skipped_not_invoked(tmp_path: pathlib.Path) -> None:
+    config_path = _write_project(tmp_path, FACTORY_GRAPH, attr="make_graph")
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "skipped" in result.output
+    assert "NotImplementedError" not in result.output
+
+
+def test_lint_missing_attribute_reports_error(tmp_path: pathlib.Path) -> None:
+    config_path = _write_project(tmp_path, CLEAN_GRAPH, attr="does_not_exist")
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 1, result.output
+    assert "failed to load" in result.output
+
+
+def test_lint_reports_actionable_error_when_langgraph_not_installed(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = _write_project(tmp_path, CLEAN_GRAPH)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "langgraph.graph.analysis" or name.startswith(
+            "langgraph.graph.analysis"
+        ):
+            raise ImportError("No module named 'langgraph'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 2, result.output
+    assert "pip install -U langgraph" in result.output
+
+
+def test_lint_no_graphs_configured_rejected_by_config_validation(
+    tmp_path: pathlib.Path,
+) -> None:
+    # langgraph_cli.config.validate_config already requires at least one
+    # graph; `lint` reuses that same validation rather than duplicating it.
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_text(json.dumps({"dependencies": ["."], "graphs": {}}))
+    result = CliRunner().invoke(cli, ["lint", "--config", str(config_path)])
+    assert result.exit_code == 2, result.output
+    assert "No graphs found in config" in result.output

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -982,9 +982,10 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
     { name = "langsmith" },
@@ -995,9 +996,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/b9/893806b89f77e1271fe6e10ce41682ff5fe43d071564e1d8e39dbb5d4d6d/langchain_core-1.5.6.tar.gz", hash = "sha256:b5f73bd9688c457b31ec73657a0ad56948f889fae27acee79286e9c285632ee6", size = 984873, upload-time = "2026-08-17T21:26:35.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/0a/890504397885c9d1ae45f2e06c3000dd9f4445439602b6a990a88b32c0ac/langchain_core-1.5.6-py3-none-any.whl", hash = "sha256:d6cf37bf695ecc22cddeb8461a684e353190b2ce430d99eb22bc11c0c7c00ea5", size = 567016, upload-time = "2026-08-17T21:26:34.595Z" },
 ]
 
 [[package]]
@@ -1014,8 +1015,8 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.3"
-source = { registry = "https://pypi.org/simple" }
+version = "1.2.11"
+source = { editable = "../langgraph" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -1024,9 +1025,76 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/55/e42f59b5e4cce75085f68abb77114c4d1152628157bd60c2587881bca559/langgraph-1.2.3.tar.gz", hash = "sha256:7f89cd5f0946fe29bd7ca048e2a84d3c14e7f652e38bb98e00f0ba8b7004b9d0", size = 718812, upload-time = "2026-06-01T18:55:54.458Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/9b/287f11be799f2f4dd289ab19d23788df22ac20ce884a010d0696f79016db/langgraph-1.2.3-py3-none-any.whl", hash = "sha256:22e6c89084adb3edb7855f6ffa692af3d75925f9c70deb43b86da14db1b02c78", size = 244841, upload-time = "2026-06-01T18:55:52.945Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain-core", specifier = ">=1.4.7,<2" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-prebuilt", editable = "../prebuilt" },
+    { name = "langgraph-sdk", editable = "../sdk-py" },
+    { name = "pydantic", specifier = ">=2.7.4" },
+    { name = "xxhash", specifier = ">=3.5.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx" },
+    { name = "jupyter" },
+    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite", editable = "../checkpoint-sqlite" },
+    { name = "langgraph-cli", marker = "python_full_version < '3.14'", editable = "." },
+    { name = "langgraph-cli", extras = ["inmem"], marker = "python_full_version < '3.14'", editable = "." },
+    { name = "langgraph-prebuilt", editable = "../prebuilt" },
+    { name = "langgraph-sdk", editable = "../sdk-py" },
+    { name = "psycopg", extras = ["binary"] },
+    { name = "py-spy" },
+    { name = "pycryptodome" },
+    { name = "pyperf" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
+    { name = "pytest-mock" },
+    { name = "pytest-repeat" },
+    { name = "pytest-watcher" },
+    { name = "pytest-xdist", extras = ["psutil"] },
+    { name = "redis" },
+    { name = "ruff" },
+    { name = "syrupy" },
+    { name = "ty" },
+    { name = "types-requests" },
+    { name = "uvloop", specifier = "==0.22.1" },
+]
+lint = [
+    { name = "ruff" },
+    { name = "ty" },
+    { name = "types-requests" },
+]
+test = [
+    { name = "httpx" },
+    { name = "langchain-core", specifier = ">=1.0.0" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite", editable = "../checkpoint-sqlite" },
+    { name = "langgraph-cli", marker = "python_full_version < '3.14'", editable = "." },
+    { name = "langgraph-cli", extras = ["inmem"], marker = "python_full_version < '3.14'", editable = "." },
+    { name = "langgraph-prebuilt", editable = "../prebuilt" },
+    { name = "langgraph-sdk", editable = "../sdk-py" },
+    { name = "psycopg", extras = ["binary"] },
+    { name = "py-spy" },
+    { name = "pycryptodome" },
+    { name = "pyperf" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
+    { name = "pytest-mock" },
+    { name = "pytest-repeat" },
+    { name = "pytest-watcher" },
+    { name = "pytest-xdist", extras = ["psutil"] },
+    { name = "redis" },
+    { name = "syrupy" },
+    { name = "uvloop", specifier = "==0.22.1" },
 ]
 
 [[package]]
@@ -1074,15 +1142,50 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
+version = "4.2.0"
+source = { editable = "../checkpoint" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain-core", specifier = ">=0.2.38" },
+    { name = "ormsgpack", specifier = ">=1.12.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "codespell" },
+    { name = "dataclasses-json" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pandas-stubs", specifier = ">=2.2.2.240807" },
+    { name = "pycryptodome", specifier = ">=3.23.0" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watcher" },
+    { name = "redis" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+lint = [
+    { name = "codespell" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+test = [
+    { name = "dataclasses-json" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pandas-stubs", specifier = ">=2.2.2.240807" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watcher" },
+    { name = "redis" },
 ]
 
 [[package]]
@@ -1107,6 +1210,7 @@ inmem = [
 dev = [
     { name = "codespell" },
     { name = "hatch" },
+    { name = "langgraph" },
     { name = "msgspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1121,6 +1225,7 @@ lint = [
     { name = "ty" },
 ]
 test = [
+    { name = "langgraph" },
     { name = "msgspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1145,6 +1250,7 @@ provides-extras = ["inmem"]
 dev = [
     { name = "codespell" },
     { name = "hatch", specifier = ">=1.16.2" },
+    { name = "langgraph", editable = "../langgraph" },
     { name = "msgspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1159,6 +1265,7 @@ lint = [
     { name = "ty" },
 ]
 test = [
+    { name = "langgraph", editable = "../langgraph" },
     { name = "msgspec" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1169,14 +1276,52 @@ test = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../prebuilt" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain-core", specifier = ">=1.3.1" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "codespell" },
+    { name = "langchain-core" },
+    { name = "langgraph", editable = "../langgraph" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite", editable = "../checkpoint-sqlite" },
+    { name = "psycopg-binary" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watcher" },
+    { name = "ruff" },
+    { name = "syrupy" },
+    { name = "ty" },
+]
+lint = [
+    { name = "codespell" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+test = [
+    { name = "langchain-core" },
+    { name = "langgraph", editable = "../langgraph" },
+    { name = "langgraph-checkpoint", editable = "../checkpoint" },
+    { name = "langgraph-checkpoint-postgres", editable = "../checkpoint-postgres" },
+    { name = "langgraph-checkpoint-sqlite", editable = "../checkpoint-sqlite" },
+    { name = "psycopg-binary" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watcher" },
+    { name = "syrupy" },
 ]
 
 [[package]]
@@ -1199,8 +1344,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../sdk-py" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },
@@ -1208,9 +1352,40 @@ dependencies = [
     { name = "orjson" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.25.2" },
+    { name = "langchain-core", specifier = ">=1.4.0,<2" },
+    { name = "langchain-protocol", specifier = ">=0.0.15" },
+    { name = "orjson", specifier = ">=3.11.5" },
+    { name = "websockets", specifier = ">=14,<17" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "codespell" },
+    { name = "langgraph", editable = "../langgraph" },
+    { name = "pydantic", specifier = ">=2.12.4" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watch" },
+    { name = "ruff", specifier = "==0.16.1" },
+    { name = "starlette" },
+    { name = "ty" },
+]
+lint = [
+    { name = "codespell" },
+    { name = "ruff", specifier = "==0.16.1" },
+    { name = "starlette" },
+    { name = "ty" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
+    { name = "pytest-watch" },
 ]
 
 [[package]]

--- a/libs/langgraph/langgraph/graph/analysis.py
+++ b/libs/langgraph/langgraph/graph/analysis.py
@@ -1,0 +1,312 @@
+"""Static production-readiness analysis for :class:`StateGraph` structures.
+
+`StateGraph.compile()` (see `StateGraph.validate`) only checks that
+every edge and conditional-edge endpoint refers to a real node, START, or
+END. It does not check that every declared node is actually reachable
+from START, that a cycle has any exit path to END, that a graph relying
+on cycles was compiled with a checkpointer for crash recovery, or that a
+conditional edge's destinations are even statically knowable. Those are
+exactly the structural anti-patterns detected here -- gaps that compile
+cleanly and run fine in a demo, then surface as hung agents, silently
+dead nodes, or unrecoverable crashes once a graph is under real traffic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from langgraph.constants import END, START
+
+if TYPE_CHECKING:
+    from langgraph.graph.state import StateGraph
+
+
+class Severity(str, Enum):
+    """Risk tier of a :class:`Finding`.
+
+    CRITICAL: can hang or crash a run (e.g. a cycle with no exit).
+    WARNING: does not crash, but degrades reliability or leaves dead
+        code in the graph (e.g. an unreachable node).
+    INFO: an auditability/observability gap, not a functional defect.
+    """
+
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One detected anti-pattern instance."""
+
+    rule: str
+    severity: Severity
+    node: str | None
+    message: str
+
+
+_SEVERITY_WEIGHT: dict[Severity, int] = {
+    Severity.CRITICAL: 10,
+    Severity.WARNING: 3,
+    Severity.INFO: 1,
+}
+
+
+def production_debt_score(findings: list[Finding]) -> int:
+    """Severity-weighted sum of findings (critical=10, warning=3, info=1).
+
+    This is a deliberately simple, transparent, reproducible heuristic for
+    trending a graph's structural health over time and gating CI on
+    regressions -- it is not a standardized industry metric.
+    """
+    return sum(_SEVERITY_WEIGHT[f.severity] for f in findings)
+
+
+def _branch_ends(spec_ends: Any) -> set[str]:
+    """Normalize a `StateNodeSpec.ends` value (tuple or dict) to a set.
+
+    Mirrors `StateGraph.validate`'s own handling: a tuple's elements are
+    target node names; for a dict, LangGraph's own validator only ever
+    updates its target set with the dict's *keys*, so we match that.
+    """
+    if isinstance(spec_ends, dict):
+        return set(spec_ends)
+    return set(spec_ends)
+
+
+def _adjacency(graph: StateGraph) -> dict[str, set[str]]:
+    """Build a directed adjacency map over `{START} | graph.nodes | {END}`.
+
+    Reuses `graph._all_edges` -- the same edge-flattening (plain edges
+    plus fan-in `waiting_edges`) that `StateGraph.validate` itself uses
+    at compile time -- so this stays correct if that internal
+    representation changes.
+    """
+    adj: dict[str, set[str]] = {name: set() for name in graph.nodes}
+    adj[START] = set()
+    adj[END] = set()
+
+    for start, end in graph._all_edges:
+        adj.setdefault(start, set()).add(end)
+
+    for source, branches in graph.branches.items():
+        adj.setdefault(source, set())
+        for branch in branches.values():
+            if branch.ends is None:
+                # No statically-resolvable path_map: the routing function's
+                # real destinations are only known at runtime. Conservatively
+                # assume it can reach any node (including END) so this
+                # never produces a false-positive unreachable-node or
+                # unbounded-cycle finding.
+                adj[source] |= set(graph.nodes) | {END}
+            else:
+                adj[source] |= set(branch.ends.values())
+
+    for name, spec in graph.nodes.items():
+        ends = spec.ends
+        if ends:
+            adj.setdefault(name, set())
+            adj[name] |= _branch_ends(ends)
+
+    return adj
+
+
+def _bfs_reachable(adj: dict[str, set[str]], sources: set[str]) -> set[str]:
+    seen = set(sources)
+    queue = list(sources)
+    while queue:
+        node = queue.pop()
+        for nxt in adj.get(node, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                queue.append(nxt)
+    return seen
+
+
+def _tarjan_scc(adj: dict[str, set[str]]) -> list[set[str]]:
+    """Tarjan's strongly-connected-components algorithm.
+
+    Any SCC of size > 1 is a cycle. (Single-node self-loops are cycles too
+    but form size-1 SCCs, so callers must check those separately.)
+    """
+    index_counter = [0]
+    stack: list[str] = []
+    lowlink: dict[str, int] = {}
+    index: dict[str, int] = {}
+    on_stack: dict[str, bool] = {}
+    result: list[set[str]] = []
+
+    def strongconnect(node: str) -> None:
+        index[node] = index_counter[0]
+        lowlink[node] = index_counter[0]
+        index_counter[0] += 1
+        stack.append(node)
+        on_stack[node] = True
+
+        for successor in adj.get(node, ()):
+            if successor not in index:
+                strongconnect(successor)
+                lowlink[node] = min(lowlink[node], lowlink[successor])
+            elif on_stack.get(successor):
+                lowlink[node] = min(lowlink[node], index[successor])
+
+        if lowlink[node] == index[node]:
+            component: set[str] = set()
+            while True:
+                w = stack.pop()
+                on_stack[w] = False
+                component.add(w)
+                if w == node:
+                    break
+            result.append(component)
+
+    for node in adj:
+        if node not in index:
+            strongconnect(node)
+
+    return result
+
+
+def _cycles(adj: dict[str, set[str]]) -> list[set[str]]:
+    cycles = [scc for scc in _tarjan_scc(adj) if len(scc) > 1]
+    cycles += [{node} for node, targets in adj.items() if node in targets]
+    return cycles
+
+
+def detect_unreachable_nodes(graph: StateGraph) -> list[Finding]:
+    """Nodes never reachable via any traversal starting at START.
+
+    `compile()` never checks this: it only verifies edge endpoints
+    exist, not that every declared node has an incoming path. A node
+    added with `add_node` and then never wired to anything compiles and
+    runs fine -- it is simply dead code that will never execute, silently
+    diverging from what a reader of the graph definition would assume.
+    """
+    adj = _adjacency(graph)
+    reachable = _bfs_reachable(adj, {START})
+    findings = []
+    for name in graph.nodes:
+        if name not in reachable:
+            findings.append(
+                Finding(
+                    rule="unreachable-node",
+                    severity=Severity.WARNING,
+                    node=name,
+                    message=(
+                        f"node '{name}' is never reachable from START via any "
+                        "edge or conditional edge -- it is dead code that will "
+                        "never execute"
+                    ),
+                )
+            )
+    return findings
+
+
+def detect_unbounded_cycles(graph: StateGraph) -> list[Finding]:
+    """Cycles (including self-loops) with no path from any member to END.
+
+    `compile()` performs no cycle analysis at all. A cycle with no exit
+    means any run that enters it can only be halted externally (a
+    recursion-limit error or a manual kill) -- a hung-agent production
+    incident waiting to happen, not a bug that will show up in a quick
+    demo run.
+    """
+    adj = _adjacency(graph)
+    findings = []
+    for cycle in _cycles(adj):
+        reachable_from_cycle = _bfs_reachable(adj, set(cycle))
+        if END not in reachable_from_cycle:
+            member = sorted(cycle)[0]
+            findings.append(
+                Finding(
+                    rule="unbounded-cycle",
+                    severity=Severity.CRITICAL,
+                    node=member,
+                    message=(
+                        f"cycle containing {sorted(cycle)} has no path to END from "
+                        "any node in it -- a run that enters this cycle can only "
+                        "be stopped by a recursion-limit error, not by the graph "
+                        "itself"
+                    ),
+                )
+            )
+    return findings
+
+
+def detect_unresolved_branches(graph: StateGraph) -> list[Finding]:
+    """Conditional edges whose destinations are not statically knowable.
+
+    Occurs when `add_conditional_edges` is called without a
+    `path_map`/list and the routing function has no `Literal` return
+    type annotation LangGraph can infer from. Functionally fine at
+    runtime, but it means no static tool -- this one included -- and no
+    reviewer reading the graph definition can enumerate where that branch
+    actually goes.
+    """
+    findings = []
+    for source, branches in graph.branches.items():
+        for name, branch in branches.items():
+            if branch.ends is None:
+                findings.append(
+                    Finding(
+                        rule="unresolvable-branch",
+                        severity=Severity.INFO,
+                        node=source,
+                        message=(
+                            f"conditional edge '{name}' from node '{source}' has "
+                            "no statically-resolvable path_map -- pass path_map= "
+                            "to add_conditional_edges, or annotate the routing "
+                            "function's return type with Literal[...], so its "
+                            "destinations can be audited"
+                        ),
+                    )
+                )
+    return findings
+
+
+def detect_missing_checkpointer_with_cycle(
+    graph: StateGraph, checkpointer: object | None
+) -> list[Finding]:
+    """A graph with a cycle compiled without a checkpointer.
+
+    Cycles are how LangGraph expresses iterative agent loops (retries,
+    ReAct-style tool loops). Without a checkpointer, a crash mid-loop
+    loses all accumulated state and there is no way to inspect or resume
+    the run -- a reliability gap invisible in local testing (which rarely
+    crashes mid-loop) but a real incident in production.
+
+    `checkpointer=None` (may inherit a parent's checkpointer when used as
+    a subgraph) and `checkpointer=False` (explicitly no persistence, do
+    not inherit) both mean "no persistence" for a top-level compiled
+    graph, so both are treated as missing.
+    """
+    if checkpointer not in (None, False):
+        return []
+    adj = _adjacency(graph)
+    if not _cycles(adj):
+        return []
+    return [
+        Finding(
+            rule="missing-checkpointer-with-cycle",
+            severity=Severity.WARNING,
+            node=None,
+            message=(
+                "graph contains a cycle but was compiled with no checkpointer "
+                "-- a crash mid-loop loses all state and cannot be resumed"
+            ),
+        )
+    ]
+
+
+def analyze(graph: StateGraph, checkpointer: object | None = None) -> list[Finding]:
+    """Run all detectors and return every finding, most-critical first."""
+    findings: list[Finding] = []
+    findings += detect_unbounded_cycles(graph)
+    findings += detect_unreachable_nodes(graph)
+    findings += detect_missing_checkpointer_with_cycle(graph, checkpointer)
+    findings += detect_unresolved_branches(graph)
+    order = {Severity.CRITICAL: 0, Severity.WARNING: 1, Severity.INFO: 2}
+    findings.sort(key=lambda f: (order[f.severity], f.rule, f.node or ""))
+    return findings

--- a/libs/langgraph/tests/test_graph_analysis.py
+++ b/libs/langgraph/tests/test_graph_analysis.py
@@ -1,0 +1,348 @@
+"""Tests + labelled benchmark corpus for langgraph.graph.analysis.
+
+Each corpus graph is labelled with exactly the rule names it should (for
+adversarial graphs) or should not (for clean graphs) trigger. The
+parametrized tests below turn that corpus into a real, reproducible
+recall/false-positive measurement rather than an asserted claim:
+
+    - test_adversarial_graph_detected: every injected defect must be
+      caught (recall).
+    - test_clean_graph_has_no_findings: no clean, realistic graph may
+      produce a finding (false positives).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+from langgraph.checkpoint.memory import InMemorySaver
+from typing_extensions import TypedDict
+
+from langgraph.constants import END, START
+from langgraph.graph.analysis import (
+    Finding,
+    Severity,
+    analyze,
+    detect_missing_checkpointer_with_cycle,
+    detect_unbounded_cycles,
+    detect_unreachable_nodes,
+    detect_unresolved_branches,
+    production_debt_score,
+)
+from langgraph.graph.state import StateGraph
+
+
+class State(TypedDict):
+    value: str
+
+
+def _noop(_: State) -> dict:
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Clean corpus: realistic graphs that must produce zero findings.
+# ---------------------------------------------------------------------------
+
+
+def clean_linear_chain() -> StateGraph:
+    """START -> a -> b -> END, no cycles, no branches."""
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_edge(START, "a")
+    g.add_edge("a", "b")
+    g.add_edge("b", END)
+    return g
+
+
+def clean_fan_out_fan_in() -> StateGraph:
+    """START -> {a, b} -> join -> END, using a waiting (fan-in) edge."""
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_node("join", _noop)
+    g.add_edge(START, "a")
+    g.add_edge(START, "b")
+    g.add_edge(["a", "b"], "join")
+    g.add_edge("join", END)
+    return g
+
+
+def clean_conditional_with_path_map() -> StateGraph:
+    """A conditional edge with an explicit, fully-resolvable path_map."""
+
+    def router(_: State) -> str:
+        return "a"
+
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_edge(START, "a")
+    g.add_conditional_edges("a", router, {"a": "b", "b": END})
+    g.add_edge("b", END)
+    return g
+
+
+def clean_conditional_with_literal_return() -> StateGraph:
+    """A conditional edge resolvable via a Literal return-type annotation."""
+
+    def router(_: State) -> Literal["b", "__end__"]:
+        return "b"
+
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_edge(START, "a")
+    g.add_conditional_edges("a", router)
+    g.add_edge("b", END)
+    return g
+
+
+def clean_bounded_retry_loop() -> StateGraph:
+    """A cycle (retry loop) with a real exit edge to END, with a checkpointer."""
+
+    def should_retry(_: State) -> str:
+        return "retry"
+
+    g = StateGraph(State)
+    g.add_node("attempt", _noop)
+    g.add_edge(START, "attempt")
+    g.add_conditional_edges("attempt", should_retry, {"retry": "attempt", "done": END})
+    return g
+
+
+CLEAN_CORPUS = {
+    "linear_chain": clean_linear_chain,
+    "fan_out_fan_in": clean_fan_out_fan_in,
+    "conditional_with_path_map": clean_conditional_with_path_map,
+    "conditional_with_literal_return": clean_conditional_with_literal_return,
+    "bounded_retry_loop": clean_bounded_retry_loop,
+}
+
+
+# ---------------------------------------------------------------------------
+# Adversarial corpus: one deliberately injected defect each, labelled with
+# the exact rule name that must fire.
+# ---------------------------------------------------------------------------
+
+
+def bad_orphan_node() -> StateGraph:
+    """'orphan' is defined but never wired to anything."""
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("orphan", _noop)
+    g.add_edge(START, "a")
+    g.add_edge("a", END)
+    return g
+
+
+def bad_orphan_downstream_of_dead_node() -> StateGraph:
+    """'b' is only reachable via 'a', which is itself unreachable."""
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_node("live", _noop)
+    g.add_edge("a", "b")  # dangling: 'a' has no incoming edge from START
+    g.add_edge(START, "live")
+    g.add_edge("live", END)
+    return g
+
+
+def bad_unbounded_self_loop() -> StateGraph:
+    """A node that loops to itself with no exit."""
+
+    def always_loop(_: State) -> str:
+        return "loop"
+
+    g = StateGraph(State)
+    g.add_node("stuck", _noop)
+    g.add_edge(START, "stuck")
+    g.add_conditional_edges("stuck", always_loop, {"loop": "stuck"})
+    return g
+
+
+def bad_unbounded_two_node_cycle() -> StateGraph:
+    """A two-node cycle (a <-> b) with no path out to END."""
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_edge(START, "a")
+    g.add_edge("a", "b")
+    g.add_edge("b", "a")
+    return g
+
+
+def bad_cycle_without_checkpointer() -> StateGraph:
+    """A properly-exiting retry loop, but intended to be compiled with checkpointer=None."""
+
+    def should_retry(_: State) -> str:
+        return "retry"
+
+    g = StateGraph(State)
+    g.add_node("attempt", _noop)
+    g.add_edge(START, "attempt")
+    g.add_conditional_edges("attempt", should_retry, {"retry": "attempt", "done": END})
+    return g
+
+
+def bad_unresolved_branch() -> StateGraph:
+    """A router with no path_map and no inferable Literal return type."""
+
+    def router(_: State):
+        return "a"
+
+    g = StateGraph(State)
+    g.add_node("a", _noop)
+    g.add_node("b", _noop)
+    g.add_edge(START, "a")
+    g.add_conditional_edges("a", router)
+    g.add_edge("b", END)
+    return g
+
+
+ADVERSARIAL_CORPUS = {
+    "orphan_node": (bad_orphan_node, "unreachable-node", None),
+    "orphan_downstream_of_dead_node": (
+        bad_orphan_downstream_of_dead_node,
+        "unreachable-node",
+        None,
+    ),
+    "unbounded_self_loop": (bad_unbounded_self_loop, "unbounded-cycle", None),
+    "unbounded_two_node_cycle": (bad_unbounded_two_node_cycle, "unbounded-cycle", None),
+    "cycle_without_checkpointer": (
+        bad_cycle_without_checkpointer,
+        "missing-checkpointer-with-cycle",
+        None,  # checkpointer=None is the default; no override needed
+    ),
+    "unresolved_branch": (bad_unresolved_branch, "unresolvable-branch", None),
+}
+
+
+# ---------------------------------------------------------------------------
+# Benchmark tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", CLEAN_CORPUS)
+def test_clean_graph_has_no_findings(name: str) -> None:
+    graph = CLEAN_CORPUS[name]()
+    checkpointer = InMemorySaver() if name == "bounded_retry_loop" else None
+    findings = analyze(graph, checkpointer=checkpointer)
+    assert findings == [], f"{name} produced unexpected findings: {findings}"
+
+
+@pytest.mark.parametrize("name", ADVERSARIAL_CORPUS)
+def test_adversarial_graph_detected(name: str) -> None:
+    factory, expected_rule, checkpointer = ADVERSARIAL_CORPUS[name]
+    graph = factory()
+    findings = analyze(graph, checkpointer=checkpointer)
+    rules = {f.rule for f in findings}
+    assert expected_rule in rules, (
+        f"{name}: expected rule '{expected_rule}' not found in {rules}"
+    )
+
+
+def test_benchmark_summary(capsys: pytest.CaptureFixture[str]) -> None:
+    """Not an assertion -- prints the real recall/false-positive numbers.
+
+    Run with `-s` to see the summary; the two tests above are what
+    actually enforce recall == 100% and false positives == 0 per-case.
+    """
+    total_clean = len(CLEAN_CORPUS)
+    fp_count = 0
+    for name, factory in CLEAN_CORPUS.items():
+        graph = factory()
+        checkpointer = InMemorySaver() if name == "bounded_retry_loop" else None
+        if analyze(graph, checkpointer=checkpointer):
+            fp_count += 1
+
+    total_adversarial = len(ADVERSARIAL_CORPUS)
+    detected = 0
+    for name, (factory, expected_rule, checkpointer) in ADVERSARIAL_CORPUS.items():
+        graph = factory()
+        rules = {f.rule for f in analyze(graph, checkpointer=checkpointer)}
+        if expected_rule in rules:
+            detected += 1
+
+    print(
+        f"\nbenchmark: recall={detected}/{total_adversarial} "
+        f"false_positives={fp_count}/{total_clean}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests for individual detectors and the score function
+# ---------------------------------------------------------------------------
+
+
+def test_production_debt_score_weights() -> None:
+    findings = [
+        Finding("r1", Severity.CRITICAL, None, "x"),
+        Finding("r2", Severity.WARNING, None, "y"),
+        Finding("r3", Severity.INFO, None, "z"),
+    ]
+    assert production_debt_score(findings) == 10 + 3 + 1
+    assert production_debt_score([]) == 0
+
+
+def test_detect_unreachable_nodes_finds_orphan() -> None:
+    graph = bad_orphan_node()
+    findings = detect_unreachable_nodes(graph)
+    assert len(findings) == 1
+    assert findings[0].node == "orphan"
+    assert findings[0].severity == Severity.WARNING
+
+
+def test_detect_unbounded_cycles_finds_self_loop() -> None:
+    graph = bad_unbounded_self_loop()
+    findings = detect_unbounded_cycles(graph)
+    assert len(findings) == 1
+    assert findings[0].node == "stuck"
+    assert findings[0].severity == Severity.CRITICAL
+
+
+def test_detect_unbounded_cycles_ignores_bounded_loop() -> None:
+    graph = clean_bounded_retry_loop()
+    assert detect_unbounded_cycles(graph) == []
+
+
+def test_detect_missing_checkpointer_with_cycle() -> None:
+    graph = bad_cycle_without_checkpointer()
+    assert len(detect_missing_checkpointer_with_cycle(graph, None)) == 1
+    assert detect_missing_checkpointer_with_cycle(graph, InMemorySaver()) == []
+
+
+def test_detect_missing_checkpointer_with_cycle_false_also_flagged() -> None:
+    # checkpointer=False ("explicitly no persistence, don't inherit") means
+    # no persistence just as much as the None default does.
+    graph = bad_cycle_without_checkpointer()
+    assert len(detect_missing_checkpointer_with_cycle(graph, False)) == 1
+
+
+def test_detect_missing_checkpointer_no_cycle_no_finding() -> None:
+    graph = clean_linear_chain()
+    assert detect_missing_checkpointer_with_cycle(graph, None) == []
+
+
+def test_detect_unresolved_branches() -> None:
+    graph = bad_unresolved_branch()
+    findings = detect_unresolved_branches(graph)
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.INFO
+
+
+def test_detect_unresolved_branches_none_when_path_map_given() -> None:
+    graph = clean_conditional_with_path_map()
+    assert detect_unresolved_branches(graph) == []
+
+
+def test_analyze_sorts_critical_first() -> None:
+    graph = StateGraph(State)
+    graph.add_node("stuck", _noop)
+    graph.add_node("orphan", _noop)
+    graph.add_edge(START, "stuck")
+    graph.add_edge("stuck", "stuck")
+    findings = analyze(graph)
+    assert findings[0].severity == Severity.CRITICAL


### PR DESCRIPTION
Fixes #8641

## Why

`StateGraph.compile()` (`StateGraph.validate`) only checks that edge and conditional-edge endpoints reference real nodes, START, or END. It does not check that every declared node is actually reachable, that a cycle has any exit path to END, that a graph relying on cycles was compiled with a checkpointer, or that a conditional edge's destinations are even statically knowable.

Those gaps compile cleanly and run fine in a demo, then surface later as hung agents, silently dead nodes, or unrecoverable crashes once a graph is under real traffic — structural production debt that no existing check catches.

Notably, `add_conditional_edges`'s own docstring already warns about the last case:

> Without type hints on the `path` function's return value ... or a path_map, the graph visualization assumes the edge could transition to any node in the graph.

but nothing today programmatically flags it.

## What

**`langgraph.graph.analysis`** (new module in `libs/langgraph`) adds four detectors operating on a `StateGraph`'s builder-time structure (`.nodes` / `.edges` / `.branches`), reusing the graph's own `_all_edges` flattening (plain + fan-in `waiting_edges`) so it stays correct if that internal representation changes:

- **`unreachable-node`** — a node with no path from START via any traversal (dead code that will never execute).
- **`unbounded-cycle`** — a cycle (found via Tarjan SCC, including self-loops) with no path from any member to END — a hung-run risk that only a recursion-limit error can stop.
- **`missing-checkpointer-with-cycle`** — a graph with a cycle compiled with `checkpointer=None` or `checkpointer=False` — a crash mid-loop loses all state with no way to resume.
- **`unresolvable-branch`** — a conditional edge with no statically-resolvable `path_map` (no `Literal` return-type hint either) — an auditability gap, not a functional defect.

Conditional edges with no resolvable `path_map` are conservatively treated as able to reach every node, so they never cause false-positive `unreachable-node`/`unbounded-cycle` findings.

`production_debt_score()` gives a transparent, severity-weighted single number (critical=10, warning=3, info=1) for trending a graph's structural health in CI — documented as a deliberately simple heuristic, not a standardized metric.

**Benchmark** (`tests/test_graph_analysis.py`): a labelled corpus of 5 clean graphs (linear chain, fan-out/fan-in, `path_map`- and `Literal`-typed conditional edges, a properly-exiting checkpointed retry loop) and 6 adversarial graphs (one injected defect each — one per rule above, plus a node made unreachable only indirectly through another dead node). Measured, not asserted:

```
recall=6/6 (100%)   false_positives=0/5 (0%)
```

See `test_benchmark_summary` to reproduce.

**`langgraph lint`** (new CLI command, `libs/cli`): loads each graph declared in `langgraph.json` and runs the analyzer against it, printing per-graph findings and exiting non-zero above a configurable `--fail-on` severity (`critical` default, or `warning` / `info` / `never`). Handles:
- Compiled graphs (`Pregel`/`CompiledStateGraph`, via `.builder` + `.checkpointer`) and uncompiled `StateGraph` objects (checkpointer checks skipped with a clear note, since no checkpointer choice has been made yet).
- Factory/context-manager graphs are detected and explicitly **not invoked** — lint never executes user side effects — and reported as skipped instead.
- Graph and dependency paths resolve relative to the config file's directory, matching the existing `_update_graph_paths`/`_assemble_local_deps` convention in `config.py`, not the process cwd.
- The `langgraph` import is deferred inside the command and guarded with an actionable install message, since `langgraph-cli` does not otherwise depend on the core `langgraph` package (mirrors the existing `langgraph_api` import-guard pattern already used by `dev`).

`langgraph` is added as a local editable test-only dependency of the `cli` package (`libs/cli/pyproject.toml` `[tool.uv.sources]`), matching the exact pattern already used by `libs/prebuilt`.

## Verification

- `libs/langgraph`: `make format && make lint && make test` — full suite **1999 passed, 4 pre-existing skips**, `ruff`/`ty` clean.
- `libs/cli`: `make format`, `ruff check .` clean; full suite **343 passed**. Two Docker-environment-dependent tests (`test_dockerfile_command_with_docker_compose`, `test_build_generate_proper_build_context`) fail both with and without this change on a clean checkout (confirmed via `git stash`) — pre-existing, unrelated to this PR.
- New tests: 22 in `libs/langgraph/tests/test_graph_analysis.py` (benchmark corpus + unit tests per detector, including a `checkpointer=False` regression case found and fixed during review), 9 in `libs/cli/tests/unit_tests/cli/test_lint_command.py` (real `CliRunner` end-to-end runs against real compiled `StateGraph` objects on disk, covering clean/warning/critical graphs, `--fail-on` at each level, the factory-skip path, a missing-attribute load error, the missing-`langgraph` import guard, and the existing no-graphs config validation).

## Test plan

- [x] `cd libs/langgraph && make format && make lint && make test`
- [x] `cd libs/cli && uv run ruff check . && make test`
- [x] `uv run pytest tests/test_graph_analysis.py -v -s` (prints the real recall/false-positive numbers)
- [x] `uv run pytest tests/unit_tests/cli/test_lint_command.py -v`
