### PR TITLE
fix: disable statement preparation for AsyncPostgresSaver pipeline mode (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -79,7 +79,7 @@ class AsyncPostgresSaver(BasePostgresSaver):
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
         async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
+            conn_string, autocommit=True, prepare_threshold=None, row_factory=dict_row
         ) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:


### PR DESCRIPTION
## What
`AsyncPostgresSaver` used with `pipeline=True` fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly`. The issue is caused by using `prepare_threshold=0` when creating the connection, which enables statement preparation for every query. In pipeline mode, prepared statements are sent as two commands (`PREPARE` then `EXECUTE`), and when the connection is closed by the server (e.g., idle timeout), the pipeline gets desynchronized, causing the SSL error.

## Fix
Change `prepare_threshold` from `0` to `None` when creating the connection. This disables statement preparation, making queries single-round-trip and preventing pipeline desynchronization when the connection is interrupted. The fix is applied only in the `from_conn_string` classmethod where both connection creation and pipeline setup happen.

Closes #5675