### PR TITLE
fix(checkpoint-sqlite): call setup() in adelete_thread to prevent OperationalError on uninitialized DB

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/aio.py
@@ -212,7 +212,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         while True:
             try:
                 yield asyncio.run_coroutine_threadsafe(
-                    anext(aiter_),  # type: ignore[arg-type]  # noqa: F821
+                    anext(aiter_),  # type: ignore[arg-type]
                     self.loop,
                 ).result()
             except StopAsyncIteration:
@@ -608,6 +608,7 @@ class AsyncSqliteSaver(BaseCheckpointSaver[str]):
         Returns:
             None
         """
+        await self.setup()
         async with self.lock, self.conn.cursor() as cur:
             await cur.execute(
                 "DELETE FROM checkpoints WHERE thread_id = ?",

--- a/libs/checkpoint-sqlite/tests/test_aiosqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_aiosqlite.py
@@ -188,3 +188,19 @@ class TestAsyncSqliteSaver:
             # (would have been dropped if injection succeeded)
             results = [c async for c in saver.alist(None, limit=None)]
             assert len(results) == 5
+
+    async def test_adelete_thread_on_uninitialized_db(self) -> None:
+        """adelete_thread must call setup() so it works on a fresh database.
+
+        Regression test for: calling adelete_thread() as the very first
+        operation raised sqlite3.OperationalError ('no such table: checkpoints')
+        because setup() was never called.  The fix adds `await self.setup()`
+        before the lock/cursor block, matching every other async method.
+        """
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            # Deleting a nonexistent thread on a fresh (never set-up) DB
+            # must be a no-op, not raise OperationalError.
+            await saver.adelete_thread("nonexistent-thread")
+            # Verify the tables now exist and are empty (setup ran implicitly).
+            results = [c async for c in saver.alist(None)]
+            assert results == []


### PR DESCRIPTION
## Summary

Calling `adelete_thread()` as the **very first** operation on a fresh `AsyncSqliteSaver` raises:

```
sqlite3.OperationalError: no such table: checkpoints
```

All other async methods (`aget_tuple`, `alist`, `aput`, `aput_writes`, `aget_delta_channel_history`) call `await self.setup()` before accessing the database tables. `adelete_thread` did not.

### Root cause

```python
# BEFORE – goes straight to the lock without ensuring tables exist
async def adelete_thread(self, thread_id: str) -> None:
    async with self.lock, self.conn.cursor() as cur:
        await cur.execute("DELETE FROM checkpoints WHERE thread_id = ?", ...)
```

### Fix

Add the same `await self.setup()` guard that every sibling method uses:

```python
# AFTER
async def adelete_thread(self, thread_id: str) -> None:
    await self.setup()                        # ← one-line fix
    async with self.lock, self.conn.cursor() as cur:
        await cur.execute("DELETE FROM checkpoints WHERE thread_id = ?", ...)
```

### Test added

`test_adelete_thread_on_uninitialized_db` in `tests/test_aiosqlite.py`:
- Opens a fresh `:memory:` connection
- Calls `adelete_thread("nonexistent-thread")` as the first and only operation
- Asserts the call completes without error
- Verifies the tables now exist and are empty (confirming `setup()` ran)

Fixes #8549

---

> Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.