### PR TITLE
fix(checkpoint): exclude legacy thread_ts metadata

### DIFF
--- a/libs/checkpoint-sqlite/tests/test_sqlite.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite.py
@@ -63,6 +63,9 @@ class TestSqliteSaver:
             config: RunnableConfig = {
                 "configurable": {
                     "thread_id": "thread-2",
+                    # Legacy checkpoint configuration keys must not be copied
+                    # into the persisted metadata.
+                    "thread_ts": "legacy-timestamp",
                     "checkpoint_ns": "",
                     "__super_private_key": "super_private_value",
                 },

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -796,6 +796,9 @@ WRITES_IDX_MAP = {ERROR: -1, SCHEDULED: -2, INTERRUPT: -3, RESUME: -4}
 
 EXCLUDED_METADATA_KEYS = {
     "thread_id",
+    # `thread_ts` was used by older checkpoint implementations and should
+    # remain configuration-only rather than leaking into checkpoint metadata.
+    "thread_ts",
     "checkpoint_id",
     "checkpoint_ns",
     "checkpoint_map",


### PR DESCRIPTION
## Summary

- exclude the legacy `thread_ts` configuration key from persisted checkpoint metadata
- add a regression guard in the SQLite checkpoint tests

## Context

Fixes #5604. Older checkpoint configurations can leak `thread_id`/`thread_ts` into metadata comparisons. `thread_id` is already excluded; this completes the compatibility filter for `thread_ts`.

## Validation

- `git diff --check` passed
- targeted pytest could not collect because this checkout lacks the `langchain_core` dependency
- repository-required `make format`, `make lint`, and `make test` could not run because `make` is unavailable in the Windows environment
