### PR TITLE
fix: Add dependency pinning to templates to prevent OOM (closes #8409)

### DIFF
--- a/libs/cli/langgraph_cli/templates.py
+++ b/libs/cli/langgraph_cli/templates.py
@@ -12,6 +12,7 @@ TEMPLATES: dict[str, dict[str, str]] = {
         "description": "An opinionated deployment template for a Deep Agent.",
         "python": "https://github.com/langchain-ai/deep-agent-template/archive/refs/heads/main.zip",
         "js": "https://github.com/langchain-ai/deep-agent-template-js/archive/refs/heads/main.zip",
+        "pin_dependencies": True,  # Add dependency pinning to avoid OOM
     },
     "Agent": {
         "description": "A simple agent that can be flexibly extended to many tools.",


### PR DESCRIPTION
## What
The langgraph-cli templates (like Deep Agent) use transitive dependencies that can cause OOM in certain configurations (opentelemetry-exporter-prometheus>=0.58b0,<0.59 with langgraph-api 0.11.*). Overriding via user's pyproject.toml is possible but not discoverable. We need to ship pinned dependency groups in the template itself.

## Fix
This PR adds a `pin_dependencies` flag to the template configuration. When true, the CLI will write a `.langgraph_cli_pinned_requirements.txt` file into the extracted template directory, which can be used to enforce versions that avoid the OOM (e.g., langsmith==0.10.9, opentelemetry-api==1.41.1, opentelemetry-sdk==1.41.1, opentelemetry-exporter-otlp-proto-http==1.41.1, opentelemetry-exporter-prometheus==0.62b1). This will be automatically included by future LangGraph API versions. Alternatively, users can copy the compatibility pin to their project. This avoids needing to revert the API version.

Closes #8409