### PR TITLE
fix(prebuilt): preserve model-level tool validation errors

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -365,7 +365,7 @@ class ToolInvocationError(ToolException):
             for error in filtered_errors:
                 loc_str = ".".join(str(loc) for loc in error.get("loc", ()))
                 msg = error.get("msg", "Unknown error")
-                error_str_parts.append(f"{loc_str}: {msg}")
+                error_str_parts.append(f"{loc_str}: {msg}" if loc_str else msg)
             error_display_str = "\n".join(error_str_parts)
         else:
             error_display_str = str(source)
@@ -545,7 +545,7 @@ def _filter_validation_errors(
     for error in validation_error.errors():
         # Check if error location contains any injected argument
         # error['loc'] is a tuple like ('field_name',) or ('field_name', 'nested_field')
-        if error["loc"] and error["loc"][0] not in injected_arg_names:
+        if not error["loc"] or error["loc"][0] not in injected_arg_names:
             # Create a copy of the error dict to avoid mutating the original
             error_copy: dict[str, Any] = {**error}
 

--- a/libs/prebuilt/tests/test_tool_node_validation_error_filtering.py
+++ b/libs/prebuilt/tests/test_tool_node_validation_error_filtering.py
@@ -17,6 +17,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool as dec_tool
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
+from pydantic import BaseModel, model_validator
 
 from langgraph.prebuilt import InjectedState, InjectedStore, ToolNode, ToolRuntime
 from langgraph.prebuilt.tool_node import ToolInvocationError
@@ -260,6 +261,56 @@ async def test_filter_multiple_injected_args() -> None:
     assert "state" not in tool_message.content.lower()
     assert "store" not in tool_message.content.lower()
     assert "runtime" not in tool_message.content.lower()
+
+
+async def test_filter_model_level_validation_errors() -> None:
+    """Test that model-level validation errors are preserved.
+
+    Pydantic model validators report errors with an empty location tuple. Those
+    errors are still LLM-actionable and should be included in the tool error
+    message so the model can correct its arguments.
+    """
+
+    class RangeArgs(BaseModel):
+        low: int
+        high: int
+
+        @model_validator(mode="after")
+        def check_bounds(self) -> "RangeArgs":
+            if self.low > self.high:
+                raise ValueError("low must be less than or equal to high")
+            return self
+
+    @dec_tool(args_schema=RangeArgs)
+    def my_tool(low: int, high: int) -> str:
+        """Tool with cross-field validation."""
+        return f"{low}-{high}"
+
+    tool_node = ToolNode([my_tool])
+
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"low": 5, "high": 1},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+    assert "low must be less than or equal to high" in tool_message.content
+    assert "\n \n" not in tool_message.content
 
 
 async def test_no_filtering_when_all_errors_are_model_args() -> None:


### PR DESCRIPTION
Closes #8648

Model-level pydantic validators raise ValidationError entries with an empty `loc`, and `ToolNode` was filtering them out before formatting the error message. That produced blank tool errors for cross-field validation failures, while field-level errors were still shown.

Fix:
- keep validation errors with empty `loc`
- avoid prefixing an empty location with `: ` when formatting `ToolInvocationError`
- add a regression test covering a `@model_validator(mode="after")` cross-field rule

Verification:
- `uv run pytest tests/test_tool_node_validation_error_filtering.py -q`
- `make format`
- `make lint`
- manual repro script now prints the model-level validator message instead of a blank error

`make test` could not run end-to-end here because the repo's test target requires Docker, which is unavailable in this environment.