### PR TITLE
fix: avoid pipeline-related SSL errors by documenting pipeline limitations (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -86,6 +86,9 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     yield cls(conn=conn, pipe=pipe, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)
+        # Note: AsyncPipeline is only safe for exclusive, non-concurrent use of the connection.
+        # If the connection is shared (e.g., with an LLM call), do not enable pipeline.
+        # See https://github.com/langchain-ai/langgraph/issues/5675
 
     async def setup(self) -> None:
         """Set up the checkpoint database asynchronously.


### PR DESCRIPTION
## What
AsyncPostgresSaver with pipeline=True can cause psycopg.OperationalError: SSL connection has been closed unexpectedly when the underlying connection is used concurrently (e.g., by LLM calls). The AsyncPipeline holds the connection and expects sequential use; concurrent I/O on the same connection breaks the pipeline.

## Fix
This change does not alter behavior but clarifies that pipeline mode is only safe for exclusive, non-concurrent use of the connection. Users should not enable pipeline when the connection might be shared with other async tasks. This prevents confusion and encourages using the default non-pipeline mode or a connection pool.

Closes #5675