### PR TITLE
fix(langgraph): update_state can permanently erase messages when the checkpointer is config-injected (LangGraph Platform)

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1147,6 +1147,7 @@ class Pregel(
         config: RunnableConfig,
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
+        saver: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
     ) -> StateSnapshot:
         if not saved:
@@ -1169,7 +1170,9 @@ class Pregel(
         channels, managed = channels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
+            saver=saver
+            if isinstance(saver, BaseCheckpointSaver)
+            else self.checkpointer
             if isinstance(self.checkpointer, BaseCheckpointSaver)
             else None,
             config=saved.config,
@@ -1270,6 +1273,7 @@ class Pregel(
         config: RunnableConfig,
         saved: CheckpointTuple | None,
         recurse: BaseCheckpointSaver | None = None,
+        saver: BaseCheckpointSaver | None = None,
         apply_pending_writes: bool = False,
     ) -> StateSnapshot:
         if not saved:
@@ -1292,7 +1296,9 @@ class Pregel(
         channels, managed = await achannels_from_checkpoint(
             self.channels,
             saved.checkpoint,
-            saver=self.checkpointer
+            saver=saver
+            if isinstance(saver, BaseCheckpointSaver)
+            else self.checkpointer
             if isinstance(self.checkpointer, BaseCheckpointSaver)
             else None,
             config=saved.config,
@@ -1430,6 +1436,7 @@ class Pregel(
             config,
             saved,
             recurse=checkpointer if subgraphs else None,
+            saver=checkpointer if isinstance(checkpointer, BaseCheckpointSaver) else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
         )
 
@@ -1474,6 +1481,7 @@ class Pregel(
             config,
             saved,
             recurse=checkpointer if subgraphs else None,
+            saver=checkpointer if isinstance(checkpointer, BaseCheckpointSaver) else None,
             apply_pending_writes=CONFIG_KEY_CHECKPOINT_ID not in config[CONF],
         )
 
@@ -1527,7 +1535,11 @@ class Pregel(
             checkpointer.list(config, before=before, limit=limit, filter=filter)
         ):
             yield self._prepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config,
+                checkpoint_tuple,
+                saver=checkpointer
+                if isinstance(checkpointer, BaseCheckpointSaver)
+                else None,
             )
 
     async def aget_state_history(
@@ -1584,7 +1596,11 @@ class Pregel(
             )
         ]:
             yield await self._aprepare_state_snapshot(
-                checkpoint_tuple.config, checkpoint_tuple
+                checkpoint_tuple.config,
+                checkpoint_tuple,
+                saver=checkpointer
+                if isinstance(checkpointer, BaseCheckpointSaver)
+                else None,
             )
 
     def bulk_update_state(
@@ -1666,9 +1682,9 @@ class Pregel(
             channels, managed = channels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
+                saver=checkpointer
                 if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
+                and isinstance(checkpointer, BaseCheckpointSaver)
                 else None,
                 config=saved.config if saved is not None else None,
             )
@@ -2132,9 +2148,9 @@ class Pregel(
             channels, managed = await achannels_from_checkpoint(
                 self.channels,
                 checkpoint,
-                saver=self.checkpointer
+                saver=checkpointer
                 if saved is not None
-                and isinstance(self.checkpointer, BaseCheckpointSaver)
+                and isinstance(checkpointer, BaseCheckpointSaver)
                 else None,
                 config=saved.config if saved is not None else None,
             )

--- a/libs/langgraph/tests/test_delta_channel_update_state.py
+++ b/libs/langgraph/tests/test_delta_channel_update_state.py
@@ -25,6 +25,7 @@ from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from typing_extensions import TypedDict
 
 from langgraph.channels.delta import DeltaChannel
+from langgraph.constants import CONFIG_KEY_CHECKPOINTER
 from langgraph.graph import START, StateGraph
 from langgraph.graph.message import _messages_delta_reducer
 from langgraph.types import StateUpdate
@@ -338,3 +339,99 @@ def test_state_history_chain_after_fresh_update_state_delta_channel() -> None:
     assert update_snapshot.metadata["step"] == 0
     assert update_snapshot.parent_config is None
     assert [m.content for m in update_snapshot.values["messages"]] == ["hello"]
+
+
+# ---------------------------------------------------------------------------
+# Config-injected checkpointer (the LangGraph Platform shape): state reads and
+# update_state must hydrate DeltaChannels with the config-resolved saver, not
+# the graph's own (absent) checkpointer.
+# ---------------------------------------------------------------------------
+
+
+def _build_detached_graph(*, snapshot_frequency: int = 1000) -> Any:
+    """Same graph as `_build_graph`, compiled WITHOUT a checkpointer.
+
+    Mirrors a platform-hosted graph, where the checkpointer is injected
+    per-request via ``config[CONF][CONFIG_KEY_CHECKPOINTER]``.
+    """
+    channel = DeltaChannel(
+        _messages_delta_reducer, snapshot_frequency=snapshot_frequency
+    )
+    State = TypedDict("State", {"messages": Annotated[list, channel]})  # type: ignore[call-overload]  # noqa: UP013
+
+    def model(state: dict) -> dict:
+        return {}
+
+    builder = StateGraph(State)
+    builder.add_node("model", model)
+    builder.add_edge(START, "model")
+    builder.set_finish_point("model")
+    return builder.compile()
+
+
+def _injected(saver: InMemorySaver, thread_id: str) -> dict:
+    return {"configurable": {"thread_id": thread_id, CONFIG_KEY_CHECKPOINTER: saver}}
+
+
+def test_get_state_with_config_injected_checkpointer_delta_channel() -> None:
+    saver = InMemorySaver()
+    graph = _build_detached_graph()
+    config = _injected(saver, "injected-read-sync")
+    messages = [HumanMessage(content="hello", id="m1"), HumanMessage(content="again", id="m2")]
+
+    graph.invoke({"messages": messages}, config)
+
+    # The head blob is a delta sentinel (frequency not reached), so hydration
+    # must replay through the config-resolved saver.
+    snapshot = graph.get_state(config)
+    assert [m.id for m in snapshot.values["messages"]] == ["m1", "m2"]
+    history = list(graph.get_state_history(config))
+    assert [m.id for m in history[0].values["messages"]] == ["m1", "m2"]
+
+
+async def test_aget_state_with_config_injected_checkpointer_delta_channel() -> None:
+    saver = InMemorySaver()
+    graph = _build_detached_graph()
+    config = _injected(saver, "injected-read-async")
+    messages = [HumanMessage(content="hello", id="m1"), HumanMessage(content="again", id="m2")]
+
+    await graph.ainvoke({"messages": messages}, config)
+
+    snapshot = await graph.aget_state(config)
+    assert [m.id for m in snapshot.values["messages"]] == ["m1", "m2"]
+    history = [s async for s in graph.aget_state_history(config)]
+    assert [m.id for m in history[0].values["messages"]] == ["m1", "m2"]
+
+
+def test_update_state_with_config_injected_checkpointer_delta_channel() -> None:
+    saver = InMemorySaver()
+    graph = _build_detached_graph()
+    config = _injected(saver, "injected-update-sync")
+
+    graph.invoke({"messages": [HumanMessage(content="hello", id="m1")]}, config)
+    graph.update_state(
+        config, {"messages": [HumanMessage(content="appended", id="m2")]}, as_node="model"
+    )
+
+    # The update must fold against the replayed value, not an empty channel —
+    # checked through a fully-attached graph so the read path is not under test.
+    attached = _build_graph(saver)
+    snapshot = attached.get_state({"configurable": {"thread_id": "injected-update-sync"}})
+    assert [m.id for m in snapshot.values["messages"]] == ["m1", "m2"]
+    assert graph.get_state(config).values["messages"] == snapshot.values["messages"]
+
+
+async def test_aupdate_state_with_config_injected_checkpointer_delta_channel() -> None:
+    saver = InMemorySaver()
+    graph = _build_detached_graph()
+    config = _injected(saver, "injected-update-async")
+
+    await graph.ainvoke({"messages": [HumanMessage(content="hello", id="m1")]}, config)
+    await graph.aupdate_state(
+        config, {"messages": [HumanMessage(content="appended", id="m2")]}, as_node="model"
+    )
+
+    attached = _build_graph(saver)
+    snapshot = await attached.aget_state({"configurable": {"thread_id": "injected-update-async"}})
+    assert [m.id for m in snapshot.values["messages"]] == ["m1", "m2"]
+    assert (await graph.aget_state(config)).values["messages"] == snapshot.values["messages"]


### PR DESCRIPTION
Fixes #8653

## The problem, as a user hits it

On LangGraph Platform, graphs are compiled **without** a checkpointer — the platform injects one through the run config. In that setup, the state APIs quietly stop seeing message history, and `update_state` can **permanently erase it**:

- `get_state` / `get_state_history` return `messages: []` for a thread that has a full conversation.
- `update_state` is worse: it folds the update against that wrongly-empty value and **commits the result**. The new head checkpoint genuinely contains no messages, so every later read and every later run continues from an empty conversation.

This is how we found it: our chat app calls `update_state(values=None, as_node=END)` to dismiss a question a thread is paused on (`interrupt()`). On the platform (server 0.12.5, langgraph 1.2.11), that call saved a head checkpoint reading `messages: []` — the user's whole conversation was gone, while the parent checkpoint still held all of it. Four messages before the call, zero after, nothing raised.

The trap is that **local testing never catches it**: `langgraph dev` and any graph compiled with `.compile(checkpointer=...)` take a different code path and behave correctly. The bug only exists in the config-injected shape — i.e., exactly and only in production.

## Minimal repro

```python
import asyncio
from typing import Annotated, TypedDict

from langgraph.channels.delta import DeltaChannel
from langgraph.checkpoint.memory import InMemorySaver
from langgraph.constants import CONFIG_KEY_CHECKPOINTER
from langgraph.graph import START, StateGraph
from langgraph.graph.message import _messages_delta_reducer


class State(TypedDict):
    messages: Annotated[list, DeltaChannel(_messages_delta_reducer)]


async def main() -> None:
    builder = StateGraph(State)
    builder.add_node("model", lambda state: {})
    builder.add_edge(START, "model")
    builder.set_finish_point("model")
    graph = builder.compile()  # no checkpointer attached, as on the platform

    saver = InMemorySaver()
    config = {"configurable": {"thread_id": "t1", CONFIG_KEY_CHECKPOINTER: saver}}

    await graph.ainvoke({"messages": [("user", "hello"), ("ai", "hi!")]}, config)

    snapshot = await graph.aget_state(config)
    print("get_state sees:", len(snapshot.values.get("messages", [])), "- expected 2")

    await graph.aupdate_state(config, {"messages": [("user", "third")]}, as_node="model")
    snapshot = await graph.aget_state(config)
    print("after update_state:", len(snapshot.values.get("messages", [])), "- expected 3")


asyncio.run(main())
```

On `langgraph==1.2.11` and current `main`:

```
get_state sees: 0 - expected 2
after update_state: 0 - expected 3
```

With this PR:

```
get_state sees: 2 - expected 2
after update_state: 3 - expected 3
```

## Why it happens

`get_state`, `get_state_history`, and `update_state` (sync and async) resolve the checkpointer from `config[CONF][CONFIG_KEY_CHECKPOINTER]` and use it for everything — except channel hydration, which is called with `saver=self.checkpointer`, the graph-attached one. On a platform-shaped graph that attribute is `None`. A plain channel doesn't care, but a `DeltaChannel` whose value is a sentinel at that checkpoint needs the saver to replay ancestor deltas (`_needs_replay` → `get_delta_channel_history`); with `saver=None` the replay is **silently skipped** and the channel hydrates empty. `update_state` then merges into that emptiness and writes it forward.

## The fix

Hydrate with the checkpointer those functions already resolved: `bulk_update_state` / `abulk_update_state` pass their local `checkpointer`, and `_prepare_state_snapshot` / `_aprepare_state_snapshot` grow a `saver` parameter fed from the four reader call sites, with `self.checkpointer` as the fallback. Graphs with an attached checkpointer are unaffected — config resolution already falls back to `self.checkpointer` there, which is why the bug never showed in that setup.

## Tests

Four regression tests in `tests/test_delta_channel_update_state.py` cover the config-injected read, history, and update paths (sync and async). They fail on `main` and pass with this change; the rest of the suite is unaffected.
