### PR TITLE
fix(langgraph): support union of literals in command destinations

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -847,13 +847,17 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                                 break
 
                     # Check if it's a Command type
-                    if (
-                        rtn_origin is Command
-                        and (rargs := get_args(rtn))
-                        and get_origin(rargs[0]) is Literal
-                        and (vals := get_args(rargs[0]))
-                    ):
-                        ends = vals
+                    if rtn_origin is Command and (rargs := get_args(rtn)):
+                        command_destinations = rargs[0]
+                        if get_origin(command_destinations) is Literal:
+                            ends = get_args(command_destinations)
+                        elif get_origin(command_destinations) is Union:
+                            ends = tuple(
+                                value
+                                for arg in get_args(command_destinations)
+                                if get_origin(arg) is Literal
+                                for value in get_args(arg)
+                            )
         except (NameError, TypeError, StopIteration):
             pass
 

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5166,6 +5166,7 @@ def test_command_union_of_literals() -> None:
         (edge.source, edge.target) for edge in graph_definition.edges
     ]
 
+
 def test_command_with_static_breakpoints(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -5127,6 +5127,45 @@ def test_command_pydantic_dataclass() -> None:
         assert graph.invoke(State(foo="")) == {"foo": "foobar"}
 
 
+def test_command_union_of_literals() -> None:
+    class State(TypedDict):
+        response: str
+
+    BillingAgent = Literal["billing_agent"]
+    TechSupportAgent = Literal["tech_support_agents"]
+
+    def router(state: State) -> Command[BillingAgent | TechSupportAgent]:
+        return Command(
+            goto="billing_agent",
+            update={"response": "billing"},
+        )
+
+    def billing_agent(state: State):
+        return {"response": state["response"] + " done"}
+
+    def tech_support_agent(state: State):
+        return {"response": state["response"] + " done"}
+
+    builder = StateGraph(State)
+    builder.add_node("router", router)
+    builder.add_node("billing_agent", billing_agent)
+    builder.add_node("tech_support_agents", tech_support_agent)
+
+    builder.add_edge(START, "router")
+    builder.add_edge("billing_agent", END)
+    builder.add_edge("tech_support_agents", END)
+
+    graph = builder.compile()
+
+    graph_definition = graph.get_graph()
+
+    assert ("router", "billing_agent") in [
+        (edge.source, edge.target) for edge in graph_definition.edges
+    ]
+    assert ("router", "tech_support_agents") in [
+        (edge.source, edge.target) for edge in graph_definition.edges
+    ]
+
 def test_command_with_static_breakpoints(
     sync_checkpointer: BaseCheckpointSaver,
 ) -> None:


### PR DESCRIPTION
Fixes langchain-ai#8369

Support Command return annotations where the destination type is a union of Literal types.

## Verification

- `python -m pytest libs\langgraph\tests\test_pregel.py -k "command_union_of_literals"`
- `python -m pytest libs\langgraph\tests\test_pregel.py -k "command_pydantic_dataclass or command_union_of_literals"`
- `ruff check libs\langgraph\langgraph\state.py libs\langgraph\tests\test_pregel.py`
- `ruff format --check libs\langgraph\langgraph\state.py libs\langgraph\tests\test_pregel.py`
- `git diff --check`
- `ty check libs\langgraph`