### PR TITLE
fix(checkpoint-postgres): bound the delta stage-1 walk at the target checkpoint

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/__init__.py
@@ -494,7 +494,14 @@ class PostgresSaver(BasePostgresSaver):
                     # ver_i, blob channel, blob version, inline_i
                     stage1_params.extend([ch, ch, ch, ch])
                 stage1_params.extend(
-                    [thread_id, checkpoint_ns, cursor, cursor, _DELTA_PAGE_SIZE]
+                    [
+                        thread_id,
+                        checkpoint_ns,
+                        checkpoint_id,
+                        cursor,
+                        cursor,
+                        _DELTA_PAGE_SIZE,
+                    ]
                 )
                 cur.execute(stage1_sql, stage1_params)
                 page = cur.fetchall()

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -442,7 +442,14 @@ class AsyncPostgresSaver(BasePostgresSaver):
                     # ver_i, blob channel, blob version, inline_i
                     stage1_params.extend([ch, ch, ch, ch])
                 stage1_params.extend(
-                    [thread_id, checkpoint_ns, cursor, cursor, _DELTA_PAGE_SIZE]
+                    [
+                        thread_id,
+                        checkpoint_ns,
+                        checkpoint_id,
+                        cursor,
+                        cursor,
+                        _DELTA_PAGE_SIZE,
+                    ]
                 )
                 await cur.execute(stage1_sql, stage1_params)
                 page = await cur.fetchall()

--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/base.py
@@ -217,9 +217,20 @@ def _build_delta_stage1_sql(channels: Sequence[str], *, paged: bool) -> str:
                checkpoint -> 'channel_values' -> %s AS inline_1
         FROM checkpoints
         WHERE thread_id = %s AND checkpoint_ns = %s
+          AND checkpoint_id <= %s
           AND (%s::text IS NULL OR checkpoint_id < %s)
         ORDER BY checkpoint_id DESC
         LIMIT %s
+
+    The `checkpoint_id <= %s` bound is the walk's target. The walk follows
+    parent links from the target down to the nearest seed, so rows newer
+    than the target can never contribute — without the bound, a walk
+    targeting an old checkpoint first pages through the entire newer prefix
+    of the chain. Worse, when the target was not in the first page the walk
+    initialized its cursor to `None` ("target is the root") and silently
+    returned an empty history, so any target deeper than one page produced
+    a full-chain scan and a wrong (empty) result. The bound puts the target
+    on the first page by construction.
 
     A stored value for a channel lives in one of two places, because `put`
     splits them:
@@ -258,9 +269,9 @@ def _build_delta_stage1_sql(channels: Sequence[str], *, paged: bool) -> str:
     and uses safe identifiers).
 
     Caller must extend params with `[ch_0 x4, ch_1 x4, ..., thread_id, ns,
-    cursor, cursor, page_size]` when `paged=True` — four per channel: the
-    version lookup, the blob's channel, the version the blob must match, and the
-    inline lookup.
+    target_checkpoint_id, cursor, cursor, page_size]` when `paged=True` — four
+    per channel: the version lookup, the blob's channel, the version the blob
+    must match, and the inline lookup.
 
     When `paged=False`, the WHERE has no cursor predicate and there's no
     LIMIT/ORDER BY — kept as a non-public helper for tests/diagnostics.
@@ -284,6 +295,7 @@ def _build_delta_stage1_sql(channels: Sequence[str], *, paged: bool) -> str:
     )
     if paged:
         sql += (
+            " AND checkpoint_id <= %s"
             " AND (%s::text IS NULL OR checkpoint_id < %s)"
             " ORDER BY checkpoint_id DESC LIMIT %s"
         )

--- a/libs/checkpoint-postgres/tests/test_delta_target_bound.py
+++ b/libs/checkpoint-postgres/tests/test_delta_target_bound.py
@@ -1,0 +1,184 @@
+"""Stage-1 paging bound for `DeltaChannel` history walks.
+
+The walk reconstructs the value *at the target checkpoint* by following
+parent links from the target down to the nearest seed, so rows newer than
+the target can never contribute. The stage-1 pager must therefore start at
+the target `checkpoint_id`, not at the thread's newest checkpoint —
+otherwise every read of an old checkpoint (e.g. `get_state_history` with
+`before`) first scans the entire newer prefix of the chain, once per
+returned checkpoint.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from langgraph.checkpoint.base import Checkpoint, empty_checkpoint
+from langgraph.checkpoint.base.id import uuid6
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+import langgraph.checkpoint.postgres as postgres_module
+import langgraph.checkpoint.postgres.aio as aio_module
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from tests.conftest import DEFAULT_URI
+
+CHANNEL = "items"
+PAGE_SIZE = 4
+CHAIN_LENGTH = 20
+# The seed lives at step 1; target step 3 keeps the expected replay identical
+# to the short-chain seed tests: w1 (the seed's own) and w2.
+TARGET_STEP = 3
+STAGE1_MARKER = "AS ver_0"
+
+
+class _CountingCursor:
+    """Pass-through cursor proxy that counts stage-1 SELECTs."""
+
+    def __init__(self, inner: Any, counts: list[str]) -> None:
+        self._inner = inner
+        self._counts = counts
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    def execute(self, query: Any, *args: Any, **kwargs: Any) -> Any:
+        if STAGE1_MARKER in str(query):
+            self._counts.append(str(query))
+        return self._inner.execute(query, *args, **kwargs)
+
+
+async def _build_chain_async(
+    saver: AsyncPostgresSaver,
+) -> tuple[list[dict], dict | None]:
+    """Seed at step 1, then delta-only steps up to `CHAIN_LENGTH`.
+
+    Returns the per-step head configs (index = step).
+    """
+    thread_id = str(uuid4())
+    configs: list[dict] = []
+    parent: dict | None = None
+    for step in range(CHAIN_LENGTH):
+        config: dict = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        if parent is not None:
+            config["configurable"]["checkpoint_id"] = parent["configurable"][
+                "checkpoint_id"
+            ]
+        cp: Checkpoint = empty_checkpoint()
+        cp["id"] = str(uuid6(clock_seq=step))
+        new_versions: dict[str, Any] = {}
+        if step == 1:
+            cp["channel_values"][CHANNEL] = _DeltaSnapshot([10, 20])
+            cp["channel_versions"][CHANNEL] = "v1"
+            new_versions[CHANNEL] = "v1"
+        else:
+            cp["channel_versions"][CHANNEL] = f"v{step}"
+        parent = await saver.aput(
+            config, cp, {"source": "loop", "step": step, "parents": {}}, new_versions
+        )
+        await saver.aput_writes(parent, [(CHANNEL, f"w{step}")], str(uuid4()))
+        configs.append(parent)
+    return configs, parent
+
+
+def _build_chain_sync(saver: PostgresSaver) -> tuple[list[dict], dict | None]:
+    thread_id = str(uuid4())
+    configs: list[dict] = []
+    parent: dict | None = None
+    for step in range(CHAIN_LENGTH):
+        config: dict = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        if parent is not None:
+            config["configurable"]["checkpoint_id"] = parent["configurable"][
+                "checkpoint_id"
+            ]
+        cp: Checkpoint = empty_checkpoint()
+        cp["id"] = str(uuid6(clock_seq=step))
+        new_versions: dict[str, Any] = {}
+        if step == 1:
+            cp["channel_values"][CHANNEL] = _DeltaSnapshot([10, 20])
+            cp["channel_versions"][CHANNEL] = "v1"
+            new_versions[CHANNEL] = "v1"
+        else:
+            cp["channel_versions"][CHANNEL] = f"v{step}"
+        parent = saver.put(
+            config, cp, {"source": "loop", "step": step, "parents": {}}, new_versions
+        )
+        saver.put_writes(parent, [(CHANNEL, f"w{step}")], str(uuid4()))
+        configs.append(parent)
+    return configs, parent
+
+
+def _assert_result(entry: dict) -> None:
+    seed = entry.get("seed")
+    assert isinstance(seed, _DeltaSnapshot), f"expected a snapshot, got {seed!r}"
+    assert seed.value == [10, 20]
+    assert [w[2] for w in entry["writes"]] == ["w1", "w2"]
+
+
+@pytest.mark.asyncio
+async def test_async_walk_pages_only_at_or_below_the_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Targeting step 3 of a 20-step chain must not page the newer prefix.
+
+    The seed sits two steps below the target, so with the pager bound to the
+    target a single stage-1 page suffices — no matter how many newer
+    checkpoints the thread has.
+    """
+    monkeypatch.setattr(aio_module, "_DELTA_PAGE_SIZE", PAGE_SIZE)
+    async with AsyncPostgresSaver.from_conn_string(DEFAULT_URI) as saver:
+        await saver.setup()
+        configs, _ = await _build_chain_async(saver)
+        target = configs[TARGET_STEP]
+
+        stage1_calls: list[str] = []
+        inner_cursor = saver._cursor
+
+        @asynccontextmanager
+        async def counting_cursor(*args: Any, **kwargs: Any):
+            async with inner_cursor(*args, **kwargs) as cur:
+                yield _CountingCursor(cur, stage1_calls)
+
+        monkeypatch.setattr(saver, "_cursor", counting_cursor)
+
+        result = await saver.aget_delta_channel_history(
+            config=target, channels=[CHANNEL]
+        )
+
+        _assert_result(result[CHANNEL])
+        assert len(stage1_calls) == 1, (
+            f"expected one stage-1 page bounded at the target, got "
+            f"{len(stage1_calls)} pages — the walk scanned the newer prefix"
+        )
+
+
+def test_sync_walk_pages_only_at_or_below_the_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sync saver: same paging bound as the async test above."""
+    monkeypatch.setattr(postgres_module, "_DELTA_PAGE_SIZE", PAGE_SIZE)
+    with PostgresSaver.from_conn_string(DEFAULT_URI) as saver:
+        saver.setup()
+        configs, _ = _build_chain_sync(saver)
+        target = configs[TARGET_STEP]
+
+        stage1_calls: list[str] = []
+        inner_cursor = saver._cursor
+
+        @contextmanager
+        def counting_cursor(*args: Any, **kwargs: Any):
+            with inner_cursor(*args, **kwargs) as cur:
+                yield _CountingCursor(cur, stage1_calls)
+
+        monkeypatch.setattr(saver, "_cursor", counting_cursor)
+
+        result = saver.get_delta_channel_history(config=target, channels=[CHANNEL])
+
+        _assert_result(result[CHANNEL])
+        assert len(stage1_calls) == 1, (
+            f"expected one stage-1 page bounded at the target, got "
+            f"{len(stage1_calls)} pages — the walk scanned the newer prefix"
+        )


### PR DESCRIPTION
`get_delta_channel_history` walks from a target checkpoint back to the nearest seed. But the stage-1 page scan always starts at the newest checkpoint of the thread, not at the target.

This causes two problems when the target is deeper than one page (1024 checkpoints):

1. The result is wrong. The walk cursor starts from `parent_of.get(target_id)`. The target row is not loaded yet, so this returns `None`, and the walk stops as if the target were the root. The method returns an empty history. Through `get_state_history`, old checkpoints then come back with empty channel values.
2. The scan is slow. The channel never finds a seed, so the pager scans the full chain. `get_state_history(before=..., limit=20)` repeats this 20 times. On a thread with ~19k checkpoints this takes ~38 s and still returns empty values.

The fix adds `AND checkpoint_id <= <target>` to the stage-1 query. Rows newer than the target are never needed, and the target row is now always on the first page. This removes both the wrong empty result and the wasted scan.

Verified with `make format`, `make lint`, and the full test suite against the compose Postgres (274 passed). New regression tests for both savers are in `tests/test_delta_target_bound.py`.
