### PR TITLE
Fix BinaryOperatorAggregate ignoring Pydantic default factories (#5225)

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -72,11 +72,17 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     ```
     """
 
-    __slots__ = ("value", "operator")
+    __slots__ = ("value", "operator", "default_factory")
 
-    def __init__(self, typ: type[Value], operator: Callable[[Value, Value], Value]):
+    def __init__(
+        self,
+        typ: type[Value],
+        operator: Callable[[Value, Value], Value],
+        default_factory: Callable[[], Value] | None = None,
+    ):
         super().__init__(typ)
         self.operator = operator
+        self.default_factory = default_factory
         # special forms from typing or collections.abc are not instantiable
         # so we need to replace them with their concrete counterparts
         typ = _strip_extras(typ)
@@ -86,10 +92,16 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
             typ = set
         if typ in (collections.abc.Mapping, collections.abc.MutableMapping):
             typ = dict
-        try:
-            self.value = typ()
-        except Exception:
-            self.value = MISSING
+        if self.default_factory is not None:
+            try:
+                self.value = self.default_factory()
+            except Exception:
+                self.value = MISSING
+        else:
+            try:
+                self.value = typ()
+            except Exception:
+                self.value = MISSING
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, BinaryOperatorAggregate) and _operators_equal(
@@ -108,13 +120,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def copy(self) -> Self:
         """Return a copy of the channel."""
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.default_factory)
         empty.key = self.key
         empty.value = self.value
         return empty
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.default_factory)
         empty.key = self.key
         if checkpoint is not MISSING:
             empty.value = checkpoint

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1823,8 +1823,25 @@ def _get_channels(
         )
 
     type_hints = get_type_hints(schema, include_extras=True)
+    
+    defaults = {}
+    if isclass(schema) and (issubclass(schema, BaseModel) or is_dataclass(schema)):
+        if issubclass(schema, BaseModel):
+            for name, field in schema.model_fields.items():
+                if field.default_factory is not None:
+                    defaults[name] = field.default_factory
+                elif field.default is not getattr(field, "default_factory", None) and field.default.__class__.__name__ != "PydanticUndefinedType":
+                    defaults[name] = lambda v=field.default: v
+        else:
+            import dataclasses
+            for field in dataclasses.fields(schema):
+                if field.default_factory is not dataclasses.MISSING:
+                    defaults[field.name] = field.default_factory
+                elif field.default is not dataclasses.MISSING:
+                    defaults[field.name] = lambda v=field.default: v
+
     all_keys = {
-        name: _get_channel(name, typ)
+        name: _get_channel(name, typ, default_factory=defaults.get(name))
         for name, typ in type_hints.items()
         if name != "__slots__"
     }
@@ -1837,18 +1854,18 @@ def _get_channels(
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[False]
+    name: str, annotation: Any, *, allow_managed: Literal[False], default_factory: Callable[[], Any] | None = None
 ) -> BaseChannel: ...
 
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[True] = True
+    name: str, annotation: Any, *, allow_managed: Literal[True] = True, default_factory: Callable[[], Any] | None = None
 ) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: bool = True
+    name: str, annotation: Any, *, allow_managed: bool = True, default_factory: Callable[[], Any] | None = None
 ) -> BaseChannel | ManagedValueSpec:
     # Strip out Required and NotRequired wrappers
     if hasattr(annotation, "__origin__") and annotation.__origin__ in (
@@ -1864,7 +1881,7 @@ def _get_channel(
     elif channel := _is_field_channel(annotation):
         channel.key = name
         return channel
-    elif channel := _is_field_binop(annotation):
+    elif channel := _is_field_binop(annotation, default_factory=default_factory):
         channel.key = name
         return channel
 
@@ -1901,7 +1918,7 @@ def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     return None
 
 
-def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
+def _is_field_binop(typ: type[Any], default_factory: Callable[[], Any] | None = None) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and callable(meta[-1]):
@@ -1914,7 +1931,7 @@ def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
                 )
                 == 2
             ):
-                return BinaryOperatorAggregate(typ, meta[-1])
+                return BinaryOperatorAggregate(typ, meta[-1], default_factory=default_factory)
             else:
                 raise ValueError(
                     f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"


### PR DESCRIPTION
Fixes #5225

When using a Pydantic BaseModel as a state schema with a field with a default_factory and mapped to BinaryOperatorAggregate (e.g. via Annotated[list[str], extend_list]) the default factory is ignored. BinaryOperatorAggregate was eagerly initializing itself with typ() (becoming []), so Pydantic's internal initialization never got to the point of using the default_factory.

The Solution:

1. Changed BinaryOperatorAggregate.__init__ to accept a default_factory argument and use it as the initial value. (Added it to __slots__ and modified copy()/from_checkpoint().
2. The schema parsing in _get_channels (in state.py) was updated to actively pull the Pydantic and dataclass field default or default_factory values and pass them down into channel creation.
<!-- If you'd like a shoutout on release, add your socials below -->

LinkedIn: https://linkedin.com/in/prathampatidar13
