### PR TITLE
Replace unnecessary BaseException catches with Exception

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -82,7 +82,7 @@ class BackgroundExecutor(AbstractContextManager):
             # This exception is an interruption signal, not an error
             # so we don't want to re-raise it on exit
             self.tasks.pop(task)
-        except BaseException:
+        except Exception:
             pass
         else:
             self.tasks.pop(task)

--- a/libs/langgraph/langgraph/stream/_mux.py
+++ b/libs/langgraph/langgraph/stream/_mux.py
@@ -337,7 +337,7 @@ class StreamMux:
         for transformer in self._transformers:
             try:
                 transformer.fail(err)
-            except BaseException:
+            except Exception:
                 pass
         for ch in self._channels:
             if not ch._closed:
@@ -440,7 +440,7 @@ class StreamMux:
         for transformer in self._transformers:
             try:
                 await transformer.afail(err)
-            except BaseException:
+            except Exception:
                 pass
         for ch in self._channels:
             if not ch._closed:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from collections import Counter, defaultdict, deque
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from random import randrange
 from typing import Annotated, Any, Literal, get_type_hints
@@ -70,6 +70,7 @@ from langgraph.pregel import (
     NodeBuilder,
     Pregel,
 )
+from langgraph.pregel._executor import BackgroundExecutor
 from langgraph.pregel._loop import PregelLoop, SyncPregelLoop
 from langgraph.pregel._runner import PregelRunner
 from langgraph.runtime import RunControl
@@ -99,6 +100,16 @@ from tests.messages import (
 pytestmark = pytest.mark.anyio
 
 logger = logging.getLogger(__name__)
+
+
+def test_background_executor_done_propagates_base_exception() -> None:
+    task = Future()
+    task.set_exception(KeyboardInterrupt())
+    executor = object.__new__(BackgroundExecutor)
+    executor.tasks = {task: (False, True)}
+
+    with pytest.raises(KeyboardInterrupt):
+        executor.done(task)
 
 
 def test_graph_validation() -> None:

--- a/libs/langgraph/tests/test_stream_subgraph_transformer.py
+++ b/libs/langgraph/tests/test_stream_subgraph_transformer.py
@@ -398,6 +398,37 @@ class _AsyncProbeTransformer(StreamTransformer):
         self.failed = err
 
 
+class _FatalFailTransformer(StreamTransformer):
+    supports_sync = True
+
+    def init(self) -> dict[str, Any]:
+        return {}
+
+    def process(self, event: ProtocolEvent) -> bool:
+        return True
+
+    def fail(self, err: BaseException) -> None:
+        raise KeyboardInterrupt
+
+    async def afail(self, err: BaseException) -> None:
+        raise KeyboardInterrupt
+
+
+def test_fail_propagates_base_exception_from_transformer() -> None:
+    mux = StreamMux([_FatalFailTransformer()], is_async=False)
+
+    with pytest.raises(KeyboardInterrupt):
+        mux.fail(RuntimeError("run failed"))
+
+
+@pytest.mark.anyio
+async def test_afail_propagates_base_exception_from_transformer() -> None:
+    mux = StreamMux([_FatalFailTransformer()], is_async=True)
+
+    with pytest.raises(KeyboardInterrupt):
+        await mux.afail(RuntimeError("run failed"))
+
+
 @pytest.mark.anyio
 async def test_async_child_mini_mux_uses_async_lane() -> None:
     mux = StreamMux(


### PR DESCRIPTION
Fixes #7900

Some cleanup and task callback paths were catching `BaseException`,
which also catches system-level exceptions such as `KeyboardInterrupt`
and `SystemExit`.

This change narrows those handlers to `Exception` while preserving
existing cancellation and interruption behavior.

Changes:
- Update stream mux failure handlers
- Update BackgroundExecutor completion handling
- Add regression tests to verify `KeyboardInterrupt` is not swallowed

Tests:
- pytest libs/langgraph/tests/test_stream_subgraph_transformer.py
- NO_DOCKER=true pytest libs/langgraph/tests/test_pregel.py
- ruff check
- git diff --check