### PR TITLE
fix(cli): decode langgraph.json as UTF-8

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -874,7 +874,7 @@ def validate(config: pathlib.Path):
     import json
 
     try:
-        with open(config) as f:
+        with open(config, encoding="utf-8") as f:
             raw_config = json.load(f)
     except json.JSONDecodeError as e:
         raise click.UsageError(f"Invalid JSON in {config}: {e.args[0]}") from None

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -607,7 +607,7 @@ def get_unknown_keys(raw_config: dict) -> list[str]:
 
 def validate_config_file(config_path: pathlib.Path) -> Config:
     """Load and validate a configuration file."""
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         config = json.load(f)
     validated = validate_config(config)
     # Enforce the package.json doesn't enforce an
@@ -616,7 +616,7 @@ def validate_config_file(config_path: pathlib.Path) -> Config:
         package_json_path = config_path.parent / "package.json"
         if package_json_path.is_file():
             try:
-                with open(package_json_path) as f:
+                with open(package_json_path, encoding="utf-8") as f:
                     package_json = json.load(f)
                     if "engines" in package_json:
                         engines = package_json["engines"]
@@ -1173,7 +1173,7 @@ def _get_node_pm_install_cmd(project_dir: pathlib.Path) -> str:
     # inspired by `package-manager-detector`
     def get_pkg_manager_name():
         try:
-            with open(project_dir / "package.json") as f:
+            with open(project_dir / "package.json", encoding="utf-8") as f:
                 pkg = json.load(f)
 
                 if (pkg_manager_name := pkg.get("packageManager")) and isinstance(

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import pathlib
 import re
@@ -8,8 +9,11 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import click
+import pytest
 from click.testing import CliRunner
 
+import langgraph_cli.cli as cli_module
+import langgraph_cli.config as config_module
 import langgraph_cli.deploy as deploy_module
 from langgraph_cli.cli import cli, prepare_args_and_stdin
 from langgraph_cli.config import Config, _get_pip_cleanup_lines, validate_config
@@ -273,6 +277,35 @@ services:
 """
     assert actual_args == expected_args
     assert clean_empty_lines(actual_stdin) == expected_stdin
+
+
+def test_validate_reads_utf8_config_when_locale_is_not_utf8(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_bytes(
+        json.dumps(
+            {
+                "python_version": "3.11",
+                "dependencies": ["."],
+                "graphs": {"代理": "./agent.py:graph"},
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
+
+    real_open = builtins.open
+
+    def ascii_open(file, mode="r", *args, encoding=None, **kwargs):
+        if encoding is None and "b" not in str(mode):
+            encoding = "ascii"
+        return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(cli_module, "open", ascii_open, raising=False)
+    monkeypatch.setattr(config_module, "open", ascii_open, raising=False)
+    result = CliRunner().invoke(cli, ["validate", "-c", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "is valid" in result.output
 
 
 def test_version_option() -> None:

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -1,3 +1,4 @@
+import builtins
 import copy
 import json
 import os
@@ -9,6 +10,7 @@ from unittest.mock import patch
 import click
 import pytest
 
+import langgraph_cli.config as config_module
 from langgraph_cli.config import (
     _BUILD_TOOLS,
     _get_pip_cleanup_lines,
@@ -599,6 +601,61 @@ def test_validate_config_file():
                 else:
                     f.write(package_content)
             validate_config_file(config_path)
+
+
+def _force_ascii_text_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate a non-UTF-8 locale (e.g. Windows GBK) for text-mode open()."""
+    real_open = builtins.open
+
+    def ascii_open(file, mode="r", *args, encoding=None, **kwargs):
+        if encoding is None and "b" not in str(mode):
+            encoding = "ascii"
+        return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(config_module, "open", ascii_open, raising=False)
+
+
+def test_validate_config_file_reads_utf8_when_locale_is_not_utf8(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "langgraph.json"
+    config = {
+        "python_version": "3.11",
+        "dependencies": ["."],
+        "graphs": {"代理": "./agent.py:graph"},
+        "env": {"APP_NAME": "测试"},
+    }
+    config_path.write_bytes(json.dumps(config, ensure_ascii=False).encode("utf-8"))
+
+    _force_ascii_text_open(monkeypatch)
+    validated = validate_config_file(config_path)
+    assert "代理" in validated["graphs"]
+    assert validated["env"]["APP_NAME"] == "测试"
+
+
+def test_validate_config_file_reads_utf8_package_json_when_locale_is_not_utf8(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "langgraph.json"
+    config_path.write_bytes(
+        json.dumps(
+            {"node_version": "20", "graphs": {"agent": "./agent.js:graph"}}
+        ).encode("utf-8")
+    )
+    (tmp_path / "package.json").write_bytes(
+        json.dumps(
+            {
+                "name": "test",
+                "description": "中文描述",
+                "engines": {"node": "20"},
+            },
+            ensure_ascii=False,
+        ).encode("utf-8")
+    )
+
+    _force_ascii_text_open(monkeypatch)
+    validated = validate_config_file(config_path)
+    assert validated["node_version"] == "20"
 
 
 def test_validate_config_multiplatform():


### PR DESCRIPTION
Fixes #8666

Read `langgraph.json` and `package.json` as UTF-8 so the CLI no longer crashes on Windows locales such as GBK when the config contains non-ASCII.

How verified: added regression tests that force text-mode `open()` to ASCII. They fail on main (`UnicodeDecodeError`) and pass with this change. Also re-ran `test_validate_config_file` and the surrounding CLI unit tests (`make format` / `ruff check` clean).