### PR TITLE
fix(checkpoint-postgres): POSTGRES_VERSION is dropped by Make, so the matrix tests pg16 twice

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -4,8 +4,10 @@
 # TESTING AND COVERAGE
 ######################
 
+POSTGRES_VERSION ?= 16
+
 start-postgres:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
 		echo "Failed to start PostgreSQL, printing logs..."; \
 		docker compose -f tests/compose-postgres.yml logs; \
 		exit 1 \
@@ -35,7 +37,7 @@ test:
 
 TEST ?= .
 test_watch:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} make start-postgres; \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) make start-postgres; \
 	uv run ptw $(TEST); \
 	EXIT_CODE=$$?; \
 	make stop-postgres; \


### PR DESCRIPTION
Fixes #8664

## The bug

`libs/checkpoint-postgres/Makefile` sets the Postgres version using shell syntax
inside a Make recipe:

```make
start-postgres:
	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up ...
```

`${VAR:-default}` is shell. Make reads `${...}` as its own variable reference,
finds no `=` inside it, and therefore treats `POSTGRES_VERSION:-16` as a
*variable name*. Nothing defines that name, so it expands to the empty string
and the recipe exports `POSTGRES_VERSION=` — blank.

`tests/compose-postgres.yml` then falls back to its own default:

```yaml
image: pgvector/pgvector:pg${POSTGRES_VERSION:-16}
```

which *is* valid shell, so the container comes up as pg16 regardless of what was
requested.

## Why it matters

`test` iterates the matrix and passes each version down:

```make
POSTGRES_VERSIONS ?= 15 16
test:
	@for version in $(POSTGRES_VERSIONS); do \
		if ! make test_pg_version POSTGRES_VERSION=$$version; then \
```

The loop runs twice and prints `Testing PostgreSQL 15` then
`Testing PostgreSQL 16`, but both runs start pg16. **PostgreSQL 15 is never
exercised, while the log says it was.** A matrix that silently collapses to one
version is worse than no matrix, because it reads as coverage.

## The fix

Declare the default with Make's own conditional assignment and reference it with
`$(...)`:

```make
POSTGRES_VERSION ?= 16

start-postgres:
	POSTGRES_VERSION=$(POSTGRES_VERSION) docker compose ...
```

`?=` keeps a bare `make start-postgres` on pg16, while letting both a
command-line override and an exported environment variable win — the latter
matters because `test_pg_version` invokes the sub-make as
`POSTGRES_VERSION=$(POSTGRES_VERSION) make start-postgres`.

`test_watch` carried the same expression and is fixed the same way.

## Verification

GNU Make 4.4.1, `alpine:3.20`, `make -n` against both revisions of the file:

**Before**

```console
$ make -n start-postgres POSTGRES_VERSION=15
POSTGRES_VERSION= docker compose -f tests/compose-postgres.yml up ...

$ make -n test_watch POSTGRES_VERSION=15
POSTGRES_VERSION= make start-postgres; \
```

**After**

```console
$ make -n start-postgres POSTGRES_VERSION=15
POSTGRES_VERSION=15 docker compose -f tests/compose-postgres.yml up ...

$ make -n start-postgres
POSTGRES_VERSION=16 docker compose -f tests/compose-postgres.yml up ...

$ make -n test_watch POSTGRES_VERSION=15
POSTGRES_VERSION=15 make start-postgres; \
```

Exported environment variable still wins over the `?=` default:

```console
$ POSTGRES_VERSION=15 make -n start-postgres
POSTGRES_VERSION=15 docker compose -f tests/compose-postgres.yml up ...
```

And the real call path, `test_pg_version`, now propagates correctly:

```console
$ make -n test_pg_version POSTGRES_VERSION=15
echo "Testing PostgreSQL 15"
POSTGRES_VERSION=15 make start-postgres
uv run pytest .
```

## Scope

One declaration and two lines, in one Makefile. No library code, no test code,
and no change to what a bare `make start-postgres` does.
