### PR TITLE
test(checkpoint): add min-versions CI check, fix stale langchain-core floor

### DIFF
--- a/.github/scripts/get_min_versions.py
+++ b/.github/scripts/get_min_versions.py
@@ -1,0 +1,96 @@
+"""Generate a pip constraints file pinning a package's direct runtime
+dependencies to the minimum versions declared in its pyproject.toml.
+
+This is used by CI to install a library against the *oldest* versions of
+its dependencies that it claims to support (e.g. `langchain-core==0.2.38`
+instead of whatever happens to be newest on PyPI), which catches code that
+silently relies on APIs added after the declared floor.
+
+Usage:
+    python get_min_versions.py path/to/pyproject.toml > min-versions-constraints.txt
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+# Matches a PEP 508 dependency string, e.g.:
+#   "langchain-core>=0.2.38"
+#   "psycopg[binary]>=3.1,<4"
+_DEP_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*(\[[^\]]*\])?\s*(.*?)\s*$")
+
+# Matches the lower-bound clause of a version specifier, e.g. ">=1.2.3" or
+# "~=1.2.3". We deliberately don't try to satisfy exclusion clauses
+# (e.g. "!=1.2.4") here -- the goal is just to find the floor.
+_LOWER_BOUND_RE = re.compile(r"(?:>=|~=)\s*([0-9][0-9A-Za-z.\-]*)")
+
+
+def parse_dependency(dep: str) -> tuple[str, str] | None:
+    """Split a PEP 508 dependency string into (name, version_spec).
+
+    Returns None if the string can't be parsed (e.g. it's a URL or a
+    local path dependency, which have no version to pin).
+    """
+    match = _DEP_RE.match(dep)
+    if not match:
+        return None
+    name, _extras, version_spec = match.groups()
+    return name, version_spec
+
+
+def get_min_version(version_spec: str) -> str | None:
+    """Return the minimum version declared in a specifier, if any.
+
+    If a dependency has multiple lower bounds (unusual, but technically
+    legal), the *highest* of them wins, since that's the effective floor.
+    """
+    candidates = [m.group(1) for m in _LOWER_BOUND_RE.finditer(version_spec)]
+    if not candidates:
+        return None
+    # Compare as tuples of ints where possible so "0.10.0" > "0.9.0".
+    def sort_key(v: str) -> tuple:
+        return tuple(int(p) if p.isdigit() else p for p in re.split(r"[.\-]", v))
+
+    return max(candidates, key=sort_key)
+
+
+def get_min_versions(pyproject_path: Path) -> dict[str, str]:
+    """Return {package_name: min_version} for every pinned direct dependency."""
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    dependencies = data.get("project", {}).get("dependencies", [])
+    pins: dict[str, str] = {}
+    for dep in dependencies:
+        parsed = parse_dependency(dep)
+        if parsed is None:
+            continue
+        name, version_spec = parsed
+        if not version_spec:
+            continue
+        min_version = get_min_version(version_spec)
+        if min_version:
+            pins[name] = min_version
+    return pins
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: get_min_versions.py <path-to-pyproject.toml>", file=sys.stderr)
+        sys.exit(1)
+
+    pyproject_path = Path(sys.argv[1])
+    if not pyproject_path.is_file():
+        print(f"No such file: {pyproject_path}", file=sys.stderr)
+        sys.exit(1)
+
+    pins = get_min_versions(pyproject_path)
+    for name, version in sorted(pins.items()):
+        print(f"{name}=={version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_test_min_versions.yml
+++ b/.github/workflows/_test_min_versions.yml
@@ -1,0 +1,52 @@
+name: test-min-versions
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        required: true
+        type: string
+        description: "From which folder this pipeline executes"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "min-versions #${{ inputs.working-directory }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Use the lowest Python version the package claims to support, so
+      # this job exercises the "oldest everything" combination rather than
+      # just the oldest dependency versions on a recent interpreter.
+      - name: Set up Python
+        uses: ./.github/actions/uv_setup
+        with:
+          python-version: "3.10"
+          cache-suffix: min-versions-${{ inputs.working-directory }}
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Generate min-versions constraints
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          python "$GITHUB_WORKSPACE/.github/scripts/get_min_versions.py" pyproject.toml \
+            | tee /tmp/min-versions-constraints.txt
+
+      - name: Install package pinned to its declared minimum versions
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          uv venv .venv-min
+          uv pip install -p .venv-min \
+            -c /tmp/min-versions-constraints.txt \
+            -e . --group test
+
+      - name: Run tests against minimum versions
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          source .venv-min/bin/activate
+          python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,29 @@ jobs:
       working-directory: ${{ matrix.working-directory }}
     secrets: inherit
 
+  # Installs libs/checkpoint pinned to the *declared* minimum versions of
+  # its direct dependencies (see .github/scripts/get_min_versions.py) and
+  # runs its test suite against them. This catches lower bounds in
+  # pyproject.toml that have drifted out of sync with what the code
+  # actually requires.
+  #
+  # Starting with just libs/checkpoint since it has no docker/db
+  # dependency; other libs can be added to this matrix as follow-ups.
+  test-min-versions:
+    needs: changes
+    name: cd ${{ matrix.working-directory }}
+    strategy:
+      matrix:
+        working-directory:
+          [
+            "libs/checkpoint",
+          ]
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.deps == 'true'
+    uses: ./.github/workflows/_test_min_versions.yml
+    with:
+      working-directory: ${{ matrix.working-directory }}
+    secrets: inherit
+
   # NOTE: we're testing langgraph separately because it requires a different matrix
   test-langgraph:
     needs: changes

--- a/libs/checkpoint/pyproject.toml
+++ b/libs/checkpoint/pyproject.toml
@@ -12,7 +12,17 @@ readme = "README.md"
 license = "MIT"
 license-files = ['LICENSE']
 dependencies = [
-    "langchain-core>=0.2.38",
+    # NOTE: keep in sync with the actual minimum required by the code, not
+    # just "whatever version we happened to develop against". This is
+    # enforced by the min-versions CI job (see .github/workflows/ci.yml),
+    # which installs the package pinned to these floors and runs the test
+    # suite against them.
+    #
+    # langchain-core: Reviver(allowed_objects=...) in jsonplus.py requires
+    # the `allowed_objects` kwarg, added in langchain-core 0.3.81. The
+    # previous floor of 0.2.38 was stale and raised a TypeError at import
+    # time when actually installed.
+    "langchain-core>=0.3.81",
     "ormsgpack>=1.12.0",
 ]
 


### PR DESCRIPTION
### Problem
`libs/checkpoint` declared `langchain-core>=0.2.38` as its minimum version[cite: 1]. However, `Reviver(allowed_objects=...)` in `jsonplus.py` relies on the `allowed_objects` kwarg, which was only added in `langchain-core 0.3.81`[cite: 1]. Installing the package at its declared floor raised the following error[cite: 1]:
`TypeError: Reviver.__init__() got an unexpected keyword argument 'allowed_objects'`[cite: 1]

### Solution
This PR aligns the declared lower bound with the actual code requirements and adds a CI job to automatically catch drifted minimum versions in the future[cite: 1].

**Changes:**
* **Bumped Floor:** Updated `libs/checkpoint/pyproject.toml` to accurately require `langchain-core>=0.3.81`[cite: 1].
* **New Script:** Added `.github/scripts/get_min_versions.py` to parse `pyproject.toml` dependencies and pin them to their absolute declared lower bounds for testing[cite: 1].
* **New Reusable Workflow:** Created `.github/workflows/_test_min_versions.yml` to install a library against these pinned minimums and run tests on the oldest supported Python version[cite: 1].
* **CI Integration:** Added the `test-min-versions` job to `.github/workflows/ci.yml` specifically for `libs/checkpoint` (other libs can be appended in follow-ups as they don't require docker/db)[cite: 1].

### Verification
* Confirmed locally that pinning `langchain-core==0.2.38` strictly reproduces the import error[cite: 1].
* Confirmed that pinning `langchain-core==0.3.81` successfully passes the full test suite (156 passed, 17 skipped) on Python 3.10, the package's declared minimum[cite: 1].