### PR TITLE
fix(cli): read langgraph.json as UTF-8 to avoid locale-dependent crashes

### DIFF
--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -607,7 +607,7 @@ def get_unknown_keys(raw_config: dict) -> list[str]:
 
 def validate_config_file(config_path: pathlib.Path) -> Config:
     """Load and validate a configuration file."""
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         config = json.load(f)
     validated = validate_config(config)
     # Enforce the package.json doesn't enforce an

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -601,6 +601,26 @@ def test_validate_config_file():
             validate_config_file(config_path)
 
 
+def test_validate_config_file_reads_utf8_config():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = pathlib.Path(tmpdir)
+        config_path = tmpdir_path / "langgraph.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "python_version": "3.11",
+                    "dependencies": ["."],
+                    "graphs": {"agént": "./agent.py:graph"},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        validated = validate_config_file(config_path)
+        assert validated["graphs"] == {"agént": "./agent.py:graph"}
+
+
 def test_validate_config_multiplatform():
     # default node
     config = validate_config(


### PR DESCRIPTION
﻿## Repro

On Windows with a non-UTF-8 locale, create a `langgraph.json` containing non-ASCII text (for example, graph key names with accented characters) and run a CLI command that loads config.

Before this change, config loading used the process default text encoding and could fail with decode errors or silently corrupt non-ASCII values depending on system locale.

## Fix

- Read `langgraph.json` using explicit `encoding="utf-8"` in the CLI config loader.
- Read `package.json` and CLI validate-config JSON with explicit UTF-8 as well, matching JSON/package.json encoding expectations.
- Add a regression test that writes non-ASCII JSON to `langgraph.json` and verifies `validate_config_file` loads/parses it successfully.

Fixes #8666.
