### PR TITLE
fix(cli): decode langgraph.json and package.json as UTF-8 regardless of locale

### DIFF
--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -874,7 +874,7 @@ def validate(config: pathlib.Path):
     import json
 
     try:
-        with open(config) as f:
+        with open(config, encoding="utf-8") as f:
             raw_config = json.load(f)
     except json.JSONDecodeError as e:
         raise click.UsageError(f"Invalid JSON in {config}: {e.args[0]}") from None

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -607,7 +607,7 @@ def get_unknown_keys(raw_config: dict) -> list[str]:
 
 def validate_config_file(config_path: pathlib.Path) -> Config:
     """Load and validate a configuration file."""
-    with open(config_path) as f:
+    with open(config_path, encoding="utf-8") as f:
         config = json.load(f)
     validated = validate_config(config)
     # Enforce the package.json doesn't enforce an
@@ -616,7 +616,7 @@ def validate_config_file(config_path: pathlib.Path) -> Config:
         package_json_path = config_path.parent / "package.json"
         if package_json_path.is_file():
             try:
-                with open(package_json_path) as f:
+                with open(package_json_path, encoding="utf-8") as f:
                     package_json = json.load(f)
                     if "engines" in package_json:
                         engines = package_json["engines"]
@@ -1173,7 +1173,7 @@ def _get_node_pm_install_cmd(project_dir: pathlib.Path) -> str:
     # inspired by `package-manager-detector`
     def get_pkg_manager_name():
         try:
-            with open(project_dir / "package.json") as f:
+            with open(project_dir / "package.json", encoding="utf-8") as f:
                 pkg = json.load(f)
 
                 if (pkg_manager_name := pkg.get("packageManager")) and isinstance(


### PR DESCRIPTION

Fixes #8665
Fix langgraph_cli to read langgraph.json and package.json as UTF-8 explicitly rather than relying on the platform locale, which can silently corrupt non-ASCII JSON content or raise UnicodeDecodeError on non-UTF-8 locales.


How I verify my code works?
Added a regression test that simulates a `cp936` locale and uses a non-ASCII graph name (`café-agent`) in a UTF-8 `langgraph.json`. Verified with `uv run python /tmp/test_utf8_cli.py`, which correctly returned `['café-agent']` from the CLI and matched the value stored in the UTF-8 file.

