### PR TITLE
fix(langgraph): honor pydantic field aliases and Annotated-reducer defaults

### DIFF
--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -72,11 +72,26 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     ```
     """
 
-    __slots__ = ("value", "operator")
+    __slots__ = ("value", "operator", "initial_value")
 
-    def __init__(self, typ: type[Value], operator: Callable[[Value, Value], Value]):
+    def __init__(
+        self,
+        typ: type[Value],
+        operator: Callable[[Value, Value], Value],
+        initial_value: Value = MISSING,
+    ):
         super().__init__(typ)
         self.operator = operator
+        # Remembered so `copy`/`from_checkpoint` can rebuild an equivalent
+        # channel without losing a caller-supplied seed value (e.g. a
+        # pydantic `Field(default_factory=...)` on the Annotated-reducer
+        # field this channel backs) -- they only know `typ`/`operator`
+        # otherwise, and re-deriving `typ()` from scratch would silently
+        # drop it on every fresh run.
+        self.initial_value = initial_value
+        if initial_value is not MISSING:
+            self.value = initial_value
+            return
         # special forms from typing or collections.abc are not instantiable
         # so we need to replace them with their concrete counterparts
         typ = _strip_extras(typ)
@@ -108,13 +123,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def copy(self) -> Self:
         """Return a copy of the channel."""
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.initial_value)
         empty.key = self.key
         empty.value = self.value
         return empty
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.initial_value)
         empty.key = self.key
         if checkpoint is not MISSING:
             empty.value = checkpoint

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -30,6 +30,7 @@ from langgraph.cache.base import BaseCache
 from langgraph.checkpoint.base import Checkpoint
 from langgraph.store.base import BaseStore
 from pydantic import BaseModel, TypeAdapter
+from pydantic_core import PydanticUndefined
 from typing_extensions import NotRequired, Required, Self, Unpack, is_typeddict
 
 from langgraph._internal import _serde
@@ -44,7 +45,7 @@ from langgraph._internal._fields import (
     get_field_default,
     get_update_as_tuples,
 )
-from langgraph._internal._pydantic import create_model
+from langgraph._internal._pydantic import create_model, get_fields
 from langgraph._internal._runnable import coerce_to_runnable
 from langgraph._internal._timeout import coerce_timeout_policy
 from langgraph._internal._typing import EMPTY_SEQ, MISSING, DeprecatedKwargs
@@ -1743,6 +1744,18 @@ _S = TypeVar("_S")
 
 
 def _coerce_state(schema: type[_S], input: dict[str, Any]) -> _S:
+    if isclass(schema) and issubclass(schema, BaseModel):
+        # `input` is keyed by field (attribute) name -- that's what channels
+        # use internally, regardless of any `Field(alias=...)` on the model.
+        # Pydantic's constructor only accepts field names in place of an
+        # alias when `populate_by_name=True` is set, so remap to aliases
+        # here rather than requiring every state model to opt into that.
+        fields = schema.model_fields
+        input = {
+            (info.alias or name): input[name]
+            for name, info in fields.items()
+            if name in input
+        }
     return schema(**input)
 
 
@@ -1823,8 +1836,19 @@ def _get_channels(
         )
 
     type_hints = get_type_hints(schema, include_extras=True)
+    # A reducer channel (BinaryOperatorAggregate) seeds its own initial value
+    # from bare `typ()` -- e.g. `[]` for `list[str]` -- since `type_hints`
+    # carries no Field default/default_factory. That silently shadows a
+    # pydantic model's `Field(default_factory=...)` on an Annotated-reducer
+    # field: the channel's placeholder is a real, present value, not a
+    # missing one, so the model constructor never gets the chance to apply
+    # its own default. Look defaults up here, when available, so the
+    # channel can be seeded correctly instead.
+    field_infos = (
+        get_fields(schema) if isclass(schema) and issubclass(schema, BaseModel) else {}
+    )
     all_keys = {
-        name: _get_channel(name, typ)
+        name: _get_channel(name, typ, default=_field_default(field_infos.get(name)))
         for name, typ in type_hints.items()
         if name != "__slots__"
     }
@@ -1835,20 +1859,41 @@ def _get_channels(
     )
 
 
+def _field_default(info: Any) -> Any:
+    """Resolve a pydantic FieldInfo's default/default_factory, or MISSING."""
+    if info is None:
+        return MISSING
+    if info.default_factory is not None:
+        try:
+            # Pydantic 2.x supports a single-arg default_factory that
+            # receives already-validated data; we have none at channel
+            # construction time, so only call the more common no-arg form.
+            return info.default_factory()
+        except TypeError:
+            return MISSING
+    if info.default is not PydanticUndefined:
+        return info.default
+    return MISSING
+
+
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[False]
+    name: str, annotation: Any, *, allow_managed: Literal[False], default: Any = MISSING
 ) -> BaseChannel: ...
 
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[True] = True
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: Literal[True] = True,
+    default: Any = MISSING,
 ) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: bool = True
+    name: str, annotation: Any, *, allow_managed: bool = True, default: Any = MISSING
 ) -> BaseChannel | ManagedValueSpec:
     # Strip out Required and NotRequired wrappers
     if hasattr(annotation, "__origin__") and annotation.__origin__ in (
@@ -1864,7 +1909,7 @@ def _get_channel(
     elif channel := _is_field_channel(annotation):
         channel.key = name
         return channel
-    elif channel := _is_field_binop(annotation):
+    elif channel := _is_field_binop(annotation, default=default):
         channel.key = name
         return channel
 
@@ -1901,7 +1946,9 @@ def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     return None
 
 
-def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
+def _is_field_binop(
+    typ: type[Any], *, default: Any = MISSING
+) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and callable(meta[-1]):
@@ -1914,7 +1961,7 @@ def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
                 )
                 == 2
             ):
-                return BinaryOperatorAggregate(typ, meta[-1])
+                return BinaryOperatorAggregate(typ, meta[-1], default)
             else:
                 raise ValueError(
                     f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"

--- a/libs/langgraph/langgraph/pregel/_io.py
+++ b/libs/langgraph/langgraph/pregel/_io.py
@@ -4,6 +4,8 @@ from collections import Counter
 from collections.abc import Iterator, Mapping, Sequence
 from typing import Any, Literal
 
+from pydantic import BaseModel
+
 from langgraph._internal._constants import (
     ERROR,
     INTERRUPT,
@@ -18,6 +20,34 @@ from langgraph.constants import START, TAG_HIDDEN
 from langgraph.errors import InvalidUpdateError
 from langgraph.pregel._log import logger
 from langgraph.types import Command, PregelExecutableTask, Send
+
+
+def normalize_input_aliases(input_schema: Any, chunk: Any) -> Any:
+    """Remap pydantic field aliases to field names in a dict input.
+
+    `map_input` below matches dict keys against channel names, which are
+    always the schema's field (attribute) names -- never aliases. A state
+    model declared with `Field(alias=...)` therefore silently drops any
+    input keyed by the alias (the natural way to call it, since pydantic
+    itself accepts aliases in its constructor): `map_input` logs a warning
+    and skips the key, the channel is never written, and the graph proceeds
+    with that field unset. Remapping alias keys to field names here, before
+    the input reaches `map_input`, keeps `map_input` itself schema-agnostic.
+    """
+    if (
+        not isinstance(chunk, dict)
+        or not isinstance(input_schema, type)
+        or not issubclass(input_schema, BaseModel)
+    ):
+        return chunk
+    alias_to_name = {
+        info.alias: name
+        for name, info in input_schema.model_fields.items()
+        if info.alias and info.alias != name
+    }
+    if not alias_to_name or not (alias_to_name.keys() & chunk.keys()):
+        return chunk
+    return {alias_to_name.get(k, k): v for k, v in chunk.items()}
 
 
 def read_channel(

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -137,7 +137,7 @@ from langgraph.pregel._checkpoint import (
     get_updated_channels_from_tasks,
 )
 from langgraph.pregel._draw import draw_graph
-from langgraph.pregel._io import map_input, read_channels
+from langgraph.pregel._io import map_input, normalize_input_aliases, read_channels
 from langgraph.pregel._loop import (
     AsyncPregelLoop,
     SyncPregelLoop,
@@ -2897,7 +2897,7 @@ class Pregel(
                         )
 
             with SyncPregelLoop(
-                input,
+                normalize_input_aliases(getattr(self, "input_schema", None), input),
                 stream=StreamProtocol(stream.put, stream_modes),
                 config=config,
                 store=store,
@@ -3351,7 +3351,7 @@ class Pregel(
                         )
 
             async with AsyncPregelLoop(
-                input,
+                normalize_input_aliases(getattr(self, "input_schema", None), input),
                 stream=StreamProtocol(stream.put_nowait, stream_modes),
                 config=config,
                 store=store,


### PR DESCRIPTION
Fixes #2555
Fixes #5225

State models with `Field(alias=...)` silently dropped input keyed by the alias, and `Annotated`-reducer fields with `Field(default_factory=...)` ignored their default. Both are channel/input-construction bugs in `graph/state.py` and `pregel/_io.py`, fixed without requiring any config change on the state model itself.

Verified against the reported repros plus the existing `test_pydantic.py`, `test_channels.py`, `test_pregel.py`, and `test_pregel_async.py` suites: no regressions.