### PR TITLE
docs: add Corridor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This repository is a monorepo. Each library lives in a subdirectory under `libs/`.
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 When you modify code in any library, run the following commands in that library's directory before creating a pull request:
 
 - `make format` – run code formatters

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository is a monorepo. Each library lives in a subdirectory under `libs/
 
 ## Corridor security analysis
 
-Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
 
 </corridor>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This repository is a monorepo. Each library lives in a subdirectory under `libs/`.
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 When you modify code in any library, run the following commands in that library's directory before creating a pull request:
 
 - `make format` – run code formatters


### PR DESCRIPTION
Add a repository-wide `<corridor>` block to `AGENTS.md` requiring agents to plan first and run Corridor `analyzePlan` before generating or modifying code. The tags are explicit and balanced so Corridor-specific guidance remains scoped.

Validation: `git diff --check` and a tag-balance assertion.