### PR TITLE
fix(checkpoint): serialize arbitrary-size integers

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -300,6 +300,7 @@ EXT_PYDANTIC_V1 = 4
 EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 EXT_DELTA_SNAPSHOT = 7
+EXT_BIG_INT = 8
 
 
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
@@ -476,6 +477,8 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, obj.value),
             ),
         )
+    elif isinstance(obj, int):
+        return ormsgpack.Ext(EXT_BIG_INT, str(obj).encode())
     elif isinstance(obj, SendProtocol):
         args: tuple[Any, ...] = (obj.node, obj.arg)
         if (timeout := getattr(obj, "timeout", None)) is not None:
@@ -739,6 +742,8 @@ def _create_msgpack_ext_hook(
                 return arr.reshape(shape, order=order)
             except Exception:
                 return None
+        elif code == EXT_BIG_INT:
+            return int(data)
         return None
 
     return ext_hook
@@ -837,6 +842,8 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             return arr.reshape(shape, order=order).tolist()
         except Exception:
             return
+    elif code == EXT_BIG_INT:
+        return int(data)
 
 
 class InvalidModuleError(Exception):
@@ -850,6 +857,7 @@ _option = (
     ormsgpack.OPT_NON_STR_KEYS
     | ormsgpack.OPT_PASSTHROUGH_DATACLASS
     | ormsgpack.OPT_PASSTHROUGH_DATETIME
+    | ormsgpack.OPT_PASSTHROUGH_BIG_INT
     | ormsgpack.OPT_PASSTHROUGH_ENUM
     | ormsgpack.OPT_PASSTHROUGH_UUID
     | ormsgpack.OPT_REPLACE_SURROGATES

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -1,4 +1,5 @@
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -324,6 +325,29 @@ def test_serde_jsonplus_json_mode() -> None:
         expected_result["my_secret_str_v1"] = "meow"
 
     assert result == expected_result
+
+
+def test_serde_jsonplus_round_trips_big_integers() -> None:
+    """Round-trip integers outside msgpack's signed and unsigned 64-bit range."""
+    digest_int = int.from_bytes(hashlib.sha256(b"dedup-key").digest(), byteorder="big")
+    value = {
+        "positive_boundary": 2**64,
+        "negative_boundary": -(2**63) - 1,
+        "dedup_key": digest_int,
+        "nested": [2**256, {"negative": -(2**256)}],
+    }
+
+    serde = JsonPlusSerializer()
+
+    assert serde.loads_typed(serde.dumps_typed(value)) == value
+
+
+def test_serde_jsonplus_json_mode_round_trips_big_integers() -> None:
+    """The JSON-compatible msgpack hook preserves large integer values."""
+    value = {"big": 2**256, "small": 1}
+    serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
+
+    assert serde.loads_typed(serde.dumps_typed(value)) == value
 
 
 def test_serde_jsonplus_bytes() -> None:


### PR DESCRIPTION
Closes #8673

---

Checkpoints currently fail to serialize Python integers outside MessagePack's signed and unsigned 64-bit ranges, even though the serializer already supports other arbitrary-precision numeric values such as `Decimal`.

This change uses a dedicated MessagePack extension for integers that fall outside the native range. In-range integers retain their existing native encoding, so existing checkpoints and their serialized representation are unaffected.

The extension is decoded by both the standard deserialization hook and the JSON-compatible hook. Regression coverage includes the first out-of-range values in each direction, a SHA-256-derived integer, nested containers, and the JSON-compatible path.

## Release note

`JsonPlusSerializer` now round-trips checkpoint values containing integers outside the 64-bit MessagePack range.

Tests:

- `uv run pytest tests/test_jsonplus.py -q` — 101 passed
- `uv run pytest tests/test_encrypted.py -q` — 17 passed
- Ruff, import-order, and type checks passed

_Disclosure: this pull request was prepared with ChatGPT (model: GPT-5) under @Yash-Chindam's direction. The commit carries an `Assisted-by:` trailer._
