### PR TITLE
fix: emit values for no-op steps

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -73,7 +73,7 @@ from langgraph.channels.base import BaseChannel
 from langgraph.channels.binop import _get_overwrite
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.untracked_value import UntrackedValue
-from langgraph.constants import TAG_HIDDEN
+from langgraph.constants import START, TAG_HIDDEN
 from langgraph.errors import (
     EmptyInputError,
     GraphInterrupt,
@@ -697,13 +697,27 @@ class PregelLoop:
             self.trigger_to_nodes,
         )
         # produce values output
-        if not self.updated_channels.isdisjoint(
-            (self.output_keys,)
-            if isinstance(self.output_keys, str)
-            else self.output_keys
+        if (
+            self.stream is not None
+            and "values" in self.stream.modes
+            and (
+                not self.updated_channels.isdisjoint(
+                    (self.output_keys,)
+                    if isinstance(self.output_keys, str)
+                    else self.output_keys
+                )
+                or any(
+                    task.name != START
+                    and (
+                        task.config is None
+                        or TAG_HIDDEN not in task.config.get("tags", ())
+                    )
+                    for task in self.tasks.values()
+                )
+            )
         ):
             self._emit(
-                "values", map_output_values, self.output_keys, writes, self.channels
+                "values", map_output_values, self.output_keys, True, self.channels
             )
         # capture delta-channel writes for exit-mode accumulator before clearing
         if self._exit_delta_writes is not None:

--- a/libs/langgraph/tests/test_pregel.py
+++ b/libs/langgraph/tests/test_pregel.py
@@ -1764,6 +1764,35 @@ def test_conditional_entrypoint_to_multiple_state_graph(
     }
 
 
+@pytest.mark.parametrize("noop_result", [None, {}])
+def test_stream_values_emits_noop_steps(noop_result: Any) -> None:
+    class State(TypedDict):
+        value: int
+
+    def increment(state: State) -> State:
+        return {"value": state["value"] + 1}
+
+    def noop(state: State) -> Any:
+        return noop_result
+
+    builder = StateGraph(State)
+    builder.add_node("increment", increment)
+    builder.add_node("noop", noop)
+    builder.add_node("finish", increment)
+    builder.add_edge(START, "increment")
+    builder.add_edge("increment", "noop")
+    builder.add_edge("noop", "finish")
+    builder.add_edge("finish", END)
+    graph = builder.compile()
+
+    assert list(graph.stream({"value": 0}, stream_mode="values")) == [
+        {"value": 0},
+        {"value": 1},
+        {"value": 1},
+        {"value": 2},
+    ]
+
+
 def test_conditional_state_graph_with_list_edge_inputs(snapshot: SnapshotAssertion):
     class State(TypedDict):
         foo: Annotated[list[str], operator.add]


### PR DESCRIPTION
## Summary

`stream_mode="values"` now emits the state snapshot after a visible no-op node, matching the documented “after each step” behavior. This covers nodes that return `None` or `{}` while preserving the existing `updates` stream and initial-step filtering.

## Root cause

The shared Pregel loop only emitted `values` when an output channel changed. A no-op node can still complete a graph step without changing an output channel, so its unchanged state snapshot was dropped.

## Validation

- `NO_DOCKER=true uv run pytest -q tests/test_pregel.py --disable-warnings` (459 passed)
- `NO_DOCKER=true uv run pytest -q tests/test_pregel.py -k 'stream_values_emits_noop_steps or interrupt_stream_mode_values' --disable-warnings` (5 passed)
- `NO_DOCKER=true uv run pytest -q tests/test_pregel_async.py -k 'interrupt_stream_mode_values' --disable-warnings` (2 passed)
- `make lint`
- `make format`

Fixes #8672
