### PR TITLE
fix: prevent SSL connection close in AsyncPostgresSaver by adding keepalives (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -78,11 +78,21 @@ class AsyncPostgresSaver(BasePostgresSaver):
         Returns:
             AsyncPostgresSaver: A new AsyncPostgresSaver instance.
         """
-        async with await AsyncConnection.connect(
-            conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
-        ) as conn:
+        # Add keepalives to prevent idle timeout that closes SSL connection
+        connect_kwargs = {
+            "autocommit": True,
+            "prepare_threshold": 0,
+            "row_factory": dict_row,
+            "keepalives": 1,
+            "keepalives_idle": 30,
+            "keepalives_interval": 15,
+            "keepalives_count": 5,
+        }
+        async with await AsyncConnection.connect(conn_string, **connect_kwargs) as conn:
             if pipeline:
                 async with conn.pipeline() as pipe:
+                    # Sync the pipeline before yielding to ensure no stale state
+                    await pipe.sync()
                     yield cls(conn=conn, pipe=pipe, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)


### PR DESCRIPTION
## What
AsyncPostgresSaver occasionally fails with `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when using the async pipeline or after long waits between operations, especially behind connection poolers like Supabase.

## Fix
Added keepalive parameters to the Postgres connection in `from_conn_string` to prevent the server from closing idle connections. Also, explicitly sync the pipeline before yielding the saver to ensure no stale state.

Closes #5675