### PR TITLE
fix(checkpoint-sqlite): walk parent chain by parent_id not ID ordering

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/_delta.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/_delta.py
@@ -26,16 +26,23 @@ from typing import Any
 
 from langgraph.checkpoint.base import DeltaChannelHistory, PendingWrite
 
-# Stage 1 streams ancestors of `target_cid` newest-first. The `<=`
-# predicate keeps target itself in the stream so we can read its
-# `parent_checkpoint_id` from the first row without a separate lookup;
-# the caller skips target's own writes/seed (matches the
-# `BaseCheckpointSaver` contract).
+# Stage 1 walks the parent chain of `target_cid` newest-first using a
+# recursive CTE that follows `parent_checkpoint_id` links. This is
+# robust to non-monotonic checkpoint IDs (e.g. a child whose ID is
+# lexicographically smaller than its parent's) — a plain `<=` range
+# scan would silently drop ancestors with "larger" IDs.
 DELTA_STAGE1_SQL = (
-    "SELECT checkpoint_id, parent_checkpoint_id, type, checkpoint "
-    "FROM checkpoints "
-    "WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id <= ? "
-    "ORDER BY checkpoint_id DESC"
+    "WITH RECURSIVE chain AS ("
+    "  SELECT checkpoint_id, parent_checkpoint_id, type, checkpoint "
+    "  FROM checkpoints "
+    "  WHERE thread_id = ? AND checkpoint_ns = ? AND checkpoint_id = ? "
+    "  UNION ALL "
+    "  SELECT c.checkpoint_id, c.parent_checkpoint_id, c.type, c.checkpoint "
+    "  FROM checkpoints c "
+    "  INNER JOIN chain ON c.checkpoint_id = chain.parent_checkpoint_id "
+    "  WHERE chain.parent_checkpoint_id IS NOT NULL"
+    ")"
+    "SELECT checkpoint_id, parent_checkpoint_id, type, checkpoint FROM chain"
 )
 
 

--- a/libs/checkpoint-sqlite/tests/test_get_delta_channel_history.py
+++ b/libs/checkpoint-sqlite/tests/test_get_delta_channel_history.py
@@ -33,6 +33,7 @@ pytest.importorskip("langgraph.channels.delta", reason="langgraph core not insta
 pytest.importorskip("langgraph.graph", reason="langgraph core not installed")
 
 from langgraph.channels.delta import DeltaChannel  # type: ignore[import-untyped]  # noqa: I001
+from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from langgraph.graph import END, START, StateGraph  # type: ignore[import-untyped]
 from typing_extensions import TypedDict
@@ -253,19 +254,119 @@ async def test_writes_history_oldest_to_newest_async() -> None:
 
 
 async def test_seed_omitted_when_walk_reaches_root_async() -> None:
-    """Async equivalent of the root-walk seed-absence check."""
+        """Async equivalent of the root-walk seed-absence check."""
+        async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+            config: RunnableConfig = {"configurable": {"thread_id": "root-async"}}
+            graph = _delta_graph(saver)
+            await _adrive(graph, config, 1)
+
+            history = [tup async for tup in saver.alist(config)]
+            root_tup = history[-1]
+            assert root_tup.parent_config is None
+
+            result = await saver.aget_delta_channel_history(
+                config=root_tup.config, channels=["items"]
+            )
+            entry = result["items"]
+            assert "seed" not in entry, f"root-walk should have no seed, got {entry}"
+            assert entry["writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Non-monotonic checkpoint IDs — regression for issue #8550
+# ---------------------------------------------------------------------------
+# When a parent checkpoint has an ID that is lexicographically *larger*
+# than its child's, the old `DELTA_STAGE1_SQL` range scan (`checkpoint_id
+# <= ?`) would silently drop the parent. The recursive CTE must walk
+# the parent chain via `parent_checkpoint_id` regardless of ID ordering.
+
+
+def _mk_ckpt(ckpt_id: str, values: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal checkpoint with a given ID and channel_values."""
+    cp = empty_checkpoint()
+    cp["id"] = ckpt_id
+    cp["channel_values"] = values
+    return cp
+
+
+def test_non_monotonic_ids_delta_history_sync() -> None:
+    """Regression for #8550: parent ID > child ID lexicographically.
+
+    Create two checkpoints on the same thread where the parent has a
+    larger checkpoint_id than its child. Verify that
+    `get_delta_channel_history` returns writes from *both* checkpoints
+    (the parent's writes must not be silently dropped by the SQL walk).
+    """
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+
+        root = saver.put(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        saver.put_writes(root, [("ch", "write-root")], "task")
+
+        child = saver.put(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        saver.put_writes(writes_cfg, [("ch", "write-child")], "task")
+
+        history = list(saver.list(config))
+        ids = {t.config["configurable"]["checkpoint_id"] for t in history}
+        assert "z-older" in ids, "parent checkpoint 'z-older' must appear in list()"
+        assert "a-younger" in ids, "child checkpoint 'a-younger' must appear in list()"
+
+        result = saver.get_delta_channel_history(config=child, channels=["ch"])
+        entry = result["ch"]
+        write_values: list[Any] = []
+        for _task_id, channel, value in entry["writes"]:
+            assert channel == "ch"
+            write_values.extend(value if isinstance(value, list) else [value])
+
+        assert "write-root" in write_values
+        assert "write-child" in write_values
+
+
+async def test_non_monotonic_ids_delta_history_async() -> None:
+    """Async equivalent: non-monotonic checkpoint IDs must not break the walk."""
     async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
-        config: RunnableConfig = {"configurable": {"thread_id": "root-async"}}
-        graph = _delta_graph(saver)
-        await _adrive(graph, config, 1)
+        config: RunnableConfig = {"configurable": {"thread_id": "t-async", "checkpoint_ns": ""}}
+
+        root = await saver.aput(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        await saver.aput_writes(root, [("ch", "write-root")], "task")
+
+        child = await saver.aput(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        await saver.aput_writes(writes_cfg, [("ch", "write-child")], "task")
 
         history = [tup async for tup in saver.alist(config)]
-        root_tup = history[-1]
-        assert root_tup.parent_config is None
+        ids = {t.config["configurable"]["checkpoint_id"] for t in history}
+        assert "z-older" in ids
+        assert "a-younger" in ids
 
-        result = await saver.aget_delta_channel_history(
-            config=root_tup.config, channels=["items"]
-        )
-        entry = result["items"]
-        assert "seed" not in entry, f"root-walk should have no seed, got {entry}"
-        assert entry["writes"] == []
+        result = await saver.aget_delta_channel_history(config=child, channels=["ch"])
+        entry = result["ch"]
+        write_values: list[Any] = []
+        for _task_id, channel, value in entry["writes"]:
+            write_values.extend(value if isinstance(value, list) else [value])
+
+        assert "write-root" in write_values
+        assert "write-child" in write_values

--- a/libs/checkpoint-sqlite/tests/test_non_monotonic_ids.py
+++ b/libs/checkpoint-sqlite/tests/test_non_monotonic_ids.py
@@ -1,0 +1,216 @@
+"""Regression tests for issue #8550: SQLite delta history skips parent
+checkpoints with non-monotonic IDs.
+
+When a parent checkpoint has an ID that is lexicographically *larger*
+than its child's (e.g. parent='z-older', child='a-younger'), the
+old `DELTA_STAGE1_SQL` range scan (`checkpoint_id <= ?`) would
+silently drop the parent. The recursive CTE must walk the parent
+chain via `parent_checkpoint_id` regardless of ID ordering.
+
+These tests use only `langgraph-checkpoint` base primitives — no
+dependency on `langgraph` core (channels, graph) — so they run in
+sqlite's standalone CI environment.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import empty_checkpoint
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+pytestmark = pytest.mark.anyio
+
+
+def _mk_ckpt(ckpt_id: str, values: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal checkpoint with a given ID and channel_values."""
+    cp = empty_checkpoint()
+    cp["id"] = ckpt_id
+    cp["channel_values"] = values
+    return cp
+
+
+# ---------------------------------------------------------------------------
+# Sync: SqliteSaver
+# ---------------------------------------------------------------------------
+
+
+def test_list_includes_non_monotonic_parent_sync() -> None:
+    """list() must return every checkpoint on the thread regardless of ID order."""
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+
+        root = saver.put(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        saver.put_writes(root, [("ch", "write-root")], "task")
+
+        child = saver.put(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        saver.put_writes(writes_cfg, [("ch", "write-child")], "task")
+
+        history = list(saver.list(config))
+        ids = {t.config["configurable"]["checkpoint_id"] for t in history}
+        assert "z-older" in ids, (
+            "parent checkpoint 'z-older' was skipped by list()"
+        )
+        assert "a-younger" in ids
+
+
+def test_delta_history_includes_non_monotonic_parent_sync() -> None:
+    """get_delta_channel_history must include writes from the
+    parent whose ID is lexicographically larger than its child's."""
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+
+        root = saver.put(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        saver.put_writes(root, [("ch", "write-root")], "task")
+
+        child = saver.put(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        saver.put_writes(writes_cfg, [("ch", "write-child")], "task")
+
+        result = saver.get_delta_channel_history(config=child, channels=["ch"])
+        entry = result["ch"]
+        write_values: list[Any] = []
+        for _task_id, channel, value in entry["writes"]:
+            assert channel == "ch"
+            write_values.extend(value if isinstance(value, list) else [value])
+
+        assert "write-root" in write_values, (
+            "parent write dropped: the walk skipped the 'z-older' ancestor"
+        )
+        assert "write-child" in write_values
+
+
+def test_delta_history_multi_hop_non_monotonic_sync() -> None:
+    """Three-hop chain with alternating large/small IDs."""
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t-hop", "checkpoint_ns": ""}}
+
+        root = saver.put(
+            config,
+            _mk_ckpt("z-grandparent", {"ch": "gp"}),
+            {},
+            {},
+        )
+        saver.put_writes(root, [("ch", "write-gp")], "task")
+
+        mid = saver.put(
+            root,
+            _mk_ckpt("a-parent", {"ch": "p"}),
+            {},
+            {},
+        )
+        saver.put_writes(mid, [("ch", "write-p")], "task")
+
+        leaf = saver.put(
+            mid,
+            _mk_ckpt("z-child", {"ch": "c"}),
+            {},
+            {},
+        )
+        writes_cfg = leaf.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        saver.put_writes(writes_cfg, [("ch", "write-c")], "task")
+
+        history = list(saver.list(config))
+        ids = {t.config["configurable"]["checkpoint_id"] for t in history}
+        assert ids == {"z-grandparent", "a-parent", "z-child"}
+
+        result = saver.get_delta_channel_history(config=leaf, channels=["ch"])
+        entry = result["ch"]
+        write_values: list[Any] = []
+        for _task_id, _ch, value in entry["writes"]:
+            write_values.extend(value if isinstance(value, list) else [value])
+
+        assert write_values == ["write-gp", "write-p", "write-c"]
+
+
+# ---------------------------------------------------------------------------
+# Async: AsyncSqliteSaver
+# ---------------------------------------------------------------------------
+
+
+async def test_list_includes_non_monotonic_parent_async() -> None:
+    async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t-async", "checkpoint_ns": ""}}
+
+        root = await saver.aput(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        await saver.aput_writes(root, [("ch", "write-root")], "task")
+
+        child = await saver.aput(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        await saver.aput_writes(writes_cfg, [("ch", "write-child")], "task")
+
+        history = [tup async for tup in saver.alist(config)]
+        ids = {t.config["configurable"]["checkpoint_id"] for t in history}
+        assert "z-older" in ids
+        assert "a-younger" in ids
+
+
+async def test_delta_history_includes_non_monotonic_parent_async() -> None:
+    async with AsyncSqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "t-async", "checkpoint_ns": ""}}
+
+        root = await saver.aput(
+            config,
+            _mk_ckpt("z-older", {"ch": "seed"}),
+            {},
+            {},
+        )
+        await saver.aput_writes(root, [("ch", "write-root")], "task")
+
+        child = await saver.aput(
+            root,
+            _mk_ckpt("a-younger", {"ch": "seed-wchild"}),
+            {},
+            {},
+        )
+        writes_cfg = child.copy()
+        writes_cfg["configurable"]["task_id"] = "task"
+        await saver.aput_writes(writes_cfg, [("ch", "write-child")], "task")
+
+        result = await saver.aget_delta_channel_history(config=child, channels=["ch"])
+        entry = result["ch"]
+        write_values: list[Any] = []
+        for _task_id, _ch, value in entry["writes"]:
+            write_values.extend(value if isinstance(value, list) else [value])
+
+        assert "write-root" in write_values
+        assert "write-child" in write_values


### PR DESCRIPTION
Fixes issue 8550: SQLite delta history skips parent checkpoints with non-monotonic IDs.

## What changed

The old `DELTA_STAGE1_SQL` used a lexicographic range scan (`checkpoint_id <= ?`)
to find ancestors of a target checkpoint. This silently dropped parents whose ID
happened to sort *after* the child (e.g. parent='z-older', child='a-younger').

The fix replaces the range scan with a recursive CTE that walks the parent chain
via `parent_checkpoint_id` regardless of ID ordering. This is robust to any
checkpoint ID assignment scheme.

## Test

Two regression tests added:
1. `test_non_monotonic_ids.py` — standalone test covering both sync and async savers
2. `test_get_delta_channel_history.py` — integration test using real DeltaChannel graphs