### PR TITLE
fix(prebuilt): respect max_concurrency in async ToolNode

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -855,7 +855,21 @@ class ToolNode(RunnableCallable):
         coros = []
         for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
             coros.append(self._arun_one(call, input_type, tool_runtime))  # type: ignore[arg-type]
-        outputs = await asyncio.gather(*coros)
+
+        # Respect max_concurrency from config (async path)
+        max_concurrency = config.get("max_concurrency") if config else None
+        if max_concurrency:
+            semaphore = asyncio.Semaphore(max_concurrency)
+        else:
+            semaphore = None
+
+        if semaphore:
+            async def _gated(coro):
+                async with semaphore:
+                    return await coro
+            outputs = await asyncio.gather(*[_gated(c) for c in coros])
+        else:
+            outputs = await asyncio.gather(*coros)
 
         return self._combine_tool_outputs(outputs, input_type)
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import dataclasses
 import json
@@ -2422,3 +2423,46 @@ def test_tool_node_list_return_mixed_with_regular_tool() -> None:
     tool_call_ids = {m.tool_call_id for m in all_msgs}
     assert list_tool_id in tool_call_ids
     assert regular_tool_id in tool_call_ids
+
+async def test_async_max_concurrency():
+    """ToolNode _afunc respects config max_concurrency."""
+    max_concurrency = 2
+    tool_count = 5
+    semaphore = asyncio.Semaphore(max_concurrency)
+    max_concurrent = [0]
+    current_concurrent = [0]
+    current_lock = asyncio.Lock()
+
+    @tool
+    async def _tracking_tool(x: int) -> str:
+        async with semaphore:
+            async with current_lock:
+                current_concurrent[0] += 1
+                if current_concurrent[0] > max_concurrent[0]:
+                    max_concurrent[0] = current_concurrent[0]
+            await asyncio.sleep(0.01)
+            async with current_lock:
+                current_concurrent[0] -= 1
+        return f"tool-{x}-done"
+
+    node = ToolNode([_tracking_tool])
+
+    tool_calls = [
+        {"name": "_tracking_tool", "args": {"x": i}, "id": f"call-{i}", "type": "tool_call"}
+        for i in range(tool_count)
+    ]
+
+    config = {
+        **_create_config_with_runtime(),
+        "max_concurrency": max_concurrency,
+    }
+
+    await node.ainvoke(
+        {"messages": [AIMessage("", tool_calls=tool_calls)]},
+        config=config,
+    )
+
+    assert max_concurrent[0] <= max_concurrency, (
+        f"Max concurrency was {max_concurrent[0]}, expected <= {max_concurrency}"
+    )
+


### PR DESCRIPTION
## Summary

Fixes #8517 — ToolNode._afunc ignores max_concurrency in the async code path.

The sync _func() already respected max_concurrency via get_executor_for_config().
The async _afunc() used bare asyncio.gather with no concurrency limit, running ALL
tool calls simultaneously regardless of the configured limit.

This adds asyncio.Semaphore(max_concurrency) gating in _afunc matching sync behavior.
No behavior change when max_concurrency is not set.

## Test

Added test_async_max_concurrency in libs/prebuilt/tests/test_tool_node.py that
verifies peak concurrency never exceeds the configured limit.