### PR TITLE
fix(checkpoint): include state paths in serialization errors

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -268,7 +268,10 @@ class JsonPlusSerializer(SerializerProtocol):
             except ormsgpack.MsgpackEncodeError as exc:
                 if self.pickle_fallback:
                     return "pickle", pickle.dumps(obj)
-                raise exc
+                message = _format_msgpack_encode_error(obj, exc)
+                if message == str(exc):
+                    raise exc
+                raise exc.__class__(message) from exc
 
     def loads_typed(self, data: tuple[str, bytes]) -> Any:
         type_, data_ = data
@@ -858,6 +861,94 @@ _option = (
 
 def _msgpack_enc(data: Any) -> bytes:
     return ormsgpack.packb(data, default=_msgpack_default, option=_option)
+
+
+def _format_msgpack_encode_error(obj: Any, exc: Exception) -> str:
+    message = str(exc)
+    context = _find_msgpack_error_context(obj)
+    if context is None:
+        return message
+
+    path, type_name = context
+    details = [f"state path: {path}"]
+    if type_name != message.rsplit(": ", 1)[-1]:
+        details.append(f"offending type: {type_name}")
+    return f"{message} ({', '.join(details)})"
+
+
+def _find_msgpack_error_context(
+    obj: Any,
+    *,
+    path: str = "$",
+    seen: set[int] | None = None,
+) -> tuple[str, str] | None:
+    try:
+        _msgpack_enc(obj)
+        return None
+    except ormsgpack.MsgpackEncodeError:
+        pass
+
+    if seen is None:
+        seen = set()
+
+    if not isinstance(obj, (str, bytes, bytearray, int, float, bool, type(None))):
+        obj_id = id(obj)
+        if obj_id in seen:
+            return path, obj.__class__.__name__
+        seen.add(obj_id)
+
+    if isinstance(obj, _DeltaSnapshot):
+        return _find_msgpack_error_context(obj.value, path=path, seen=seen)
+    elif hasattr(obj, "model_dump") and callable(obj.model_dump):
+        return _find_msgpack_error_context(obj.model_dump(), path=path, seen=seen)
+    elif hasattr(obj, "get_secret_value") and callable(obj.get_secret_value):
+        return _find_msgpack_error_context(
+            obj.get_secret_value(), path=path, seen=seen
+        )
+    elif hasattr(obj, "dict") and callable(obj.dict):
+        return _find_msgpack_error_context(obj.dict(), path=path, seen=seen)
+    elif hasattr(obj, "_asdict") and callable(obj._asdict):
+        return _find_msgpack_error_context(obj._asdict(), path=path, seen=seen)
+    elif dataclasses.is_dataclass(obj):
+        for field in dataclasses.fields(obj):
+            context = _find_msgpack_error_context(
+                getattr(obj, field.name),
+                path=f"{path}.{field.name}",
+                seen=seen,
+            )
+            if context is not None:
+                return context
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            context = _find_msgpack_error_context(
+                value,
+                path=f"{path}{_format_msgpack_path_segment(key)}",
+                seen=seen,
+            )
+            if context is not None:
+                return context
+    elif isinstance(obj, (list, tuple, deque)):
+        for index, value in enumerate(obj):
+            context = _find_msgpack_error_context(
+                value, path=f"{path}[{index}]", seen=seen
+            )
+            if context is not None:
+                return context
+    elif isinstance(obj, (set, frozenset)):
+        for index, value in enumerate(obj):
+            context = _find_msgpack_error_context(
+                value, path=f"{path}[{index}]", seen=seen
+            )
+            if context is not None:
+                return context
+
+    return path, obj.__class__.__name__
+
+
+def _format_msgpack_path_segment(key: Any) -> str:
+    if isinstance(key, str) and key.isidentifier():
+        return f".{key}"
+    return f"[{key!r}]"
 
 
 def _normalize_allowlist(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -104,6 +104,17 @@ class Person:
     name: str
 
 
+class UnserializableValue:
+    pass
+
+
+class StateWithUnserializableValue(BaseModel):
+    text: str
+    error_var: object | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
 def test_serde_jsonplus() -> None:
     uid = uuid.UUID(int=1)
     deque_instance = deque([1, 2, 3])
@@ -334,6 +345,33 @@ def test_serde_jsonplus_bytes() -> None:
 
     assert dumped == ("bytes", some_bytes)
     assert serde.loads_typed(dumped) == some_bytes
+
+
+def test_msgpack_encode_error_includes_pydantic_state_path() -> None:
+    serde = JsonPlusSerializer()
+    state = StateWithUnserializableValue(
+        text="Hello, world!", error_var=UnserializableValue()
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        serde.dumps_typed(state)
+
+    message = str(exc_info.value)
+    assert "Type is not msgpack serializable: StateWithUnserializableValue" in message
+    assert "state path: $.error_var" in message
+    assert "offending type: UnserializableValue" in message
+
+
+def test_msgpack_encode_error_includes_nested_key_path() -> None:
+    serde = JsonPlusSerializer()
+    obj = {"state": [1, {"bad": UnserializableValue()}]}
+
+    with pytest.raises(TypeError) as exc_info:
+        serde.dumps_typed(obj)
+
+    message = str(exc_info.value)
+    assert "Type is not msgpack serializable: UnserializableValue" in message
+    assert "state path: $.state[1].bad" in message
 
 
 def test_lc2_json_safe_type_revives_without_allowlist() -> None:


### PR DESCRIPTION
Fixes #8606.

## Summary

When MessagePack serialization fails, append the first unserializable value's state/key path to the existing error message. If the encoder reports an outer container or Pydantic model, also append the actual offending leaf type.

Before:
```
TypeError: Type is not msgpack serializable: StateWithUnserializableValue
```

After:
```
TypeError: Type is not msgpack serializable: StateWithUnserializableValue (state path: $.error_var, offending type: UnserializableValue)
```

Nested dictionaries and sequences report paths such as `$.state[1].bad`.

## Implementation

The change is deliberately limited to the error path in `JsonPlusSerializer.dumps_typed()`. It does not change successful serialization, pickle fallback behavior, or the exception class. The augmented error is chained from the original `MsgpackEncodeError`, preserving the underlying exception for debugging.

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio -p no:cacheprovider tests/test_jsonplus.py -k "test_serde_jsonplus or test_msgpack_nested_pydantic_serializes_as_dict or msgpack_encode_error_includes"`
  - 69 passed, 32 deselected

Adds regression coverage for:
- a Pydantic state object containing an unserializable field;
- a nested dictionary/list value containing an unserializable leaf.