### PR TITLE
fix(checkpoint): serialize C-contiguous datetime64/timedelta64 numpy arrays

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -516,7 +516,11 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         obj, np_mod.ndarray
     ):
         order = "F" if obj.flags.f_contiguous and not obj.flags.c_contiguous else "C"
-        if obj.flags.c_contiguous:
+        # Zero-copy fast path via the buffer protocol for C-contiguous arrays.
+        # datetime64 ('M') and timedelta64 ('m') are C-contiguous but do not
+        # expose a buffer (memoryview raises ValueError), so route them through
+        # the tobytes() path below, which serializes them correctly.
+        if obj.flags.c_contiguous and obj.dtype.kind not in "Mm":
             mv = memoryview(obj)
             try:
                 meta = (obj.dtype.str, obj.shape, order, mv)

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -612,6 +612,31 @@ def test_serde_jsonplus_numpy_array(arr: np.ndarray) -> None:
 @pytest.mark.parametrize(
     "arr",
     [
+        # C-contiguous datetime64/timedelta64 arrays do not expose a buffer, so
+        # the memoryview fast path used to raise and the whole value failed to
+        # serialize. They must round-trip like any other numpy array.
+        np.array(["2020-01-01", "2020-02-01", "2020-03-01"], dtype="datetime64[D]"),
+        np.array([1, 2, 3], dtype="datetime64[ns]"),
+        np.array([1, 2, 3], dtype="timedelta64[s]"),
+        np.array(["2020-01-01", "2020-02-01"], dtype="datetime64[D]").reshape(2, 1),
+    ],
+)
+def test_serde_jsonplus_numpy_datetime_array(arr: np.ndarray) -> None:
+    assert arr.flags.c_contiguous  # exercises the previously-broken fast path
+    serde = JsonPlusSerializer()
+
+    dumped = serde.dumps_typed(arr)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == arr.dtype
+    assert result.shape == arr.shape
+    assert np.array_equal(result, arr)
+
+
+@pytest.mark.parametrize(
+    "arr",
+    [
         np.arange(6, dtype=np.float32).reshape(2, 3),
         np.asfortranarray(np.arange(4, dtype=np.complex128).reshape(2, 2)),
     ],


### PR DESCRIPTION
Fixes #8689

## Problem
`JsonPlusSerializer._msgpack_default` takes a zero-copy `memoryview(obj)` fast path for any C-contiguous numpy array. `datetime64` (dtype kind 'M') and `timedelta64` ('m') arrays are C-contiguous but do not expose the buffer protocol, so `memoryview()` raises `ValueError: cannot include dtype 'M' in a buffer` and the value fails to serialize (surfacing as `TypeError: Type is not msgpack serializable: numpy.ndarray`).

The non-contiguous branch already handles these dtypes correctly via `tobytes()`, so the same data serializes when non-contiguous and crashes when contiguous — meaning any graph whose state holds a datetime64/timedelta64 array (e.g. from `pandas.Series.values` or a numpy time series) crashes when the checkpointer tries to save.

## Fix
Gate the memoryview fast path on `obj.dtype.kind not in "Mm"`, routing datetime64/timedelta64 through the existing `tobytes()` path. Numeric/object arrays are unchanged (byte-identical output). The decode path already reconstructs these dtypes from bytes (the unit is preserved through `dtype.str`), so no decoder change is needed.

## Tests
Added `test_serde_jsonplus_numpy_datetime_array`, parametrized over `datetime64[D]`, `datetime64[ns]`, `timedelta64[s]`, and a reshaped 2-D datetime64 array. It fails on `main` (4 failures) and passes with this change; existing numpy serde tests continue to pass. `make lint` (ruff + ty) passes.

This change was written with AI assistance and reviewed by me before submission.