### PR TITLE
prebuilt: add human_approval() ToolCallWrapper for HITL workflows

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/__init__.py
+++ b/libs/prebuilt/langgraph/prebuilt/__init__.py
@@ -2,6 +2,13 @@
 
 from langgraph.prebuilt._tool_call_transformer import ToolCallTransformer
 from langgraph.prebuilt.chat_agent_executor import create_react_agent
+from langgraph.prebuilt.human_approval import (
+    ApprovalDecision,
+    ApprovalValidationError,
+    PendingApproval,
+    async_human_approval,
+    human_approval,
+)
 from langgraph.prebuilt.tool_node import (
     InjectedState,
     InjectedStore,
@@ -12,12 +19,17 @@ from langgraph.prebuilt.tool_node import (
 from langgraph.prebuilt.tool_validator import ValidationNode
 
 __all__ = [
-    "create_react_agent",
-    "ToolNode",
-    "ToolCallTransformer",
-    "tools_condition",
-    "ValidationNode",
+    "ApprovalDecision",
+    "ApprovalValidationError",
     "InjectedState",
     "InjectedStore",
+    "PendingApproval",
+    "ToolCallTransformer",
+    "ToolNode",
     "ToolRuntime",
+    "ValidationNode",
+    "async_human_approval",
+    "create_react_agent",
+    "human_approval",
+    "tools_condition",
 ]

--- a/libs/prebuilt/langgraph/prebuilt/human_approval.py
+++ b/libs/prebuilt/langgraph/prebuilt/human_approval.py
@@ -1,0 +1,602 @@
+"""Human-in-the-loop approval gate for `ToolNode` tool calls.
+
+Provides a `human_approval()` / `async_human_approval()` factory that returns a
+`ToolCallWrapper` for `ToolNode(wrap_tool_call=...)`.
+
+Policy evaluation per tool call (deny → allow → interrupt):
+
+- **deny**: return a terminal denial `ToolMessage` (no interrupt, no execution)
+- **allow**: execute immediately (no pending record)
+- **unclassified**: create a durable `PendingApproval` and pause via `interrupt()`
+
+Resume accepts a structured `ApprovalDecision` bound to the pending record.
+Edited arguments rebind execution to a new digest and mark the original call
+as superseded. Audit fields are stamped on `ToolMessage.additional_kwargs`
+while dispatchability is determined solely by whether a terminal tool result
+was produced — history visibility is not execution authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import asdict, dataclass, field
+from fnmatch import fnmatchcase
+from typing import Any, Literal, cast
+
+from langchain_core.messages import ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.types import Command, interrupt
+
+from langgraph.prebuilt.tool_node import (
+    AsyncToolCallWrapper,
+    ToolCallRequest,
+    ToolCallWrapper,
+)
+
+PolicyResult = Literal["allow", "deny", "requires_approval"]
+DecisionShape = Literal["approve_or_reject", "approve_reject_or_edit"]
+TerminalState = Literal[
+    "approved",
+    "rejected",
+    "edited",
+    "deferred",
+    "expired",
+    "cancelled",
+    "executed",
+]
+DecisionAction = Literal["approve", "reject", "edit", "defer"]
+
+_AUDIT_KW = "pending_approval"
+_DENIAL_CONTENT = "Tool call denied by human_approval policy."
+_REJECT_CONTENT = "Tool call rejected by human reviewer."
+_VALIDATION_FAIL_CONTENT = "Approval decision rejected: {reason}"
+
+
+def canonical_args_digest(args: dict[str, Any] | None) -> str:
+    """Return a SHA-256 hex digest of tool arguments with stable key ordering."""
+    payload = json.dumps(args or {}, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _resume_preimage(
+    *,
+    thread_id: str,
+    node_name: str,
+    tool_name: str,
+    tool_call_id: str,
+    args_digest: str,
+) -> str:
+    return "|".join((thread_id, node_name, tool_name, tool_call_id, args_digest))
+
+
+def compute_resume_token(
+    *,
+    thread_id: str,
+    node_name: str,
+    tool_name: str,
+    tool_call_id: str,
+    args_digest: str,
+    secret: str | None = None,
+) -> str:
+    """Derive a deterministic resume token for interrupt replay safety.
+
+    LangGraph re-executes the node from the top on resume, so the token must
+    be stable across that re-execution. When `secret` is set, the token is an
+    HMAC-SHA-256 and is not forgeable without the secret.
+    """
+    preimage = _resume_preimage(
+        thread_id=thread_id,
+        node_name=node_name,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        args_digest=args_digest,
+    )
+    if secret is not None:
+        return hmac.new(
+            secret.encode("utf-8"),
+            preimage.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+    return hashlib.sha256(preimage.encode("utf-8")).hexdigest()
+
+
+def _thread_id_from_config(config: RunnableConfig | None) -> str:
+    if not config:
+        return ""
+    configurable = config.get("configurable") or {}
+    thread_id = configurable.get("thread_id")
+    return str(thread_id) if thread_id is not None else ""
+
+
+def _node_name_from_request(request: ToolCallRequest) -> str:
+    runtime = request.runtime
+    if runtime is None:
+        return ""
+    config = getattr(runtime, "config", None) or {}
+    metadata = config.get("metadata") or {}
+    for key in ("langgraph_node", "checkpoint_ns"):
+        value = metadata.get(key)
+        if value:
+            return str(value)
+    return str(getattr(runtime, "tool_call_id", "") or "")
+
+
+@dataclass
+class PendingApproval:
+    """Durable pending decision record for one gated tool call."""
+
+    thread_id: str
+    node_name: str
+    tool_name: str
+    tool_call_id: str
+    args_digest: str
+    policy_result: PolicyResult
+    decision_shape: DecisionShape
+    resume_token: str = ""
+    terminal_state: TerminalState | None = None
+    approved_args_digest: str | None = None
+    supersedes_tool_call_id: str | None = None
+    approved_tool_call_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.resume_token:
+            self.resume_token = compute_resume_token(
+                thread_id=self.thread_id,
+                node_name=self.node_name,
+                tool_name=self.tool_name,
+                tool_call_id=self.tool_call_id,
+                args_digest=self.args_digest,
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PendingApproval:
+        return cls(**{k: data[k] for k in cls.__dataclass_fields__ if k in data})
+
+
+@dataclass
+class ApprovalDecision:
+    """Structured human decision that must bind to a `PendingApproval`."""
+
+    token: str
+    tool_call_id: str
+    action: DecisionAction
+    edited_args: dict[str, Any] | None = None
+    message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ApprovalDecision:
+        return cls(
+            token=str(data.get("token", "")),
+            tool_call_id=str(data.get("tool_call_id", "")),
+            action=cast("DecisionAction", data.get("action", "")),
+            edited_args=data.get("edited_args"),
+            message=data.get("message"),
+        )
+
+
+@dataclass
+class _ApprovalPolicy:
+    allow: list[str] = field(default_factory=list)
+    deny: list[str] = field(default_factory=list)
+    decision_shape: DecisionShape = "approve_reject_or_edit"
+    secret: str | None = None
+    deny_on_error: bool = True
+
+    def classify(self, tool_name: str) -> PolicyResult:
+        if _match_patterns(tool_name, self.deny):
+            return "deny"
+        if _match_patterns(tool_name, self.allow):
+            return "allow"
+        return "requires_approval"
+
+
+def _match_patterns(name: str, patterns: Sequence[str]) -> bool:
+    return any(fnmatchcase(name, pattern) for pattern in patterns)
+
+
+class ApprovalValidationError(ValueError):
+    """Raised when a resume decision does not resolve the pending record."""
+
+
+def validate_decision(
+    pending: PendingApproval,
+    decision: ApprovalDecision | dict[str, Any],
+) -> ApprovalDecision:
+    """Validate a resume decision against a pending approval record.
+
+    Fail-closed: any mismatch or malformed payload raises
+    `ApprovalValidationError` without revealing the expected token.
+    """
+    if not isinstance(decision, ApprovalDecision):
+        if not isinstance(decision, dict):
+            msg = "decision must be an ApprovalDecision or dict"
+            raise ApprovalValidationError(msg)
+        decision = ApprovalDecision.from_dict(decision)
+
+    if pending.terminal_state is not None:
+        msg = "approval request already resolved"
+        raise ApprovalValidationError(msg)
+
+    if not decision.token or not hmac.compare_digest(
+        decision.token, pending.resume_token
+    ):
+        msg = "resume token mismatch"
+        raise ApprovalValidationError(msg)
+
+    if decision.tool_call_id != pending.tool_call_id:
+        msg = "tool_call_id mismatch"
+        raise ApprovalValidationError(msg)
+
+    if decision.action not in {"approve", "reject", "edit", "defer"}:
+        msg = "invalid decision action"
+        raise ApprovalValidationError(msg)
+
+    if decision.action == "edit" and pending.decision_shape == "approve_or_reject":
+        msg = "edit not allowed for this decision_shape"
+        raise ApprovalValidationError(msg)
+
+    if decision.action == "edit" and not decision.edited_args:
+        msg = "edited_args required when action is edit"
+        raise ApprovalValidationError(msg)
+
+    return decision
+
+
+def _denial_message(
+    request: ToolCallRequest,
+    *,
+    content: str,
+    pending: PendingApproval | None = None,
+    terminal_state: TerminalState = "rejected",
+) -> ToolMessage:
+    kwargs: dict[str, Any] = {}
+    if pending is not None:
+        record = PendingApproval(
+            **{**pending.to_dict(), "terminal_state": terminal_state}
+        )
+        kwargs[_AUDIT_KW] = record.to_dict()
+    return ToolMessage(
+        content=content,
+        name=request.tool_call["name"],
+        tool_call_id=request.tool_call["id"],
+        status="error",
+        additional_kwargs=kwargs,
+    )
+
+
+def _stamp_audit(
+    result: ToolMessage | Command,
+    pending: PendingApproval,
+) -> ToolMessage | Command:
+    if isinstance(result, Command):
+        return result
+    audit = dict(result.additional_kwargs or {})
+    audit[_AUDIT_KW] = pending.to_dict()
+    result.additional_kwargs = audit
+    return result
+
+
+def _build_pending(
+    request: ToolCallRequest,
+    policy: _ApprovalPolicy,
+) -> PendingApproval:
+    tool_call = request.tool_call
+    config = getattr(request.runtime, "config", None) if request.runtime else None
+    thread_id = _thread_id_from_config(config)
+    node_name = _node_name_from_request(request)
+    tool_name = str(tool_call["name"])
+    tool_call_id = str(tool_call["id"])
+    args_digest = canonical_args_digest(tool_call.get("args"))
+    return PendingApproval(
+        thread_id=thread_id,
+        node_name=node_name,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        args_digest=args_digest,
+        policy_result="requires_approval",
+        decision_shape=policy.decision_shape,
+        resume_token=compute_resume_token(
+            thread_id=thread_id,
+            node_name=node_name,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            args_digest=args_digest,
+            secret=policy.secret,
+        ),
+    )
+
+
+def _apply_decision(
+    request: ToolCallRequest,
+    execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    pending: PendingApproval,
+    raw_decision: Any,
+    *,
+    deny_on_error: bool,
+) -> ToolMessage | Command:
+    try:
+        decision = validate_decision(pending, raw_decision)
+    except ApprovalValidationError as exc:
+        if deny_on_error:
+            return _denial_message(
+                request,
+                content=_VALIDATION_FAIL_CONTENT.format(reason=str(exc)),
+                pending=pending,
+                terminal_state="cancelled",
+            )
+        raise
+
+    if decision.action == "defer":
+        pending.terminal_state = None
+        # Re-enter interrupt so the call stays pending with no execution.
+        raw_decision = interrupt(pending.to_dict())
+        return _apply_decision(
+            request,
+            execute,
+            pending,
+            raw_decision,
+            deny_on_error=deny_on_error,
+        )
+
+    if decision.action == "reject":
+        pending.terminal_state = "rejected"
+        pending.approved_tool_call_id = None
+        content = decision.message or _REJECT_CONTENT
+        return _denial_message(
+            request,
+            content=content,
+            pending=pending,
+            terminal_state="rejected",
+        )
+
+    if decision.action == "edit":
+        edited_args = cast("dict[str, Any]", decision.edited_args)
+        approved_digest = canonical_args_digest(edited_args)
+        pending.terminal_state = "edited"
+        pending.approved_args_digest = approved_digest
+        pending.supersedes_tool_call_id = pending.tool_call_id
+        pending.approved_tool_call_id = pending.tool_call_id
+        modified_call = {
+            **request.tool_call,
+            "args": edited_args,
+        }
+        result = execute(request.override(tool_call=modified_call))
+        pending.terminal_state = "executed"
+        return _stamp_audit(result, pending)
+
+    # approve
+    pending.terminal_state = "approved"
+    pending.approved_args_digest = pending.args_digest
+    pending.approved_tool_call_id = pending.tool_call_id
+    result = execute(request)
+    pending.terminal_state = "executed"
+    return _stamp_audit(result, pending)
+
+
+async def _aapply_decision(
+    request: ToolCallRequest,
+    execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    pending: PendingApproval,
+    raw_decision: Any,
+    *,
+    deny_on_error: bool,
+) -> ToolMessage | Command:
+    try:
+        decision = validate_decision(pending, raw_decision)
+    except ApprovalValidationError as exc:
+        if deny_on_error:
+            return _denial_message(
+                request,
+                content=_VALIDATION_FAIL_CONTENT.format(reason=str(exc)),
+                pending=pending,
+                terminal_state="cancelled",
+            )
+        raise
+
+    if decision.action == "defer":
+        pending.terminal_state = None
+        raw_decision = interrupt(pending.to_dict())
+        return await _aapply_decision(
+            request,
+            execute,
+            pending,
+            raw_decision,
+            deny_on_error=deny_on_error,
+        )
+
+    if decision.action == "reject":
+        pending.terminal_state = "rejected"
+        pending.approved_tool_call_id = None
+        content = decision.message or _REJECT_CONTENT
+        return _denial_message(
+            request,
+            content=content,
+            pending=pending,
+            terminal_state="rejected",
+        )
+
+    if decision.action == "edit":
+        edited_args = cast("dict[str, Any]", decision.edited_args)
+        approved_digest = canonical_args_digest(edited_args)
+        pending.terminal_state = "edited"
+        pending.approved_args_digest = approved_digest
+        pending.supersedes_tool_call_id = pending.tool_call_id
+        pending.approved_tool_call_id = pending.tool_call_id
+        modified_call = {
+            **request.tool_call,
+            "args": edited_args,
+        }
+        result = await execute(request.override(tool_call=modified_call))
+        pending.terminal_state = "executed"
+        return _stamp_audit(result, pending)
+
+    pending.terminal_state = "approved"
+    pending.approved_args_digest = pending.args_digest
+    pending.approved_tool_call_id = pending.tool_call_id
+    result = await execute(request)
+    pending.terminal_state = "executed"
+    return _stamp_audit(result, pending)
+
+
+def human_approval(
+    allow: Sequence[str] | None = None,
+    deny: Sequence[str] | None = None,
+    *,
+    decision_shape: DecisionShape = "approve_reject_or_edit",
+    secret: str | None = None,
+    deny_on_error: bool = True,
+) -> ToolCallWrapper:
+    """Create a sync tool-call wrapper that gates execution on human approval.
+
+    Args:
+        allow: Glob patterns for tools that execute without approval.
+        deny: Glob patterns for tools that are blocked without interrupting.
+            Deny is evaluated before allow.
+        decision_shape: Whether reviewers may edit arguments, or only
+            approve/reject.
+        secret: Optional HMAC key for non-forgeable resume tokens. Required for
+            production when interrupt payloads may be visible to untrusted
+            clients. Token remains deterministic across node re-execution.
+        deny_on_error: When `True` (default), invalid resume decisions fail
+            closed with a denial `ToolMessage` instead of raising. Policy or
+            validation failures never fall through to tool execution.
+
+    Returns:
+        A `ToolCallWrapper` suitable for `ToolNode(wrap_tool_call=...)`.
+
+    Example:
+        ```python
+        from langgraph.prebuilt import ToolNode, human_approval
+
+        wrapper = human_approval(allow=["read_*"], deny=["drop_*"], secret="...")
+        node = ToolNode(tools, wrap_tool_call=wrapper)
+        ```
+    """
+    policy = _ApprovalPolicy(
+        allow=list(allow) if allow is not None else [],
+        deny=list(deny) if deny is not None else [],
+        decision_shape=decision_shape,
+        secret=secret,
+        deny_on_error=deny_on_error,
+    )
+
+    def wrapper(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        try:
+            result = policy.classify(str(request.tool_call["name"]))
+        except Exception:
+            if policy.deny_on_error:
+                return _denial_message(
+                    request,
+                    content="Approval policy evaluation failed; denying execution.",
+                    terminal_state="cancelled",
+                )
+            raise
+
+        if result == "deny":
+            denied = _build_pending(request, policy)
+            denied.policy_result = "deny"
+            denied.terminal_state = "rejected"
+            return _denial_message(
+                request,
+                content=_DENIAL_CONTENT,
+                pending=denied,
+                terminal_state="rejected",
+            )
+
+        if result == "allow":
+            return execute(request)
+
+        pending = _build_pending(request, policy)
+        raw_decision = interrupt(pending.to_dict())
+        return _apply_decision(
+            request,
+            execute,
+            pending,
+            raw_decision,
+            deny_on_error=policy.deny_on_error,
+        )
+
+    return wrapper
+
+
+def async_human_approval(
+    allow: Sequence[str] | None = None,
+    deny: Sequence[str] | None = None,
+    *,
+    decision_shape: DecisionShape = "approve_reject_or_edit",
+    secret: str | None = None,
+    deny_on_error: bool = True,
+) -> AsyncToolCallWrapper:
+    """Async variant of `human_approval` for `ToolNode(awrap_tool_call=...)`."""
+    policy = _ApprovalPolicy(
+        allow=list(allow) if allow is not None else [],
+        deny=list(deny) if deny is not None else [],
+        decision_shape=decision_shape,
+        secret=secret,
+        deny_on_error=deny_on_error,
+    )
+
+    async def wrapper(
+        request: ToolCallRequest,
+        execute: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        try:
+            result = policy.classify(str(request.tool_call["name"]))
+        except Exception:
+            if policy.deny_on_error:
+                return _denial_message(
+                    request,
+                    content="Approval policy evaluation failed; denying execution.",
+                    terminal_state="cancelled",
+                )
+            raise
+
+        if result == "deny":
+            denied = _build_pending(request, policy)
+            denied.policy_result = "deny"
+            denied.terminal_state = "rejected"
+            return _denial_message(
+                request,
+                content=_DENIAL_CONTENT,
+                pending=denied,
+                terminal_state="rejected",
+            )
+
+        if result == "allow":
+            return await execute(request)
+
+        pending = _build_pending(request, policy)
+        raw_decision = interrupt(pending.to_dict())
+        return await _aapply_decision(
+            request,
+            execute,
+            pending,
+            raw_decision,
+            deny_on_error=policy.deny_on_error,
+        )
+
+    return wrapper
+
+
+__all__ = [
+    "ApprovalDecision",
+    "ApprovalValidationError",
+    "PendingApproval",
+    "async_human_approval",
+    "canonical_args_digest",
+    "compute_resume_token",
+    "human_approval",
+    "validate_decision",
+]

--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1053,6 +1053,10 @@ class ToolNode(RunnableCallable):
         # Call wrapper with request and execute callable
         try:
             return self._wrap_tool_call(tool_request, execute)
+        except GraphBubbleUp:
+            # interrupt() / GraphInterrupt must always propagate, including when
+            # raised from wrap_tool_call (same contract as _execute_tool_sync).
+            raise
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:
@@ -1208,6 +1212,10 @@ class ToolNode(RunnableCallable):
             # None check was performed above already
             self._wrap_tool_call = cast("ToolCallWrapper", self._wrap_tool_call)
             return self._wrap_tool_call(tool_request, _sync_execute)
+        except GraphBubbleUp:
+            # interrupt() / GraphInterrupt must always propagate, including when
+            # raised from wrap_tool_call / awrap_tool_call.
+            raise
         except Exception as e:
             # Wrapper threw an exception
             if not self._handle_tool_errors:

--- a/libs/prebuilt/tests/test_human_approval.py
+++ b/libs/prebuilt/tests/test_human_approval.py
@@ -1,0 +1,605 @@
+"""Tests for human_approval ToolCallWrapper (HITL pending-decision contract)."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import START, StateGraph, add_messages
+from langgraph.types import Command, Interrupt, interrupt
+from typing_extensions import TypedDict
+
+from langgraph.prebuilt.human_approval import (
+    ApprovalDecision,
+    ApprovalValidationError,
+    PendingApproval,
+    _ApprovalPolicy,
+    async_human_approval,
+    canonical_args_digest,
+    compute_resume_token,
+    human_approval,
+    validate_decision,
+)
+from langgraph.prebuilt.tool_node import ToolNode
+from tests.any_str import AnyStr
+
+
+@tool
+def read_file(path: str) -> str:
+    """Read a file."""
+    return f"contents:{path}"
+
+
+@tool
+def send_email(to: str, body: str) -> str:
+    """Send an email."""
+    return f"sent:{to}:{body}"
+
+
+@tool
+def drop_table(name: str) -> str:
+    """Drop a table."""
+    return f"dropped:{name}"
+
+
+class AgentState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+
+
+def _build_graph(
+    *,
+    allow: list[str] | None = None,
+    deny: list[str] | None = None,
+    decision_shape: str = "approve_reject_or_edit",
+    secret: str | None = None,
+):
+    wrapper = human_approval(
+        allow=allow,
+        deny=deny,
+        decision_shape=decision_shape,  # type: ignore[arg-type]
+        secret=secret,
+    )
+    tools = ToolNode([read_file, send_email, drop_table], wrap_tool_call=wrapper)
+    builder = StateGraph(AgentState)
+    builder.add_node("tools", tools)
+    builder.add_edge(START, "tools")
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+def _ai_tool_call(
+    name: str, args: dict[str, Any], call_id: str = "call_1"
+) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": name, "args": args, "id": call_id, "type": "tool_call"}],
+    )
+
+
+def _pending_from_result(result: dict[str, Any]) -> dict[str, Any]:
+    interrupts = result.get("__interrupt__") or ()
+    assert interrupts, f"expected interrupt, got {result!r}"
+    value = interrupts[0].value
+    assert isinstance(value, dict)
+    return value
+
+
+# --- unit helpers -----------------------------------------------------------
+
+
+def test_canonical_args_digest_is_order_independent() -> None:
+    a = canonical_args_digest({"b": 1, "a": 2})
+    b = canonical_args_digest({"a": 2, "b": 1})
+    assert a == b
+    assert len(a) == 64
+
+
+def test_resume_token_hmac_requires_secret() -> None:
+    kwargs = dict(
+        thread_id="t1",
+        node_name="tools",
+        tool_name="send_email",
+        tool_call_id="c1",
+        args_digest="abc",
+    )
+    plain = compute_resume_token(**kwargs)
+    keyed = compute_resume_token(**kwargs, secret="s3cret")
+    assert plain != keyed
+    assert keyed == compute_resume_token(**kwargs, secret="s3cret")
+    assert keyed != compute_resume_token(**kwargs, secret="other")
+
+
+def test_policy_matching_is_case_sensitive() -> None:
+    policy = _ApprovalPolicy(allow=["read_*"], deny=["delete_*"])
+    assert policy.classify("read_file") == "allow"
+    assert policy.classify("Read_file") == "requires_approval"
+    assert policy.classify("delete_file") == "deny"
+    assert policy.classify("Delete_file") == "requires_approval"
+
+
+def test_allow_deny_lists_are_copied_at_construction() -> None:
+    allow = ["read_*"]
+    deny = ["drop_*"]
+    graph = _build_graph(allow=allow, deny=deny)
+    allow.append("send_*")
+    deny.clear()
+
+    config = {"configurable": {"thread_id": "copy-1"}}
+    # send_email must still interrupt (not allow-listed at construction)
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "b"}),
+            ]
+        },
+        config,
+    )
+    assert "__interrupt__" in result
+
+    # drop_table must still deny (deny list copied)
+    result2 = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("drop_table", {"name": "users"}, call_id="c2"),
+            ]
+        },
+        {"configurable": {"thread_id": "copy-2"}},
+    )
+    msg = result2["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "denied" in msg.content.lower()
+
+
+def test_validate_decision_token_mismatch_hides_expected() -> None:
+    pending = PendingApproval(
+        thread_id="t",
+        node_name="tools",
+        tool_name="send_email",
+        tool_call_id="c1",
+        args_digest="d",
+        policy_result="requires_approval",
+        decision_shape="approve_reject_or_edit",
+        resume_token="expected-token-value",
+    )
+    with pytest.raises(ApprovalValidationError, match="resume token mismatch") as exc:
+        validate_decision(
+            pending,
+            ApprovalDecision(token="wrong", tool_call_id="c1", action="approve"),
+        )
+    assert "expected-token-value" not in str(exc.value)
+
+
+def test_decision_shape_blocks_edit_when_approve_or_reject_only() -> None:
+    pending = PendingApproval(
+        thread_id="t",
+        node_name="tools",
+        tool_name="send_email",
+        tool_call_id="c1",
+        args_digest="d",
+        policy_result="requires_approval",
+        decision_shape="approve_or_reject",
+        resume_token="tok",
+    )
+    with pytest.raises(ApprovalValidationError, match="edit not allowed"):
+        validate_decision(
+            pending,
+            ApprovalDecision(
+                token="tok",
+                tool_call_id="c1",
+                action="edit",
+                edited_args={"to": "x", "body": "y"},
+            ),
+        )
+    # approve still ok
+    validate_decision(
+        pending,
+        ApprovalDecision(token="tok", tool_call_id="c1", action="approve"),
+    )
+
+
+def test_terminal_state_blocks_replay() -> None:
+    for terminal in (
+        "approved",
+        "rejected",
+        "edited",
+        "expired",
+        "cancelled",
+        "executed",
+    ):
+        pending = PendingApproval(
+            thread_id="t",
+            node_name="tools",
+            tool_name="send_email",
+            tool_call_id="c1",
+            args_digest="d",
+            policy_result="requires_approval",
+            decision_shape="approve_reject_or_edit",
+            resume_token="tok",
+            terminal_state=terminal,  # type: ignore[arg-type]
+        )
+        with pytest.raises(ApprovalValidationError, match="already resolved"):
+            validate_decision(
+                pending,
+                ApprovalDecision(token="tok", tool_call_id="c1", action="approve"),
+            )
+
+
+# --- integration: allow / deny / interrupt ---------------------------------
+
+
+def test_allow_listed_tool_passes_without_pending_record() -> None:
+    graph = _build_graph(allow=["read_*"], deny=["drop_*"])
+    config = {"configurable": {"thread_id": "allow-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("read_file", {"path": "/tmp/a"}),
+            ]
+        },
+        config,
+    )
+    assert "__interrupt__" not in result
+    msg = result["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.content == "contents:/tmp/a"
+    assert "pending_approval" not in (msg.additional_kwargs or {})
+
+
+def test_deny_listed_tool_returns_terminal_denial_without_interrupt() -> None:
+    graph = _build_graph(allow=["read_*"], deny=["drop_*"])
+    config = {"configurable": {"thread_id": "deny-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("drop_table", {"name": "users"}),
+            ]
+        },
+        config,
+    )
+    assert "__interrupt__" not in result
+    msg = result["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    audit = msg.additional_kwargs["pending_approval"]
+    assert audit["policy_result"] == "deny"
+    assert audit["terminal_state"] == "rejected"
+
+
+def test_unclassified_tool_creates_pending_record_and_does_not_execute() -> None:
+    executed = {"n": 0}
+
+    @tool
+    def send_email_tracked(to: str, body: str) -> str:
+        """Send an email."""
+        executed["n"] += 1
+        return f"sent:{to}:{body}"
+
+    wrapper = human_approval(allow=["read_*"], deny=["drop_*"])
+    tools = ToolNode([send_email_tracked], wrap_tool_call=wrapper)
+    builder = StateGraph(AgentState)
+    builder.add_node("tools", tools)
+    builder.add_edge(START, "tools")
+    graph = builder.compile(checkpointer=InMemorySaver())
+
+    config = {"configurable": {"thread_id": "pending-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "send_email_tracked",
+                            "args": {"to": "a@b.com", "body": "hi"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+    assert pending["tool_name"] == "send_email_tracked"
+    assert pending["tool_call_id"] == "call_1"
+    assert pending["policy_result"] == "requires_approval"
+    assert pending["terminal_state"] is None
+    assert pending["args_digest"] == canonical_args_digest(
+        {"to": "a@b.com", "body": "hi"}
+    )
+    assert executed["n"] == 0
+
+
+def test_resume_for_one_call_cannot_approve_another() -> None:
+    graph = _build_graph(secret="test-secret")
+    config = {"configurable": {"thread_id": "cross-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "b"}),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+
+    # Forge a decision for a different tool_call_id with the real token.
+    bad = ApprovalDecision(
+        token=pending["resume_token"],
+        tool_call_id="other_call",
+        action="approve",
+    )
+    resumed = graph.invoke(Command(resume=bad.to_dict()), config)
+    msg = resumed["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert "tool_call_id mismatch" in msg.content
+
+
+def test_edited_args_change_approved_digest_and_bind_execution() -> None:
+    graph = _build_graph(secret="test-secret")
+    config = {"configurable": {"thread_id": "edit-1"}}
+    original_args = {"to": "a@b.com", "body": "draft"}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", original_args),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+    edited = {"to": "safe@b.com", "body": "approved"}
+    decision = ApprovalDecision(
+        token=pending["resume_token"],
+        tool_call_id=pending["tool_call_id"],
+        action="edit",
+        edited_args=edited,
+    )
+    resumed = graph.invoke(Command(resume=decision.to_dict()), config)
+    msg = resumed["messages"][-1]
+    assert isinstance(msg, ToolMessage)
+    assert msg.content == "sent:safe@b.com:approved"
+    audit = msg.additional_kwargs["pending_approval"]
+    assert audit["args_digest"] == canonical_args_digest(original_args)
+    assert audit["approved_args_digest"] == canonical_args_digest(edited)
+    assert audit["args_digest"] != audit["approved_args_digest"]
+    assert audit["supersedes_tool_call_id"] == pending["tool_call_id"]
+    assert audit["terminal_state"] == "executed"
+
+
+def test_reject_leaves_call_visible_but_non_dispatchable() -> None:
+    """Dual-view invariant: history keeps the call; dispatch set has no executable original."""
+    graph = _build_graph(secret="test-secret")
+    config = {"configurable": {"thread_id": "reject-1"}}
+    ai = _ai_tool_call("send_email", {"to": "a", "body": "b"})
+    result = graph.invoke({"messages": [HumanMessage("hi"), ai]}, config)
+    pending = _pending_from_result(result)
+
+    decision = ApprovalDecision(
+        token=pending["resume_token"],
+        tool_call_id=pending["tool_call_id"],
+        action="reject",
+        message="Do not send.",
+    )
+    resumed = graph.invoke(Command(resume=decision.to_dict()), config)
+    messages = resumed["messages"]
+
+    # Audit / history view: original AI tool call still present
+    assert any(
+        isinstance(m, AIMessage)
+        and any(tc.get("id") == "call_1" for tc in (m.tool_calls or []))
+        for m in messages
+    )
+
+    # Dispatch / runtime view: a terminal ToolMessage consumed the call
+    tool_msgs = [
+        m for m in messages if isinstance(m, ToolMessage) and m.tool_call_id == "call_1"
+    ]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0].status == "error"
+    audit = tool_msgs[0].additional_kwargs["pending_approval"]
+    assert audit["terminal_state"] == "rejected"
+    assert audit["approved_tool_call_id"] is None
+
+    # Graph finished tools node; nothing left to dispatch for call_1
+    state = graph.get_state(config)
+    assert state.next == ()
+
+
+def test_modify_records_supersession_before_executing_successor() -> None:
+    graph = _build_graph(secret="test-secret")
+    config = {"configurable": {"thread_id": "modify-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "old"}),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+    decision = ApprovalDecision(
+        token=pending["resume_token"],
+        tool_call_id=pending["tool_call_id"],
+        action="edit",
+        edited_args={"to": "b", "body": "new"},
+    )
+    resumed = graph.invoke(Command(resume=decision.to_dict()), config)
+    msg = resumed["messages"][-1]
+    audit = msg.additional_kwargs["pending_approval"]
+    assert audit["supersedes_tool_call_id"] == "call_1"
+    assert audit["approved_tool_call_id"] == "call_1"
+    assert msg.content == "sent:b:new"
+
+
+def test_checkpoint_resume_preserves_pending_and_outcome() -> None:
+    graph = _build_graph(secret="test-secret")
+    config = {"configurable": {"thread_id": "ckpt-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "b"}),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+
+    # Reconnect: load state from checkpointer
+    state = graph.get_state(config)
+    assert state.tasks
+    assert state.tasks[0].interrupts == (Interrupt(value=pending, id=AnyStr()),)
+
+    decision = ApprovalDecision(
+        token=pending["resume_token"],
+        tool_call_id=pending["tool_call_id"],
+        action="approve",
+    )
+    resumed = graph.invoke(Command(resume=decision.to_dict()), config)
+    msg = resumed["messages"][-1]
+    assert msg.content == "sent:a:b"
+    assert msg.additional_kwargs["pending_approval"]["terminal_state"] == "executed"
+
+    # Duplicate resume after terminal outcome is a no-op / does not re-execute
+    again = graph.invoke(Command(resume=decision.to_dict()), config)
+    tool_msgs = [
+        m
+        for m in again["messages"]
+        if isinstance(m, ToolMessage) and m.tool_call_id == "call_1"
+    ]
+    assert len(tool_msgs) == 1
+
+
+def test_hmac_token_not_forgeable_without_secret() -> None:
+    graph = _build_graph(secret="server-secret")
+    config = {"configurable": {"thread_id": "hmac-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "b"}),
+            ]
+        },
+        config,
+    )
+    pending = _pending_from_result(result)
+    forged = compute_resume_token(
+        thread_id=pending["thread_id"],
+        node_name=pending["node_name"],
+        tool_name=pending["tool_name"],
+        tool_call_id=pending["tool_call_id"],
+        args_digest=pending["args_digest"],
+        secret=None,  # attacker without server secret
+    )
+    assert forged != pending["resume_token"]
+    resumed = graph.invoke(
+        Command(
+            resume=ApprovalDecision(
+                token=forged,
+                tool_call_id=pending["tool_call_id"],
+                action="approve",
+            ).to_dict()
+        ),
+        config,
+    )
+    msg = resumed["messages"][-1]
+    assert msg.status == "error"
+    assert "resume token mismatch" in msg.content
+
+
+async def test_async_allow_and_deny_paths() -> None:
+    def _config() -> RunnableConfig:
+        runtime = Mock()
+        runtime.store = None
+        runtime.context = None
+        runtime.stream_writer = lambda _: None
+        return {"configurable": {"__pregel_runtime": runtime}}
+
+    allow_wrapper = async_human_approval(allow=["read_*"], deny=["drop_*"])
+    deny_wrapper = async_human_approval(allow=["read_*"], deny=["drop_*"])
+
+    allow_node = ToolNode([read_file], awrap_tool_call=allow_wrapper)
+    deny_node = ToolNode([drop_table], awrap_tool_call=deny_wrapper)
+
+    allowed = await allow_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "read_file",
+                            "args": {"path": "x"},
+                            "id": "1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_config(),
+    )
+    assert allowed["messages"][-1].content == "contents:x"
+
+    denied = await deny_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "drop_table",
+                            "args": {"name": "t"},
+                            "id": "2",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_config(),
+    )
+    assert denied["messages"][-1].status == "error"
+
+
+def test_wrap_tool_call_interrupt_propagates_with_bool_handle_errors() -> None:
+    """GraphBubbleUp from wrap_tool_call must not be converted to ToolMessage."""
+
+    def raising_wrapper(request, execute):
+        return interrupt({"need": "approval"})
+
+    node = ToolNode(
+        [send_email], wrap_tool_call=raising_wrapper, handle_tool_errors=True
+    )
+    builder = StateGraph(AgentState)
+    builder.add_node("tools", node)
+    builder.add_edge(START, "tools")
+    graph = builder.compile(checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "bubble-1"}}
+    result = graph.invoke(
+        {
+            "messages": [
+                HumanMessage("hi"),
+                _ai_tool_call("send_email", {"to": "a", "body": "b"}),
+            ]
+        },
+        config,
+    )
+    assert "__interrupt__" in result
+    assert result["__interrupt__"][0].value == {"need": "approval"}


### PR DESCRIPTION
## Summary
- Adds `human_approval()` / `async_human_approval()` in `libs/prebuilt` as a `ToolCallWrapper` for `ToolNode(wrap_tool_call=...)`, implementing the allow → deny → interrupt policy and durable `PendingApproval` binding discussed in #8026.
- Resume decisions (`approve` / `reject` / `edit` / `defer`) must match token + `tool_call_id`; edits rebind execution to `approved_args_digest` and record supersession so history-visible calls are not dispatchable after reject/modify.
- Fixes `ToolNode` so `GraphBubbleUp` / `interrupt()` raised from wrappers always propagates (including when `handle_tool_errors=True`).

## Test plan
- [x] `pytest libs/prebuilt/tests/test_human_approval.py` (18/18)
- [x] `make format` / `make lint` in `libs/prebuilt`
- [ ] Reviewer: allow-listed tool executes with no pending record
- [ ] Reviewer: deny-listed tool returns terminal denial without interrupt
- [ ] Reviewer: unclassified tool interrupts; tool does not run before resume
- [ ] Reviewer: cross-call resume / forged HMAC token fail closed
- [ ] Reviewer: edit updates approved digest; reject dual-view (history vs dispatch)

Fixes #8026