### PR TITLE
fix(checkpoint): serialize Fraction/complex and preserve dict subclasses

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/_msgpack.py
@@ -30,10 +30,15 @@ SAFE_MSGPACK_TYPES: frozenset[tuple[str, ...]] = frozenset(
         ("uuid", "UUID"),
         # numeric
         ("decimal", "Decimal"),
+        ("fractions", "Fraction"),
+        ("builtins", "complex"),
         # collections
         ("builtins", "set"),
         ("builtins", "frozenset"),
         ("collections", "deque"),
+        ("collections", "Counter"),
+        ("collections", "OrderedDict"),
+        ("collections", "defaultdict"),
         # ip addresses
         ("ipaddress", "IPv4Address"),
         ("ipaddress", "IPv4Interface"),

--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import decimal
+import fractions
 import importlib
 import json
 import logging
@@ -10,7 +11,7 @@ import pathlib
 import pickle
 import re
 import sys
-from collections import deque
+from collections import Counter, OrderedDict, defaultdict, deque
 from collections.abc import Callable, Iterable, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
@@ -378,6 +379,64 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
                 (obj.__class__.__module__, obj.__class__.__name__, str(obj)),
             ),
         )
+    elif isinstance(obj, fractions.Fraction):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.numerator, obj.denominator),
+                ),
+            ),
+        )
+    elif isinstance(obj, complex):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (obj.real, obj.imag),
+                ),
+            ),
+        )
+    elif isinstance(obj, Counter):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, dict(obj)),
+            ),
+        )
+    elif isinstance(obj, OrderedDict):
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_SINGLE_ARG,
+            _msgpack_enc(
+                (obj.__class__.__module__, obj.__class__.__name__, list(obj.items())),
+            ),
+        )
+    elif isinstance(obj, defaultdict):
+        try:
+            factory_ref = _encode_default_factory(obj.default_factory)
+        except ValueError:
+            _warn_once(
+                _warned_unregistered_types,
+                ("collections", "defaultdict"),
+                "Cannot serialize defaultdict default_factory %r; "
+                "checkpoint will store a plain dict instead.",
+                obj.default_factory,
+            )
+            return dict(obj)
+        return ormsgpack.Ext(
+            EXT_CONSTRUCTOR_POS_ARGS,
+            _msgpack_enc(
+                (
+                    obj.__class__.__module__,
+                    obj.__class__.__name__,
+                    (factory_ref, dict(obj)),
+                ),
+            ),
+        )
     elif isinstance(obj, (set, frozenset, deque)):
         return ormsgpack.Ext(
             EXT_CONSTRUCTOR_SINGLE_ARG,
@@ -530,6 +589,39 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
 
     elif isinstance(obj, BaseException):
         return repr(obj)
+    elif (np_mod := sys.modules.get("numpy")) is not None and isinstance(
+        obj, np_mod.generic
+    ):
+        return obj.item()
+    elif isinstance(obj, str) and type(obj) is not str:
+        return str(obj)
+    elif isinstance(obj, bool):
+        return obj
+    elif isinstance(obj, int) and type(obj) is not int:
+        return int(obj)
+    elif isinstance(obj, float) and type(obj) is not float:
+        return float(obj)
+    elif isinstance(obj, bytes) and type(obj) is not bytes:
+        return bytes(obj)
+    elif isinstance(obj, bytearray) and type(obj) is not bytearray:
+        return bytearray(obj)
+    elif isinstance(obj, list) and type(obj) is not list:
+        return list(obj)
+    elif isinstance(obj, tuple) and type(obj) is not tuple:
+        return tuple(obj)
+    elif isinstance(obj, dict) and type(obj) is not dict:
+        _warn_once(
+            _warned_unregistered_types,
+            (obj.__class__.__module__, obj.__class__.__name__),
+            "Serializing dict subclass %s.%s as a plain dict.",
+            obj.__class__.__module__,
+            obj.__class__.__name__,
+        )
+        return dict(obj)
+    elif isinstance(obj, set) and type(obj) is not set:
+        return set(obj)
+    elif isinstance(obj, frozenset) and type(obj) is not frozenset:
+        return frozenset(obj)
     else:
         raise TypeError(f"Object of type {obj.__class__.__name__} is not serializable")
 
@@ -660,6 +752,11 @@ def _create_msgpack_ext_hook(
                     return tup[2]
                 if tup[0] == "langgraph.types" and tup[1] == "Send":
                     return _send_from_args(tup[2])
+                if tup[0] == "collections" and tup[1] == "defaultdict":
+                    factory_ref, items = tup[2]
+                    result = defaultdict(_decode_default_factory(factory_ref))
+                    result.update(items)
+                    return result
                 # module, name, args
                 return getattr(importlib.import_module(tup[0]), tup[1])(*tup[2])
             except Exception:
@@ -851,9 +948,42 @@ _option = (
     | ormsgpack.OPT_PASSTHROUGH_DATACLASS
     | ormsgpack.OPT_PASSTHROUGH_DATETIME
     | ormsgpack.OPT_PASSTHROUGH_ENUM
+    | ormsgpack.OPT_PASSTHROUGH_SUBCLASS
     | ormsgpack.OPT_PASSTHROUGH_UUID
     | ormsgpack.OPT_REPLACE_SURROGATES
 )
+
+
+_BUILTIN_DEFAULT_FACTORIES: dict[type[Any] | None, tuple[str, str] | None] = {
+    None: None,
+    list: ("builtins", "list"),
+    int: ("builtins", "int"),
+    set: ("builtins", "set"),
+    dict: ("builtins", "dict"),
+    float: ("builtins", "float"),
+    str: ("builtins", "str"),
+    bool: ("builtins", "bool"),
+}
+
+
+def _encode_default_factory(
+    factory: Callable[[], Any] | None,
+) -> tuple[str, str] | None:
+    if factory in _BUILTIN_DEFAULT_FACTORIES:
+        return _BUILTIN_DEFAULT_FACTORIES[factory]
+    mod = getattr(factory, "__module__", None)
+    name = getattr(factory, "__name__", None)
+    if mod == "builtins" and name:
+        return (mod, name)
+    msg = f"Cannot serialize defaultdict default_factory: {factory!r}"
+    raise ValueError(msg)
+
+
+def _decode_default_factory(ref: tuple[str, str] | None) -> Callable[[], Any] | None:
+    if ref is None:
+        return None
+    mod, name = ref
+    return getattr(importlib.import_module(mod), name)
 
 
 def _msgpack_enc(data: Any) -> bytes:

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -8,10 +8,11 @@ import re
 import sys
 import tempfile
 import uuid
-from collections import deque
+from collections import Counter, OrderedDict, defaultdict, deque
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
 from enum import Enum
+from fractions import Fraction
 from ipaddress import IPv4Address
 from zoneinfo import ZoneInfo
 
@@ -1230,3 +1231,101 @@ def test_msgpack_nested_pydantic_serializes_as_dict(
     # No blocking should occur - inner is serialized as dict, not ext
     assert "blocked" not in caplog.text.lower()
     assert result == obj
+
+
+def test_serde_fraction_and_complex_roundtrip() -> None:
+    """Regression for #8185: Fraction and complex must round-trip like Decimal."""
+    serde = JsonPlusSerializer()
+    fraction = Fraction(1, 3)
+    value = complex(1, 2)
+
+    assert serde.loads_typed(serde.dumps_typed(fraction)) == fraction
+    assert serde.loads_typed(serde.dumps_typed(value)) == value
+    assert serde.loads_typed(serde.dumps_typed(Decimal("1.5"))) == Decimal("1.5")
+
+
+def test_serde_fraction_and_complex_strict_mode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+
+    for obj in (Fraction(2, 5), complex(-3.5, 4.25)):
+        caplog.clear()
+        restored = serde.loads_typed(serde.dumps_typed(obj))
+        assert restored == obj
+        assert "blocked" not in caplog.text.lower()
+
+
+@pytest.mark.parametrize(
+    ("factory", "payload"),
+    [
+        (list, {"a": [1]}),
+        (int, {"x": 1}),
+    ],
+)
+def test_serde_defaultdict_preserves_default_factory(
+    factory: type,
+    payload: dict[str, object],
+) -> None:
+    """Regression for #8184: defaultdict must not downcast to plain dict."""
+    serde = JsonPlusSerializer()
+    original: defaultdict = defaultdict(factory, payload)
+
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert isinstance(restored, defaultdict)
+    assert restored.default_factory is factory
+    assert dict(restored) == payload
+    if factory is list:
+        restored["new"].append(0)
+        assert restored["new"] == [0]
+    else:
+        assert restored["missing"] == 0
+        restored["missing"] += 2
+        assert restored["missing"] == 2
+
+
+def test_serde_counter_and_ordered_dict_roundtrip() -> None:
+    """Regression for #8184: Counter and OrderedDict must preserve type semantics."""
+    serde = JsonPlusSerializer()
+
+    counter = Counter({"b": 3, "a": 1})
+    restored_counter = serde.loads_typed(serde.dumps_typed(counter))
+    assert isinstance(restored_counter, Counter)
+    assert restored_counter.most_common(1) == [("b", 3)]
+    assert dict(restored_counter) == dict(counter)
+
+    ordered = OrderedDict([("first", 1), ("second", 2)])
+    ordered.move_to_end("first")
+    restored_ordered = serde.loads_typed(serde.dumps_typed(ordered))
+    assert isinstance(restored_ordered, OrderedDict)
+    assert list(restored_ordered.keys()) == list(ordered.keys())
+    restored_ordered.move_to_end("second")
+    assert list(restored_ordered.keys()) == ["first", "second"]
+
+
+def test_serde_defaultdict_unencodable_factory_downcasts_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    serde = JsonPlusSerializer()
+    original = defaultdict(lambda: [])
+    original["a"].append(1)
+
+    caplog.set_level(logging.WARNING, logger="langgraph.checkpoint.serde.jsonplus")
+    restored = serde.loads_typed(serde.dumps_typed(original))
+
+    assert isinstance(restored, dict)
+    assert not isinstance(restored, defaultdict)
+    assert restored == {"a": [1]}
+    assert "default_factory" in caplog.text
+
+
+def test_serde_numpy_scalar_in_dict_roundtrip() -> None:
+    serde = JsonPlusSerializer()
+    payload = {"count": np.int64(7), "ratio": np.float64(1.25)}
+
+    restored = serde.loads_typed(serde.dumps_typed(payload))
+
+    assert restored == {"count": 7, "ratio": 1.25}
+    assert type(restored["count"]) is int
+    assert type(restored["ratio"]) is float


### PR DESCRIPTION
## Summary
- **#8185**: Add `fractions.Fraction` and `complex` handlers to `JsonPlusSerializer._msgpack_default`, using positional constructor args for lossless round-trip (same ext pattern as other stdlib numerics). Register both in `SAFE_MSGPACK_TYPES` for strict mode.
- **#8184**: Enable `OPT_PASSTHROUGH_SUBCLASS` so `defaultdict` / `Counter` / `OrderedDict` reach the encoder instead of being silently downcast to plain `dict`. Each gets an explicit ext handler; `defaultdict` also preserves encodable `default_factory` values (builtins). Unencodable factories warn and fall back to plain dict. Native-base subclass fallbacks (e.g. numpy scalars → `.item()`) prevent regressions from passthrough.

## Test plan
- [x] `pytest libs/checkpoint/tests/test_jsonplus.py` — 106/106
- [x] `make test` in `libs/checkpoint` — 163 passed
- [x] `make format` / `make lint` in `libs/checkpoint`
- [x] Fraction / complex round-trip + strict-mode tests (#8185)
- [x] defaultdict / Counter / OrderedDict type-preservation tests (#8184)
- [x] numpy scalar in dict round-trip (passthrough fallback)
- [x] unencodable defaultdict factory warns and downcasts

Fixes #8184
Fixes #8185

Made with [Cursor](https://cursor.com)