### PR TITLE
fix(checkpoint): skip None channel values in get_delta_channel_history across all savers

### DIFF
--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_delta_channel_history.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_delta_channel_history.py
@@ -267,6 +267,69 @@ async def test_history_seed_ancestor_own_writes_are_replayed(
     )
 
 
+async def test_history_none_plain_value_is_not_a_seed(
+    saver: BaseCheckpointSaver,
+) -> None:
+    """A `None` value in `channel_values` is not a valid seed — the walk must
+    keep going past it rather than terminating there.
+
+    `None` shows up at a migration boundary where a thread moved from a
+    regular channel (e.g. `BinaryOperatorAggregate`) to `DeltaChannel` with a
+    reducer that had cleared the accumulated value to `None`. Treating it as
+    a seed stops the walk early and hands a `None` base to the reducer on
+    replay, which crashes for any reducer that doesn't special-case `None`.
+
+    Step 1 stores `None` (the boundary checkpoint); nothing else in the
+    chain ever populates `channel_values`. The walk must pass through step
+    1 without stopping and reach the root — so `seed` is absent from the
+    result, AND step 0's write (older than step 1) must still be collected,
+    which only happens if the walk actually continued past step 1 instead
+    of wrongly terminating there.
+    """
+    tid = str(uuid4())
+    configs: list = []
+    parent_cfg = None
+
+    for step in range(4):
+        config = {"configurable": {"thread_id": tid, "checkpoint_ns": ""}}
+        if parent_cfg:
+            config["configurable"]["checkpoint_id"] = parent_cfg["configurable"][
+                "checkpoint_id"
+            ]
+        cv: dict = {}
+        cvs: dict = {}
+        # Step 1: migration-boundary checkpoint — value cleared to None.
+        if step == 1:
+            cv["ch"] = None
+            cvs["ch"] = step + 1
+        cp = Checkpoint(
+            v=1,
+            id=str(uuid6(clock_seq=-1)),
+            ts="",
+            channel_values=cv,
+            channel_versions=cvs,
+            versions_seen={},
+            updated_channels=None,
+        )
+        parent_cfg = await saver.aput(config, cp, generate_metadata(step=step), cvs)
+        configs.append(parent_cfg)
+        if step != 1:
+            await saver.aput_writes(parent_cfg, [("ch", step)], str(uuid4()))
+
+    head = configs[-1]
+    result = await saver.aget_delta_channel_history(config=head, channels=["ch"])
+    entry = result["ch"]
+
+    assert "seed" not in entry, (
+        f"a None channel value must not be treated as a seed, got {entry}"
+    )
+    values = [w[2] for w in entry["writes"]]
+    assert values == [0, 2], (
+        "expected the walk to continue past the None at step 1 and collect "
+        f"step 0's write too, got {values}"
+    )
+
+
 ALL_DELTA_CHANNEL_HISTORY_TESTS = [
     test_history_returns_writes_oldest_first,
     test_history_seed_is_nearest_snapshot,
@@ -276,6 +339,7 @@ ALL_DELTA_CHANNEL_HISTORY_TESTS = [
     test_history_walk_to_root_no_seed,
     test_history_migration_plain_value_as_seed,
     test_history_seed_ancestor_own_writes_are_replayed,
+    test_history_none_plain_value_is_not_a_seed,
 ]
 
 

--- a/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/_delta.py
+++ b/libs/checkpoint-sqlite/langgraph/checkpoint/sqlite/_delta.py
@@ -89,8 +89,13 @@ def step_walk_with_row(
     For each subsequent row, if `cid` matches the walk's current
     position, we deserialize the blob, append the cid to every
     not-yet-seeded channel's chain, and check `channel_values` for
-    seeds. The deserialized checkpoint is dropped before advancing — no
-    cross-row cache, so peak in-flight is one deserialized checkpoint.
+    seeds. A `None` value is treated as "nothing stored" rather than a
+    seed — it shows up at a migration boundary where a thread moved from
+    a regular channel to `DeltaChannel` with a reducer that had cleared
+    the value to `None` — so the walk keeps going past it instead of
+    terminating there. The deserialized checkpoint is dropped before
+    advancing — no cross-row cache, so peak in-flight is one deserialized
+    checkpoint.
 
     Off-path rows (different branch on the same thread) advance the
     cursor without doing any work.
@@ -115,7 +120,9 @@ def step_walk_with_row(
         chain_by_ch[ch].append(cid)
     ckpt = serde.loads_typed((type_tag, blob))
     channel_values: Mapping[str, Any] = ckpt.get("channel_values") or {}
-    for ch in [ch for ch in active if ch in channel_values]:
+    for ch in [
+        ch for ch in active if ch in channel_values and channel_values[ch] is not None
+    ]:
         seed_val_by_ch[ch] = channel_values[ch]
         seeded.add(ch)
         active.discard(ch)

--- a/libs/checkpoint-sqlite/tests/test_get_delta_channel_history.py
+++ b/libs/checkpoint-sqlite/tests/test_get_delta_channel_history.py
@@ -193,6 +193,51 @@ def test_seed_present_when_snapshot_in_ancestor_sync() -> None:
         assert seed.value == snapshot_value
 
 
+def test_none_channel_value_is_not_a_seed_sync() -> None:
+    """A `None` value in `channel_values` must not terminate the walk.
+
+    `None` shows up at a migration boundary where a thread moved from a
+    regular channel to `DeltaChannel` with a reducer that had cleared the
+    value to `None`. Treating it as a seed stops the walk early and hands a
+    `None` base to the reducer on replay.
+    """
+    with SqliteSaver.from_conn_string(":memory:") as saver:
+        config: RunnableConfig = {"configurable": {"thread_id": "none-seed-sync"}}
+        graph = _delta_graph(saver)
+        _drive(graph, config, 2)
+
+        history = list(saver.list(config))
+        assert len(history) >= 2
+        leaf_tup = history[0]
+        ancestor_tup = next(
+            (tup for tup in history if tup.parent_config is not None), None
+        )
+        assert ancestor_tup is not None
+        parent_cfg = ancestor_tup.parent_config
+        assert parent_cfg is not None
+        parent_tup = saver.get_tuple(parent_cfg)
+        assert parent_tup is not None
+
+        # Overwrite the ancestor's channel value with a real None — not the
+        # absence of a key — mirroring a cleared-to-None migration boundary.
+        parent_tup.checkpoint["channel_values"]["items"] = None
+        parent_tup.checkpoint["channel_versions"].setdefault("items", 1)
+        saver.put(
+            parent_tup.parent_config or {"configurable": parent_cfg["configurable"]},
+            parent_tup.checkpoint,
+            parent_tup.metadata,
+            {},
+        )
+
+        result = saver.get_delta_channel_history(
+            config=leaf_tup.config, channels=["items"]
+        )
+        entry = result["items"]
+        assert "seed" not in entry, (
+            f"a None channel value must not be treated as a seed, got {entry}"
+        )
+
+
 def test_seed_omitted_when_walk_reaches_root_sync() -> None:
     """`get_delta_channel_history` on the root checkpoint → no `seed` key, no writes."""
     with SqliteSaver.from_conn_string(":memory:") as saver:

--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -595,9 +595,13 @@ class BaseCheckpointSaver(Generic[V]):
         For each requested channel, walks ancestors of the checkpoint
         identified by `config` (following `parent_config`) and accumulates
         `pending_writes` for that channel. The walk terminates per-channel
-        at the nearest ancestor whose `channel_values[ch]` is populated;
-        that value is returned as `seed`. If the walk reaches the root
-        without finding a stored value, `seed` is omitted from that
+        at the nearest ancestor whose `channel_values[ch]` is populated
+        with a non-`None` value; that value is returned as `seed`. A
+        `None` entry is treated as "nothing stored" — it shows up at a
+        migration boundary where a thread moved from a regular channel to
+        `DeltaChannel` with a reducer that had cleared the value to
+        `None` — so the walk keeps going past it. If the walk reaches the
+        root without finding a stored value, `seed` is omitted from that
         channel's entry — the consumer treats the absence as "start
         empty."
 
@@ -637,8 +641,10 @@ class BaseCheckpointSaver(Generic[V]):
                         collected_by_ch[ch].append(write)
             for ch in list(remaining):
                 if ch in tup.checkpoint["channel_values"]:
-                    seed_by_ch[ch] = tup.checkpoint["channel_values"][ch]
-                    remaining.discard(ch)
+                    value = tup.checkpoint["channel_values"][ch]
+                    if value is not None:
+                        seed_by_ch[ch] = value
+                        remaining.discard(ch)
             cursor_config = tup.parent_config
         result: dict[str, DeltaChannelHistory] = {}
         for ch in channels:
@@ -678,8 +684,10 @@ class BaseCheckpointSaver(Generic[V]):
                         collected_by_ch[ch].append(write)
             for ch in list(remaining):
                 if ch in tup.checkpoint["channel_values"]:
-                    seed_by_ch[ch] = tup.checkpoint["channel_values"][ch]
-                    remaining.discard(ch)
+                    value = tup.checkpoint["channel_values"][ch]
+                    if value is not None:
+                        seed_by_ch[ch] = value
+                        remaining.discard(ch)
             cursor_config = tup.parent_config
         result: dict[str, DeltaChannelHistory] = {}
         for ch in channels:

--- a/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/memory/__init__.py
@@ -145,8 +145,13 @@ class InMemorySaver(
         """Override: walk the parent chain ONCE for all requested channels.
 
         Each channel terminates independently at the nearest ancestor
-        whose stored blob is non-empty. Other channels keep walking until
-        they find their own terminator or hit the root.
+        whose stored blob is non-empty and deserializes to a non-`None`
+        value. A `None` blob is treated as "nothing stored" — it shows up
+        at a migration boundary where a thread moved from a regular
+        channel to `DeltaChannel` with a reducer that had cleared the
+        value to `None` — so that channel keeps walking past it. Other
+        channels keep walking until they find their own terminator or hit
+        the root.
 
         A blob is the value AT its ancestor, prior to the writes stored
         under that same ancestor (those writes produce its child, which
@@ -195,7 +200,10 @@ class InMemorySaver(
                     blob_entry = self.blobs.get((thread_id, checkpoint_ns, ch, ver))
                     if blob_entry is None or blob_entry[0] == "empty":
                         continue
-                    blob_value_by_ch[ch] = self.serde.loads_typed(blob_entry)
+                    value = self.serde.loads_typed(blob_entry)
+                    if value is None:
+                        continue
+                    blob_value_by_ch[ch] = value
                     terminated_here.add(ch)
 
             step_writes = self.writes.get((thread_id, checkpoint_ns, cp_id), {})

--- a/libs/checkpoint/tests/test_memory.py
+++ b/libs/checkpoint/tests/test_memory.py
@@ -707,3 +707,102 @@ class TestPreDeltaBlobTerminator:
         assert "PRE-DELTA-WRITE" in values
         # And the pending write at the target is never folded in.
         assert "PENDING-AT-TARGET" not in values
+
+
+class TestNoneBlobIsNotASeed:
+    """A `None` blob must not terminate the ancestor walk.
+
+    `None` shows up at a migration boundary where a thread moved from a
+    regular channel to `DeltaChannel` with a reducer that had cleared the
+    accumulated value to `None`. Treating it as a seed stops the walk early
+    and hands a `None` base to the reducer on replay, which crashes for any
+    reducer that doesn't special-case `None`.
+    """
+
+    def test_walk_skips_none_blob_to_find_real_seed(self) -> None:
+        """cp1's blob is a real (serialized) `None` — nearer than cp0's real
+        blob `["A"]`. The walk must not stop at cp1; it must keep going and
+        seed from cp0 instead, replaying every write in between.
+        """
+        saver = InMemorySaver()
+        serde = JsonPlusSerializer()
+        thread_id, ns, channel = "t1", "", "messages"
+
+        v0 = "00000000000000000000000000000000.0"
+        v1 = "00000000000000000000000000000001.0"
+        v2 = "00000000000000000000000000000002.0"
+        v3 = "00000000000000000000000000000003.0"
+
+        saver.blobs[(thread_id, ns, channel, v0)] = serde.dumps_typed(["A"])
+        # Real None, not the "empty" sentinel — must not be read as a seed.
+        saver.blobs[(thread_id, ns, channel, v1)] = serde.dumps_typed(None)
+        saver.blobs[(thread_id, ns, channel, v2)] = ("empty", b"")
+        saver.blobs[(thread_id, ns, channel, v3)] = ("empty", b"")
+
+        cp0 = empty_checkpoint()
+        cp0["id"] = "cp0"
+        cp0["channel_versions"][channel] = v0
+        cp1 = empty_checkpoint()
+        cp1["id"] = "cp1"
+        cp1["channel_versions"][channel] = v1
+        cp2 = empty_checkpoint()
+        cp2["id"] = "cp2"
+        cp2["channel_versions"][channel] = v2
+        cp3 = empty_checkpoint()
+        cp3["id"] = "cp3"
+        cp3["channel_versions"][channel] = v3
+
+        saver.storage[thread_id][ns] = {
+            "cp0": (serde.dumps_typed(cp0), serde.dumps_typed({}), None),
+            "cp1": (serde.dumps_typed(cp1), serde.dumps_typed({}), "cp0"),
+            "cp2": (serde.dumps_typed(cp2), serde.dumps_typed({}), "cp1"),
+            "cp3": (serde.dumps_typed(cp3), serde.dumps_typed({}), "cp2"),
+        }
+        # Stored AT the seed ancestor (cp0) — not subsumed, must be replayed.
+        saver.writes[(thread_id, ns, "cp0")][("task0", 0)] = (
+            "task0",
+            channel,
+            serde.dumps_typed("AT-SEED-WRITE"),
+            "",
+        )
+        # Stored AT the None checkpoint (cp1) — the walk must pass through
+        # cp1 to reach cp0, so this write must be replayed too.
+        saver.writes[(thread_id, ns, "cp1")][("task1", 0)] = (
+            "task1",
+            channel,
+            serde.dumps_typed("PAST-NONE-WRITE"),
+            "",
+        )
+        saver.writes[(thread_id, ns, "cp2")][("task2", 0)] = (
+            "task2",
+            channel,
+            serde.dumps_typed("B"),
+            "",
+        )
+        saver.writes[(thread_id, ns, "cp3")][("task3", 0)] = (
+            "task3",
+            channel,
+            serde.dumps_typed("PENDING-AT-TARGET"),
+            "",
+        )
+
+        config: RunnableConfig = {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": ns,
+                "checkpoint_id": "cp3",
+            }
+        }
+        result = saver.get_delta_channel_history(config=config, channels=[channel])[
+            channel
+        ]
+
+        assert result["seed"] == ["A"], (
+            f"expected the walk to skip the None blob at cp1 and seed from "
+            f"cp0, got {result.get('seed', '<missing>')!r}"
+        )
+        values = [v for _, _, v in result["writes"]]
+        assert values == ["AT-SEED-WRITE", "PAST-NONE-WRITE", "B"], (
+            f"expected writes from cp0 through cp2 to be replayed in order, "
+            f"got {values}"
+        )


### PR DESCRIPTION
Fixes #8686

## Problem
`get_delta_channel_history` treats a `None` channel value as a 
valid seed, causing migrated threads to break with TypeError.

PostgresSaver already guards against this (`has_blob or inline is 
not None`, added in #8535). The three other implementations never 
got the same check.

## Fix
Ports the `value is not None` guard to:
- `libs/checkpoint/langgraph/checkpoint/base/__init__.py`
- `libs/checkpoint/langgraph/checkpoint/memory/__init__.py`
- `libs/checkpoint/langgraph/checkpoint/sqlite/_delta.py`

## Tests
- Conformance suite: `test_history_none_plain_value_is_not_a_seed`
  runs against InMemorySaver and AsyncSqliteSaver
- Narrow InMemorySaver test proving walk skips None blob
- Narrow SqliteSaver test on optimized path

All tests confirmed failing pre-fix, passing post-fix.
`ruff format`, `ruff check`, `ty check` clean on all packages.