### PR TITLE
fix(store): reject negative pagination values

### DIFF
--- a/libs/checkpoint/langgraph/store/base/__init__.py
+++ b/libs/checkpoint/langgraph/store/base/__init__.py
@@ -840,6 +840,7 @@ class BaseStore(ABC):
                 Natural language search support depends on your store implementation
                 and requires proper embedding configuration.
         """
+        _validate_pagination(limit, offset)
         return self.batch(
             [
                 SearchOp(
@@ -984,6 +985,7 @@ class BaseStore(ABC):
             # [("a", "b", "c"), ("a", "b", "d"), ("a", "b", "f")]
             ```
         """
+        _validate_pagination(limit, offset)
         match_conditions = []
         if prefix:
             match_conditions.append(MatchCondition(match_type="prefix", path=prefix))
@@ -1091,6 +1093,7 @@ class BaseStore(ABC):
                 Natural language search support depends on your store implementation
                 and requires proper embedding configuration.
         """
+        _validate_pagination(limit, offset)
         return (
             await self.abatch(
                 [
@@ -1245,6 +1248,7 @@ class BaseStore(ABC):
             # Returns: [("a", "b", "c"), ("a", "b", "d"), ("a", "b", "f")]
             ```
         """
+        _validate_pagination(limit, offset)
         match_conditions = []
         if prefix:
             match_conditions.append(MatchCondition(match_type="prefix", path=prefix))
@@ -1281,6 +1285,13 @@ def _validate_namespace(namespace: tuple[str, ...]) -> None:
         raise InvalidNamespaceError(
             f'Root label for namespace cannot be "langgraph". Got: {namespace}'
         )
+
+
+def _validate_pagination(limit: int, offset: int) -> None:
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
 
 
 def _ensure_refresh(

--- a/libs/checkpoint/langgraph/store/base/batch.py
+++ b/libs/checkpoint/langgraph/store/base/batch.py
@@ -25,6 +25,7 @@ from langgraph.store.base import (
     _ensure_refresh,
     _ensure_ttl,
     _validate_namespace,
+    _validate_pagination,
 )
 
 F = TypeVar("F", bound=Callable)
@@ -111,6 +112,7 @@ class AsyncBatchedBaseStore(BaseStore):
         offset: int = 0,
         refresh_ttl: bool | None = None,
     ) -> list[SearchItem]:
+        _validate_pagination(limit, offset)
         self._ensure_task()
         fut = self._loop.create_future()
         self._aqueue.put_nowait(
@@ -169,6 +171,7 @@ class AsyncBatchedBaseStore(BaseStore):
         limit: int = 100,
         offset: int = 0,
     ) -> list[tuple[str, ...]]:
+        _validate_pagination(limit, offset)
         self._ensure_task()
         fut = self._loop.create_future()
         match_conditions = []

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -316,6 +316,33 @@ def test_list_namespaces_basic() -> None:
     assert result == expected
 
 
+@pytest.mark.parametrize("method", ["search", "list_namespaces"])
+@pytest.mark.parametrize("parameter", ["limit", "offset"])
+def test_negative_pagination_is_rejected(method: str, parameter: str) -> None:
+    store = InMemoryStore()
+
+    with pytest.raises(ValueError, match=f"^{parameter} must be non-negative$"):
+        if method == "search":
+            store.search(("test",), **{parameter: -1})
+        else:
+            store.list_namespaces(**{parameter: -1})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["asearch", "alist_namespaces"])
+@pytest.mark.parametrize("parameter", ["limit", "offset"])
+async def test_negative_async_pagination_is_rejected(
+    method: str, parameter: str
+) -> None:
+    store = MockAsyncBatchedStore()
+
+    with pytest.raises(ValueError, match=f"^{parameter} must be non-negative$"):
+        if method == "asearch":
+            await store.asearch(("test",), **{parameter: -1})
+        else:
+            await store.alist_namespaces(**{parameter: -1})
+
+
 def test_list_namespaces_with_wildcards() -> None:
     store = InMemoryStore()
 


### PR DESCRIPTION
## Problem

`BaseStore` pagination accepts negative `limit` and `offset` values without defining their behavior. The same request then behaves differently across store implementations: in-memory slicing can silently drop items, SQLite treats a negative limit as unbounded, and PostgreSQL rejects it.

## Root Cause

The public `search`, `asearch`, `list_namespaces`, and `alist_namespaces` methods pass pagination values directly into store operations. `AsyncBatchedBaseStore` has separate public implementations and also bypasses a shared validation point.

## Solution

Validate `limit` and `offset` at the public store API boundary and raise `ValueError` when either value is negative. This keeps all store implementations on one explicit contract while leaving direct low-level batch operations unchanged.

## Changes

- Added shared non-negative pagination validation to `BaseStore` sync/async APIs.
- Applied the same validation to `AsyncBatchedBaseStore` entry points.
- Added synchronous and asynchronous regression coverage for search and namespace pagination.

## Testing

- Baseline: `py -3.10 -m uv run --locked --group test pytest tests/test_store.py -k "list_namespaces or search" -q` — 11 passed.
- Focused regression: `py -3.10 -m uv run --locked --group test pytest tests/test_store.py -k "list_namespaces or search or negative" -q` — 19 passed.
- Full library store test: `py -3.10 -m uv run --locked --group test pytest tests/test_store.py -q` — 32 passed.
- Format: `py -3.10 -m uv run --locked --group lint ruff format ...` — changed files formatted.
- Lint: `py -3.10 -m uv run --locked --group lint ruff check langgraph/store/base/__init__.py langgraph/store/base/batch.py tests/test_store.py` — passed.
- Typecheck: `py -3.10 -m uv run --locked --group lint ty check` — passed.
- `git diff --check` — passed.
- Repository `make format`, `make lint`, and `make test` were unavailable because GNU Make is not installed on Windows; the equivalent locked `uv` gates above were run.

## Compatibility/Risk

This changes only invalid negative pagination inputs, which previously had inconsistent behavior and could silently lose results. Valid non-negative pagination behavior is unchanged. Callers that intentionally passed negative values will now receive a clear `ValueError`.

## Notes for Reviewer

The validation is intentionally at the public API boundary; direct `SearchOp`/`ListNamespacesOp` batch submission remains untouched. The tests cover both the base in-memory path and the asynchronous batching path.

## Linked Issue

Fixes #8696
