### PR TITLE
Fix datetime64/timedelta64 serialization in JsonPlusSerializer (Fixes #8689)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -516,7 +516,10 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         obj, np_mod.ndarray
     ):
         order = "F" if obj.flags.f_contiguous and not obj.flags.c_contiguous else "C"
-        if obj.flags.c_contiguous:
+        # datetime64 (dtype.kind 'M') and timedelta64 (dtype.kind 'm') arrays
+        # are C-contiguous but do not support the buffer protocol, so memoryview()
+        # raises ValueError. Route them through the tobytes() path instead.
+        if obj.flags.c_contiguous and obj.dtype.kind not in "Mm":
             mv = memoryview(obj)
             try:
                 meta = (obj.dtype.str, obj.shape, order, mv)

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -626,6 +626,26 @@ def test_serde_jsonplus_numpy_array_json_hook(arr: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
+    "arr",
+    [
+        np.array(["2020-01-01", "2020-02-01"], dtype="datetime64[D]"),
+        np.array([1, 2, 3], dtype="timedelta64[D]"),
+        np.array(["2020-01-01", "2020-02-01", "2020-03-01"], dtype="datetime64[D]")[::2],
+    ],
+)
+def test_serde_jsonplus_datetime64_timedelta64_arrays(arr: np.ndarray) -> None:
+    """Test that datetime64 and timedelta64 arrays (C-contiguous and non-contiguous) serialize and round-trip correctly."""
+    serde = JsonPlusSerializer()
+
+    dumped = serde.dumps_typed(arr)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == arr.dtype
+    assert np.array_equal(result, arr)
+
+
+@pytest.mark.parametrize(
     "df",
     [
         pd.DataFrame(),


### PR DESCRIPTION
## Summary

This PR fixes issue #8689 where `datetime64` and `timedelta64` numpy arrays fail to serialize in `JsonPlusSerializer`.

## Problem

`datetime64` (dtype.kind 'M') and `timedelta64` (dtype.kind 'm') numpy arrays are C-contiguous but do not support the buffer protocol. When the `JsonPlusSerializer` tried to use the fast path with `memoryview(obj)` for C-contiguous arrays, it raised `ValueError: cannot include dtype 'M' in a buffer`, which surfaced as a `TypeError`.

## Solution

Modified the serialization logic in `_msgpack_default` to route `datetime64` (dtype.kind 'M') and `timedelta64` (dtype.kind 'm') arrays through the `tobytes()` path instead of the `memoryview()` fast path, since these dtypes don't support the buffer protocol.

## Changes

- Modified `_msgpack_default` in `libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py` to check `obj.dtype.kind not in \"Mm\"` before using the memoryview fast path
- Added tests for `datetime64` and `timedelta64` arrays (both C-contiguous and non-contiguous)

## Testing

- All existing tests pass (102 tests in test_jsonplus.py)
- Added 3 new tests for datetime64/timedelta64 arrays (C-contiguous and non-contiguous)
- Verified the exact reproduction case from the issue now works

Fixes #8689