### PR TITLE
fix(checkpoint): serialize numpy scalars in JsonPlusSerializer (#8705)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -300,6 +300,7 @@ EXT_PYDANTIC_V1 = 4
 EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 EXT_DELTA_SNAPSHOT = 7
+EXT_NUMPY_SCALAR = 8
 
 
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
@@ -527,6 +528,12 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             buf = obj.tobytes(order="A")
             meta = (obj.dtype.str, obj.shape, order, buf)
             return ormsgpack.Ext(EXT_NUMPY_ARRAY, _msgpack_enc(meta))
+    elif (np_mod := sys.modules.get("numpy")) is not None and isinstance(
+        obj, np_mod.generic
+    ):
+        buf = obj.tobytes()
+        meta = (obj.dtype.str, buf)
+        return ormsgpack.Ext(EXT_NUMPY_SCALAR, _msgpack_enc(meta))
 
     elif isinstance(obj, BaseException):
         return repr(obj)
@@ -739,6 +746,17 @@ def _create_msgpack_ext_hook(
                 return arr.reshape(shape, order=order)
             except Exception:
                 return None
+        elif code == EXT_NUMPY_SCALAR:
+            try:
+                import numpy as _np
+
+                dtype_str, buf = ormsgpack.unpackb(
+                    data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+                )
+                arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
+                return arr[0]
+            except Exception:
+                return None
         return None
 
     return ext_hook
@@ -835,6 +853,19 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             )
             arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
             return arr.reshape(shape, order=order).tolist()
+        except Exception:
+            return
+    elif code == EXT_NUMPY_SCALAR:
+        try:
+            import numpy as _np
+
+            dtype_str, buf = ormsgpack.unpackb(
+                data,
+                ext_hook=_msgpack_ext_hook_to_json,
+                option=ormsgpack.OPT_NON_STR_KEYS,
+            )
+            arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
+            return arr[0].item()
         except Exception:
             return
 

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -626,6 +626,54 @@ def test_serde_jsonplus_numpy_array_json_hook(arr: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
+    "val",
+    [
+        np.float64(3.14159),
+        np.float32(1.5),
+        np.int64(42),
+        np.int32(100),
+        np.int16(-5),
+        np.int8(12),
+        np.uint8(255),
+        np.bool_(True),
+        np.bool_(False),
+        np.complex128(1 + 2j),
+        np.datetime64("2024-01-01T00:00:00"),
+        np.timedelta64(5, "D"),
+    ],
+)
+def test_serde_jsonplus_numpy_scalar(val: np.generic) -> None:
+    serde = JsonPlusSerializer()
+
+    dumped = serde.dumps_typed(val)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert isinstance(result, type(val))
+    assert result.dtype == val.dtype
+    assert result == val
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        np.float64(3.14159),
+        np.float32(1.5),
+        np.int64(42),
+        np.int32(100),
+        np.bool_(True),
+        np.bool_(False),
+    ],
+)
+def test_serde_jsonplus_numpy_scalar_json_hook(val: np.generic) -> None:
+    serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
+    dumped = serde.dumps_typed(val)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert type(result) is type(val.item())
+    assert result == val.item()
+
+
+@pytest.mark.parametrize(
     "df",
     [
         pd.DataFrame(),


### PR DESCRIPTION
### Description
Fixes #8705.

`JsonPlusSerializer` currently supports `numpy.ndarray` (`EXT_NUMPY_ARRAY = 6`), but `numpy.generic` scalar instances (such as `np.float64`, `np.int64`, `np.bool_`, `np.datetime64`, `np.timedelta64`, etc. produced by Pandas operations or NumPy reductions like `arr.mean()` / `arr[0]`) raise `TypeError: Type is not msgpack serializable: numpy.float64` during state checkpointing.

This PR introduces `EXT_NUMPY_SCALAR = 8` to handle `numpy.generic` scalar instances:
1. **Serialization (`_msgpack_default`)**: Serializes `isinstance(obj, np_mod.generic)` by encoding `(obj.dtype.str, obj.tobytes())` under `EXT_NUMPY_SCALAR`.
2. **Deserialization (`_create_msgpack_ext_hook`)**: Reconstructs the exact scalar instance via `_np.frombuffer(buf, dtype=_np.dtype(dtype_str))[0]`, preserving the exact dtype and value.
3. **JSON Hook (`_msgpack_ext_hook_to_json`)**: Uses `.item()` to safely downcast to native Python primitives for JSON-compatible consumers.
4. **Testing**: Adds comprehensive unit tests for `test_serde_jsonplus_numpy_scalar` (covering 12 scalar dtypes) and `test_serde_jsonplus_numpy_scalar_json_hook`.

### Testing
- Added unit tests in `libs/checkpoint/tests/test_jsonplus.py`
- All 169 checkpoint tests pass locally