### PR TITLE
fix(checkpoint): support serialization of datetime64 and timedelta64 ndarrays (#8689)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -516,7 +516,7 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         obj, np_mod.ndarray
     ):
         order = "F" if obj.flags.f_contiguous and not obj.flags.c_contiguous else "C"
-        if obj.flags.c_contiguous:
+        if obj.flags.c_contiguous and obj.dtype.kind not in "Mm":
             mv = memoryview(obj)
             try:
                 meta = (obj.dtype.str, obj.shape, order, mv)

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -596,6 +596,10 @@ def test_serde_jsonplus_bytearray() -> None:
         np.arange(9, dtype=np.int32).reshape(3, 3),
         np.asfortranarray(np.arange(9, dtype=np.float64).reshape(3, 3)),
         np.arange(12, dtype=np.int16)[::2].reshape(3, 2),
+        np.array(["2020-01-01", "2020-02-01"], dtype="datetime64[D]"),
+        np.array(["2024-01-01T12:00:00", "2024-01-02T12:00:00"], dtype="datetime64[s]"),
+        np.array([1, 2, 3], dtype="timedelta64[D]"),
+        np.array([100, 200, 300], dtype="timedelta64[ms]"),
     ],
 )
 def test_serde_jsonplus_numpy_array(arr: np.ndarray) -> None:
@@ -614,6 +618,8 @@ def test_serde_jsonplus_numpy_array(arr: np.ndarray) -> None:
     [
         np.arange(6, dtype=np.float32).reshape(2, 3),
         np.asfortranarray(np.arange(4, dtype=np.complex128).reshape(2, 2)),
+        np.array(["2020-01-01", "2020-02-01"], dtype="datetime64[D]"),
+        np.array([1, 2, 3], dtype="timedelta64[D]"),
     ],
 )
 def test_serde_jsonplus_numpy_array_json_hook(arr: np.ndarray) -> None:


### PR DESCRIPTION
### Description
Fixes #8689.

`JsonPlusSerializer` supports `numpy.ndarray` serialization via a dedicated msgpack extension (`EXT_NUMPY_ARRAY = 6`). When an array is C-contiguous, `_msgpack_default` enters a fast path calling `memoryview(obj)`.

However, NumPy `datetime64` (`dtype.kind == "M"`) and `timedelta64` (`dtype.kind == "m"`) arrays do not expose the Python buffer protocol, causing `memoryview()` to raise `ValueError: cannot include dtype 'M' in a buffer` (surfacing as `TypeError: Type is not msgpack serializable: numpy.ndarray`).

This PR:
1. Updates the fast-path condition in `_msgpack_default` to `obj.flags.c_contiguous and obj.dtype.kind not in "Mm"`.
2. Dtypes `'M'` and `'m'` naturally fall back to `obj.tobytes(order="A")`, which serializes correctly and is already supported on deserialization.
3. Adds test cases for C-contiguous `datetime64` and `timedelta64` arrays in `test_serde_jsonplus_numpy_array` and `test_serde_jsonplus_numpy_array_json_hook`.

### Testing
- Added unit tests in `libs/checkpoint/tests/test_jsonplus.py`
- All tests pass locally