### PR TITLE
fix(checkpoint): score zero-norm query vectors as 0.0 instead of nan

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -505,10 +505,13 @@ def _cosine_similarity(X: list[float], Y: list[list[float]]) -> list[float]:
         X_norm = np.linalg.norm(X_arr)
         Y_norm = np.linalg.norm(Y_arr, axis=1)
 
-        # Avoid division by zero
-        mask = Y_norm != 0
+        # Avoid division by zero: a zero-norm vector on either side has no
+        # direction, so it scores 0.0 against everything. This matches the
+        # pure-Python fallback below.
         similarities = np.zeros_like(Y_norm)
-        similarities[mask] = np.dot(Y_arr[mask], X_arr) / (Y_norm[mask] * X_norm)
+        if X_norm != 0:
+            mask = Y_norm != 0
+            similarities[mask] = np.dot(Y_arr[mask], X_arr) / (Y_norm[mask] * X_norm)
         return similarities.tolist()
 
     similarities = []

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -17,7 +17,7 @@ from langgraph.store.base import (
     get_text_at_path,
 )
 from langgraph.store.base.batch import AsyncBatchedBaseStore
-from langgraph.store.memory import InMemoryStore
+from langgraph.store.memory import InMemoryStore, _cosine_similarity
 from tests.embed_test_utils import CharacterEmbeddings
 
 
@@ -1044,3 +1044,19 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+@pytest.mark.parametrize("use_numpy", [True, False])
+def test_cosine_similarity_zero_norm(
+    use_numpy: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A zero-norm vector on either side scores 0.0 rather than nan."""
+    if not use_numpy:
+        monkeypatch.setattr("langgraph.store.memory._check_numpy", lambda: False)
+
+    # Zero-norm query against non-zero candidates.
+    assert _cosine_similarity([0.0, 0.0], [[1.0, 2.0], [3.0, 4.0]]) == [0.0, 0.0]
+    # Zero-norm candidate against a non-zero query.
+    assert _cosine_similarity([1.0, 0.0], [[0.0, 0.0], [1.0, 0.0]]) == [0.0, 1.0]
+    # Zero-norm on both sides.
+    assert _cosine_similarity([0.0, 0.0], [[0.0, 0.0]]) == [0.0]


### PR DESCRIPTION
Fixes #8367

The numpy path in `_cosine_similarity` masks zero-norm candidate vectors (`Y`) but never checks the query vector (`X`), so an all-zeros query embedding divides by zero and every score comes back `nan`. Because `nan` compares as neither greater nor less, the `sorted()` in `_batch_search` then leaves search results in an arbitrary order. The pure-Python fallback already returns `0.0` here — this makes the numpy path agree with it.

**How I verified:** `make test` in `libs/checkpoint` passes (153 passed, 22 skipped). The new `test_cosine_similarity_zero_norm` is parametrized over both the numpy and pure-Python paths; reverting just the source change fails it on the numpy path with `assert [nan, nan] == [0.0, 0.0]`. `ruff check` and `ruff format` are clean on both files touched.
