### PR TITLE
fix(checkpoint): preserve created_at when upserting in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -407,12 +407,17 @@ class InMemoryStore(BaseStore):
                 self._data[namespace].pop(key, None)
                 self._vectors[namespace].pop(key, None)
             else:
+                now = datetime.now(timezone.utc)
+                existing = self._data[namespace].get(key)
                 self._data[namespace][key] = Item(
                     value=op.value,
                     key=key,
                     namespace=namespace,
-                    created_at=datetime.now(timezone.utc),
-                    updated_at=datetime.now(timezone.utc),
+                    # An upsert keeps the original creation timestamp, matching
+                    # PostgresStore, whose ON CONFLICT clause updates only
+                    # `updated_at`.
+                    created_at=existing.created_at if existing else now,
+                    updated_at=now,
                 )
 
     def _extract_texts(

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1044,3 +1044,42 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_put_preserves_created_at() -> None:
+    """Upserting an existing key keeps `created_at` and advances `updated_at`."""
+    store = InMemoryStore()
+    store.put(("ns",), "key", {"count": 1})
+    original = store.get(("ns",), "key")
+    assert original is not None
+
+    store.put(("ns",), "key", {"count": 2})
+    updated = store.get(("ns",), "key")
+    assert updated is not None
+
+    assert updated.value == {"count": 2}
+    assert updated.created_at == original.created_at
+    assert updated.updated_at >= original.updated_at
+
+    # Deleting drops the item, so a later put creates it afresh.
+    store.delete(("ns",), "key")
+    store.put(("ns",), "key", {"count": 3})
+    recreated = store.get(("ns",), "key")
+    assert recreated is not None
+    assert recreated.created_at > original.created_at
+
+
+async def test_aput_preserves_created_at() -> None:
+    """The async batch path preserves `created_at` on upsert too."""
+    store = InMemoryStore()
+    await store.aput(("ns",), "key", {"count": 1})
+    original = await store.aget(("ns",), "key")
+    assert original is not None
+
+    await store.aput(("ns",), "key", {"count": 2})
+    updated = await store.aget(("ns",), "key")
+    assert updated is not None
+
+    assert updated.value == {"count": 2}
+    assert updated.created_at == original.created_at
+    assert updated.updated_at >= original.updated_at


### PR DESCRIPTION
Fixes #8340

`_apply_put_ops` builds every `Item` with `created_at=datetime.now(timezone.utc)`, so re-putting an existing key overwrites its original creation timestamp. `Item.created_at` is documented as "Timestamp of item creation", and `PostgresStore` already preserves it — its upsert is `ON CONFLICT (prefix, key) DO UPDATE SET value = ..., updated_at = CURRENT_TIMESTAMP`, which leaves `created_at` alone. This brings `InMemoryStore` in line.

Deleting a key still removes the item, so a later put creates it fresh. As a side effect, a newly created item now gets the same instant for both timestamps instead of two `now()` calls microseconds apart.

**How I verified:** `make test` in `libs/checkpoint` passes (153 passed, 22 skipped). Added sync and async regression tests; both fail without the source change.
