### PR TITLE
fix(checkpoint-postgres): expand POSTGRES_VERSION in the shell, not Make

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -5,7 +5,7 @@
 ######################
 
 start-postgres:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
+	POSTGRES_VERSION=$${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
 		echo "Failed to start PostgreSQL, printing logs..."; \
 		docker compose -f tests/compose-postgres.yml logs; \
 		exit 1 \
@@ -35,7 +35,7 @@ test:
 
 TEST ?= .
 test_watch:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} make start-postgres; \
+	POSTGRES_VERSION=$${POSTGRES_VERSION:-16} make start-postgres; \
 	uv run ptw $(TEST); \
 	EXIT_CODE=$$?; \
 	make stop-postgres; \


### PR DESCRIPTION
Fixes #8664

`POSTGRES_VERSION=${POSTGRES_VERSION:-16}` uses a single `$`, so Make expands it before `/bin/sh` ever sees it — and Make reads it as a reference to a variable literally named `POSTGRES_VERSION:-16`, which is undefined. The recipe therefore runs with `POSTGRES_VERSION=` and `tests/compose-postgres.yml` falls back to its own `pg16` default. The practical effect is that the advertised `POSTGRES_VERSIONS ?= 15 16` matrix tests pg16 twice and never runs against 15. Escaping as `$$` hands the default to the shell instead.

**How I verified:** with a stub `docker` on `PATH` that echoes the value it receives:

| invocation | before | after |
| --- | --- | --- |
| `make start-postgres POSTGRES_VERSION=15` | `POSTGRES_VERSION=[]` | `POSTGRES_VERSION=[15]` |
| `POSTGRES_VERSION=15 make start-postgres` | `POSTGRES_VERSION=[]` | `POSTGRES_VERSION=[15]` |
| `make start-postgres` (default) | `POSTGRES_VERSION=[]` | `POSTGRES_VERSION=[16]` |
