### PR TITLE
fix(checkpoint): serialize C-contiguous datetime64/timedelta64 numpy arrays

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -516,7 +516,7 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
         obj, np_mod.ndarray
     ):
         order = "F" if obj.flags.f_contiguous and not obj.flags.c_contiguous else "C"
-        if obj.flags.c_contiguous:
+        if obj.flags.c_contiguous and obj.dtype.kind not in "mM":
             mv = memoryview(obj)
             try:
                 meta = (obj.dtype.str, obj.shape, order, mv)

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -596,6 +596,8 @@ def test_serde_jsonplus_bytearray() -> None:
         np.arange(9, dtype=np.int32).reshape(3, 3),
         np.asfortranarray(np.arange(9, dtype=np.float64).reshape(3, 3)),
         np.arange(12, dtype=np.int16)[::2].reshape(3, 2),
+        np.array(["2020-01-01", "2020-02-01"], dtype="datetime64[D]"),
+        np.array([1, 2], dtype="timedelta64[D]"),
     ],
 )
 def test_serde_jsonplus_numpy_array(arr: np.ndarray) -> None:


### PR DESCRIPTION
## Summary

Fixes #8689.

`JsonPlusSerializer` used the `memoryview` fast path for every C-contiguous NumPy array. NumPy `datetime64` and `timedelta64` arrays cannot be exposed through that buffer path, so serialization failed even though the existing `tobytes(order="A")` path already supports them.

This change routes datetime-like dtypes through the existing byte serialization path and adds round-trip regression coverage for both dtypes.

## Tests

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ruff check --select I .`
- `uv run ty check .`
- `uv run pytest tests/test_jsonplus.py -q` (101 passed)
