### PR TITLE
fix(checkpoint-postgres): honor POSTGRES_VERSION overrides in Makefile

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -4,8 +4,16 @@
 # TESTING AND COVERAGE
 ######################
 
+# `${POSTGRES_VERSION:-16}` is a shell parameter expansion, but Make expands
+# `${...}` before invoking the shell, and `POSTGRES_VERSION:-16` is not a Make
+# variable — so it collapsed to the empty string, ignoring both an explicit
+# override and the intended default. Use a Make `?=` default instead so the
+# variable participates in Make's normal precedence rules (command line >
+# environment > Makefile default).
+POSTGRES_VERSION ?= 16
+
 start-postgres:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
 		echo "Failed to start PostgreSQL, printing logs..."; \
 		docker compose -f tests/compose-postgres.yml logs; \
 		exit 1 \
@@ -35,7 +43,7 @@ test:
 
 TEST ?= .
 test_watch:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} make start-postgres; \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) make start-postgres; \
 	uv run ptw $(TEST); \
 	EXIT_CODE=$$?; \
 	make stop-postgres; \


### PR DESCRIPTION
## Summary

Fixes #8664.

`libs/checkpoint-postgres/Makefile` uses `${POSTGRES_VERSION:-16}` in the `start-postgres` and `test_watch` recipes. That is POSIX shell parameter-expansion syntax, but Make expands `${...}` into its own variables **before** the recipe is handed to the shell — and there is no Make variable named `POSTGRES_VERSION:-16`, so the whole expression collapses to the empty string.

Concretely, before this patch:

```console
$ make -n start-postgres                       # expected: POSTGRES_VERSION=16
POSTGRES_VERSION= docker compose ...

$ POSTGRES_VERSION=15 make -n start-postgres   # expected: POSTGRES_VERSION=15
POSTGRES_VERSION= docker compose ...
```

The knock-on effect is what the issue reporter saw: `make test` iterates `POSTGRES_VERSIONS="15 16"` and delegates to `test_pg_version POSTGRES_VERSION=15`, which then invokes `start-postgres` and re-hits the bug — PostgreSQL 15 never boots, so the whole matrix effectively runs on PostgreSQL 16 twice.

## Fix

Declare `POSTGRES_VERSION ?= 16` as a proper Make variable and use `$(POSTGRES_VERSION)` in the recipes. Make's normal variable precedence (**command line > environment > Makefile default**) now applies uniformly, so all three surfaces resolve consistently:

```console
$ make -n start-postgres
POSTGRES_VERSION=16 docker compose ...

$ make -n start-postgres POSTGRES_VERSION=15
POSTGRES_VERSION=15 docker compose ...

$ POSTGRES_VERSION=15 make -n start-postgres
POSTGRES_VERSION=15 docker compose ...
```

`test_pg_version` was already using `$(POSTGRES_VERSION)` correctly — it just relied on the caller passing a value, which `make test` does explicitly. The remaining two callers (`start-postgres` and `test_watch`) are now aligned.

## Testing

Verified locally with `make -n` (dry-run) that all three invocation styles produce the expected `POSTGRES_VERSION=15` / `POSTGRES_VERSION=16` value. Also matches the reproduction script in the linked issue.

Happy to add a `.PHONY` note or a Makefile assertion if maintainers prefer belt-and-braces coverage.