### PR TITLE
fix(checkpoint): add nested checkpoint metadata round-trip coverage to PUT suite (#8701)

### DIFF
--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/spec/test_put.py
@@ -123,6 +123,32 @@ async def test_put_preserves_metadata(saver: BaseCheckpointSaver) -> None:
     assert tup.metadata.get("custom_key") == "custom_value"
 
 
+async def test_put_preserves_nested_metadata(saver: BaseCheckpointSaver) -> None:
+    """Deeply nested, JSON-compatible metadata round-trips unchanged."""
+    nested = {
+        "profile": {
+            "name": "alice",
+            "tags": ["admin", "rag"],
+            "prefs": {"theme": "dark", "n": 3, "flag": True},
+            "empty_dict": {},
+            "empty_list": [],
+        },
+        "metrics": [{"step": 1, "score": 0.95}, {"step": 2, "score": 0.99}],
+    }
+    md = generate_metadata(source="input", step=1, user=nested)
+    config = generate_config()
+    cp = generate_checkpoint()
+
+    stored = await saver.aput(config, cp, md, {})
+    tup = await saver.aget_tuple(stored)
+    assert tup is not None
+    # Flat fields are still preserved alongside nested structure.
+    assert tup.metadata["source"] == "input"
+    assert tup.metadata["step"] == 1
+    # Deep equality on the nested JSON-compatible structure.
+    assert tup.metadata["user"] == nested
+
+
 async def test_put_root_namespace(saver: BaseCheckpointSaver) -> None:
     """checkpoint_ns='' works."""
     config = generate_config(checkpoint_ns="")
@@ -374,6 +400,7 @@ ALL_PUT_TESTS = [
     test_put_preserves_channel_versions,
     test_put_preserves_versions_seen,
     test_put_preserves_metadata,
+    test_put_preserves_nested_metadata,
     test_put_root_namespace,
     test_put_child_namespace,
     test_put_default_namespace,


### PR DESCRIPTION
Fixes #8701

## Problem

Issue #8701: the conformance suite validates checkpoint metadata only at the **flat** level. `test_put_preserves_metadata` covers scalar keys (`source`, `step`, `custom_key`), but nothing covers **deeply nested, JSON-compatible metadata** (nested dicts, lists, empty containers). A saver that silently flattens or drops nested structures would pass today's suite while corrupting user metadata — and since checkpoint metadata is read back for tracing/routing decisions, a backend-dependent loss is invisible to tests.

## Change

Add `test_put_preserves_nested_metadata` to the PUT conformance spec and register it in `ALL_PUT_TESTS` so every saver validated by the suite (memory, SQLite, PostgreSQL) exercises it.

- Nested structure includes multi-level dicts, list-of-dicts, empty dict/list, and mixed scalar types (str/int/float/bool) — all JSON-compatible per the issue's scope.
- Asserts deep equality after `aput` + `aget_tuple` round trip, plus flat fields (`source`/`step`) still preserved alongside.
- No schema changes, no serialization format changes, no migrations — per the issue's non-goals.

## Validation

- New test passes on `InMemorySaver` (full conformance suite green).
- **Sabotage run**: a saver that flattens only nested metadata (leaving flat fields intact) fails the new test while the pre-existing flat test still passes — confirming this covers a real gap the old suite could not catch.

## Scope

Single test file, +27 lines, no production code touched. Ready for review.
