### PR TITLE
fix(prebuilt): accept raw tool content blocks

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1444,6 +1444,15 @@ class ToolNode(RunnableCallable):
         if isinstance(response, list):
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
+            if all(
+                isinstance(r, dict) and r.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for r in response
+            ):
+                return ToolMessage(
+                    content=cast("str | list", msg_content_output(response)),
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                )
             msg = (
                 f"Tool {tool_call['name']} returned a list with invalid element "
                 "types: expected all Command or ToolMessage"

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -269,6 +269,42 @@ async def test_tool_node_tool_call_input() -> None:
     ]
 
 
+def test_tool_node_accepts_raw_content_blocks_from_tool_invoke() -> None:
+    class RawContentBlockTool(BaseTool):
+        name: str = "raw_content_blocks"
+        description: str = "Return raw message content blocks."
+
+        def invoke(
+            self, input: Any, config: RunnableConfig | None = None, **kwargs: Any
+        ):
+            return [{"type": "text", "text": "raw content"}]
+
+        def _run(self, *args: Any, **kwargs: Any) -> NoReturn:
+            raise AssertionError("invoke returns before _run")
+
+    result = ToolNode([RawContentBlockTool()]).invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "raw_content_blocks",
+                            "args": {},
+                            "id": "raw-call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][-1]
+    assert tool_message.content == [{"type": "text", "text": "raw content"}]
+    assert tool_message.tool_call_id == "raw-call"
+
+
 def test_tool_node_error_handling_default_invocation() -> None:
     tn = ToolNode([tool1])
     result = tn.invoke(


### PR DESCRIPTION
## Summary

- Treat raw tool response content block lists as valid `ToolMessage` content in `ToolNode._normalize_tool_response`
- Add regression coverage for a `BaseTool.invoke()` path that returns raw content blocks

Fixes #7985

## Testing

- `uv run pytest tests/test_tool_node.py -k raw_content_blocks -q`
- `uv run pytest tests/test_tool_node.py -q`
- `uv run ruff format langgraph/prebuilt/tool_node.py tests/test_tool_node.py --check`
- `uv run ruff check langgraph/prebuilt/tool_node.py tests/test_tool_node.py`
- `git diff --check`