### PR TITLE
fix: fallback to non-pipeline mode on SSL error in AsyncPostgresSaver (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -82,8 +82,12 @@ class AsyncPostgresSaver(BasePostgresSaver):
             conn_string, autocommit=True, prepare_threshold=0, row_factory=dict_row
         ) as conn:
             if pipeline:
-                async with conn.pipeline() as pipe:
-                    yield cls(conn=conn, pipe=pipe, serde=serde)
+                try:
+                    async with conn.pipeline() as pipe:
+                        yield cls(conn=conn, pipe=pipe, serde=serde)
+                except psycopg.OperationalError:
+                    # Fallback to non-pipeline if pipeline fails
+                    yield cls(conn=conn, serde=serde)
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
AsyncPostgresSaver fails with “SSL connection has been closed unexpectedly” when using AsyncPipeline, specifically with Supabase pooler connections.

## Fix
Catch psycopg.OperationalError in `from_conn_string` when using pipeline mode and fall back to non-pipeline mode, which avoids the SSL issue. This ensures the checkpointer works even in environments where pipelining is not supported or is unstable.

Closes #5675