### PR TITLE
fix(checkpoint): align BaseCache set and aset parameter names across implementations

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/cache/sqlite/__init__.py
+++ b/libs/checkpoint-sqlite/langgraph/cache/sqlite/__init__.py
@@ -75,11 +75,11 @@ class SqliteCache(BaseCache[ValueT]):
         """Asynchronously get the cached values for the given keys."""
         return await asyncio.to_thread(self.get, keys)
 
-    def set(self, mapping: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+    def set(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
         """Set the cached values for the given keys and TTLs."""
         with self._lock, self._conn:
             now = datetime.datetime.now(datetime.timezone.utc)
-            for key, (value, ttl) in mapping.items():
+            for key, (value, ttl) in pairs.items():
                 if ttl is not None:
                     delta = datetime.timedelta(seconds=ttl)
                     expiry: float | None = (now + delta).timestamp()
@@ -91,9 +91,9 @@ class SqliteCache(BaseCache[ValueT]):
                     (",".join(key[0]), key[1], expiry, encoding, raw),
                 )
 
-    async def aset(self, mapping: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+    async def aset(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
         """Asynchronously set the cached values for the given keys and TTLs."""
-        await asyncio.to_thread(self.set, mapping)
+        await asyncio.to_thread(self.set, pairs)
 
     def clear(self, namespaces: Sequence[Namespace] | None = None) -> None:
         """Delete the cached values for the given namespaces.

--- a/libs/checkpoint-sqlite/tests/test_sqlite_cache.py
+++ b/libs/checkpoint-sqlite/tests/test_sqlite_cache.py
@@ -1,0 +1,51 @@
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langgraph.cache.base import FullKey
+
+from langgraph.cache.sqlite import SqliteCache
+
+
+def test_sqlite_cache_signature() -> None:
+    set_params = list(inspect.signature(SqliteCache.set).parameters.keys())
+    assert "pairs" in set_params, "SqliteCache.set must have 'pairs' parameter"
+
+    aset_params = list(inspect.signature(SqliteCache.aset).parameters.keys())
+    assert "pairs" in aset_params, "SqliteCache.aset must have 'pairs' parameter"
+
+
+def test_sqlite_cache_keyword_args(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "cache_sync.db")
+    cache = SqliteCache(path=db_path)
+    key: FullKey = (("ns",), "k1")
+    value: tuple[Any, int | None] = ({"data": 123}, 60)
+
+    # Calling with keyword argument 'pairs'
+    cache.set(pairs={key: value})
+    res = cache.get([key])
+    assert res == {key: {"data": 123}}
+
+    # Calling with positional argument
+    key2: FullKey = (("ns",), "k2")
+    cache.set({key2: ({"data": 456}, None)})
+    assert cache.get([key2]) == {key2: {"data": 456}}
+
+
+@pytest.mark.asyncio
+async def test_sqlite_cache_async_keyword_args(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "cache_async.db")
+    cache = SqliteCache(path=db_path)
+    key: FullKey = (("ns",), "k1")
+    value: tuple[Any, int | None] = ({"data": 789}, 60)
+
+    # Calling with keyword argument 'pairs'
+    await cache.aset(pairs={key: value})
+    res = await cache.aget([key])
+    assert res == {key: {"data": 789}}
+
+    # Calling with positional argument
+    key2: FullKey = (("ns",), "k2")
+    await cache.aset({key2: ({"data": 999}, None)})
+    assert await cache.aget([key2]) == {key2: {"data": 999}}

--- a/libs/checkpoint/langgraph/cache/memory/__init__.py
+++ b/libs/checkpoint/langgraph/cache/memory/__init__.py
@@ -35,11 +35,11 @@ class InMemoryCache(BaseCache[ValueT]):
         """Asynchronously get the cached values for the given keys."""
         return self.get(keys)
 
-    def set(self, keys: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
-        """Set the cached values for the given keys."""
+    def set(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+        """Set the cached values for the given keys and TTLs."""
         with self._lock:
             now = datetime.datetime.now(datetime.timezone.utc)
-            for (ns, key), (value, ttl) in keys.items():
+            for (ns, key), (value, ttl) in pairs.items():
                 if ttl is not None:
                     delta = datetime.timedelta(seconds=ttl)
                     expiry: float | None = (now + delta).timestamp()
@@ -52,9 +52,9 @@ class InMemoryCache(BaseCache[ValueT]):
                     expiry,
                 )
 
-    async def aset(self, keys: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
-        """Asynchronously set the cached values for the given keys."""
-        self.set(keys)
+    async def aset(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+        """Asynchronously set the cached values for the given keys and TTLs."""
+        self.set(pairs)
 
     def clear(self, namespaces: Sequence[Namespace] | None = None) -> None:
         """Delete the cached values for the given namespaces.

--- a/libs/checkpoint/langgraph/cache/redis/__init__.py
+++ b/libs/checkpoint/langgraph/cache/redis/__init__.py
@@ -81,15 +81,15 @@ class RedisCache(BaseCache[ValueT]):
         """Asynchronously get the cached values for the given keys."""
         return self.get(keys)
 
-    def set(self, mapping: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+    def set(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
         """Set the cached values for the given keys and TTLs."""
-        if not mapping:
+        if not pairs:
             return
 
         # Use pipeline for efficient batch operations
         pipe = self.redis.pipeline()
 
-        for (ns, key), (value, ttl) in mapping.items():
+        for (ns, key), (value, ttl) in pairs.items():
             redis_key = self._make_key(ns, key)
             encoding, data = self.serde.dumps_typed(value)
 
@@ -107,9 +107,9 @@ class RedisCache(BaseCache[ValueT]):
             # Silently fail if Redis is unavailable
             pass
 
-    async def aset(self, mapping: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
+    async def aset(self, pairs: Mapping[FullKey, tuple[ValueT, int | None]]) -> None:
         """Asynchronously set the cached values for the given keys and TTLs."""
-        self.set(mapping)
+        self.set(pairs)
 
     def clear(self, namespaces: Sequence[Namespace] | None = None) -> None:
         """Delete the cached values for the given namespaces.

--- a/libs/checkpoint/tests/test_cache.py
+++ b/libs/checkpoint/tests/test_cache.py
@@ -1,0 +1,54 @@
+import inspect
+from typing import Any
+
+import pytest
+
+from langgraph.cache.base import BaseCache, FullKey
+from langgraph.cache.memory import InMemoryCache
+from langgraph.cache.redis import RedisCache
+
+
+def test_base_cache_signatures() -> None:
+    for cache_cls in (BaseCache, InMemoryCache, RedisCache):
+        set_params = list(inspect.signature(cache_cls.set).parameters.keys())
+        assert "pairs" in set_params, (
+            f"{cache_cls.__name__}.set must have 'pairs' parameter"
+        )
+
+        aset_params = list(inspect.signature(cache_cls.aset).parameters.keys())
+        assert "pairs" in aset_params, (
+            f"{cache_cls.__name__}.aset must have 'pairs' parameter"
+        )
+
+
+def test_in_memory_cache_keyword_args() -> None:
+    cache = InMemoryCache()
+    key: FullKey = (("ns",), "k1")
+    value: tuple[Any, int | None] = ({"data": 123}, 60)
+
+    # Calling with keyword argument 'pairs'
+    cache.set(pairs={key: value})
+    res = cache.get([key])
+    assert res == {key: {"data": 123}}
+
+    # Calling with positional argument
+    key2: FullKey = (("ns",), "k2")
+    cache.set({key2: ({"data": 456}, None)})
+    assert cache.get([key2]) == {key2: {"data": 456}}
+
+
+@pytest.mark.asyncio
+async def test_in_memory_cache_async_keyword_args() -> None:
+    cache = InMemoryCache()
+    key: FullKey = (("ns",), "k1")
+    value: tuple[Any, int | None] = ({"data": 789}, 60)
+
+    # Calling with keyword argument 'pairs'
+    await cache.aset(pairs={key: value})
+    res = await cache.aget([key])
+    assert res == {key: {"data": 789}}
+
+    # Calling with positional argument
+    key2: FullKey = (("ns",), "k2")
+    await cache.aset({key2: ({"data": 999}, None)})
+    assert await cache.aget([key2]) == {key2: {"data": 999}}


### PR DESCRIPTION
Fixes #8717

Align the \set\ and \set\ parameter name to \pairs\ across \InMemoryCache\, \RedisCache\, and \SqliteCache\ to match the \BaseCache\ abstract base class signature.