### PR TITLE
feat(cli): support flattened builds

### DIFF
--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -35,7 +35,9 @@ jobs:
             tag: langgraph-test-d
     name: "CLI integration test (${{ matrix.python-version }}, ${{ matrix.example.name }}, ${{ matrix.build_mode }})"
     env:
+      BUILD_ARGS: ${{ matrix.build_mode == 'flat' && '--flat' || '' }}
       HAS_LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY != '' }}
+      TAG_SUFFIX: ${{ matrix.build_mode == 'flat' && '-flat' || '' }}
     defaults:
       run:
         working-directory: libs/cli
@@ -61,7 +63,7 @@ jobs:
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
         working-directory: ${{ matrix.example.workdir }}
         run: |
-          langgraph build ${{ matrix.build_mode == 'flat' && '--flat' || '' }} -t ${{ matrix.example.tag }}${{ matrix.build_mode == 'flat' && '-flat' || '' }}
+          langgraph build $BUILD_ARGS -t ${{ matrix.example.tag }}$TAG_SUFFIX
       - name: Test service ${{ matrix.example.name }}
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: ${{ matrix.example.workdir }}
@@ -74,98 +76,98 @@ jobs:
           if [ -f ../.env ]; then echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> ../.env; fi
           # Run the integration test using the built tag
           REPO_ROOT=$(git rev-parse --show-toplevel)
-          timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}${{ matrix.build_mode == 'flat' && '-flat' || '' }}
+          timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}$TAG_SUFFIX
 
       - name: Build JS service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/js-examples
         run: |
-          langgraph build -t langgraph-test-e
+          langgraph build $BUILD_ARGS -t langgraph-test-e$TAG_SUFFIX
 
       - name: Build JS monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/js-monorepo-example
         run: |
-          langgraph build -t langgraph-test-f -c apps/agent/langgraph.json --build-command "yarn run turbo build" --install-command "yarn install"
+          langgraph build $BUILD_ARGS -t langgraph-test-f$TAG_SUFFIX -c apps/agent/langgraph.json --build-command "yarn run turbo build" --install-command "yarn install"
 
       - name: Build Python monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/python-monorepo-example
         run: |
-          langgraph build -t langgraph-test-g -c apps/agent/langgraph.json
+          langgraph build $BUILD_ARGS -t langgraph-test-g$TAG_SUFFIX -c apps/agent/langgraph.json
       - name: Test Python monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/python-monorepo-example
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp apps/agent/.env.example apps/agent/.env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> apps/agent/.env
-          timeout 60 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g -c apps/agent/langgraph.json
+          timeout 60 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g$TAG_SUFFIX -c apps/agent/langgraph.json
 
       - name: Build prerelease reqs service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs
         run: |
-          langgraph build -t langgraph-test-h
+          langgraph build $BUILD_ARGS -t langgraph-test-h$TAG_SUFFIX
       - name: Test prerelease reqs service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp ../.env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
+          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h$TAG_SUFFIX
           echo "Finished starting up langgraph-test-h"
-          LANGGRAPH_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langgraph'); print(v);")
+          LANGGRAPH_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h$TAG_SUFFIX python -c "import sys; from importlib.metadata import version; v = version('langgraph'); print(v);")
           if [ "$LANGGRAPH_VERSION" != "1.1.5" ]; then
             echo "LANGGRAPH_VERSION != 1.1.5; $LANGGRAPH_VERSION"
             exit 1
           fi
-          LANGCHAIN_OPENAI_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langchain-openai'); print(v);")
+          LANGCHAIN_OPENAI_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h$TAG_SUFFIX python -c "import sys; from importlib.metadata import version; v = version('langchain-openai'); print(v);")
           if [ "$LANGCHAIN_OPENAI_VERSION" != "1.1.14" ]; then
             echo "LANGCHAIN_OPENAI_VERSION != 1.1.14; $LANGCHAIN_OPENAI_VERSION"
             exit 1
           fi
-          LANGCHAIN_ANTHROPIC_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langchain-anthropic'); print(v);")
+          LANGCHAIN_ANTHROPIC_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h$TAG_SUFFIX python -c "import sys; from importlib.metadata import version; v = version('langchain-anthropic'); print(v);")
           if [ "$LANGCHAIN_ANTHROPIC_VERSION" != "1.4.6" ]; then
             echo "LANGCHAIN_ANTHROPIC_VERSION != 1.4.6; $LANGCHAIN_ANTHROPIC_VERSION"
             exit 1
           fi
 
       - name: Build and test prerelease reqs fail service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs_fail
         run: |
-          langgraph build -t langgraph-test-i || [ $? -eq 1 ]
+          langgraph build $BUILD_ARGS -t langgraph-test-i$TAG_SUFFIX || [ $? -eq 1 ]
 
       - name: Build uv simple service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/uv-examples/simple
         run: |
-          langgraph build -t langgraph-test-uv-simple
+          langgraph build $BUILD_ARGS -t langgraph-test-uv-simple$TAG_SUFFIX
       - name: Test uv simple service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/uv-examples/simple
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple
+          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple$TAG_SUFFIX
 
       - name: Build uv monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
         working-directory: libs/cli/uv-examples/monorepo/apps/agent
         run: |
-          langgraph build -t langgraph-test-uv-monorepo
+          langgraph build $BUILD_ARGS -t langgraph-test-uv-monorepo$TAG_SUFFIX
       - name: Test uv monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/uv-examples/monorepo/apps/agent
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo
+          timeout 60 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo$TAG_SUFFIX

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -76,9 +76,9 @@ jobs:
           if [ -f ../.env ]; then echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> ../.env; fi
           # Run the integration test using the built tag
           REPO_ROOT=$(git rev-parse --show-toplevel)
-          timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}
+          timeout 90 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}
           if [ "${{ matrix.example.name }}" = "A" ]; then
-            timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}-flat
+            timeout 90 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}-flat
           fi
 
       - name: Build JS service
@@ -106,7 +106,7 @@ jobs:
         run: |
           cp apps/agent/.env.example apps/agent/.env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> apps/agent/.env
-          timeout 60 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g -c apps/agent/langgraph.json
+          timeout 90 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g -c apps/agent/langgraph.json
 
       - name: Build prerelease reqs service
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
@@ -121,7 +121,7 @@ jobs:
         run: |
           cp ../.env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
+          timeout 90 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
           echo "Finished starting up langgraph-test-h"
           LANGGRAPH_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langgraph'); print(v);")
           if [ "$LANGGRAPH_VERSION" != "1.1.5" ]; then
@@ -158,7 +158,7 @@ jobs:
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple
+          timeout 90 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple
 
       - name: Build uv monorepo service
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
@@ -173,4 +173,4 @@ jobs:
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 60 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo
+          timeout 90 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -17,6 +17,9 @@ jobs:
         python-version:
           - "3.10"
           - "3.14"
+        build_mode:
+          - layered
+          - flat
         example:
           - name: A
             workdir: libs/cli/examples
@@ -30,7 +33,7 @@ jobs:
           - name: D
             workdir: libs/cli/examples/graphs_reqs_b
             tag: langgraph-test-d
-    name: "CLI integration test"
+    name: "CLI integration test (${{ matrix.python-version }}, ${{ matrix.example.name }}, ${{ matrix.build_mode }})"
     env:
       HAS_LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY != '' }}
     defaults:
@@ -58,12 +61,7 @@ jobs:
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
         working-directory: ${{ matrix.example.workdir }}
         run: |
-          langgraph build -t ${{ matrix.example.tag }}
-      - name: Build flattened service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
-        working-directory: ${{ matrix.example.workdir }}
-        run: |
-          langgraph build --flat -t ${{ matrix.example.tag }}-flat
+          langgraph build ${{ matrix.build_mode == 'flat' && '--flat' || '' }} -t ${{ matrix.example.tag }}${{ matrix.build_mode == 'flat' && '-flat' || '' }}
       - name: Test service ${{ matrix.example.name }}
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: ${{ matrix.example.workdir }}
@@ -76,52 +74,49 @@ jobs:
           if [ -f ../.env ]; then echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> ../.env; fi
           # Run the integration test using the built tag
           REPO_ROOT=$(git rev-parse --show-toplevel)
-          timeout 90 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}
-          if [ "${{ matrix.example.name }}" = "A" ]; then
-            timeout 90 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}-flat
-          fi
+          timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}${{ matrix.build_mode == 'flat' && '-flat' || '' }}
 
       - name: Build JS service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/js-examples
         run: |
           langgraph build -t langgraph-test-e
 
       - name: Build JS monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/js-monorepo-example
         run: |
           langgraph build -t langgraph-test-f -c apps/agent/langgraph.json --build-command "yarn run turbo build" --install-command "yarn install"
 
       - name: Build Python monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/python-monorepo-example
         run: |
           langgraph build -t langgraph-test-g -c apps/agent/langgraph.json
       - name: Test Python monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/python-monorepo-example
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp apps/agent/.env.example apps/agent/.env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> apps/agent/.env
-          timeout 90 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g -c apps/agent/langgraph.json
+          timeout 60 python ../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-g -c apps/agent/langgraph.json
 
       - name: Build prerelease reqs service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs
         run: |
           langgraph build -t langgraph-test-h
       - name: Test prerelease reqs service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp ../.env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 90 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
+          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-h
           echo "Finished starting up langgraph-test-h"
           LANGGRAPH_VERSION=$(docker run --rm --entrypoint "" langgraph-test-h python -c "import sys; from importlib.metadata import version; v = version('langgraph'); print(v);")
           if [ "$LANGGRAPH_VERSION" != "1.1.5" ]; then
@@ -140,37 +135,37 @@ jobs:
           fi
 
       - name: Build and test prerelease reqs fail service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/examples/graph_prerelease_reqs_fail
         run: |
           langgraph build -t langgraph-test-i || [ $? -eq 1 ]
 
       - name: Build uv simple service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/uv-examples/simple
         run: |
           langgraph build -t langgraph-test-uv-simple
       - name: Test uv simple service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/uv-examples/simple
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 90 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple
+          timeout 60 python ../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-simple
 
       - name: Build uv monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' }}
         working-directory: libs/cli/uv-examples/monorepo/apps/agent
         run: |
           langgraph build -t langgraph-test-uv-monorepo
       - name: Test uv monorepo service
-        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' && env.HAS_LANGSMITH_API_KEY == 'true' }}
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' && matrix.build_mode == 'layered' && env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: libs/cli/uv-examples/monorepo/apps/agent
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         run: |
           cp .env.example .env
           echo "LANGSMITH_API_KEY=${{ secrets.LANGSMITH_API_KEY }}" >> .env
-          timeout 90 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo
+          timeout 60 python ../../../../../../.github/scripts/run_langgraph_cli_test.py -t langgraph-test-uv-monorepo

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -58,7 +58,12 @@ jobs:
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
         working-directory: ${{ matrix.example.workdir }}
         run: |
-          langgraph build --single-user-layer -t ${{ matrix.example.tag }}
+          langgraph build -t ${{ matrix.example.tag }}
+      - name: Build flattened service
+        if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') && matrix.example.name == 'A' }}
+        working-directory: ${{ matrix.example.workdir }}
+        run: |
+          langgraph build --flat -t ${{ matrix.example.tag }}-flat
       - name: Test service ${{ matrix.example.name }}
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: ${{ matrix.example.workdir }}
@@ -72,6 +77,9 @@ jobs:
           # Run the integration test using the built tag
           REPO_ROOT=$(git rev-parse --show-toplevel)
           timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}
+          if [ "${{ matrix.example.name }}" = "A" ]; then
+            timeout 60 python "$REPO_ROOT/.github/scripts/run_langgraph_cli_test.py" -t ${{ matrix.example.tag }}-flat
+          fi
 
       - name: Build JS service
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&matrix.example.name == 'A' }}

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -58,7 +58,7 @@ jobs:
         if: (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch')
         working-directory: ${{ matrix.example.workdir }}
         run: |
-          langgraph build -t ${{ matrix.example.tag }}
+          langgraph build --single-user-layer -t ${{ matrix.example.tag }}
       - name: Test service ${{ matrix.example.name }}
         if: ${{ (steps.changed-files.outputs.all || github.event_name == 'workflow_dispatch') &&env.HAS_LANGSMITH_API_KEY == 'true' }}
         working-directory: ${{ matrix.example.workdir }}

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ __pypackages__/
 
 # Environments
 .env
+.env.*
 .envrc
 *.crt
 *.key

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -412,7 +412,7 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
     "--flat",
     is_flag=True,
     envvar="LANGGRAPH_CLI_FLAT_IMAGES",
-    help="Flatten generated Python build steps into one image layer when supported.",
+    help="Flatten generated build steps into one image layer when supported.",
 )
 @click.argument("docker_build_args", nargs=-1, type=click.UNPROCESSED)
 @cli.command(

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -412,7 +412,7 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
     "--flat",
     "single_user_layer",
     is_flag=True,
-    envvar="LANGGRAPH_CLI_FLAT",
+    envvar="LANGGRAPH_CLI_FLAT_IMAGES",
     help="Flatten generated Python build steps into one image layer when supported.",
 )
 @click.argument("docker_build_args", nargs=-1, type=click.UNPROCESSED)

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -408,6 +408,11 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
     "--build-command",
     help="Custom build command to run from the langgraph.json directory. If not provided, uses default build process.",
 )
+@click.option(
+    "--single-user-layer",
+    is_flag=True,
+    help="Combine generated Python build steps into one image layer when supported.",
+)
 @click.argument("docker_build_args", nargs=-1, type=click.UNPROCESSED)
 @cli.command(
     help="📦 Build LangGraph API server Docker image.",
@@ -426,6 +431,7 @@ def build(
     tag: str,
     install_command: str | None,
     build_command: str | None,
+    single_user_layer: bool,
 ):
     if install_command and langgraph_cli.config.has_disallowed_build_command_content(
         install_command
@@ -461,6 +467,7 @@ def build(
             docker_build_args,
             install_command,
             build_command,
+            single_user_layer=single_user_layer,
         )
 
 

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -410,7 +410,6 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
 )
 @click.option(
     "--flat",
-    "single_user_layer",
     is_flag=True,
     envvar="LANGGRAPH_CLI_FLAT_IMAGES",
     help="Flatten generated Python build steps into one image layer when supported.",
@@ -433,7 +432,7 @@ def build(
     tag: str,
     install_command: str | None,
     build_command: str | None,
-    single_user_layer: bool,
+    flat: bool,
 ):
     if install_command and langgraph_cli.config.has_disallowed_build_command_content(
         install_command
@@ -469,7 +468,7 @@ def build(
             docker_build_args,
             install_command,
             build_command,
-            single_user_layer=single_user_layer,
+            flat=flat,
         )
 
 

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -411,6 +411,7 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
 @click.option(
     "--single-user-layer",
     is_flag=True,
+    envvar="LANGGRAPH_CLI_SINGLE_USER_LAYER",
     help="Combine generated Python build steps into one image layer when supported.",
 )
 @click.argument("docker_build_args", nargs=-1, type=click.UNPROCESSED)

--- a/libs/cli/langgraph_cli/cli.py
+++ b/libs/cli/langgraph_cli/cli.py
@@ -409,10 +409,11 @@ For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KE
     help="Custom build command to run from the langgraph.json directory. If not provided, uses default build process.",
 )
 @click.option(
-    "--single-user-layer",
+    "--flat",
+    "single_user_layer",
     is_flag=True,
-    envvar="LANGGRAPH_CLI_SINGLE_USER_LAYER",
-    help="Combine generated Python build steps into one image layer when supported.",
+    envvar="LANGGRAPH_CLI_FLAT",
+    help="Flatten generated Python build steps into one image layer when supported.",
 )
 @click.argument("docker_build_args", nargs=-1, type=click.UNPROCESSED)
 @cli.command(

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1176,50 +1176,67 @@ build-backend = "setuptools.build_meta"
 PYPROJECT"""
 
 
-def _build_flat_dockerfile(
-    config_path: pathlib.Path,
-    config: Config,
-    local_deps: LocalDeps,
-    pypi_deps: list[str],
-    local_reqs_pip_install: str,
-    local_deps_install_command: str,
-    pip_cleanup: str,
+_FLAT_BUILD_CONTEXT = pathlib.PurePosixPath("/__build_context")
+_FLAT_ADDITIONAL_CONTEXTS = pathlib.PurePosixPath("/__additional_contexts")
+
+
+def _render_flat_dockerfile(
+    *,
     image: str,
+    dockerfile_lines: list[str],
     env_vars: list[str],
-    additional_context_names: dict[pathlib.Path, str],
+    commands: list[str],
+    workdir: str | None,
+    additional_context_names: dict[pathlib.Path, str] | None = None,
 ) -> str:
-    context = pathlib.PurePosixPath("/__build_context")
-    additional_context_root = pathlib.PurePosixPath("/__additional_contexts")
-    js_working_dir = (
-        local_deps.working_dir
-        if config.get("ui") or config.get("node_version")
-        else None
+    mounts = [f"--mount=type=bind,target={_FLAT_BUILD_CONTEXT},readonly"]
+    mounts.extend(
+        f"--mount=type=bind,from={name},"
+        f"target={_FLAT_ADDITIONAL_CONTEXTS / name},readonly"
+        for name in (additional_context_names or {}).values()
     )
-    commands = ["set -eu"]
 
-    if js_working_dir:
-        commands.append("/storage/install-node.sh")
+    return os.linesep.join(
+        [
+            "# syntax=docker/dockerfile:1.7",
+            f"FROM {image}",
+            *dockerfile_lines,
+            *env_vars,
+            f"RUN {' '.join(mounts)} <<'USER_LAYER'",
+            *commands,
+            "USER_LAYER",
+            f"WORKDIR {workdir}" if workdir else "",
+        ]
+    )
 
-    def source_path(
-        path: pathlib.Path,
-        relative_path: str = ".",
-        additional_relative_path: str = ".",
-    ) -> str:
-        if name := additional_context_names.get(path):
-            return str(additional_context_root / name / additional_relative_path)
-        return str(context / relative_path)
 
-    if pip_config_file := config.get("pip_config_file"):
-        source = shlex.quote(str(context / pip_config_file))
-        commands.append(f"cp {source} /pipconfig.txt")
-    if pypi_deps:
-        commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
+def _flat_context_source(
+    path: pathlib.Path,
+    relative_path: str,
+    additional_context_names: dict[pathlib.Path, str],
+    *,
+    additional_relative_path: str = ".",
+) -> str:
+    if name := additional_context_names.get(path):
+        return str(_FLAT_ADDITIONAL_CONTEXTS / name / additional_relative_path)
+    return str(_FLAT_BUILD_CONTEXT / relative_path)
+
+
+def _flat_local_dependency_commands(
+    *,
+    config_path: pathlib.Path,
+    local_deps: LocalDeps,
+    local_reqs_pip_install: str,
+    additional_context_names: dict[pathlib.Path, str],
+) -> list[str]:
+    commands = []
 
     for reqpath, destination in local_deps.pip_reqs:
-        source = source_path(
+        source = _flat_context_source(
             reqpath.parent,
             str(reqpath.relative_to(config_path.parent)),
-            reqpath.name,
+            additional_context_names,
+            additional_relative_path=reqpath.name,
         )
         destination_parent = pathlib.PurePosixPath(destination).parent
         commands.append(f"""mkdir -p {shlex.quote(str(destination_parent))}
@@ -1231,17 +1248,52 @@ cp {shlex.quote(source)} {shlex.quote(destination)}""")
         commands.append(f"{local_reqs_pip_install} {requirements}")
 
     for full_path, (relative_path, name) in local_deps.real_pkgs.items():
-        source = f"{source_path(full_path, relative_path)}/."
+        source = f"{_flat_context_source(full_path, relative_path, additional_context_names)}/."
         destination = f"/deps/{name}"
         commands.append(f"""mkdir -p {shlex.quote(destination)}
 cp -a {shlex.quote(source)} {shlex.quote(destination)}/""")
 
     for full_path, (relative_path, destination) in local_deps.faux_pkgs.items():
-        source = f"{source_path(full_path, relative_path)}/."
+        source = f"{_flat_context_source(full_path, relative_path, additional_context_names)}/."
         pyproject = _faux_package_pyproject_command(full_path.name)
         commands.append(f"""mkdir -p {shlex.quote(destination)}
 cp -a {shlex.quote(source)} {shlex.quote(destination)}/
 {pyproject}""")
+
+    return commands
+
+
+def _build_flat_python_commands(
+    *,
+    config_path: pathlib.Path,
+    config: Config,
+    local_deps: LocalDeps,
+    pypi_deps: list[str],
+    local_reqs_pip_install: str,
+    local_deps_install_command: str,
+    pip_cleanup: str,
+    additional_context_names: dict[pathlib.Path, str],
+    js_working_dir: str | None,
+) -> list[str]:
+    commands = ["set -eu"]
+
+    if js_working_dir:
+        commands.append("/storage/install-node.sh")
+
+    if pip_config_file := config.get("pip_config_file"):
+        source = shlex.quote(str(_FLAT_BUILD_CONTEXT / pip_config_file))
+        commands.append(f"cp {source} /pipconfig.txt")
+    if pypi_deps:
+        commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
+
+    commands.extend(
+        _flat_local_dependency_commands(
+            config_path=config_path,
+            local_deps=local_deps,
+            local_reqs_pip_install=local_reqs_pip_install,
+            additional_context_names=additional_context_names,
+        )
+    )
 
     commands.append(local_deps_install_command)
     if js_working_dir:
@@ -1256,31 +1308,50 @@ cp -a {shlex.quote(source)} {shlex.quote(destination)}/
         for line in pip_cleanup.splitlines()
         if line and not line.startswith("#")
     )
+    return commands
 
-    mounts = ["--mount=type=bind,target=/__build_context,readonly"]
-    mounts.extend(
-        f"--mount=type=bind,from={name},target={additional_context_root / name},readonly"
-        for name in additional_context_names.values()
-    )
-    run = f"RUN {' '.join(mounts)} <<'USER_LAYER'"
-    node_env = (
-        f"ENV NODE_VERSION={config.get('node_version') or DEFAULT_NODE_VERSION}"
-        if js_working_dir
-        else ""
-    )
 
-    return os.linesep.join(
-        [
-            "# syntax=docker/dockerfile:1.7",
-            f"FROM {image}",
-            *config["dockerfile_lines"],
-            node_env,
+def _build_flat_python_dockerfile(
+    config_path: pathlib.Path,
+    config: Config,
+    local_deps: LocalDeps,
+    pypi_deps: list[str],
+    local_reqs_pip_install: str,
+    local_deps_install_command: str,
+    pip_cleanup: str,
+    image: str,
+    env_vars: list[str],
+    additional_context_names: dict[pathlib.Path, str],
+) -> str:
+    js_working_dir = (
+        local_deps.working_dir
+        if config.get("ui") or config.get("node_version")
+        else None
+    )
+    commands = _build_flat_python_commands(
+        config_path=config_path,
+        config=config,
+        local_deps=local_deps,
+        pypi_deps=pypi_deps,
+        local_reqs_pip_install=local_reqs_pip_install,
+        local_deps_install_command=local_deps_install_command,
+        pip_cleanup=pip_cleanup,
+        additional_context_names=additional_context_names,
+        js_working_dir=js_working_dir,
+    )
+    if js_working_dir:
+        env_vars = [
+            f"ENV NODE_VERSION={config.get('node_version') or DEFAULT_NODE_VERSION}",
             *env_vars,
-            run,
-            *commands,
-            "USER_LAYER",
-            f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
         ]
+
+    return _render_flat_dockerfile(
+        image=image,
+        dockerfile_lines=config["dockerfile_lines"],
+        env_vars=env_vars,
+        commands=commands,
+        workdir=local_deps.working_dir,
+        additional_context_names=additional_context_names,
     )
 
 
@@ -1567,7 +1638,7 @@ ADD {relpath} /deps/{name}
 
     if flat:
         return (
-            _build_flat_dockerfile(
+            _build_flat_python_dockerfile(
                 config_path=config_path,
                 config=config,
                 local_deps=local_deps,
@@ -1620,6 +1691,34 @@ ADD {relpath} /deps/{name}
     return os.linesep.join(docker_file_contents), additional_contexts
 
 
+def _build_flat_node_dockerfile(
+    *,
+    config: Config,
+    image: str,
+    env_vars: list[str],
+    destination: str,
+    install_workdir: str,
+    build_workdir: str,
+    install_command: str,
+    build_command: str,
+) -> str:
+    commands = [
+        "set -eu",
+        f"mkdir -p {shlex.quote(destination)}\n"
+        f"cp -a {shlex.quote(f'{_FLAT_BUILD_CONTEXT}/.')} "
+        f"{shlex.quote(destination)}/",
+        f"cd {shlex.quote(install_workdir)}\n{install_command}",
+        f"cd {shlex.quote(build_workdir)}\n{build_command}",
+    ]
+    return _render_flat_dockerfile(
+        image=image,
+        dockerfile_lines=config["dockerfile_lines"],
+        env_vars=env_vars,
+        commands=commands,
+        workdir=build_workdir,
+    )
+
+
 def node_config_to_docker(
     config_path: pathlib.Path,
     config: Config,
@@ -1667,27 +1766,17 @@ def node_config_to_docker(
     )
 
     if flat:
-        context = pathlib.PurePosixPath("/__build_context")
         destination = container_root if build_context else faux_path
-        commands = [
-            "set -eu",
-            f"mkdir -p {shlex.quote(destination)}\n"
-            f"cp -a {shlex.quote(f'{context}/.')} {shlex.quote(destination)}/",
-            f"cd {shlex.quote(install_workdir)}\n{install_cmd}",
-            f"cd {shlex.quote(build_workdir)}\n{build_cmd}",
-        ]
         return (
-            os.linesep.join(
-                [
-                    "# syntax=docker/dockerfile:1.7",
-                    f"FROM {image_str}",
-                    *config["dockerfile_lines"],
-                    *env_vars,
-                    "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
-                    *commands,
-                    "USER_LAYER",
-                    f"WORKDIR {build_workdir}",
-                ]
+            _build_flat_node_dockerfile(
+                config=config,
+                image=image_str,
+                env_vars=env_vars,
+                destination=destination,
+                install_workdir=install_workdir,
+                build_workdir=build_workdir,
+                install_command=install_cmd,
+                build_command=build_cmd,
             ),
             {},
         )

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1162,9 +1162,7 @@ def _build_runtime_env_vars(config: Config) -> list[str]:
     return env_vars
 
 
-def _supports_single_user_layer(
-    config: Config, local_deps: LocalDeps, escape_variables: bool
-) -> bool:
+def _can_flatten(config: Config, local_deps: LocalDeps, escape_variables: bool) -> bool:
     return not (
         config["dockerfile_lines"]
         or local_deps.additional_contexts
@@ -1188,7 +1186,7 @@ build-backend = "setuptools.build_meta"
 PYPROJECT"""
 
 
-def _build_single_user_layer_dockerfile(
+def _build_flat_dockerfile(
     config_path: pathlib.Path,
     config: Config,
     local_deps: LocalDeps,
@@ -1211,12 +1209,8 @@ def _build_single_user_layer_dockerfile(
     for reqpath, destination in local_deps.pip_reqs:
         source = context / reqpath.relative_to(config_path.parent)
         destination_parent = pathlib.PurePosixPath(destination).parent
-        commands.extend(
-            [
-                f"mkdir -p {shlex.quote(str(destination_parent))}",
-                f"cp {shlex.quote(str(source))} {shlex.quote(destination)}",
-            ]
-        )
+        commands.append(f"""mkdir -p {shlex.quote(str(destination_parent))}
+cp {shlex.quote(str(source))} {shlex.quote(destination)}""")
     if local_deps.pip_reqs:
         requirements = " ".join(
             f"-r {destination}" for _, destination in local_deps.pip_reqs
@@ -1226,22 +1220,15 @@ def _build_single_user_layer_dockerfile(
     for _, (relative_path, name) in local_deps.real_pkgs.items():
         source = f"{context / relative_path}/."
         destination = f"/deps/{name}"
-        commands.extend(
-            [
-                f"mkdir -p {shlex.quote(destination)}",
-                f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
-            ]
-        )
+        commands.append(f"""mkdir -p {shlex.quote(destination)}
+cp -a {shlex.quote(source)} {shlex.quote(destination)}/""")
 
     for full_path, (relative_path, destination) in local_deps.faux_pkgs.items():
         source = f"{context / relative_path}/."
-        commands.extend(
-            [
-                f"mkdir -p {shlex.quote(destination)}",
-                f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
-                _faux_package_pyproject_command(full_path.name),
-            ]
-        )
+        pyproject = _faux_package_pyproject_command(full_path.name)
+        commands.append(f"""mkdir -p {shlex.quote(destination)}
+cp -a {shlex.quote(source)} {shlex.quote(destination)}/
+{pyproject}""")
 
     commands.append(local_deps_install_command)
     commands.extend(
@@ -1368,7 +1355,7 @@ def python_config_to_docker(
     api_version: str | None = None,
     *,
     escape_variables: bool = False,
-    single_user_layer: bool = False,
+    flat: bool = False,
 ) -> tuple[str, dict[str, str]]:
     """Generate a Dockerfile from the configuration."""
     source_kind = _get_source_kind(config)
@@ -1544,11 +1531,9 @@ ADD {relpath} /deps/{name}
         pip_installer=pip_installer,
     )
 
-    if single_user_layer and _supports_single_user_layer(
-        config, local_deps, escape_variables
-    ):
+    if flat and _can_flatten(config, local_deps, escape_variables):
         return (
-            _build_single_user_layer_dockerfile(
+            _build_flat_dockerfile(
                 config_path=config_path,
                 config=config,
                 local_deps=local_deps,
@@ -1746,7 +1731,7 @@ def config_to_docker(
     build_command: str | None = None,
     build_context: str | None = None,
     escape_variables: bool = False,
-    single_user_layer: bool = False,
+    flat: bool = False,
 ) -> tuple[str, dict[str, str]]:
     base_image = base_image or default_base_image(config)
 
@@ -1767,7 +1752,7 @@ def config_to_docker(
         base_image=base_image,
         api_version=api_version,
         escape_variables=escape_variables,
-        single_user_layer=single_user_layer,
+        flat=flat,
     )
 
 

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1178,6 +1178,10 @@ PYPROJECT"""
 
 _FLAT_BUILD_CONTEXT = pathlib.PurePosixPath("/__build_context")
 _FLAT_ADDITIONAL_CONTEXTS = pathlib.PurePosixPath("/__additional_contexts")
+_DEFAULT_NODE_BUILD_COMMAND = (
+    '(test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, '
+    'skipping") || tsx /api/langgraph_api/js/build.mts'
+)
 
 
 def _render_flat_dockerfile(
@@ -1222,6 +1226,11 @@ def _flat_context_source(
     return str(_FLAT_BUILD_CONTEXT / relative_path)
 
 
+def _copy_directory_command(source: str, destination: str) -> str:
+    return f"""mkdir -p {shlex.quote(destination)}
+cp -a {shlex.quote(f"{source}/.")} {shlex.quote(destination)}/"""
+
+
 def _flat_local_dependency_commands(
     *,
     config_path: pathlib.Path,
@@ -1248,17 +1257,17 @@ cp {shlex.quote(source)} {shlex.quote(destination)}""")
         commands.append(f"{local_reqs_pip_install} {requirements}")
 
     for full_path, (relative_path, name) in local_deps.real_pkgs.items():
-        source = f"{_flat_context_source(full_path, relative_path, additional_context_names)}/."
-        destination = f"/deps/{name}"
-        commands.append(f"""mkdir -p {shlex.quote(destination)}
-cp -a {shlex.quote(source)} {shlex.quote(destination)}/""")
+        source = _flat_context_source(
+            full_path, relative_path, additional_context_names
+        )
+        commands.append(_copy_directory_command(source, f"/deps/{name}"))
 
     for full_path, (relative_path, destination) in local_deps.faux_pkgs.items():
-        source = f"{_flat_context_source(full_path, relative_path, additional_context_names)}/."
+        source = _flat_context_source(
+            full_path, relative_path, additional_context_names
+        )
         pyproject = _faux_package_pyproject_command(full_path.name)
-        commands.append(f"""mkdir -p {shlex.quote(destination)}
-cp -a {shlex.quote(source)} {shlex.quote(destination)}/
-{pyproject}""")
+        commands.append(f"{_copy_directory_command(source, destination)}\n{pyproject}")
 
     return commands
 
@@ -1696,7 +1705,6 @@ def _build_flat_node_dockerfile(
     config: Config,
     image: str,
     env_vars: list[str],
-    destination: str,
     install_workdir: str,
     build_workdir: str,
     install_command: str,
@@ -1704,9 +1712,7 @@ def _build_flat_node_dockerfile(
 ) -> str:
     commands = [
         "set -eu",
-        f"mkdir -p {shlex.quote(destination)}\n"
-        f"cp -a {shlex.quote(f'{_FLAT_BUILD_CONTEXT}/.')} "
-        f"{shlex.quote(destination)}/",
+        _copy_directory_command(str(_FLAT_BUILD_CONTEXT), install_workdir),
         f"cd {shlex.quote(install_workdir)}\n{install_command}",
         f"cd {shlex.quote(build_workdir)}\n{build_command}",
     ]
@@ -1737,42 +1743,32 @@ def node_config_to_docker(
     if build_context:
         relative_workdir = _calculate_relative_workdir(config_path, build_context)
         container_name = pathlib.Path(build_context).name
-        if relative_workdir:
-            faux_path = f"/deps/{container_name}/{relative_workdir}"
-        else:
-            faux_path = f"/deps/{container_name}"
+        install_workdir = f"/deps/{container_name}"
+        build_workdir = (
+            f"{install_workdir}/{relative_workdir}"
+            if relative_workdir
+            else install_workdir
+        )
     else:
         # Backward compatibility: use the original behavior
-        faux_path = f"/deps/{config_path.parent.name}"
+        install_workdir = build_workdir = f"/deps/{config_path.parent.name}"
 
     image_str = docker_tag(config, base_image, api_version)
 
     env_vars = _build_runtime_env_vars(config)
 
-    # For monorepo support, we need to handle install and build commands differently
-    if build_context:
-        # Monorepo case: install from root, build from config directory
-        container_root = f"/deps/{pathlib.Path(build_context).name}"
-        install_workdir = container_root
-    else:
-        # Original behavior: everything happens in the same directory
-        install_workdir = faux_path
-
-    build_workdir = faux_path
     build_cmd = (
         build_command
         if build_context and build_command
-        else '(test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts'
+        else _DEFAULT_NODE_BUILD_COMMAND
     )
 
     if flat:
-        destination = container_root if build_context else faux_path
         return (
             _build_flat_node_dockerfile(
                 config=config,
                 image=image_str,
                 env_vars=env_vars,
-                destination=destination,
                 install_workdir=install_workdir,
                 build_workdir=build_workdir,
                 install_command=install_cmd,
@@ -1786,7 +1782,7 @@ def node_config_to_docker(
         "",
         os.linesep.join(config["dockerfile_lines"]),
         "",
-        f"ADD . {faux_path if not build_context else container_root}",
+        f"ADD . {install_workdir}",
         "",
         f"WORKDIR {install_workdir}",
         "",

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1162,6 +1162,107 @@ def _build_runtime_env_vars(config: Config) -> list[str]:
     return env_vars
 
 
+def _supports_single_user_layer(
+    config: Config, local_deps: LocalDeps, escape_variables: bool
+) -> bool:
+    return not (
+        config["dockerfile_lines"]
+        or local_deps.additional_contexts
+        or config.get("ui")
+        or config.get("node_version")
+        or escape_variables
+    )
+
+
+def _faux_package_pyproject_command(package_name: str) -> str:
+    pyproject_path = shlex.quote(f"/deps/outer-{package_name}/pyproject.toml")
+    return f"""cat > {pyproject_path} <<'PYPROJECT'
+[project]
+name = {json.dumps(package_name)}
+version = "0.1"
+[tool.setuptools.package-data]
+"*" = ["**/*"]
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+PYPROJECT"""
+
+
+def _build_single_user_layer_dockerfile(
+    config_path: pathlib.Path,
+    config: Config,
+    local_deps: LocalDeps,
+    pypi_deps: list[str],
+    local_reqs_pip_install: str,
+    local_deps_install_command: str,
+    pip_cleanup: str,
+    image: str,
+    env_vars: list[str],
+) -> str:
+    context = pathlib.PurePosixPath("/__build_context")
+    commands = ["set -eu"]
+
+    if pip_config_file := config.get("pip_config_file"):
+        source = shlex.quote(str(context / pip_config_file))
+        commands.append(f"cp {source} /pipconfig.txt")
+    if pypi_deps:
+        commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
+
+    for reqpath, destination in local_deps.pip_reqs:
+        source = context / reqpath.relative_to(config_path.parent)
+        destination_parent = pathlib.PurePosixPath(destination).parent
+        commands.extend(
+            [
+                f"mkdir -p {shlex.quote(str(destination_parent))}",
+                f"cp {shlex.quote(str(source))} {shlex.quote(destination)}",
+            ]
+        )
+    if local_deps.pip_reqs:
+        requirements = " ".join(
+            f"-r {destination}" for _, destination in local_deps.pip_reqs
+        )
+        commands.append(f"{local_reqs_pip_install} {requirements}")
+
+    for _, (relative_path, name) in local_deps.real_pkgs.items():
+        source = f"{context / relative_path}/."
+        destination = f"/deps/{name}"
+        commands.extend(
+            [
+                f"mkdir -p {shlex.quote(destination)}",
+                f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
+            ]
+        )
+
+    for full_path, (relative_path, destination) in local_deps.faux_pkgs.items():
+        source = f"{context / relative_path}/."
+        commands.extend(
+            [
+                f"mkdir -p {shlex.quote(destination)}",
+                f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
+                _faux_package_pyproject_command(full_path.name),
+            ]
+        )
+
+    commands.append(local_deps_install_command)
+    commands.extend(
+        line.removeprefix("RUN ")
+        for line in pip_cleanup.splitlines()
+        if line and not line.startswith("#")
+    )
+
+    return os.linesep.join(
+        [
+            "# syntax=docker/dockerfile:1.7",
+            f"FROM {image}",
+            "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
+            *commands,
+            "USER_LAYER",
+            *env_vars,
+            f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
+        ]
+    )
+
+
 def _get_node_pm_install_cmd(project_dir: pathlib.Path) -> str:
     def test_file(file_name):
         full_path = project_dir / file_name
@@ -1430,90 +1531,36 @@ ADD {relpath} /deps/{name}
         )
     image_str = docker_tag(config, base_image, api_version)
     dep_vname = "$$dep" if escape_variables else "$dep"
-    local_deps_install_str = f"""RUN for dep in /deps/*; do \
+    local_deps_install_command = f"""for dep in /deps/*; do \
             echo "Installing {dep_vname}"; \
             if [ -d "{dep_vname}" ]; then \
                 echo "Installing {dep_vname}"; \
                 (cd "{dep_vname}" && {global_reqs_pip_install} -e .); \
             fi; \
         done"""
+    pip_cleanup = _get_pip_cleanup_lines(
+        install_cmd=install_cmd,
+        to_uninstall=build_tools_to_uninstall,
+        pip_installer=pip_installer,
+    )
 
-    if (
-        single_user_layer
-        and not config["dockerfile_lines"]
-        and not local_deps.additional_contexts
-        and not config.get("ui")
-        and not config.get("node_version")
-        and not escape_variables
+    if single_user_layer and _supports_single_user_layer(
+        config, local_deps, escape_variables
     ):
-        commands = ["set -eu"]
-        context = pathlib.PurePosixPath("/__build_context")
-        if pip_config_file := config.get("pip_config_file"):
-            commands.append(
-                f"cp {shlex.quote(str(context / pip_config_file))} /pipconfig.txt"
-            )
-        if pypi_deps:
-            commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
-        for reqpath, destpath in local_deps.pip_reqs:
-            source = context / reqpath.relative_to(config_path.parent)
-            commands.extend(
-                [
-                    f"mkdir -p {shlex.quote(str(pathlib.PurePosixPath(destpath).parent))}",
-                    f"cp {shlex.quote(str(source))} {shlex.quote(destpath)}",
-                ]
-            )
-        if local_deps.pip_reqs:
-            commands.append(
-                f"{local_reqs_pip_install} "
-                + " ".join(f"-r {path}" for _, path in local_deps.pip_reqs)
-            )
-        for _, (relpath, name) in local_deps.real_pkgs.items():
-            destination = f"/deps/{name}"
-            source = f"{context / relpath}/."
-            commands.extend(
-                [
-                    f"mkdir -p {shlex.quote(destination)}",
-                    f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
-                ]
-            )
-        for fullpath, (relpath, destpath) in local_deps.faux_pkgs.items():
-            source = f"{context / relpath}/."
-            pyproject = shlex.quote(f"/deps/outer-{fullpath.name}/pyproject.toml")
-            commands.extend(
-                [
-                    f"mkdir -p {shlex.quote(destpath)}",
-                    f"cp -a {shlex.quote(source)} {shlex.quote(destpath)}/",
-                    "for line in '[project]' "
-                    f"'name = \"{fullpath.name}\"' "
-                    "'version = \"0.1\"' "
-                    "'[tool.setuptools.package-data]' "
-                    '\'"*" = ["**/*"]\' '
-                    "'[build-system]' "
-                    "'requires = [\"setuptools>=61\"]' "
-                    "'build-backend = \"setuptools.build_meta\"'; do "
-                    f'echo "$line" >> {pyproject}; done',
-                ]
-            )
-        commands.append(local_deps_install_str.removeprefix("RUN "))
-        commands.extend(
-            line.removeprefix("RUN ")
-            for line in _get_pip_cleanup_lines(
-                install_cmd=install_cmd,
-                to_uninstall=build_tools_to_uninstall,
-                pip_installer=pip_installer,
-            ).splitlines()
-            if line and not line.startswith("#")
+        return (
+            _build_single_user_layer_dockerfile(
+                config_path=config_path,
+                config=config,
+                local_deps=local_deps,
+                pypi_deps=pypi_deps,
+                local_reqs_pip_install=local_reqs_pip_install,
+                local_deps_install_command=local_deps_install_command,
+                pip_cleanup=pip_cleanup,
+                image=image_str,
+                env_vars=env_vars,
+            ),
+            additional_contexts,
         )
-        docker_file_contents = [
-            "# syntax=docker/dockerfile:1.7",
-            f"FROM {image_str}",
-            "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
-            *commands,
-            "USER_LAYER",
-            *env_vars,
-            f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
-        ]
-        return os.linesep.join(docker_file_contents), additional_contexts
 
     # Prepare docker file contents
     docker_file_contents = []
@@ -1537,18 +1584,14 @@ ADD {relpath} /deps/{name}
             installs,
             "",
             "# -- Installing all local dependencies --",
-            local_deps_install_str,
+            f"RUN {local_deps_install_command}",
             "# -- End of local dependencies install --",
             os.linesep.join(env_vars),
             "",
             js_inst_str,
             "",
             # Add pip cleanup after all installations are complete
-            _get_pip_cleanup_lines(
-                install_cmd=install_cmd,
-                to_uninstall=build_tools_to_uninstall,
-                pip_installer=pip_installer,
-            ),
+            pip_cleanup,
             "",
             f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
         ]

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1162,16 +1162,6 @@ def _build_runtime_env_vars(config: Config) -> list[str]:
     return env_vars
 
 
-def _can_flatten(config: Config, local_deps: LocalDeps, escape_variables: bool) -> bool:
-    return not (
-        config["dockerfile_lines"]
-        or local_deps.additional_contexts
-        or config.get("ui")
-        or config.get("node_version")
-        or escape_variables
-    )
-
-
 def _faux_package_pyproject_command(package_name: str) -> str:
     pyproject_path = shlex.quote(f"/deps/outer-{package_name}/pyproject.toml")
     return f"""cat > {pyproject_path} <<'PYPROJECT'
@@ -1196,9 +1186,28 @@ def _build_flat_dockerfile(
     pip_cleanup: str,
     image: str,
     env_vars: list[str],
+    additional_context_names: dict[pathlib.Path, str],
 ) -> str:
     context = pathlib.PurePosixPath("/__build_context")
+    additional_context_root = pathlib.PurePosixPath("/__additional_contexts")
+    js_working_dir = (
+        local_deps.working_dir
+        if config.get("ui") or config.get("node_version")
+        else None
+    )
     commands = ["set -eu"]
+
+    if js_working_dir:
+        commands.append("/storage/install-node.sh")
+
+    def source_path(
+        path: pathlib.Path,
+        relative_path: str = ".",
+        additional_relative_path: str = ".",
+    ) -> str:
+        if name := additional_context_names.get(path):
+            return str(additional_context_root / name / additional_relative_path)
+        return str(context / relative_path)
 
     if pip_config_file := config.get("pip_config_file"):
         source = shlex.quote(str(context / pip_config_file))
@@ -1207,44 +1216,69 @@ def _build_flat_dockerfile(
         commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
 
     for reqpath, destination in local_deps.pip_reqs:
-        source = context / reqpath.relative_to(config_path.parent)
+        source = source_path(
+            reqpath.parent,
+            str(reqpath.relative_to(config_path.parent)),
+            reqpath.name,
+        )
         destination_parent = pathlib.PurePosixPath(destination).parent
         commands.append(f"""mkdir -p {shlex.quote(str(destination_parent))}
-cp {shlex.quote(str(source))} {shlex.quote(destination)}""")
+cp {shlex.quote(source)} {shlex.quote(destination)}""")
     if local_deps.pip_reqs:
         requirements = " ".join(
             f"-r {destination}" for _, destination in local_deps.pip_reqs
         )
         commands.append(f"{local_reqs_pip_install} {requirements}")
 
-    for _, (relative_path, name) in local_deps.real_pkgs.items():
-        source = f"{context / relative_path}/."
+    for full_path, (relative_path, name) in local_deps.real_pkgs.items():
+        source = f"{source_path(full_path, relative_path)}/."
         destination = f"/deps/{name}"
         commands.append(f"""mkdir -p {shlex.quote(destination)}
 cp -a {shlex.quote(source)} {shlex.quote(destination)}/""")
 
     for full_path, (relative_path, destination) in local_deps.faux_pkgs.items():
-        source = f"{context / relative_path}/."
+        source = f"{source_path(full_path, relative_path)}/."
         pyproject = _faux_package_pyproject_command(full_path.name)
         commands.append(f"""mkdir -p {shlex.quote(destination)}
 cp -a {shlex.quote(source)} {shlex.quote(destination)}/
 {pyproject}""")
 
     commands.append(local_deps_install_command)
+    if js_working_dir:
+        working_dir = shlex.quote(js_working_dir)
+        commands.append(
+            f"cd {working_dir}\n"
+            f"{_get_node_pm_install_cmd(config_path.parent)} "
+            "&& tsx /api/langgraph_api/js/build.mts"
+        )
     commands.extend(
         line.removeprefix("RUN ")
         for line in pip_cleanup.splitlines()
         if line and not line.startswith("#")
     )
 
+    mounts = ["--mount=type=bind,target=/__build_context,readonly"]
+    mounts.extend(
+        f"--mount=type=bind,from={name},target={additional_context_root / name},readonly"
+        for name in additional_context_names.values()
+    )
+    run = f"RUN {' '.join(mounts)} <<'USER_LAYER'"
+    node_env = (
+        f"ENV NODE_VERSION={config.get('node_version') or DEFAULT_NODE_VERSION}"
+        if js_working_dir
+        else ""
+    )
+
     return os.linesep.join(
         [
             "# syntax=docker/dockerfile:1.7",
             f"FROM {image}",
-            "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
+            *config["dockerfile_lines"],
+            node_env,
+            *env_vars,
+            run,
             *commands,
             "USER_LAYER",
-            *env_vars,
             f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
         ]
     )
@@ -1531,7 +1565,7 @@ ADD {relpath} /deps/{name}
         pip_installer=pip_installer,
     )
 
-    if flat and _can_flatten(config, local_deps, escape_variables):
+    if flat:
         return (
             _build_flat_dockerfile(
                 config_path=config_path,
@@ -1543,6 +1577,7 @@ ADD {relpath} /deps/{name}
                 pip_cleanup=pip_cleanup,
                 image=image_str,
                 env_vars=env_vars,
+                additional_context_names=additional_context_names,
             ),
             additional_contexts,
         )
@@ -1593,6 +1628,7 @@ def node_config_to_docker(
     install_command: str | None = None,
     build_command: str | None = None,
     build_context: str | None = None,
+    flat: bool = False,
 ) -> tuple[str, dict[str, str]]:
     # Calculate paths for monorepo support
     install_root = (
@@ -1619,22 +1655,42 @@ def node_config_to_docker(
         # Monorepo case: install from root, build from config directory
         container_root = f"/deps/{pathlib.Path(build_context).name}"
         install_workdir = container_root
-        install_step = f"RUN {install_cmd}"
-
-        if build_command:
-            build_step = f"RUN {build_command}"
-        else:
-            build_step = 'RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts'
     else:
         # Original behavior: everything happens in the same directory
         install_workdir = faux_path
-        install_step = f"RUN {install_cmd}"
-        build_step = 'RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts'
 
-    if build_context:
-        build_workdir = faux_path
-    else:
-        build_workdir = faux_path
+    build_workdir = faux_path
+    build_cmd = (
+        build_command
+        if build_context and build_command
+        else '(test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts'
+    )
+
+    if flat:
+        context = pathlib.PurePosixPath("/__build_context")
+        destination = container_root if build_context else faux_path
+        commands = [
+            "set -eu",
+            f"mkdir -p {shlex.quote(destination)}\n"
+            f"cp -a {shlex.quote(f'{context}/.')} {shlex.quote(destination)}/",
+            f"cd {shlex.quote(install_workdir)}\n{install_cmd}",
+            f"cd {shlex.quote(build_workdir)}\n{build_cmd}",
+        ]
+        return (
+            os.linesep.join(
+                [
+                    "# syntax=docker/dockerfile:1.7",
+                    f"FROM {image_str}",
+                    *config["dockerfile_lines"],
+                    *env_vars,
+                    "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
+                    *commands,
+                    "USER_LAYER",
+                    f"WORKDIR {build_workdir}",
+                ]
+            ),
+            {},
+        )
 
     docker_file_contents = [
         f"FROM {image_str}",
@@ -1645,13 +1701,13 @@ def node_config_to_docker(
         "",
         f"WORKDIR {install_workdir}",
         "",
-        install_step,
+        f"RUN {install_cmd}",
         "",
         os.linesep.join(env_vars),
         "",
         f"WORKDIR {build_workdir}",
         "",
-        build_step,
+        f"RUN {build_cmd}",
     ]
 
     return os.linesep.join(docker_file_contents), {}
@@ -1744,6 +1800,7 @@ def config_to_docker(
             install_command=install_command,
             build_command=build_command,
             build_context=build_context,
+            flat=flat,
         )
 
     return python_config_to_docker(

--- a/libs/cli/langgraph_cli/config.py
+++ b/libs/cli/langgraph_cli/config.py
@@ -1267,6 +1267,7 @@ def python_config_to_docker(
     api_version: str | None = None,
     *,
     escape_variables: bool = False,
+    single_user_layer: bool = False,
 ) -> tuple[str, dict[str, str]]:
     """Generate a Dockerfile from the configuration."""
     source_kind = _get_source_kind(config)
@@ -1428,6 +1429,91 @@ ADD {relpath} /deps/{name}
             ]
         )
     image_str = docker_tag(config, base_image, api_version)
+    dep_vname = "$$dep" if escape_variables else "$dep"
+    local_deps_install_str = f"""RUN for dep in /deps/*; do \
+            echo "Installing {dep_vname}"; \
+            if [ -d "{dep_vname}" ]; then \
+                echo "Installing {dep_vname}"; \
+                (cd "{dep_vname}" && {global_reqs_pip_install} -e .); \
+            fi; \
+        done"""
+
+    if (
+        single_user_layer
+        and not config["dockerfile_lines"]
+        and not local_deps.additional_contexts
+        and not config.get("ui")
+        and not config.get("node_version")
+        and not escape_variables
+    ):
+        commands = ["set -eu"]
+        context = pathlib.PurePosixPath("/__build_context")
+        if pip_config_file := config.get("pip_config_file"):
+            commands.append(
+                f"cp {shlex.quote(str(context / pip_config_file))} /pipconfig.txt"
+            )
+        if pypi_deps:
+            commands.append(f"{local_reqs_pip_install} {' '.join(pypi_deps)}")
+        for reqpath, destpath in local_deps.pip_reqs:
+            source = context / reqpath.relative_to(config_path.parent)
+            commands.extend(
+                [
+                    f"mkdir -p {shlex.quote(str(pathlib.PurePosixPath(destpath).parent))}",
+                    f"cp {shlex.quote(str(source))} {shlex.quote(destpath)}",
+                ]
+            )
+        if local_deps.pip_reqs:
+            commands.append(
+                f"{local_reqs_pip_install} "
+                + " ".join(f"-r {path}" for _, path in local_deps.pip_reqs)
+            )
+        for _, (relpath, name) in local_deps.real_pkgs.items():
+            destination = f"/deps/{name}"
+            source = f"{context / relpath}/."
+            commands.extend(
+                [
+                    f"mkdir -p {shlex.quote(destination)}",
+                    f"cp -a {shlex.quote(source)} {shlex.quote(destination)}/",
+                ]
+            )
+        for fullpath, (relpath, destpath) in local_deps.faux_pkgs.items():
+            source = f"{context / relpath}/."
+            pyproject = shlex.quote(f"/deps/outer-{fullpath.name}/pyproject.toml")
+            commands.extend(
+                [
+                    f"mkdir -p {shlex.quote(destpath)}",
+                    f"cp -a {shlex.quote(source)} {shlex.quote(destpath)}/",
+                    "for line in '[project]' "
+                    f"'name = \"{fullpath.name}\"' "
+                    "'version = \"0.1\"' "
+                    "'[tool.setuptools.package-data]' "
+                    '\'"*" = ["**/*"]\' '
+                    "'[build-system]' "
+                    "'requires = [\"setuptools>=61\"]' "
+                    "'build-backend = \"setuptools.build_meta\"'; do "
+                    f'echo "$line" >> {pyproject}; done',
+                ]
+            )
+        commands.append(local_deps_install_str.removeprefix("RUN "))
+        commands.extend(
+            line.removeprefix("RUN ")
+            for line in _get_pip_cleanup_lines(
+                install_cmd=install_cmd,
+                to_uninstall=build_tools_to_uninstall,
+                pip_installer=pip_installer,
+            ).splitlines()
+            if line and not line.startswith("#")
+        )
+        docker_file_contents = [
+            "# syntax=docker/dockerfile:1.7",
+            f"FROM {image_str}",
+            "RUN --mount=type=bind,target=/__build_context,readonly <<'USER_LAYER'",
+            *commands,
+            "USER_LAYER",
+            *env_vars,
+            f"WORKDIR {local_deps.working_dir}" if local_deps.working_dir else "",
+        ]
+        return os.linesep.join(docker_file_contents), additional_contexts
 
     # Prepare docker file contents
     docker_file_contents = []
@@ -1442,14 +1528,6 @@ ADD {relpath} /deps/{name}
         )
 
     # Add main dockerfile content
-    dep_vname = "$$dep" if escape_variables else "$dep"
-    local_deps_install_str = f"""RUN for dep in /deps/*; do \
-            echo "Installing {dep_vname}"; \
-            if [ -d "{dep_vname}" ]; then \
-                echo "Installing {dep_vname}"; \
-                (cd "{dep_vname}" && {global_reqs_pip_install} -e .); \
-            fi; \
-        done"""
     docker_file_contents.extend(
         [
             f"FROM {image_str}",
@@ -1625,6 +1703,7 @@ def config_to_docker(
     build_command: str | None = None,
     build_context: str | None = None,
     escape_variables: bool = False,
+    single_user_layer: bool = False,
 ) -> tuple[str, dict[str, str]]:
     base_image = base_image or default_base_image(config)
 
@@ -1645,6 +1724,7 @@ def config_to_docker(
         base_image=base_image,
         api_version=api_version,
         escape_variables=escape_variables,
+        single_user_layer=single_user_layer,
     )
 
 

--- a/libs/cli/langgraph_cli/docker.py
+++ b/libs/cli/langgraph_cli/docker.py
@@ -345,7 +345,7 @@ def build_docker_image(
     docker_command: Sequence[str] | None = None,
     extra_flags: Sequence[str] = (),
     verbose: bool = True,
-    single_user_layer: bool = False,
+    flat: bool = False,
 ):
     """Build a Docker image from a LangGraph config."""
     # pull latest images
@@ -388,7 +388,7 @@ def build_docker_image(
         install_command=install_command,
         build_command=build_command,
         build_context=build_context,
-        single_user_layer=single_user_layer,
+        flat=flat,
     )
     # add additional_contexts
     if additional_contexts:

--- a/libs/cli/langgraph_cli/docker.py
+++ b/libs/cli/langgraph_cli/docker.py
@@ -345,6 +345,7 @@ def build_docker_image(
     docker_command: Sequence[str] | None = None,
     extra_flags: Sequence[str] = (),
     verbose: bool = True,
+    single_user_layer: bool = False,
 ):
     """Build a Docker image from a LangGraph config."""
     # pull latest images
@@ -387,6 +388,7 @@ def build_docker_image(
         install_command=install_command,
         build_command=build_command,
         build_context=build_context,
+        single_user_layer=single_user_layer,
     )
     # add additional_contexts
     if additional_contexts:

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -320,6 +320,14 @@ def test_top_level_help_truncates_command_descriptions_to_single_line() -> None:
     assert "[Beta] List LangSmith Deployments." in deploy_list_line
 
 
+def test_build_help_includes_flat_option() -> None:
+    result = CliRunner().invoke(cli, ["build", "--help"])
+
+    assert result.exit_code == 0
+    assert "--flat" in result.output
+    assert "--single-user-layer" not in result.output
+
+
 def test_dev_command_requires_ssl_certfile_and_keyfile_together(tmp_path) -> None:
     config_path = tmp_path / "langgraph.json"
     config_path.write_text(

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -320,14 +320,6 @@ def test_top_level_help_truncates_command_descriptions_to_single_line() -> None:
     assert "[Beta] List LangSmith Deployments." in deploy_list_line
 
 
-def test_build_help_includes_flat_option() -> None:
-    result = CliRunner().invoke(cli, ["build", "--help"])
-
-    assert result.exit_code == 0
-    assert "--flat" in result.output
-    assert "--single-user-layer" not in result.output
-
-
 def test_dev_command_requires_ssl_certfile_and_keyfile_together(tmp_path) -> None:
     config_path = tmp_path / "langgraph.json"
     config_path.write_text(

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -723,14 +723,14 @@ WORKDIR /deps/outer-unit_tests/unit_tests\
     }
 
 
-def test_config_to_docker_single_user_layer():
+def test_config_to_docker_flat():
     dockerfile, additional_contexts = config_to_docker(
         PATH_TO_CONFIG,
         validate_config(
             {"dependencies": ["."], "graphs": {"agent": "./agent.py:graph"}}
         ),
         base_image="langchain/langgraph-api",
-        single_user_layer=True,
+        flat=True,
     )
 
     assert additional_contexts == {}

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -742,6 +742,48 @@ def test_config_to_docker_flat():
     assert dockerfile.endswith("WORKDIR /deps/outer-unit_tests/unit_tests")
 
 
+def test_config_to_docker_flat_with_custom_lines_and_escaped_variables():
+    dockerfile, _ = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "dependencies": ["."],
+                "graphs": {"agent": "./agent.py:graph"},
+                "dockerfile_lines": ["RUN echo custom"],
+            }
+        ),
+        base_image="langchain/langgraph-api",
+        escape_variables=True,
+        flat=True,
+    )
+
+    assert dockerfile.index("RUN echo custom") < dockerfile.index("USER_LAYER")
+    assert 'echo "Installing $$dep"' in dockerfile
+
+
+def test_config_to_docker_flat_with_additional_context():
+    dockerfile, additional_contexts = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {"dependencies": [".", ".."], "graphs": {"agent": "./agent.py:graph"}}
+        ),
+        base_image="langchain/langgraph-api",
+        flat=True,
+    )
+
+    assert additional_contexts == {
+        "outer-tests": str(pathlib.Path(__file__).parent.parent.absolute()),
+    }
+    assert (
+        "--mount=type=bind,from=outer-tests,"
+        "target=/__additional_contexts/outer-tests,readonly" in dockerfile
+    )
+    assert (
+        "cp -a /__additional_contexts/outer-tests/. /deps/outer-tests/tests/"
+        in dockerfile
+    )
+
+
 def test_config_to_docker_outside_path():
     graphs = {"agent": "./agent.py:graph"}
     actual_docker_stdin, additional_contexts = config_to_docker(
@@ -1017,6 +1059,28 @@ RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not foun
     assert additional_contexts == {}
 
 
+def test_config_to_docker_nodejs_flat():
+    dockerfile, additional_contexts = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "node_version": "20",
+                "graphs": {"agent": "./graphs/agent.js:graph"},
+                "dockerfile_lines": ["RUN echo custom"],
+            }
+        ),
+        base_image="langchain/langgraphjs-api",
+        flat=True,
+    )
+
+    assert additional_contexts == {}
+    assert dockerfile.index("RUN echo custom") < dockerfile.index("USER_LAYER")
+    assert "cp -a /__build_context/. /deps/unit_tests/" in dockerfile
+    assert "cd /deps/unit_tests\nnpm i" in dockerfile
+    assert "tsx /api/langgraph_api/js/build.mts" in dockerfile
+    assert dockerfile.endswith("WORKDIR /deps/unit_tests")
+
+
 def test_config_to_docker_python_encryption():
     # Test that encryption config is included in validation
     graphs = {"agent": "./agent.py:graph"}
@@ -1231,6 +1295,29 @@ WORKDIR /deps/outer-unit_tests/unit_tests"""
 
     assert clean_empty_lines(actual_docker_stdin) == expected_docker_stdin
     assert additional_contexts == {}
+
+
+def test_config_to_docker_gen_ui_python_flat():
+    dockerfile, additional_contexts = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {
+                "dependencies": ["."],
+                "graphs": {"agent": "./agent.py:graph"},
+                "ui": {"agent": "./graphs/agent.ui.jsx"},
+            }
+        ),
+        base_image="langchain/langgraph-api",
+        flat=True,
+    )
+
+    assert additional_contexts == {}
+    assert dockerfile.count("\nRUN ") == 1
+    assert dockerfile.index("ENV NODE_VERSION=20") < dockerfile.index("\nRUN ")
+    assert dockerfile.index("ENV LANGGRAPH_UI=") < dockerfile.index("\nRUN ")
+    assert "/storage/install-node.sh" in dockerfile
+    assert "cd /deps/outer-unit_tests/unit_tests\nnpm i" in dockerfile
+    assert "tsx /api/langgraph_api/js/build.mts" in dockerfile
 
 
 def test_config_to_docker_multiplatform():

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -737,6 +737,8 @@ def test_config_to_docker_single_user_layer():
     assert dockerfile.count("\nRUN ") == 1
     assert "--mount=type=bind" in dockerfile
     assert "cp -a /__build_context/. /deps/outer-unit_tests/unit_tests/" in dockerfile
+    assert "cat > /deps/outer-unit_tests/pyproject.toml <<'PYPROJECT'" in dockerfile
+    assert '[tool.setuptools.package-data]\n"*" = ["**/*"]' in dockerfile
     assert dockerfile.endswith("WORKDIR /deps/outer-unit_tests/unit_tests")
 
 

--- a/libs/cli/tests/unit_tests/test_config.py
+++ b/libs/cli/tests/unit_tests/test_config.py
@@ -723,6 +723,23 @@ WORKDIR /deps/outer-unit_tests/unit_tests\
     }
 
 
+def test_config_to_docker_single_user_layer():
+    dockerfile, additional_contexts = config_to_docker(
+        PATH_TO_CONFIG,
+        validate_config(
+            {"dependencies": ["."], "graphs": {"agent": "./agent.py:graph"}}
+        ),
+        base_image="langchain/langgraph-api",
+        single_user_layer=True,
+    )
+
+    assert additional_contexts == {}
+    assert dockerfile.count("\nRUN ") == 1
+    assert "--mount=type=bind" in dockerfile
+    assert "cp -a /__build_context/. /deps/outer-unit_tests/unit_tests/" in dockerfile
+    assert dockerfile.endswith("WORKDIR /deps/outer-unit_tests/unit_tests")
+
+
 def test_config_to_docker_outside_path():
     graphs = {"agent": "./agent.py:graph"}
     actual_docker_stdin, additional_contexts = config_to_docker(


### PR DESCRIPTION
## Summary

- add an opt-in --single-user-layer flag to langgraph build
- generate one bind-mounted RUN for source copy, dependency installation, API restoration, and build-tool cleanup
- preserve runtime ENV and WORKDIR in the resulting image config
- retain the existing layered generator for unsupported or more complex build shapes

## Expected impact

In the Kubernetes BuildKit benchmark, combining the generated Python user steps into one non-empty filesystem layer reduced median C3 + gVisor solve time by about 10 seconds (54.93s to 44.76s). Fast samples showed roughly 20–24 seconds of structural savings. Compressed image size was effectively unchanged; the gain came from avoiding repeated native-snapshot copies.

This deliberately trades fine-grained warm-cache reuse for faster cold, short-lived builders.

## Validation

- make format
- make lint
- make test (337 passed)
- Docker Buildx outline validation of a generated single-layer Dockerfile