### PR TITLE
fix(langgraph): preserve scheduled task errors through cleanup

### DIFF
--- a/libs/langgraph/langgraph/stream/_mux.py
+++ b/libs/langgraph/langgraph/stream/_mux.py
@@ -385,7 +385,8 @@ class StreamMux:
         then auto-closes channels and the main event log.
 
         If any scheduled task raised under `on_error="raise"`, or any
-        transformer's `afinalize` raises, the exception propagates.
+        transformer's `afinalize` raises, the exception propagates after
+        all transformers, channels, and the main event log are cleaned up.
         The caller (the pump) handles it by routing into `afail`.
 
         Raises:
@@ -393,9 +394,10 @@ class StreamMux:
                 error, re-raised after cleanup.
         """
         pending = self._collect_scheduled_tasks()
+        first_task_error: BaseException | None = None
         if pending:
             results = await asyncio.gather(*pending, return_exceptions=True)
-            first_err = next(
+            first_task_error = next(
                 (
                     r
                     for r in results
@@ -404,22 +406,26 @@ class StreamMux:
                 ),
                 None,
             )
-            if first_err is not None:
-                raise first_err
 
-        first_error: BaseException | None = None
-        for transformer in self._transformers:
-            try:
-                await transformer.afinalize()
-            except BaseException as e:
-                if first_error is None:
-                    first_error = e
-        for ch in self._channels:
-            if not ch._closed:
-                ch.close()
-        self._events.close()
-        if first_error is not None:
-            raise first_error
+        first_finalize_error: BaseException | None = None
+        try:
+            for transformer in self._transformers:
+                try:
+                    await transformer.afinalize()
+                except BaseException as e:
+                    if first_finalize_error is None:
+                        first_finalize_error = e
+            for ch in self._channels:
+                if not ch._closed:
+                    ch.close()
+            self._events.close()
+        finally:
+            self._clear_scheduled_tasks()
+
+        if first_task_error is not None:
+            raise first_task_error
+        if first_finalize_error is not None:
+            raise first_finalize_error
 
     async def afail(self, err: BaseException) -> None:
         """Fail on the async lane.
@@ -432,30 +438,39 @@ class StreamMux:
             err: The exception that ended the run.
         """
         pending = self._collect_scheduled_tasks()
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        try:
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
-        for transformer in self._transformers:
-            try:
-                await transformer.afail(err)
-            except BaseException:
-                pass
-        for ch in self._channels:
-            if not ch._closed:
-                ch.fail(err)
-        if not self._events._closed:
-            self._events.fail(err)
+            for transformer in self._transformers:
+                try:
+                    await transformer.afail(err)
+                except BaseException:
+                    pass
+            for ch in self._channels:
+                if not ch._closed:
+                    ch.fail(err)
+            if not self._events._closed:
+                self._events.fail(err)
+        finally:
+            self._clear_scheduled_tasks()
 
     def _collect_scheduled_tasks(self) -> list[asyncio.Task[Any]]:
-        """Return a snapshot of in-flight tasks scheduled via transformers."""
+        """Return scheduled tasks awaiting lifecycle cleanup."""
         return [
             task
             for transformer in self._transformers
             for task in getattr(transformer, "_stream_scheduled_tasks", ())
-            if not task.done()
         ]
+
+    def _clear_scheduled_tasks(self) -> None:
+        """Release scheduled-task references after lifecycle cleanup."""
+        for transformer in self._transformers:
+            tasks = getattr(transformer, "_stream_scheduled_tasks", None)
+            if tasks is not None:
+                tasks.clear()
 
     # ------------------------------------------------------------------
     # Binding and StreamChannel auto-wiring

--- a/libs/langgraph/langgraph/stream/_types.py
+++ b/libs/langgraph/langgraph/stream/_types.py
@@ -240,8 +240,10 @@ class StreamTransformer(ABC):
 
         The mux holds the task reference, awaits all scheduled tasks
         during `aclose()` before calling `afinalize()`, and cancels
-        them on `afail()`. Authors don't need to track tasks or
-        implement the last-task-closes-the-log dance.
+        them on `afail()`. Failed tasks scheduled with
+        `on_error="raise"` stay available until lifecycle cleanup so
+        their errors can be propagated reliably. Authors don't need to
+        track tasks or implement the last-task-closes-the-log dance.
 
         Requires a running event loop — call only under `astream()`.
         Set `requires_async = True` on the class so registration under
@@ -253,8 +255,7 @@ class StreamTransformer(ABC):
             on_error: `"log"` (default) catches and logs any exception
                 the coroutine raises, so a single failure doesn't tear
                 down the run. `"raise"` lets the exception propagate
-                when the mux joins pendings, converting the close path
-                into the fail path.
+                when the mux closes, after the normal cleanup hooks run.
 
         Returns:
             The asyncio Task. Authors rarely need to await it directly
@@ -279,7 +280,10 @@ class StreamTransformer(ABC):
         task = asyncio.create_task(wrapped)
         tasks = self._scheduled_task_set()
         tasks.add(task)
-        task.add_done_callback(tasks.discard)
+        if on_error == "log":
+            task.add_done_callback(tasks.discard)
+        else:
+            task.add_done_callback(self._retain_scheduled_error)
         return task
 
     @staticmethod
@@ -303,6 +307,19 @@ class StreamTransformer(ABC):
             tasks = set()
             self._stream_scheduled_tasks = tasks
         return tasks
+
+    def _retain_scheduled_error(self, task: asyncio.Task[Any]) -> None:
+        """Keep failed raise-mode tasks until the mux cleans them up.
+
+        Successful and cancelled tasks can be released as soon as they
+        finish. Retrieving the exception here also prevents asyncio from
+        reporting it as an unhandled task exception before `aclose()` joins
+        the task.
+        """
+        tasks = self._scheduled_task_set()
+        tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            tasks.add(task)
 
 
 def transformer_requires_async(transformer: StreamTransformer) -> bool:

--- a/libs/langgraph/tests/test_pregel_stream_events_v3.py
+++ b/libs/langgraph/tests/test_pregel_stream_events_v3.py
@@ -1564,8 +1564,44 @@ class TestAsyncTransformerLane:
 
         mux = StreamMux([Strict()], is_async=True)
         await mux.apush(_event("values", {}))
+        # Let the task finish before close; completed errors must still be
+        # retained for the mux to propagate.
+        await asyncio.sleep(0.01)
         with pytest.raises(ValueError, match="strict boom"):
             await mux.aclose()
+
+    async def test_schedule_on_error_raise_cleans_up_before_reraising(self) -> None:
+        finalized = False
+
+        class Strict(StreamTransformer):
+            requires_async = True
+
+            def __init__(self) -> None:
+                self._log: StreamChannel[str] = StreamChannel()
+
+            def init(self) -> dict[str, Any]:
+                return {"out": self._log}
+
+            def process(self, event: ProtocolEvent) -> bool:
+                async def work() -> None:
+                    raise ValueError("strict boom")
+
+                self.schedule(work(), on_error="raise")
+                return True
+
+            async def afinalize(self) -> None:
+                nonlocal finalized
+                finalized = True
+
+        t = Strict()
+        mux = StreamMux([t], is_async=True)
+        await mux.apush(_event("values", {}))
+        await asyncio.sleep(0.01)
+        with pytest.raises(ValueError, match="strict boom"):
+            await mux.aclose()
+        assert finalized
+        assert t._log._closed
+        assert mux._events._closed
 
     async def test_afail_cancels_pending_scheduled_tasks(self) -> None:
         cancelled = asyncio.Event()


### PR DESCRIPTION
Fixes #8715

`StreamTransformer.schedule(on_error="raise")` now preserves failures that complete before `StreamMux.aclose()`. The mux runs transformer, channel, and event-log cleanup before re-raising the task error, with regression coverage for both behaviors.

Verification:
- `make format`
- `make lint`
- Full `langgraph` test suite: 1,998 passed, 4 skipped