### PR TITLE
fix(prebuilt): only inject ToolRuntime into ToolRuntime-typed parameters

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1999,10 +1999,6 @@ def _get_all_injected_args(tool: BaseTool) -> _InjectedArgs:
         if _is_injected_arg_type(type_):
             all_injected_keys.add(name)
 
-        # Check for runtime (special case: parameter named "runtime")
-        if name == "runtime":
-            runtime_arg = name
-
         # Check for InjectedState
         if state_inj := _get_injection_from_type(type_, InjectedState):
             if isinstance(state_inj, InjectedState) and state_inj.field:
@@ -2017,7 +2013,11 @@ def _get_all_injected_args(tool: BaseTool) -> _InjectedArgs:
         if _get_injection_from_type(type_, InjectedStore):
             store_arg = name
 
-        # Check for ToolRuntime
+        # Check for ToolRuntime. Detection is annotation-driven: a parameter is
+        # injected only when it is typed as ToolRuntime (regardless of its
+        # name, per the ToolRuntime contract). Matching on the name "runtime"
+        # alone would hijack regular model-controlled parameters that happen
+        # to be called "runtime".
         if _get_injection_from_type(type_, ToolRuntime):
             runtime_arg = name
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2012,6 +2012,68 @@ async def test_tool_node_inject_runtime_dynamic_tool_via_wrap_tool_call_async() 
     assert tool_message.tool_call_id == "call_dynamic_2"
 
 
+def test_tool_node_regular_param_named_runtime_not_injected() -> None:
+    """Test that a regular parameter named "runtime" is not hijacked by injection.
+
+    ToolRuntime injection is annotation-driven: only parameters typed as
+    `ToolRuntime` are injected. A regular model-controlled parameter that
+    happens to be named "runtime" (e.g. `runtime: str`) must receive the
+    value provided by the model instead of a `ToolRuntime` instance.
+    """
+
+    @dec_tool
+    def schedule_task(task: str, runtime: str) -> str:
+        """Schedule a task for a time of day."""
+        return f"Scheduled {task} at {runtime}"
+
+    tool_node = ToolNode([schedule_task], handle_tool_errors=True)
+
+    tool_call = {
+        "name": "schedule_task",
+        "args": {"task": "backup", "runtime": "morning"},
+        "id": "call_runtime_1",
+        "type": "tool_call",
+    }
+    msg = AIMessage("", tool_calls=[tool_call])
+    result = tool_node.invoke(
+        {"messages": [msg]},
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][-1]
+    assert tool_message.status == "success"
+    assert tool_message.content == "Scheduled backup at morning"
+    assert tool_message.tool_call_id == "call_runtime_1"
+
+
+async def test_tool_node_regular_param_named_runtime_not_injected_async() -> None:
+    """Async version of test_tool_node_regular_param_named_runtime_not_injected."""
+
+    @dec_tool
+    async def schedule_task(task: str, runtime: str) -> str:
+        """Schedule a task for a time of day."""
+        return f"Scheduled {task} at {runtime}"
+
+    tool_node = ToolNode([schedule_task], handle_tool_errors=True)
+
+    tool_call = {
+        "name": "schedule_task",
+        "args": {"task": "backup", "runtime": "morning"},
+        "id": "call_runtime_2",
+        "type": "tool_call",
+    }
+    msg = AIMessage("", tool_calls=[tool_call])
+    result = await tool_node.ainvoke(
+        {"messages": [msg]},
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][-1]
+    assert tool_message.status == "success"
+    assert tool_message.content == "Scheduled backup at morning"
+    assert tool_message.tool_call_id == "call_runtime_2"
+
+
 def test_tool_runtime_defaults_tools_to_empty_list() -> None:
     runtime = ToolRuntime(
         state={},


### PR DESCRIPTION
# fix(prebuilt): only inject ToolRuntime into ToolRuntime-typed parameters

Fixes #8728

## What

`_get_all_injected_args` matched the runtime argument by **name only**, in addition to the type annotation:

```python
# Check for runtime (special case: parameter named "runtime")
if name == "runtime":
    runtime_arg = name
```

As a result, any regular model-controlled parameter named `runtime` (e.g. `runtime: str`) was treated as a `ToolRuntime` injection target:

- `_inject_tool_args` silently overwrote the model-provided value with a `ToolRuntime` instance before the tool ran.
- `_filter_validation_errors` then stripped the resulting validation error (because `runtime` was marked as injected), so with `handle_tool_errors=True` the model received an **empty** error message (`with error:\n \n`) and had no way to self-correct.

## Why this is the right fix

The documented `ToolRuntime` contract (in the `ToolRuntime` docstring in this file) is:

> When a tool function has a parameter named `runtime` with type hint `ToolRuntime`, the tool execution system will automatically inject an instance ...

Detection is meant to be annotation-driven. The annotation check right below the removed branch (`_get_injection_from_type(type_, ToolRuntime)`) already handles all documented injection cases, including subclasses, `Annotated`/`Union` nesting, and subscripted generics via `_is_injection` — so the name-only branch only produced false positives.

## Changes

- `libs/prebuilt/langgraph/prebuilt/tool_node.py`: removed the name-only `name == "runtime"` branch from `_get_all_injected_args`; the annotation-driven check is now the sole runtime detector (with an explanatory comment).
- `libs/prebuilt/tests/test_tool_node.py`: added sync + async regression tests asserting that a regular `runtime: str` parameter receives the model's value.

## Verification

- New regression tests fail on `main` (tool call errors with an empty message) and pass with this fix.
- Existing runtime-injection behavior is preserved: `runtime: ToolRuntime` injection still works in sync/async paths and for dynamic tools created via `wrap_tool_call` (covered by the existing `test_tool_node_inject_runtime_*` tests).
- `make format`, `make lint` (ruff + ty), and the full `libs/prebuilt` test suite (230 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
