### PR TITLE
fix(langgraph): propagate tee source errors to all branches

### DIFF
--- a/libs/langgraph/langgraph/stream/stream_channel.py
+++ b/libs/langgraph/langgraph/stream/stream_channel.py
@@ -266,6 +266,7 @@ class StreamChannel(Generic[T]):
         source = self.__iter__()
         buffers: list[deque[T]] = [deque() for _ in range(n)]
         exhausted = [False]
+        error: list[BaseException | None] = [None]
 
         def branch(i: int) -> Iterator[T]:
             buf = buffers[i]
@@ -273,13 +274,19 @@ class StreamChannel(Generic[T]):
                 if buf:
                     yield buf.popleft()
                 elif exhausted[0]:
+                    if error[0] is not None:
+                        raise error[0]
                     return
                 else:
                     try:
                         item = next(source)
                     except StopIteration:
                         exhausted[0] = True
-                        return
+                    except Exception as e:
+                        error[0] = e
+                        exhausted[0] = True
+                    if exhausted[0]:
+                        continue
                     for b in buffers:
                         b.append(item)
 

--- a/libs/langgraph/tests/test_pregel_stream_events_v3.py
+++ b/libs/langgraph/tests/test_pregel_stream_events_v3.py
@@ -1768,6 +1768,18 @@ class TestDrainOnConsume:
         assert list(a) == [0, 1, 2]
         assert list(b) == [0, 1, 2]
 
+    def test_tee_propagates_source_error_to_every_branch(self) -> None:
+        log: StreamChannel[int] = StreamChannel()
+        log._bind(is_async=False)
+        a, b = log.tee(2)
+        log.push(1)
+        log.push(2)
+        log.fail(ValueError("boom"))
+
+        for branch in (a, b):
+            with pytest.raises(ValueError, match="boom"):
+                list(branch)
+
     @pytest.mark.anyio
     async def test_atee_fans_out(self) -> None:
         log: StreamChannel[int] = StreamChannel()


### PR DESCRIPTION
## Summary

- preserve source exceptions in the shared synchronous tee state
- re-raise the source exception from every branch
- add regression coverage for multiple branches consuming a failed source

## Tests

- `pytest tests/test_pregel_stream_events_v3.py` (110 passed)
- `ruff check .`
- `ruff format --check .`
- `ty check langgraph`

Fixes #8716