### PR TITLE
fix(langgraph): align async initial update inference

### DIFF
--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2372,7 +2372,11 @@ class Pregel(
                 # find last node that updated the state, if not provided
                 if as_node is None and len(self.nodes) == 1:
                     as_node = tuple(self.nodes)[0]
-                elif as_node is None and not saved:
+                elif as_node is None and not any(
+                    v
+                    for vv in checkpoint["versions_seen"].values()
+                    for v in vv.values()
+                ):
                     if (
                         isinstance(self.input_channels, str)
                         and self.input_channels in self.nodes

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -8467,6 +8467,27 @@ async def test_bulk_state_updates(async_checkpointer: BaseCheckpointSaver) -> No
         )
 
 
+async def test_aupdate_state_infers_input_node_after_initial_update() -> None:
+    class State(TypedDict):
+        items: Annotated[list[str], operator.add]
+
+    graph = (
+        StateGraph(State)
+        .add_node("a", lambda state: {"items": ["a"]})
+        .add_node("b", lambda state: {"items": ["b"]})
+        .add_edge(START, "a")
+        .add_edge("a", "b")
+        .add_edge("b", END)
+        .compile(checkpointer=InMemorySaver())
+    )
+    config = {"configurable": {"thread_id": "1"}}
+
+    await graph.aupdate_state(config, {"items": ["first"]}, as_node=START)
+    await graph.aupdate_state(config, {"items": ["second"]})
+
+    assert (await graph.aget_state(config)).values == {"items": ["first", "second"]}
+
+
 async def test_update_as_input(
     async_checkpointer: BaseCheckpointSaver, durability: Durability
 ) -> None:


### PR DESCRIPTION
## Summary

- make async state-update inference use checkpoint `versions_seen`, matching the synchronous path
- avoid treating an existing initial checkpoint as node execution history
- add regression coverage for repeated initial async state updates without `as_node`

## Tests

- `pytest tests/test_pregel_async.py::test_aupdate_state_infers_input_node_after_initial_update`
- `ruff check .`
- `ruff format --check .`
- `ty check langgraph`

Fixes #8714