### PR TITLE
fix(checkpoint): skip sync-only checkpointers

### DIFF
--- a/libs/checkpoint-conformance/README.md
+++ b/libs/checkpoint-conformance/README.md
@@ -16,7 +16,7 @@ uv add langgraph-checkpoint-conformance
 
 ## 🤔 What is this?
 
-This library provides a conformance test suite for [LangGraph](https://github.com/langchain-ai/langgraph) checkpointer implementations. It validates that a `BaseCheckpointSaver` subclass correctly implements the checkpoint storage contract — blob round-trips, metadata preservation, namespace isolation, incremental channel updates, and more.
+This library provides an async conformance test suite for [LangGraph](https://github.com/langchain-ai/langgraph) checkpointer implementations. It validates that a `BaseCheckpointSaver` subclass correctly implements the async checkpoint storage contract — blob round-trips, metadata preservation, namespace isolation, incremental channel updates, and more. Sync-only savers are detected and reported as `SKIPPED (sync-only saver)`.
 
 ## 📖 Documentation
 
@@ -30,16 +30,19 @@ Register your checkpointer with `@checkpointer_test` and run `validate()`:
 import asyncio
 from langgraph.checkpoint.conformance import checkpointer_test, validate
 
+
 @checkpointer_test(name="MyCheckpointer")
 async def my_checkpointer():
     saver = MyCheckpointer(...)
     yield saver
     # cleanup runs after yield
 
+
 async def main():
     report = await validate(my_checkpointer)
     report.print_report()
     assert report.passed_all_base()
+
 
 asyncio.run(main())
 ```
@@ -50,9 +53,11 @@ Or in a pytest test:
 import pytest
 from langgraph.checkpoint.conformance import checkpointer_test, validate
 
+
 @checkpointer_test(name="MyCheckpointer")
 async def my_checkpointer():
     yield MyCheckpointer(...)
+
 
 @pytest.mark.asyncio
 async def test_conformance():
@@ -116,6 +121,7 @@ async def db_lifespan():
     await create_database()
     yield
     await drop_database()
+
 
 @checkpointer_test(name="PostgresSaver", lifespan=db_lifespan)
 async def pg_checkpointer():

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/capabilities.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/capabilities.py
@@ -49,8 +49,8 @@ EXTENDED_CAPABILITIES = frozenset(
 
 ALL_CAPABILITIES = BASE_CAPABILITIES | EXTENDED_CAPABILITIES
 
-# Maps capability to the async method name on BaseCheckpointSaver (or subclass).
-_CAPABILITY_METHOD_MAP: dict[Capability, str] = {
+# Maps capabilities to their async and sync method names on BaseCheckpointSaver.
+_ASYNC_CAPABILITY_METHOD_MAP: dict[Capability, str] = {
     Capability.PUT: "aput",
     Capability.PUT_WRITES: "aput_writes",
     Capability.GET_TUPLE: "aget_tuple",
@@ -62,6 +62,18 @@ _CAPABILITY_METHOD_MAP: dict[Capability, str] = {
     Capability.DELTA_CHANNEL_HISTORY: "aget_delta_channel_history",
 }
 
+_SYNC_CAPABILITY_METHOD_MAP: dict[Capability, str] = {
+    Capability.PUT: "put",
+    Capability.PUT_WRITES: "put_writes",
+    Capability.GET_TUPLE: "get_tuple",
+    Capability.LIST: "list",
+    Capability.DELETE_THREAD: "delete_thread",
+    Capability.DELETE_FOR_RUNS: "delete_for_runs",
+    Capability.COPY_THREAD: "copy_thread",
+    Capability.PRUNE: "prune",
+    Capability.DELTA_CHANNEL_HISTORY: "get_delta_channel_history",
+}
+
 
 @dataclass(frozen=True)
 class DetectedCapabilities:
@@ -69,21 +81,30 @@ class DetectedCapabilities:
 
     detected: frozenset[Capability]
     missing: frozenset[Capability]
+    sync_only: bool = False
 
     @classmethod
     def from_instance(cls, saver: BaseCheckpointSaver) -> DetectedCapabilities:
         """Detect capabilities from a checkpointer instance."""
         inner_type = type(saver)
         detected: set[Capability] = set()
+        sync_detected: set[Capability] = set()
 
-        for cap, method_name in _CAPABILITY_METHOD_MAP.items():
+        for cap, method_name in _ASYNC_CAPABILITY_METHOD_MAP.items():
             if _is_overridden(inner_type, method_name):
                 detected.add(cap)
+
+        for cap, method_name in _SYNC_CAPABILITY_METHOD_MAP.items():
+            if _is_overridden(inner_type, method_name):
+                sync_detected.add(cap)
 
         detected_fs = frozenset(detected)
         return cls(
             detected=detected_fs,
             missing=ALL_CAPABILITIES - detected_fs,
+            sync_only=(
+                BASE_CAPABILITIES <= sync_detected and not BASE_CAPABILITIES <= detected
+            ),
         )
 
 

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/report.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/report.py
@@ -99,6 +99,7 @@ class CapabilityResult:
     tests_failed: int = 0
     tests_skipped: int = 0
     failures: list[str] = field(default_factory=list)
+    skip_reason: str | None = None
 
 
 @dataclass
@@ -107,6 +108,7 @@ class CapabilityReport:
 
     checkpointer_name: str
     results: dict[str, CapabilityResult] = field(default_factory=dict)
+    skip_reason: str | None = None
 
     def passed_all_base(self) -> bool:
         """Whether all base capability tests passed."""
@@ -118,6 +120,8 @@ class CapabilityReport:
 
     def passed_all(self) -> bool:
         """Whether every detected capability's tests passed."""
+        if self.skip_reason is not None:
+            return False
         for result in self.results.values():
             if result.detected and result.passed is not True:
                 return False
@@ -125,6 +129,8 @@ class CapabilityReport:
 
     def conformance_level(self) -> str:
         """Return a human-readable conformance level string."""
+        if self.skip_reason is not None:
+            return "SKIPPED"
         if self.passed_all():
             return "FULL"
         if self.passed_all_base():
@@ -153,6 +159,9 @@ class CapabilityReport:
                 if result is None:
                     icon = "  "
                     suffix = "(no tests)"
+                elif result.skip_reason is not None:
+                    icon = "--"
+                    suffix = f"({result.skip_reason})"
                 elif not result.detected:
                     icon = "⊘ "
                     suffix = "(not implemented)"
@@ -176,7 +185,10 @@ class CapabilityReport:
             1 for r in self.results.values() if r.detected and r.passed is True
         )
         level = self.conformance_level()
-        print(f"{'':>2}  Result: {level} ({passed}/{total})")
+        if self.skip_reason is not None:
+            print(f"{'':>2}  Result: {level} ({self.skip_reason})")
+        else:
+            print(f"{'':>2}  Result: {level} ({passed}/{total})")
         print(f"{'':>2}{border}\n")
 
     def to_dict(self) -> dict[str, Any]:
@@ -184,6 +196,7 @@ class CapabilityReport:
         return {
             "checkpointer_name": self.checkpointer_name,
             "conformance_level": self.conformance_level(),
+            "skip_reason": self.skip_reason,
             "results": {
                 name: {
                     "detected": r.detected,
@@ -192,6 +205,7 @@ class CapabilityReport:
                     "tests_failed": r.tests_failed,
                     "tests_skipped": r.tests_skipped,
                     "failures": r.failures,
+                    "skip_reason": r.skip_reason,
                 }
                 for name, r in self.results.items()
             },

--- a/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
+++ b/libs/checkpoint-conformance/langgraph/checkpoint/conformance/validate.py
@@ -72,6 +72,23 @@ async def validate(
         caps_to_test = set(Capability)
 
     async with registered.enter_lifespan():
+        # The conformance specs exercise the async API. Detect sync-only savers
+        # once up front so async signpost methods that raise NotImplementedError
+        # are not mistaken for implementations and reported as test failures.
+        async with registered.create() as saver:
+            detected = DetectedCapabilities.from_instance(saver)
+
+        if detected.sync_only:
+            report.skip_reason = "sync-only saver"
+            for cap in Capability:
+                report.results[cap.value] = CapabilityResult(
+                    detected=False,
+                    passed=None,
+                    tests_skipped=1,
+                    skip_reason=report.skip_reason,
+                )
+            return report
+
         for cap in Capability:
             if cap in caps_to_test and cap.value not in registered.skip_capabilities:
                 # Create a fresh checkpointer for each capability suite.

--- a/libs/checkpoint-conformance/tests/test_validate_sync_only.py
+++ b/libs/checkpoint-conformance/tests/test_validate_sync_only.py
@@ -1,0 +1,66 @@
+"""Tests for sync-only checkpointer detection."""
+
+from __future__ import annotations
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import InMemorySaver
+
+from langgraph.checkpoint.conformance import checkpointer_test, validate
+from langgraph.checkpoint.conformance.capabilities import DetectedCapabilities
+
+
+class SyncOnlySaver(InMemorySaver):
+    """In-memory saver with only the sync API exposed as implemented."""
+
+    aget_tuple = BaseCheckpointSaver.aget_tuple
+    alist = BaseCheckpointSaver.alist
+    aput = BaseCheckpointSaver.aput
+    aput_writes = BaseCheckpointSaver.aput_writes
+    adelete_thread = BaseCheckpointSaver.adelete_thread
+
+
+class SignpostedSyncOnlySaver(SyncOnlySaver):
+    """Sync-only saver with async methods that explicitly refuse calls."""
+
+    async def aget_tuple(self, *args, **kwargs):
+        raise NotImplementedError("use an async saver")
+
+    async def alist(self, *args, **kwargs):
+        raise NotImplementedError("use an async saver")
+        yield
+
+    async def aput(self, *args, **kwargs):
+        raise NotImplementedError("use an async saver")
+
+
+@checkpointer_test(name="SignpostedSyncOnlySaver")
+async def signposted_sync_only_checkpointer():
+    yield SignpostedSyncOnlySaver()
+
+
+@checkpointer_test(name="SyncOnlySaver")
+async def sync_only_checkpointer():
+    yield SyncOnlySaver()
+
+
+def test_detects_sync_only_savers_with_or_without_async_signposts() -> None:
+    assert DetectedCapabilities.from_instance(SyncOnlySaver()).sync_only
+    assert DetectedCapabilities.from_instance(SignpostedSyncOnlySaver()).sync_only
+    assert not DetectedCapabilities.from_instance(InMemorySaver()).sync_only
+
+
+async def test_validate_skips_sync_only_saver(capsys) -> None:
+    for registered in (sync_only_checkpointer, signposted_sync_only_checkpointer):
+        report = await validate(registered)
+
+        assert report.conformance_level() == "SKIPPED"
+        assert report.skip_reason == "sync-only saver"
+        assert not report.passed_all()
+        assert not report.passed_all_base()
+        assert all(
+            result.skip_reason == "sync-only saver"
+            for result in report.results.values()
+        )
+
+    report.print_report()
+    assert "Result: SKIPPED (sync-only saver)" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- detect checkpointers with complete synchronous base capabilities but incomplete async capabilities
- report these implementations as `SKIPPED (sync-only saver)` instead of failed async implementations
- document the async-only scope and add coverage for silent and signposted sync-only savers

## Tests

- `uv run pytest` (3 passed)
- `uv run ruff check .`
- `uv run ty check`
- verified the report against `SqliteSaver`

Fixes #8722