### PR TITLE
fix(checkpoint): stop InMemoryStore reads from creating namespaces

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -259,7 +259,9 @@ class InMemoryStore(BaseStore):
 
             for key, item in self._data[namespace].items():
                 if filter_func(item):
-                    if op.query and (embeddings := self._vectors[namespace].get(key)):
+                    if op.query and (
+                        embeddings := self._vectors.get(namespace, {}).get(key)
+                    ):
                         filtered.append((item, list(embeddings.values())))
                     else:
                         filtered.append((item, []))
@@ -386,7 +388,9 @@ class InMemoryStore(BaseStore):
         ] = {}
         for i, op in enumerate(ops):
             if isinstance(op, GetOp):
-                item = self._data[op.namespace].get(op.key)
+                # Read through `.get` so that looking up an unknown namespace
+                # does not insert an empty one into the backing defaultdict.
+                item = self._data.get(op.namespace, {}).get(op.key)
                 results.append(item)
             elif isinstance(op, SearchOp):
                 search_ops[i] = (op, self._filter_items(op))
@@ -404,8 +408,17 @@ class InMemoryStore(BaseStore):
     def _apply_put_ops(self, put_ops: dict[tuple[tuple[str, ...], str], PutOp]) -> None:
         for (namespace, key), op in put_ops.items():
             if op.value is None:
-                self._data[namespace].pop(key, None)
-                self._vectors[namespace].pop(key, None)
+                # Deleting must not create the namespace, and a namespace that
+                # loses its last item stops existing, so that `list_namespaces`
+                # only ever reports namespaces that hold at least one item.
+                if (items := self._data.get(namespace)) is not None:
+                    items.pop(key, None)
+                    if not items:
+                        del self._data[namespace]
+                if (vectors := self._vectors.get(namespace)) is not None:
+                    vectors.pop(key, None)
+                    if not vectors:
+                        del self._vectors[namespace]
             else:
                 self._data[namespace][key] = Item(
                     value=op.value,

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -316,6 +316,43 @@ def test_list_namespaces_basic() -> None:
     assert result == expected
 
 
+def test_list_namespaces_only_reports_populated_namespaces() -> None:
+    store = InMemoryStore()
+    store.put(("real",), "key", {"v": 1})
+
+    # A miss is a read: it must not bring the namespace into existence.
+    assert store.get(("ghost",), "key") is None
+    assert store.list_namespaces() == [("real",)]
+
+    # Neither may deleting a key that was never written.
+    store.delete(("ghost",), "key")
+    assert store.list_namespaces() == [("real",)]
+
+    # A namespace stops existing once its last item is removed.
+    store.delete(("real",), "key")
+    assert store.list_namespaces() == []
+
+
+async def test_alist_namespaces_only_reports_populated_namespaces() -> None:
+    store = InMemoryStore()
+    await store.aput(("real",), "key", {"v": 1})
+
+    assert await store.aget(("ghost",), "key") is None
+    await store.adelete(("ghost",), "key")
+    assert await store.alist_namespaces() == [("real",)]
+
+    await store.adelete(("real",), "key")
+    assert await store.alist_namespaces() == []
+
+
+def test_repeated_misses_do_not_grow_the_store() -> None:
+    store = InMemoryStore()
+    for i in range(100):
+        assert store.get(("users", str(i)), "prefs") is None
+
+    assert store.list_namespaces() == []
+
+
 def test_list_namespaces_with_wildcards() -> None:
     store = InMemoryStore()
 


### PR DESCRIPTION

Fixes #8734

`InMemoryStore` no longer creates a namespace when a read misses, and it drops a
namespace once its last item is deleted, so `list_namespaces` only ever reports
namespaces that actually hold an item.

## Root cause

`InMemoryStore` keeps its items in `self._data`, a `defaultdict(dict)` keyed by
namespace. Indexing a defaultdict with a missing key inserts an entry, and two
paths indexed it directly instead of reading through it.

In `_prepare_ops`, the `GetOp` branch read `self._data[op.namespace].get(op.key)`.
When the namespace was unknown, that lookup created an empty namespace as a side
effect of what should be a pure read.

In `_apply_put_ops`, the delete branch called `self._data[namespace].pop(key, None)`.
Deleting a key in a namespace that was never written created that namespace, and
deleting the last key of a real namespace left an empty dict behind instead of
removing it.

`_handle_list_namespaces` lists `self._data.keys()` without checking whether a
namespace holds anything, so both leftovers surfaced through the public
`list_namespaces` API. `_filter_items` had the same pattern against `self._vectors`.

The practical cost is a store that grows once per distinct namespace looked up.
An agent that reads a user's memory before writing it leaks one dict entry per
user for the life of the process, and `list_namespaces` reports every user it has
ever looked at rather than every user it has stored.

## Fix

Read through `dict.get` on the get path and on the vector lookup, so a miss stays
a miss. On the delete path, only touch a namespace that already exists, and remove
it once it becomes empty. Writes still go through the defaultdict, which is the one
place where autovivification is wanted.

The resulting invariant is that `self._data` holds exactly the namespaces with at
least one item. That matches the SQL-backed stores, which derive namespaces from
the rows that actually exist, so callers now get the same answer from
`list_namespaces` whether they run on `InMemoryStore` or on a persistent store.

## How I verified

Three regression tests in `libs/checkpoint/tests/test_store.py` cover the sync path,
the async path, and repeated misses. All three fail on `main` and pass with this
change. `make lint` and `make test` pass for `libs/checkpoint`, with 151 passed and
22 skipped.
