### PR TITLE
fix: make uuid6 generation thread-safe to avoid race condition (closes #8409)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/id.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/id.py
@@ -93,9 +93,10 @@ def uuid6(node: int | None = None, clock_seq: int | None = None) -> UUID:
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     timestamp = nanoseconds // 100 + 0x01B21DD213814000
-    if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
-        timestamp = _last_v6_timestamp + 1
-    _last_v6_timestamp = timestamp
+    with _uuid_lock:
+        if _last_v6_timestamp is not None and timestamp <= _last_v6_timestamp:
+            timestamp = _last_v6_timestamp + 1
+        _last_v6_timestamp = timestamp
     if clock_seq is None:
         clock_seq = random.getrandbits(14)  # instead of stable storage
     if node is None:


### PR DESCRIPTION
## What

Under high concurrency with multiple threads, the module-level `_last_v6_timestamp` is accessed without synchronization. This race can cause duplicate timestamps or reordering, and in extreme cases may lead to resource exhaustion and OOM when many threads are generating UUIDs rapidly (e.g., with langgraph-api and opentelemetry-exporter-prometheus).

## Fix

Add a lock around the timestamp check-and-set operation to ensure atomicity. This makes the UUID generation thread-safe and prevents potential race conditions.

Closes #8409