### PR TITLE
fix: sync pipeline before closing connection in AsyncPostgresSaver.from_conn_string (closes #5675)

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/aio.py
@@ -84,6 +84,9 @@ class AsyncPostgresSaver(BasePostgresSaver):
             if pipeline:
                 async with conn.pipeline() as pipe:
                     yield cls(conn=conn, pipe=pipe, serde=serde)
+                    # Ensure all buffered data is written and the server has processed it
+                    # before the connection is closed to avoid SSL/connection errors
+                    await pipe.sync()
             else:
                 yield cls(conn=conn, serde=serde)
 


### PR DESCRIPTION
## What
When `AsyncPostgresSaver.from_conn_string` is used with `pipeline=True`, the pipeline's internal buffer may contain unsent data when the connection is closed. This can cause `psycopg.OperationalError: consuming input failed: SSL connection has been closed unexpectedly` when the context manager exits, especially under concurrent operations or when messages are written just before close.

## Fix
Explicitly call `await pipe.sync()` before the connection context manager exits. This ensures all buffered pipeline commands are flushed to the server and the server's responses are processed, preventing the connection from being closed with pending data.

## Impact
This is a minimal, targeted fix that only affects pipeline mode and ensures clean shutdown of the connection, eliminating the SSL error.

Closes #5675