### PR TITLE
fix(checkpoint): serialize numpy scalars in JsonPlusSerializer

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -300,6 +300,7 @@ EXT_PYDANTIC_V1 = 4
 EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 EXT_DELTA_SNAPSHOT = 7
+EXT_NUMPY_SCALAR = 8
 
 
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
@@ -528,6 +529,15 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             meta = (obj.dtype.str, obj.shape, order, buf)
             return ormsgpack.Ext(EXT_NUMPY_ARRAY, _msgpack_enc(meta))
 
+    elif (np_mod := sys.modules.get("numpy")) is not None and isinstance(
+        obj, np_mod.generic
+    ):
+        # numpy scalars (np.float64, np.int64, np.bool_, ...) are what indexing
+        # or reducing an array returns. Unlike 0-d arrays they don't match the
+        # ndarray branch above and aren't natively msgpack serializable.
+        meta = (obj.dtype.str, obj.tobytes())
+        return ormsgpack.Ext(EXT_NUMPY_SCALAR, _msgpack_enc(meta))
+
     elif isinstance(obj, BaseException):
         return repr(obj)
     else:
@@ -739,6 +749,16 @@ def _create_msgpack_ext_hook(
                 return arr.reshape(shape, order=order)
             except Exception:
                 return None
+        elif code == EXT_NUMPY_SCALAR:
+            try:
+                import numpy as _np
+
+                dtype_str, buf = ormsgpack.unpackb(
+                    data, ext_hook=ext_hook, option=ormsgpack.OPT_NON_STR_KEYS
+                )
+                return _np.frombuffer(buf, dtype=_np.dtype(dtype_str))[0]
+            except Exception:
+                return None
         return None
 
     return ext_hook
@@ -835,6 +855,18 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             )
             arr = _np.frombuffer(buf, dtype=_np.dtype(dtype_str))
             return arr.reshape(shape, order=order).tolist()
+        except Exception:
+            return
+    elif code == EXT_NUMPY_SCALAR:
+        try:
+            import numpy as _np
+
+            dtype_str, buf = ormsgpack.unpackb(
+                data,
+                ext_hook=_msgpack_ext_hook_to_json,
+                option=ormsgpack.OPT_NON_STR_KEYS,
+            )
+            return _np.frombuffer(buf, dtype=_np.dtype(dtype_str))[0].item()
         except Exception:
             return
 

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -626,6 +626,59 @@ def test_serde_jsonplus_numpy_array_json_hook(arr: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
+    "scalar",
+    [
+        np.float64(1.5),
+        np.float32(1.5),
+        np.int64(7),
+        np.int32(-7),
+        np.uint8(255),
+        np.bool_(True),
+        np.complex128(1 + 2j),
+    ],
+)
+def test_serde_jsonplus_numpy_scalar(scalar: np.generic) -> None:
+    serde = JsonPlusSerializer()
+
+    dumped = serde.dumps_typed(scalar)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert isinstance(result, np.generic)
+    assert result.dtype == scalar.dtype
+    assert result == scalar
+
+
+def test_serde_jsonplus_numpy_scalar_from_array() -> None:
+    """A scalar obtained by indexing/reducing an array round-trips like the array."""
+    serde = JsonPlusSerializer()
+    arr = np.array([1.0, 2.0])
+
+    for scalar in (arr[0], arr.mean(), arr.sum()):
+        result = serde.loads_typed(serde.dumps_typed(scalar))
+        assert isinstance(result, np.generic)
+        assert result == scalar
+
+
+@pytest.mark.parametrize(
+    ("scalar", "expected"),
+    [
+        (np.float64(1.5), 1.5),
+        (np.int64(7), 7),
+        (np.bool_(True), True),
+    ],
+)
+def test_serde_jsonplus_numpy_scalar_json_hook(
+    scalar: np.generic, expected: object
+) -> None:
+    serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
+    dumped = serde.dumps_typed(scalar)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert type(result) is type(expected)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     "df",
     [
         pd.DataFrame(),


### PR DESCRIPTION
Fixes #8705

numpy scalars (`np.float64`, `np.int64`, `np.bool_`, ...) — what array indexing and reductions return — had no branch in `JsonPlusSerializer` and aren't natively msgpack serializable, so a state value holding one raised `Type is not msgpack serializable`. A 0-d array of the same data round-trips fine, so the failure is easy to hit by accident.

Adds an `EXT_NUMPY_SCALAR` ext type (dtype string + raw bytes), mirroring the existing `EXT_NUMPY_ARRAY` handling, with matching decode branches in the ext hook and the JSON ext hook.

How verified: new round-trip tests in `test_jsonplus.py` covering float/int/uint/bool/complex scalars, scalars taken from `arr[0]`/`.mean()`/`.sum()`, and the JSON hook path. `make format`, `make lint`, `make test` pass for `libs/checkpoint`.