### PR TITLE
fix(langgraph): include dtype in default cache keys

### DIFF
--- a/libs/langgraph/langgraph/_internal/_cache.py
+++ b/libs/langgraph/langgraph/_internal/_cache.py
@@ -5,22 +5,42 @@ from typing import Any
 
 
 def _freeze(obj: Any, depth: int = 10) -> Hashable:
-    if isinstance(obj, Hashable) or depth <= 0:
-        # already hashable, no need to freeze
+    if depth <= 0:
         return obj
-    elif isinstance(obj, Mapping):
+    # Plain tuples are Hashable even when they contain unhashable values
+    # (`isinstance` is type-based). Walk them so positional args and keyword
+    # values take the same path.
+    if type(obj) is tuple:
+        return tuple(_freeze(x, depth - 1) for x in obj)
+    if isinstance(obj, Hashable):
+        return obj
+    if isinstance(obj, Mapping):
         # sort keys so {"a":1,"b":2} == {"b":2,"a":1}
         return tuple(sorted((k, _freeze(v, depth - 1)) for k, v in obj.items()))
-    elif isinstance(obj, Sequence):
+    if isinstance(obj, Sequence):
         return tuple(_freeze(x, depth - 1) for x in obj)
-    # numpy / pandas etc. can provide their own .tobytes()
-    elif hasattr(obj, "tobytes"):
-        return (
+    # numpy / pandas / PIL etc. can provide their own .tobytes()
+    if hasattr(obj, "tobytes"):
+        dtype = getattr(obj, "dtype", None)
+        key: tuple[Any, ...] = (
             type(obj).__name__,
             obj.tobytes(),
-            obj.shape if hasattr(obj, "shape") else None,
+            getattr(obj, "shape", None),
+            str(dtype) if dtype is not None else None,
+            getattr(obj, "strides", None),
         )
-    return obj  # strings, ints, dataclasses with frozen=True, etc.
+        # PIL Image: mode is a str like "P" / "RGB". ndarray.size is an int.
+        mode = getattr(obj, "mode", None)
+        if isinstance(mode, str):
+            palette = None
+            getpalette = getattr(obj, "getpalette", None)
+            if callable(getpalette):
+                raw = getpalette()
+                if raw is not None:
+                    palette = tuple(raw)
+            key += (mode, getattr(obj, "size", None), palette)
+        return key
+    return obj
 
 
 def default_cache_key(*args: Any, **kwargs: Any) -> str | bytes:

--- a/libs/langgraph/tests/test_cache.py
+++ b/libs/langgraph/tests/test_cache.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph._internal._cache import default_cache_key
+
+
+class _Array:
+    """Minimal tobytes() object with numpy-like metadata."""
+
+    def __init__(
+        self,
+        data: bytes,
+        *,
+        dtype: str,
+        shape: tuple[int, ...],
+        strides: tuple[int, ...] = (1,),
+    ) -> None:
+        self._data = data
+        self.dtype = dtype
+        self.shape = shape
+        self.strides = strides
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+class _Image:
+    """Minimal tobytes() object with PIL-like metadata."""
+
+    def __init__(
+        self,
+        data: bytes,
+        *,
+        mode: str,
+        size: tuple[int, int],
+        palette: list[int] | None = None,
+    ) -> None:
+        self._data = data
+        self.mode = mode
+        self.size = size
+        self._palette = palette
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+    def getpalette(self) -> list[int] | None:
+        return self._palette
+
+
+def test_tobytes_dtype_is_part_of_key() -> None:
+    same_bytes = b"\xc8"
+    uint8 = _Array(same_bytes, dtype="uint8", shape=(1,))
+    int8 = _Array(same_bytes, dtype="int8", shape=(1,))
+    assert default_cache_key(arr=uint8) != default_cache_key(arr=int8)
+
+
+def test_tobytes_identical_inputs_share_a_key() -> None:
+    a = _Array(b"\xc8", dtype="uint8", shape=(1,))
+    b = _Array(b"\xc8", dtype="uint8", shape=(1,))
+    assert default_cache_key(arr=a) == default_cache_key(arr=b)
+
+
+def test_positional_tobytes_dtype_is_part_of_key() -> None:
+    same_bytes = b"\xc8"
+    uint8 = _Array(same_bytes, dtype="uint8", shape=(1,))
+    int8 = _Array(same_bytes, dtype="int8", shape=(1,))
+    assert default_cache_key(uint8) != default_cache_key(int8)
+
+
+def test_tobytes_inside_tuple_uses_dtype() -> None:
+    same_bytes = b"\xc8"
+    uint8 = _Array(same_bytes, dtype="uint8", shape=(1,))
+    int8 = _Array(same_bytes, dtype="int8", shape=(1,))
+    assert default_cache_key(payload=(uint8,)) != default_cache_key(payload=(int8,))
+
+
+def test_mapping_key_order_does_not_change_key() -> None:
+    assert default_cache_key(payload={"a": 1, "b": 2}) == default_cache_key(
+        payload={"b": 2, "a": 1}
+    )
+
+
+def test_pil_palette_is_part_of_key() -> None:
+    data = b"\x00\x01"
+    size = (1, 2)
+    red = _Image(data, mode="P", size=size, palette=[255, 0, 0])
+    blue = _Image(data, mode="P", size=size, palette=[0, 0, 255])
+    assert default_cache_key(img=red) != default_cache_key(img=blue)
+
+
+def test_depth_guard_does_not_raise() -> None:
+    nested: Any = []
+    cur = nested
+    for _ in range(20):
+        nxt: list[Any] = []
+        cur.append(nxt)
+        cur = nxt
+    default_cache_key(nested)
+
+
+def test_numpy_dtype_collision_from_issue() -> None:
+    np = pytest.importorskip("numpy")
+    a = np.array([200], dtype=np.uint8)
+    b = np.array([-56], dtype=np.int8)
+    assert a.tobytes() == b.tobytes()
+    assert default_cache_key(arr=a) != default_cache_key(arr=b)
+    assert default_cache_key(a) != default_cache_key(b)


### PR DESCRIPTION
Fixes #8009

`default_cache_key` hashed `tobytes()` objects as `(typename, bytes, shape)`, so `uint8 [200]` and `int8 [-56]` shared a key when passed as kwargs. Tuples short-circuit as Hashable, so the positional path pickled the array (dtype included) and did not collide. This puts dtype/strides on the tobytes branch, walks plain tuples so both paths use it, and adds `tests/test_cache.py`.

Verified with `make format`, `make lint`, and `NO_DOCKER=true uv run pytest tests/test_cache.py` in `libs/langgraph` (7 passed, 1 skipped without numpy).

## Release note

Default cache keys for numpy (and other `tobytes()`) inputs now include dtype and related metadata, so arrays that share a byte layout no longer collide. Existing cache entries for those inputs will miss once.