### PR TITLE
fix(langgraph): copy channel containers when taking a checkpoint

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -44,13 +44,15 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         return empty
 
     def checkpoint(self) -> set[Value]:
-        return self.seen
+        # Copy: `update()` adds to this set in place, so handing out the live
+        # object would let a later superstep mutate an already-taken checkpoint.
+        return self.seen.copy()
 
     def from_checkpoint(self, checkpoint: set[Value]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            empty.seen = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -122,13 +124,15 @@ class NamedBarrierValueAfterFinish(
         return empty
 
     def checkpoint(self) -> tuple[set[Value], bool]:
-        return (self.seen, self.finished)
+        # Copy: see `NamedBarrierValue.checkpoint`.
+        return (self.seen.copy(), self.finished)
 
     def from_checkpoint(self, checkpoint: tuple[set[Value], bool]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            seen, empty.finished = checkpoint
+            empty.seen = seen.copy()
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -61,7 +61,9 @@ class Topic(
         return empty
 
     def checkpoint(self) -> list[Value]:
-        return self.values
+        # Copy: `update()` extends this list in place, so handing out the live
+        # object would let a later superstep mutate an already-taken checkpoint.
+        return self.values.copy()
 
     def from_checkpoint(self, checkpoint: list[Value]) -> Self:
         empty = self.__class__(self.typ, self.accumulate)
@@ -69,9 +71,9 @@ class Topic(
         if checkpoint is not MISSING:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
-                empty.values = checkpoint[1]
+                empty.values = checkpoint[1].copy()
             else:
-                empty.values = checkpoint
+                empty.values = checkpoint.copy()
         return empty
 
     def update(self, values: Sequence[Value | list[Value]]) -> bool:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -14,6 +14,10 @@ from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate, _get_overwrite
 from langgraph.channels.delta import DeltaChannel
 from langgraph.channels.last_value import LastValue
+from langgraph.channels.named_barrier_value import (
+    NamedBarrierValue,
+    NamedBarrierValueAfterFinish,
+)
 from langgraph.channels.topic import Topic
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.errors import EmptyChannelError, InvalidUpdateError
@@ -89,6 +93,110 @@ def test_topic_accumulate() -> None:
     assert channel.get() == ["a", "b", "b", "c", "d", "d"]
     assert channel.update(["e"])
     assert channel.get() == ["a", "b", "b", "c", "d", "d", "e"]
+
+
+def test_topic_checkpoint_is_not_aliased() -> None:
+    """`checkpoint()` must not hand out the list `update()` extends in place."""
+    channel = Topic(str, accumulate=True).from_checkpoint(MISSING)
+    channel.update(["a", "b"])
+
+    checkpoint = channel.checkpoint()
+    channel.update(["c"])
+
+    assert checkpoint == ["a", "b"]
+
+
+def test_topic_from_checkpoint_is_not_aliased() -> None:
+    """Channels restored from one checkpoint must be independent of each other."""
+    source = Topic(str, accumulate=True).from_checkpoint(MISSING)
+    source.update(["a", "b"])
+    checkpoint = source.checkpoint()
+
+    one = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    two = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    one.update(["c"])
+
+    assert one.get() == ["a", "b", "c"]
+    assert two.get() == ["a", "b"]
+    assert checkpoint == ["a", "b"]
+
+
+def test_topic_from_checkpoint_tuple_is_not_aliased() -> None:
+    """The backwards-compatible tuple form must copy too."""
+    checkpoint = (None, ["a"])
+    channel = Topic(str, accumulate=True).from_checkpoint(checkpoint)
+    channel.update(["b"])
+
+    assert channel.get() == ["a", "b"]
+    assert checkpoint[1] == ["a"]
+
+
+@pytest.mark.parametrize("cls", [NamedBarrierValue, NamedBarrierValueAfterFinish])
+def test_named_barrier_value_checkpoint_is_not_aliased(cls: type) -> None:
+    channel = cls(str, {"a", "b"}).from_checkpoint(MISSING)
+    channel.update(["a"])
+
+    checkpoint = channel.checkpoint()
+    channel.update(["b"])
+
+    seen = checkpoint[0] if isinstance(checkpoint, tuple) else checkpoint
+    assert seen == {"a"}
+
+
+@pytest.mark.parametrize("cls", [NamedBarrierValue, NamedBarrierValueAfterFinish])
+def test_named_barrier_value_from_checkpoint_is_not_aliased(cls: type) -> None:
+    source = cls(str, {"a", "b"}).from_checkpoint(MISSING)
+    source.update(["a"])
+    checkpoint = source.checkpoint()
+
+    restored = cls(str, {"a", "b"}).from_checkpoint(checkpoint)
+    restored.update(["b"])
+
+    # The source never saw "b", so its barrier must still be closed.
+    assert not source.is_available()
+    seen = checkpoint[0] if isinstance(checkpoint, tuple) else checkpoint
+    assert seen == {"a"}
+
+
+@pytest.mark.parametrize("durability", ["sync", "async", "exit"])
+def test_topic_accumulate_checkpoint_history_matches_durability(
+    durability: str,
+) -> None:
+    """A taken checkpoint must not absorb writes from later supersteps.
+
+    `create_checkpoint` stores whatever `checkpoint()` returns. When that was
+    the channel's live list, a later superstep extended it in place, so under
+    `durability="async"` (serialized after the fact) the persisted history for
+    an earlier step showed values that step never had.
+    """
+
+    class State(TypedDict):
+        logs: Annotated[list, Topic(str, accumulate=True)]
+
+    builder = StateGraph(State)
+    for name in ("a", "b", "c"):
+        builder.add_node(name, (lambda n: lambda state: {"logs": n})(name))
+    builder.add_edge(START, "a")
+    builder.add_edge("a", "b")
+    builder.add_edge("b", "c")
+    graph = builder.compile(checkpointer=InMemorySaver())
+
+    config = {"configurable": {"thread_id": "1"}}
+    assert graph.invoke({"logs": []}, config, durability=durability)["logs"] == [
+        "a",
+        "b",
+        "c",
+    ]
+
+    history = {
+        state.metadata["step"]: state.values["logs"]
+        for state in graph.get_state_history(config)
+        if state.values.get("logs") is not None
+    }
+    if durability != "exit":
+        assert history[1] == ["a"]
+        assert history[2] == ["a", "b"]
+    assert history[3] == ["a", "b", "c"]
 
 
 def test_binop() -> None:


### PR DESCRIPTION
Fixes #8748

**Rescoped.** This originally also carried `Fixes #7992` and the `from_checkpoint` copies that go with it. @vidigoat reported #7992 and filed #7993 for it back on June 2, so that half is theirs — I've dropped it. `from_checkpoint` is untouched on this branch and #7992's aliasing still reproduces here unchanged.

`Topic.checkpoint()` returns the channel's live list, and `NamedBarrierValue.checkpoint()` its live `seen` set. `create_checkpoint` stores that return value straight into `channel_values`, and `update()` mutates the same object in place — so every later superstep retroactively edits a checkpoint that has already been taken.

Whether that surfaces depends on when the checkpoint is serialized. Under `durability="sync"` the write happens before the next superstep, so history reads correctly. Under `durability="async"` it happens after, so the mutated container is what gets persisted:

```
durability='sync' : step1=['a'] step2=['a', 'b']      step3=['a', 'b', 'c']
durability='async': step1=['a'] step2=['a', 'b', 'c'] step3=['a', 'b', 'c']   <- step 2 never had 'c'
resume from step 2 -> ['a', 'b', 'c', 'c']                                    <- 'c' replayed onto its own output
```

Deterministic, 10/10 runs. The persisted data itself is wrong, so it stays wrong after a restart, and forking or time-travelling from an affected checkpoint replays work already present in the state.

This copies in `checkpoint()` for `Topic`, `NamedBarrierValue` and `NamedBarrierValueAfterFinish`. Both channels' `copy()` methods already do exactly this (`self.values.copy()`, `self.seen.copy()`), so it's the existing discipline applied to one more method.

**Why this is separate from #7992.** That issue asks for `from_checkpoint` to copy, which is what #7993 and #8180 implement. I applied that change on its own and re-ran the repro above — the async history is unchanged, because the value that reaches `create_checkpoint` comes from `checkpoint()`, not `from_checkpoint()`. The two are independent halves of the same aliasing problem and neither subsumes the other. I also confirmed they compose: with #7993's `from_checkpoint` copies applied on top of this branch, all 40 tests in `test_channels.py` pass.

I went with copying at the boundary rather than making `update()` rebind (`self.values = [*self.values, ...]`), since that would turn an accumulating topic into O(n²) over a run. Cost here is one shallow container copy per checkpoint for two channel types — and a `Topic`'s list is already walked in full by serialization on the very next line.

Not addressed here: #8314 covers a different aliasing axis (`LastValue` sharing objects with the *caller*), which needs its own fix.

### How I verified

`libs/langgraph`: `make format`, `make lint` (ruff + ty) and the test suite all pass — **2003 passed, 4 skipped**, run with `NO_DOCKER=true` (no Postgres/Redis locally; `test_redis_cache.py` needs a live server). `ty check` reports the same 6 pre-existing diagnostics as `main`, none in the touched files.

6 tests added. 4 fail on `main` and pass with this change; the 2 that pass either way are the `sync`/`exit` durability controls, which should be unaffected:

- `checkpoint()` not aliased, for `Topic` and both barrier classes
- end-to-end `get_state_history()` regression parametrized over `sync`/`async`/`exit`

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/
