### PR TITLE
fix(checkpoint): handle EXT_DELTA_SNAPSHOT in `_msgpack_ext_hook_to_json`

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -800,6 +800,17 @@ def _msgpack_ext_hook_to_json(code: int, data: bytes) -> Any:
             return tup[2]
         except Exception:
             return
+    elif code == EXT_DELTA_SNAPSHOT:
+        # A DeltaChannel stores occasional full snapshots of its value as a
+        # single ext blob. Unwrap it (recursively through the same hook) so the
+        # JSON read path keeps the snapshot base instead of silently returning
+        # None; otherwise DeltaChannel.from_checkpoint() replays against a None
+        # baseline and all history written before the last snapshot is lost.
+        return ormsgpack.unpackb(
+            data,
+            ext_hook=_msgpack_ext_hook_to_json,
+            option=ormsgpack.OPT_NON_STR_KEYS,
+        )
     elif code == EXT_PYDANTIC_V1:
         try:
             tup = ormsgpack.unpackb(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -41,6 +41,7 @@ from langgraph.checkpoint.serde.jsonplus import (
     _warned_blocked_types,
     _warned_unregistered_types,
 )
+from langgraph.checkpoint.serde.types import _DeltaSnapshot
 from langgraph.store.base import Item
 
 
@@ -324,6 +325,27 @@ def test_serde_jsonplus_json_mode() -> None:
         expected_result["my_secret_str_v1"] = "meow"
 
     assert result == expected_result
+
+
+def test_serde_jsonplus_delta_snapshot_json_hook() -> None:
+    """EXT_DELTA_SNAPSHOT survives the JSON read path.
+
+    Regression test for _msgpack_ext_hook_to_json silently returning None
+    for ext code 7 (_DeltaSnapshot blobs written by DeltaChannel). With the
+    snapshot decoded as None, DeltaChannel.from_checkpoint() loses its
+    baseline and every message written before the last snapshot is missing from
+    the JSON state view -- the multi-turn, long-thread history-loss symptom.
+    """
+    snapshot = _DeltaSnapshot([HumanMessage(content="hi", id="snap-msg")])
+    serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
+    value = serde.loads_typed(serde.dumps_typed(snapshot))
+
+    assert value is not None
+    assert isinstance(value, list)
+    assert len(value) == 1
+    assert value[0]["content"] == "hi"
+    assert value[0]["id"] == "snap-msg"
+    assert value[0]["type"] == "human"
 
 
 def test_serde_jsonplus_bytes() -> None:


### PR DESCRIPTION
## Summary

`_msgpack_ext_hook_to_json` serializes `_DeltaSnapshot` (msgpack ext code 7) to `None` on the JSON read path. These snapshot blobs are written every `snapshot_frequency` writes by a `DeltaChannel` (the `messages` channel used by `deepagents` >= 0.7.7). When a checkpoint is read through the JSON view (e.g. `GET /threads/{id}/state`, `/history` via `Checkpointer(unpack_hook=_msgpack_ext_hook_to_json)`), the snapshot decodes to `None`, so `DeltaChannel.from_checkpoint()` loses its baseline and only the writes after the last snapshot survive.

### Symptom
On long multi-turn threads (enough writes to trigger a snapshot), the state / SSE echo silently loses all user turns and earlier AI messages, and ordering looks corrupted. Short threads (< snapshot_frequency writes) never snapshot and therefore look fine — which is why this is intermittent by thread length.

## Root cause

`langgraph/checkpoint/serde/jsonplus.py`:

- object path (`_create_msgpack_ext_hook`) already unwraps `EXT_DELTA_SNAPSHOT` (`#L634`);
- the JSON-view hook `_msgpack_ext_hook_to_json` handles `EXT_CONSTRUCTOR_*`, `EXT_METHOD_SINGLE_ARG`, `EXT_PYDANTIC_*`, `EXT_NUMPY_ARRAY` but has **no branch for `EXT_DELTA_SNAPSHOT`**, and falls through to `return None`.

## Fix

Add an `EXT_DELTA_SNAPSHOT` branch that unwraps the snapshot with the same hook (recursively), mirroring the object-path behavior:

```python
elif code == EXT_DELTA_SNAPSHOT:
    return ormsgpack.unpackb(
        data,
        ext_hook=_msgpack_ext_hook_to_json,
        option=ormsgpack.OPT_NON_STR_KEYS,
    )
```

## Reproduction

```python
from langchain_core.messages import HumanMessage
from langgraph.checkpoint.serde.jsonplus import (
    JsonPlusSerializer,
    _msgpack_ext_hook_to_json,
)
from langgraph.checkpoint.serde.types import _DeltaSnapshot

snapshot = _DeltaSnapshot([HumanMessage(content=hi, id=snap-msg)])
serde = JsonPlusSerializer(__unpack_ext_hook__=_msgpack_ext_hook_to_json)
value = serde.loads_typed(serde.dumps_typed(snapshot))
assert value is not None  # fails before this PR, passes after
```

## Tests

Added `test_serde_jsonplus_delta_snapshot_json_hook` covering:
- ext code 7 no longer decodes to `None`;
- the snapshot is unwrapped to a JSON-view list containing the original message fields.

Ran `uv run pytest tests/test_jsonplus.py tests/test_conformance_delta.py`: 100 passed, 1 skipped.

## Notes

- Fix candidate is a 3-line branch; the module-level JSON hook is what the read-side endpoints use.
