### PR TITLE
fix(channels): enforce defensive copy in Topic and NamedBarrierValue checkpoints (#8748)

### DIFF
--- a/libs/langgraph/langgraph/channels/named_barrier_value.py
+++ b/libs/langgraph/langgraph/channels/named_barrier_value.py
@@ -44,13 +44,13 @@ class NamedBarrierValue(Generic[Value], BaseChannel[Value, Value, set[Value]]):
         return empty
 
     def checkpoint(self) -> set[Value]:
-        return self.seen
+        return self.seen.copy()
 
     def from_checkpoint(self, checkpoint: set[Value]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen = checkpoint
+            empty.seen = set(checkpoint)
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:
@@ -122,13 +122,14 @@ class NamedBarrierValueAfterFinish(
         return empty
 
     def checkpoint(self) -> tuple[set[Value], bool]:
-        return (self.seen, self.finished)
+        return (self.seen.copy(), self.finished)
 
     def from_checkpoint(self, checkpoint: tuple[set[Value], bool]) -> Self:
         empty = self.__class__(self.typ, self.names)
         empty.key = self.key
         if checkpoint is not MISSING:
-            empty.seen, empty.finished = checkpoint
+            seen_raw, empty.finished = checkpoint
+            empty.seen = set(seen_raw)
         return empty
 
     def update(self, values: Sequence[Value]) -> bool:

--- a/libs/langgraph/langgraph/channels/topic.py
+++ b/libs/langgraph/langgraph/channels/topic.py
@@ -61,7 +61,7 @@ class Topic(
         return empty
 
     def checkpoint(self) -> list[Value]:
-        return self.values
+        return self.values.copy()
 
     def from_checkpoint(self, checkpoint: list[Value]) -> Self:
         empty = self.__class__(self.typ, self.accumulate)
@@ -69,9 +69,9 @@ class Topic(
         if checkpoint is not MISSING:
             if isinstance(checkpoint, tuple):
                 # backwards compatibility
-                empty.values = checkpoint[1]
+                empty.values = list(checkpoint[1])
             else:
-                empty.values = checkpoint
+                empty.values = list(checkpoint)
         return empty
 
     def update(self, values: Sequence[Value | list[Value]]) -> bool:

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -796,3 +796,17 @@ def test_delta_channel_from_checkpoint_seed_none_is_distinct_from_sentinel() -> 
     ch = spec.from_checkpoint(None)
     ch.replay_writes([("t0", "x", "after")])
     assert ch.get() == "after"
+
+
+def test_topic_checkpoint_immutability_on_subsequent_updates() -> None:
+    """Ensure Topic.checkpoint() returns a defensive copy so subsequent updates do not mutate historical checkpoints."""
+    channel = Topic(str, accumulate=True).from_checkpoint(MISSING)
+    channel.update(["a"])
+    checkpoint_step1 = channel.checkpoint()
+
+    channel.update(["b"])
+    checkpoint_step2 = channel.checkpoint()
+
+    assert checkpoint_step1 == ["a"], "Step 1 checkpoint must not be mutated by Step 2 update"
+    assert checkpoint_step2 == ["a", "b"]
+


### PR DESCRIPTION
### Summary

Fixes #8748: Enforce defensive copy semantics in `Topic.checkpoint()` and `NamedBarrierValue.checkpoint()` to prevent retroactive checkpoint corruption under `durability="async"`.

### Problem
`Topic.checkpoint()` and `NamedBarrierValue.checkpoint()` previously returned live mutable references (`self.values` and `self.seen`). In `durability="async"` mode, background serialization occurs after subsequent supersteps have already mutated these containers in-place. This caused historical checkpoints to be retroactively overwritten with future superstep data, breaking checkpoint replay and time-travel forks.

### Solution
- Updated `Topic.checkpoint()` and `from_checkpoint()` to perform defensive copies.
- Updated `NamedBarrierValue.checkpoint()` and `from_checkpoint()` to copy the `seen` set.
- Added regression test `test_topic_checkpoint_immutability_on_subsequent_updates` in `test_channels.py` asserting checkpoint immutability.
