### PR TITLE
fix(checkpoint): stop InMemoryStore reads from creating namespaces

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -259,7 +259,9 @@ class InMemoryStore(BaseStore):
 
             for key, item in self._data[namespace].items():
                 if filter_func(item):
-                    if op.query and (embeddings := self._vectors[namespace].get(key)):
+                    if op.query and (
+                        embeddings := self._vectors.get(namespace, {}).get(key)
+                    ):
                         filtered.append((item, list(embeddings.values())))
                     else:
                         filtered.append((item, []))
@@ -386,7 +388,9 @@ class InMemoryStore(BaseStore):
         ] = {}
         for i, op in enumerate(ops):
             if isinstance(op, GetOp):
-                item = self._data[op.namespace].get(op.key)
+                # Read through `.get` so that looking up an unknown namespace
+                # does not insert an empty one into the backing defaultdict.
+                item = self._data.get(op.namespace, {}).get(op.key)
                 results.append(item)
             elif isinstance(op, SearchOp):
                 search_ops[i] = (op, self._filter_items(op))
@@ -404,8 +408,17 @@ class InMemoryStore(BaseStore):
     def _apply_put_ops(self, put_ops: dict[tuple[tuple[str, ...], str], PutOp]) -> None:
         for (namespace, key), op in put_ops.items():
             if op.value is None:
-                self._data[namespace].pop(key, None)
-                self._vectors[namespace].pop(key, None)
+                # Deleting must not create the namespace, and a namespace that
+                # loses its last item stops existing, so that `list_namespaces`
+                # only ever reports namespaces that hold at least one item.
+                if (items := self._data.get(namespace)) is not None:
+                    items.pop(key, None)
+                    if not items:
+                        del self._data[namespace]
+                if (vectors := self._vectors.get(namespace)) is not None:
+                    vectors.pop(key, None)
+                    if not vectors:
+                        del self._vectors[namespace]
             else:
                 self._data[namespace][key] = Item(
                     value=dict(op.value),

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -330,6 +330,43 @@ def test_list_namespaces_basic() -> None:
     assert result == expected
 
 
+def test_list_namespaces_only_reports_populated_namespaces() -> None:
+    store = InMemoryStore()
+    store.put(("real",), "key", {"v": 1})
+
+    # A miss is a read: it must not bring the namespace into existence.
+    assert store.get(("ghost",), "key") is None
+    assert store.list_namespaces() == [("real",)]
+
+    # Neither may deleting a key that was never written.
+    store.delete(("ghost",), "key")
+    assert store.list_namespaces() == [("real",)]
+
+    # A namespace stops existing once its last item is removed.
+    store.delete(("real",), "key")
+    assert store.list_namespaces() == []
+
+
+async def test_alist_namespaces_only_reports_populated_namespaces() -> None:
+    store = InMemoryStore()
+    await store.aput(("real",), "key", {"v": 1})
+
+    assert await store.aget(("ghost",), "key") is None
+    await store.adelete(("ghost",), "key")
+    assert await store.alist_namespaces() == [("real",)]
+
+    await store.adelete(("real",), "key")
+    assert await store.alist_namespaces() == []
+
+
+def test_repeated_misses_do_not_grow_the_store() -> None:
+    store = InMemoryStore()
+    for i in range(100):
+        assert store.get(("users", str(i)), "prefs") is None
+
+    assert store.list_namespaces() == []
+
+
 def test_list_namespaces_with_wildcards() -> None:
     store = InMemoryStore()
 


### PR DESCRIPTION
Fixes #8734

## Summary
- Read through `dict.get` on `InMemoryStore` get/delete paths so misses do not autovivify ghost namespaces in the backing `defaultdict`.
- Remove namespaces once their last item is deleted.
- Guard vector lookups the same way during search filtering.

## Test plan
- [x] `pytest libs/checkpoint/tests/test_store.py::test_list_namespaces_only_reports_populated_namespaces`
- [x] `pytest libs/checkpoint/tests/test_store.py::test_alist_namespaces_only_reports_populated_namespaces`
- [x] Sync + async delete/search namespace tests pass locally

**AI disclosure:** Implemented with AI assistance; contributor reviewed and validated all changes.