### PR TITLE
fix(prebuilt): respect max_concurrency in async ToolNode

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -73,6 +73,7 @@ from langchain_core.runnables.config import (
     get_config_list,
     get_executor_for_config,
 )
+from langchain_core.runnables.utils import gather_with_concurrency
 from langchain_core.tools import BaseTool, InjectedToolArg
 from langchain_core.tools import tool as create_tool
 from langchain_core.tools.base import (
@@ -855,7 +856,7 @@ class ToolNode(RunnableCallable):
         coros = []
         for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
             coros.append(self._arun_one(call, input_type, tool_runtime))  # type: ignore[arg-type]
-        outputs = await asyncio.gather(*coros)
+        outputs = await gather_with_concurrency(config.get("max_concurrency"), *coros)
 
         return self._combine_tool_outputs(outputs, input_type)
 

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import dataclasses
 import json
@@ -2383,6 +2384,32 @@ async def test_tool_node_list_return_async_smoke() -> None:
     assert isinstance(result, list)
     commands = [r for r in result if isinstance(r, Command)]
     assert len(commands) == 1 and commands[0].update == {"foo": "bar"}
+
+
+async def test_tool_node_async_respects_max_concurrency() -> None:
+    """Async tool calls honor RunnableConfig.max_concurrency."""
+    active = 0
+    max_active = 0
+
+    async def probe(value: int) -> str:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return str(value)
+
+    tool_calls = [
+        {"name": "probe", "args": {"value": i}, "id": f"call-{i}"}
+        for i in range(3)
+    ]
+    result = await ToolNode([probe]).ainvoke(
+        {"messages": [AIMessage("", tool_calls=tool_calls)]},
+        config={**_create_config_with_runtime(), "max_concurrency": 1},
+    )
+
+    assert len(result["messages"]) == 3
+    assert max_active == 1
 
 
 def test_tool_node_list_return_mixed_with_regular_tool() -> None:


### PR DESCRIPTION
Fixes #8517

ToolNode._afunc currently dispatches all tool coroutines with asyncio.gather, so RunnableConfig.max_concurrency only applies to the sync path. This uses the existing gather_with_concurrency helper and adds a regression test for the async path.

How did you verify your code works?
- python3 -m compileall -q libs/prebuilt/langgraph/prebuilt/tool_node.py libs/prebuilt/tests/test_tool_node.py
- git diff --check

I also tried the package make targets, but this server image does not have uv or Docker installed.
