### PR TITLE
fix(prebuilt): handle MCP content block lists in ToolNode

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1442,6 +1442,15 @@ class ToolNode(RunnableCallable):
             response.content = cast("str | list", msg_content_output(response.content))
             return response
         if isinstance(response, list):
+            if all(
+                isinstance(r, dict) and r.get("type") in TOOL_MESSAGE_BLOCK_TYPES
+                for r in response
+            ):
+                return ToolMessage(
+                    content=cast("list[dict]", response),
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"],
+                )
             if all(isinstance(r, (Command, ToolMessage)) for r in response):
                 return self._validate_tool_command_list(response, tool_call, input_type)
             msg = (

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -2266,6 +2266,34 @@ def _invoke_returning(
     )
 
 
+def test_tool_node_content_block_list_return() -> None:
+    """A tool returning LangChain content blocks becomes a ToolMessage."""
+    content = [{"type": "text", "text": "test content"}]
+    result = _invoke_returning(content)
+
+    assert isinstance(result, dict)
+    message = result["messages"][0]
+    assert isinstance(message, ToolMessage)
+    assert message.content == content
+    assert message.tool_call_id == "call-1"
+
+
+async def test_tool_node_content_block_list_return_async() -> None:
+    """The async path accepts the same content block format."""
+    content = [{"type": "text", "text": "test content"}]
+    node = ToolNode([_ReturningTool(return_value=content)])
+    result = await node.ainvoke(
+        {"messages": [AIMessage("", tool_calls=[_list_tool_call()])]},
+        config=_create_config_with_runtime(),
+    )
+
+    assert isinstance(result, dict)
+    message = result["messages"][0]
+    assert isinstance(message, ToolMessage)
+    assert message.content == content
+    assert message.tool_call_id == "call-1"
+
+
 def test_tool_node_list_return_command_and_tool_message() -> None:
     """Valid: tool returns [Command(update={...}), ToolMessage(...)]."""
     outer_id = "call-1"


### PR DESCRIPTION
Fixes #7985

ToolNode currently rejects the list of content blocks returned by MCP tools and raises TypeError. This accepts valid LangChain content block lists by wrapping them in a ToolMessage, preserving the structured content, and adds sync and async regression tests.

How did you verify your code works?
- python3 -m compileall -q libs/prebuilt/langgraph/prebuilt/tool_node.py libs/prebuilt/tests/test_tool_node.py
- git diff --check

I also tried the package make targets, but this server image does not have uv or Docker installed.
