### PR TITLE
fix(checkpoint-sqlite): support nested object equality filters

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -458,7 +458,9 @@ class BaseSqliteStore:
                 for key, value in op.filter.items():
                     _validate_filter_key(key)
 
-                    if isinstance(value, dict):
+                    if isinstance(value, dict) and any(
+                        key.startswith("$") for key in value
+                    ):
                         for op_name, val in value.items():
                             condition, filter_params_ = self._get_filter_condition(
                                 key, op_name, val

--- a/libs/checkpoint-sqlite/tests/test_async_store.py
+++ b/libs/checkpoint-sqlite/tests/test_async_store.py
@@ -718,6 +718,27 @@ async def test_search_items(
             await store.adelete(ns, key)
 
 
+async def test_nested_object_filter(store: AsyncSqliteStore) -> None:
+    """Test that literal nested objects are not parsed as operator maps."""
+    await store.aput(
+        ("docs",),
+        "matching",
+        {"config": {"alpha": 1, "beta": 2}, "score": 3},
+    )
+    await store.aput(
+        ("docs",),
+        "different",
+        {"config": {"alpha": 1, "beta": 9}, "score": 1},
+    )
+
+    results = await store.asearch(("docs",), filter={"config": {"alpha": 1, "beta": 2}})
+
+    assert [item.key for item in results] == ["matching"]
+
+    operator_results = await store.asearch(("docs",), filter={"score": {"$gt": 2}})
+    assert [item.key for item in operator_results] == ["matching"]
+
+
 async def test_async_namespace_segment_boundary(store: AsyncSqliteStore) -> None:
     """Segment-aware scoping on the async path.
 

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -1069,6 +1069,27 @@ def test_sql_injection_vulnerability(store: SqliteStore) -> None:
         store.search(("docs",), filter={malicious_key: "dummy"})
 
 
+def test_nested_object_filter(store: SqliteStore) -> None:
+    """Test that literal nested objects are not parsed as operator maps."""
+    store.put(
+        ("docs",),
+        "matching",
+        {"config": {"alpha": 1, "beta": 2}, "score": 3},
+    )
+    store.put(
+        ("docs",),
+        "different",
+        {"config": {"alpha": 1, "beta": 9}, "score": 1},
+    )
+
+    results = store.search(("docs",), filter={"config": {"alpha": 1, "beta": 2}})
+
+    assert [item.key for item in results] == ["matching"]
+
+    operator_results = store.search(("docs",), filter={"score": {"$gt": 2}})
+    assert [item.key for item in operator_results] == ["matching"]
+
+
 def test_sql_injection_filter_values(store: SqliteStore) -> None:
     """Test that SQL injection via malicious filter values is properly escaped."""
     # Setup: Create documents with different access levels


### PR DESCRIPTION
## Summary

- Treat dictionary filter values as literal nested-object equality filters unless they contain `$`-prefixed operators.
- Preserve the existing operator filter behavior for `$eq`, `$gt`, `$gte`, `$lt`, `$lte`, and `$ne`.
- Add synchronous and asynchronous regression tests for memory/file SQLite connections.

## Validation

- `uv run --frozen pytest` in `libs/checkpoint-sqlite` (122 passed, 2 skipped)
- `uv run --frozen ruff check .` passed.
- `uv run --frozen ruff check --select I langgraph tests` passed.
- `uv run --frozen ty check langgraph tests` passed.
- `uv run --frozen ruff format langgraph tests --diff` passed.
- `git diff --check` passed.

Closes #8786
