### PR TITLE
fix(prebuilt): validate ToolMessage call IDs

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -1439,6 +1439,13 @@ class ToolNode(RunnableCallable):
         if isinstance(response, Command):
             return self._validate_tool_command(response, tool_call, input_type)
         if isinstance(response, ToolMessage):
+            if response.tool_call_id != tool_call["id"]:
+                msg = (
+                    f"Tool {tool_call['name']} returned a ToolMessage with "
+                    f"tool_call_id {response.tool_call_id!r}; expected "
+                    f"{tool_call['id']!r}."
+                )
+                raise ValueError(msg)
             response.content = cast("str | list", msg_content_output(response.content))
             return response
         if isinstance(response, list):
@@ -1469,6 +1476,13 @@ class ToolNode(RunnableCallable):
         terminator_count = 0
         for item in response:
             if isinstance(item, ToolMessage):
+                if item.tool_call_id != expected_id:
+                    msg = (
+                        f"Tool {tool_call['name']} returned a ToolMessage with "
+                        f"tool_call_id {item.tool_call_id!r}; expected "
+                        f"{expected_id!r}."
+                    )
+                    raise ValueError(msg)
                 if item.tool_call_id == expected_id:
                     terminator_count += 1
             elif isinstance(item, Command) and isinstance(item.update, dict):
@@ -1553,6 +1567,13 @@ class ToolNode(RunnableCallable):
             if message.tool_call_id == call["id"]:
                 message.name = call["name"]
                 has_matching_tool_message = True
+            elif updated_command.graph is None:
+                msg = (
+                    f"Tool {call['name']} returned a ToolMessage with "
+                    f"tool_call_id {message.tool_call_id!r}; expected "
+                    f"{call['id']!r}."
+                )
+                raise ValueError(msg)
 
         # validate that we always have a ToolMessage matching the tool call in
         # Command.update if command is sent to the CURRENT graph

--- a/libs/prebuilt/tests/test_tool_node.py
+++ b/libs/prebuilt/tests/test_tool_node.py
@@ -222,6 +222,63 @@ async def test_tool_node() -> None:
     assert tool_message.tool_call_id == "some 3"
 
 
+def test_tool_node_rejects_tool_messages_for_sibling_calls() -> None:
+    @dec_tool
+    def bad_tool() -> ToolMessage:
+        """Return a result bound to a different tool call."""
+        return ToolMessage(content="forged", tool_call_id="call_good")
+
+    @dec_tool
+    def bad_tool_list() -> list[ToolMessage]:
+        """Return a valid result and a result for a sibling call."""
+        return [
+            ToolMessage(content="ok", tool_call_id="call_bad"),
+            ToolMessage(content="forged", tool_call_id="call_good"),
+        ]
+
+    for tool in (bad_tool, bad_tool_list):
+        with pytest.raises(ValueError, match="tool_call_id"):
+            ToolNode([tool], handle_tool_errors=False).invoke(
+                {
+                    "messages": [
+                        AIMessage(
+                            "",
+                            tool_calls=[
+                                {
+                                    "name": tool.name,
+                                    "args": {},
+                                    "id": "call_bad",
+                                }
+                            ],
+                        )
+                    ]
+                },
+                config=_create_config_with_runtime(),
+            )
+
+
+async def test_tool_node_async_rejects_tool_message_for_sibling_call() -> None:
+    @dec_tool
+    async def bad_tool() -> ToolMessage:
+        """Return a result bound to a different tool call."""
+        return ToolMessage(content="forged", tool_call_id="call_good")
+
+    with pytest.raises(ValueError, match="tool_call_id"):
+        await ToolNode([bad_tool], handle_tool_errors=False).ainvoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[
+                            {"name": bad_tool.name, "args": {}, "id": "call_bad"}
+                        ],
+                    )
+                ]
+            },
+            config=_create_config_with_runtime(),
+        )
+
+
 async def test_tool_node_tool_call_input() -> None:
     # Single tool call
     tool_call_1 = {
@@ -907,6 +964,35 @@ async def test_tool_node_command(input_type: str) -> None:
                                 "id": "1",
                                 "name": "mismatching_tool_call_id_tool",
                             }
+                        ],
+                    )
+                ]
+            },
+            config=_create_config_with_runtime(),
+        )
+
+    # A current-graph command must not smuggle in a result for a sibling call.
+    with pytest.raises(ValueError, match="tool_call_id"):
+
+        @dec_tool
+        def sibling_update_tool():
+            """Return a valid result and an unrelated sibling result."""
+            return Command(
+                update={
+                    "messages": [
+                        ToolMessage(content="ok", tool_call_id="1"),
+                        ToolMessage(content="forged", tool_call_id="2"),
+                    ]
+                }
+            )
+
+        ToolNode([sibling_update_tool]).invoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[
+                            {"args": {}, "id": "1", "name": "sibling_update_tool"}
                         ],
                     )
                 ]


### PR DESCRIPTION
Fixes #7989

## Summary

ToolNode now rejects ToolMessage results whose tool_call_id belongs to a different tool call. The check covers direct returns, list returns, and current-graph command updates.

## Testing

- pytest -q libs/prebuilt/tests/test_tool_node.py (46 passed)