### PR TITLE
fix(prebuilt): preserve model-level validation errors

### DIFF
--- a/libs/prebuilt/langgraph/prebuilt/tool_node.py
+++ b/libs/prebuilt/langgraph/prebuilt/tool_node.py
@@ -365,7 +365,7 @@ class ToolInvocationError(ToolException):
             for error in filtered_errors:
                 loc_str = ".".join(str(loc) for loc in error.get("loc", ()))
                 msg = error.get("msg", "Unknown error")
-                error_str_parts.append(f"{loc_str}: {msg}")
+                error_str_parts.append(f"{loc_str}: {msg}" if loc_str else msg)
             error_display_str = "\n".join(error_str_parts)
         else:
             error_display_str = str(source)
@@ -545,7 +545,7 @@ def _filter_validation_errors(
     for error in validation_error.errors():
         # Check if error location contains any injected argument
         # error['loc'] is a tuple like ('field_name',) or ('field_name', 'nested_field')
-        if error["loc"] and error["loc"][0] not in injected_arg_names:
+        if not error["loc"] or error["loc"][0] not in injected_arg_names:
             # Create a copy of the error dict to avoid mutating the original
             error_copy: dict[str, Any] = {**error}
 

--- a/libs/prebuilt/tests/test_tool_node_validation_error_filtering.py
+++ b/libs/prebuilt/tests/test_tool_node_validation_error_filtering.py
@@ -17,6 +17,7 @@ from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import tool as dec_tool
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
+from pydantic import BaseModel, model_validator
 
 from langgraph.prebuilt import InjectedState, InjectedStore, ToolNode, ToolRuntime
 from langgraph.prebuilt.tool_node import ToolInvocationError
@@ -468,3 +469,73 @@ async def test_sync_tool_validation_error_filtering() -> None:
     assert tool_message.status == "error"
     assert "value" in tool_message.content
     assert "state" not in tool_message.content.lower()
+
+
+class RangeArgs(BaseModel):
+    low: int
+    high: int
+
+    @model_validator(mode="after")
+    def check_bounds(self) -> "RangeArgs":
+        if self.low > self.high:
+            raise ValueError("low must be less than or equal to high")
+        return self
+
+
+@dec_tool(args_schema=RangeArgs)
+def get_range(low: int, high: int) -> str:
+    """Return a range."""
+    return f"{low}-{high}"
+
+
+async def test_model_level_validation_errors_are_visible_to_the_model() -> None:
+    """Keep model-level Pydantic errors in ToolNode feedback."""
+    result = await ToolNode([get_range]).ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "get_range",
+                            "args": {"low": 5, "high": 1},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+    assert "low must be less than or equal to high" in tool_message.content
+    assert "with error:\n \n Please fix" not in tool_message.content
+
+
+def test_sync_model_level_validation_errors_are_visible_to_the_model() -> None:
+    """Keep model-level Pydantic errors in sync ToolNode feedback."""
+    result = ToolNode([get_range]).invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[
+                        {
+                            "name": "get_range",
+                            "args": {"low": 5, "high": 1},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+    assert "low must be less than or equal to high" in tool_message.content


### PR DESCRIPTION
Fixes #8648

## Summary

Keep model-level Pydantic validation errors when ToolNode filters errors for injected arguments. Also avoid adding an empty location prefix for loc == (), so the model receives the actual validation message.

## Testing

- pytest -q libs/prebuilt/tests/test_tool_node_validation_error_filtering.py (10 passed)