### PR TITLE
fix(langgraph): seed reducer channel with configured field default

### DIFF
--- a/libs/langgraph/langgraph/_internal/_fields.py
+++ b/libs/langgraph/langgraph/_internal/_fields.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import copy
 import dataclasses
 import types
 import weakref
-from collections.abc import Generator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from typing import Annotated, Any, Optional, Union, get_origin, get_type_hints
 
 from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 from typing_extensions import NotRequired, ReadOnly, Required
 
 from langgraph._internal._typing import MISSING
@@ -120,6 +122,41 @@ def get_field_default(name: str, type_: Any, schema: type[Any]) -> Any:
     if _is_optional_type(type_):
         return None
     return ...
+
+
+def get_field_default_factory(name: str, schema: type[Any]) -> Callable[[], Any] | None:
+    """Return a zero-arg factory for a field's configured default, if any.
+
+    Used to seed reducer channels (`BinaryOperatorAggregate`) with the state
+    schema's real default instead of the bare type's empty value. Returns a
+    factory (not a precomputed value) so that mutable defaults aren't shared
+    by reference across separate graph invocations. TypedDict has no native
+    per-field default concept, so it always returns None.
+    """
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        field_info = schema.model_fields.get(name)
+        if field_info is not None:
+            if field_info.default_factory is not None:
+                return field_info.default_factory
+            if field_info.default is not PydanticUndefined:
+                default_value = field_info.default
+                return lambda: copy.deepcopy(default_value)
+        return None
+    if dataclasses.is_dataclass(schema):
+        field_info = next(
+            (f for f in dataclasses.fields(schema) if f.name == name), None
+        )
+        if field_info is not None:
+            if field_info.default_factory is not dataclasses.MISSING:
+                return field_info.default_factory
+            if (
+                field_info.default is not dataclasses.MISSING
+                and field_info.default is not ...
+            ):
+                default_value = field_info.default
+                return lambda: copy.deepcopy(default_value)
+        return None
+    return None
 
 
 def get_enhanced_type_hints(

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -72,11 +72,20 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     ```
     """
 
-    __slots__ = ("value", "operator")
+    __slots__ = ("value", "operator", "default_factory")
 
-    def __init__(self, typ: type[Value], operator: Callable[[Value, Value], Value]):
+    def __init__(
+        self,
+        typ: type[Value],
+        operator: Callable[[Value, Value], Value],
+        default_factory: Callable[[], Value] | None = None,
+    ):
         super().__init__(typ)
         self.operator = operator
+        self.default_factory = default_factory
+        if default_factory is not None:
+            self.value = default_factory()
+            return
         # special forms from typing or collections.abc are not instantiable
         # so we need to replace them with their concrete counterparts
         typ = _strip_extras(typ)
@@ -108,13 +117,13 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
 
     def copy(self) -> Self:
         """Return a copy of the channel."""
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.default_factory)
         empty.key = self.key
         empty.value = self.value
         return empty
 
     def from_checkpoint(self, checkpoint: Value) -> Self:
-        empty = self.__class__(self.typ, self.operator)
+        empty = self.__class__(self.typ, self.operator, self.default_factory)
         empty.key = self.key
         if checkpoint is not MISSING:
             empty.value = checkpoint

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -42,6 +42,7 @@ from langgraph._internal._constants import (
 from langgraph._internal._fields import (
     get_cached_annotated_keys,
     get_field_default,
+    get_field_default_factory,
     get_update_as_tuples,
 )
 from langgraph._internal._pydantic import create_model
@@ -1824,7 +1825,7 @@ def _get_channels(
 
     type_hints = get_type_hints(schema, include_extras=True)
     all_keys = {
-        name: _get_channel(name, typ)
+        name: _get_channel(name, typ, schema=schema)
         for name, typ in type_hints.items()
         if name != "__slots__"
     }
@@ -1837,18 +1838,30 @@ def _get_channels(
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[False]
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: Literal[False],
+    schema: type[Any] | None = None,
 ) -> BaseChannel: ...
 
 
 @overload
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: Literal[True] = True
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: Literal[True] = True,
+    schema: type[Any] | None = None,
 ) -> BaseChannel | ManagedValueSpec: ...
 
 
 def _get_channel(
-    name: str, annotation: Any, *, allow_managed: bool = True
+    name: str,
+    annotation: Any,
+    *,
+    allow_managed: bool = True,
+    schema: type[Any] | None = None,
 ) -> BaseChannel | ManagedValueSpec:
     # Strip out Required and NotRequired wrappers
     if hasattr(annotation, "__origin__") and annotation.__origin__ in (
@@ -1864,7 +1877,7 @@ def _get_channel(
     elif channel := _is_field_channel(annotation):
         channel.key = name
         return channel
-    elif channel := _is_field_binop(annotation):
+    elif channel := _is_field_binop(name, annotation, schema):
         channel.key = name
         return channel
 
@@ -1901,7 +1914,9 @@ def _is_field_channel(typ: type[Any]) -> BaseChannel | None:
     return None
 
 
-def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
+def _is_field_binop(
+    name: str, typ: type[Any], schema: type[Any] | None = None
+) -> BinaryOperatorAggregate | None:
     if hasattr(typ, "__metadata__"):
         meta = typ.__metadata__
         if len(meta) >= 1 and callable(meta[-1]):
@@ -1914,7 +1929,14 @@ def _is_field_binop(typ: type[Any]) -> BinaryOperatorAggregate | None:
                 )
                 == 2
             ):
-                return BinaryOperatorAggregate(typ, meta[-1])
+                default_factory = (
+                    get_field_default_factory(name, schema)
+                    if schema is not None
+                    else None
+                )
+                return BinaryOperatorAggregate(
+                    typ, meta[-1], default_factory=default_factory
+                )
             else:
                 raise ValueError(
                     f"Invalid reducer signature. Expected (a, b) -> c. Got {sig}"

--- a/libs/langgraph/tests/test_state.py
+++ b/libs/langgraph/tests/test_state.py
@@ -7,7 +7,7 @@ from typing import Annotated as Annotated2
 
 import pytest
 from langchain_core.runnables import RunnableConfig
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import NotRequired, Required, TypedDict
 
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -246,6 +246,60 @@ def test_state_schema_default_values(kw_only_: bool):
     assert (
         set(json_schema["properties"].keys()) == expected_required | expected_optional
     )
+
+
+def _extend_list(original: list[str], new: list[str]) -> list[str]:
+    original.extend(new)
+    return original
+
+
+@pytest.mark.parametrize("schema_style", ["pydantic", "dataclass"])
+def test_reducer_field_with_nonempty_default(schema_style: str) -> None:
+    """A reducer field's configured default should seed the channel, not be
+    silently discarded in favor of the bare type's empty value. See #5225."""
+    if schema_style == "pydantic":
+
+        class OverallState(BaseModel):
+            variable: Annotated[list[str], _extend_list] = Field(
+                default_factory=lambda: ["default"]
+            )
+    else:
+
+        @dataclass
+        class OverallState:  # type: ignore[no-redef]
+            variable: Annotated[list[str], _extend_list] = field(
+                default_factory=lambda: ["default"]
+            )
+
+    def node(state: Any) -> dict[str, Any]:
+        return {"variable": ["appended"]}
+
+    builder = StateGraph(OverallState)
+    builder.add_node("n", node)
+    builder.add_edge("__start__", "n")
+    graph = builder.compile()
+
+    assert graph.invoke({})["variable"] == ["default", "appended"]
+    # A second invocation must not reuse/mutate the same default list object.
+    assert graph.invoke({})["variable"] == ["default", "appended"]
+
+
+def test_reducer_field_typed_dict_default_unchanged() -> None:
+    """TypedDict has no native default concept; a reducer field on one should
+    keep accumulating only what's explicitly written, unaffected by #5225's fix."""
+
+    class OverallState(TypedDict):
+        variable: Annotated[list[str], _extend_list]
+
+    def node(state: Any) -> dict[str, Any]:
+        return {"variable": ["appended"]}
+
+    builder = StateGraph(OverallState)
+    builder.add_node("n", node)
+    builder.add_edge("__start__", "n")
+    graph = builder.compile()
+
+    assert graph.invoke({"variable": ["seed"]})["variable"] == ["seed", "appended"]
 
 
 def test__get_node_name() -> None:


### PR DESCRIPTION
Fixes #5225

`BinaryOperatorAggregate` (the channel backing any `Annotated[Type, reducer]` state field) seeded its value from the bare type (`typ()`) rather than the schema's configured default, so a non-empty default (e.g. `Field(default_factory=lambda: ["default"])`) was silently discarded on the first graph invocation.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

## What changed

- `langgraph/channels/binop.py`: `BinaryOperatorAggregate` accepts an optional `default_factory`, used to seed `self.value` only when no checkpointed value exists yet. Behavior is unchanged when no factory is provided. `copy()`/`from_checkpoint()` forward the factory so it survives across invocations.
- `langgraph/_internal/_fields.py`: new `get_field_default_factory()` resolves a field's real default (Pydantic `model_fields` / dataclass `fields()`) as a zero-arg factory, so mutable defaults aren't shared by reference across separate invocations. Returns `None` for TypedDict, which has no native default concept and is unaffected by this change.
- `langgraph/graph/state.py`: threads the schema class through `_get_channels` → `_get_channel` → `_is_field_binop` so the reducer channel can look up and use the field's real default.

No changes to checkpoint/execution logic — channels are already rebuilt from checkpoint on every invocation, and a real checkpointed value always overwrites the seeded default, so this can't affect state on a persisted thread.

## How I verified this works

- Added a regression test (`tests/test_state.py::test_reducer_field_with_nonempty_default`, parametrized over Pydantic and dataclass schemas) reproducing the issue's exact repro; confirmed it fails on `main` (`['appended']` instead of `['default', 'appended']`) and passes with this fix. It also asserts a second `invoke()` doesn't reuse/mutate the same default object.
- Added `test_reducer_field_typed_dict_default_unchanged` confirming TypedDict behavior is untouched.
- `make format`, `make lint`, and `make test` all pass in `libs/langgraph` (2000 passed, 4 skipped — up from 1997 passed on `main`, i.e. only the 3 new tests, no regressions).

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/
