### PR TITLE
fix(langgraph): keep StateGraph.compile() from mutating the builder

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -6,7 +6,7 @@ import typing
 import warnings
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Hashable, Sequence
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, is_dataclass, replace
 from datetime import timedelta
 from functools import partial
 from inspect import isclass, isfunction, ismethod, signature
@@ -1287,16 +1287,21 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         # Apply builder defaults to node specs. Per-node values always win.
         # Error-handler routing and cache_policy are only assigned to regular
         # nodes. Retry and timeout defaults also apply to error-handler nodes.
+        #
+        # Defaults are applied to a local copy of the node specs rather than to
+        # `self.nodes`, so that `compile()` leaves the builder untouched and
+        # compiling the same builder twice is not an error.
         defaults = self._node_defaults
+        nodes: dict[str, StateNodeSpec[Any, ContextT]] = dict(self.nodes)
         default_handler_name: str | None = None
         if defaults.error_handler is not None:
-            if _DEFAULT_ERROR_HANDLER_NODE in self.nodes:
+            if _DEFAULT_ERROR_HANDLER_NODE in nodes:
                 raise ValueError(
                     f"Auto-generated default error handler node "
                     f"`{_DEFAULT_ERROR_HANDLER_NODE}` already exists."
                 )
             default_handler_name = _DEFAULT_ERROR_HANDLER_NODE
-            self.nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
+            nodes[default_handler_name] = StateNodeSpec[Any, ContextT](
                 coerce_to_runnable(
                     defaults.error_handler,  # type: ignore[arg-type]
                     name=default_handler_name,
@@ -1310,7 +1315,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             )
 
         # Apply builder defaults to node specs. Per-node values always win.
-        for spec in self.nodes.values():
+        for node_name, spec in list(nodes.items()):
+            updated = spec
             # error_handler: regular nodes only — handlers must never
             # catch themselves or other handlers.
             if (
@@ -1318,11 +1324,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 and default_handler_name is not None
                 and spec.error_handler_node is None
             ):
-                spec.error_handler_node = default_handler_name
+                updated = replace(updated, error_handler_node=default_handler_name)
             # retry: all nodes — handlers should be retried on transient
             # failures just like regular nodes.
             if defaults.retry_policy is not None and spec.retry_policy is None:
-                spec.retry_policy = defaults.retry_policy
+                updated = replace(updated, retry_policy=defaults.retry_policy)
             # cache: regular nodes only — caching an error-handler result
             # is unsafe because the input (failed-node state) may differ
             # across failures even when the cache key matches.
@@ -1331,15 +1337,17 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
                 and defaults.cache_policy is not None
                 and spec.cache_policy is None
             ):
-                spec.cache_policy = defaults.cache_policy
+                updated = replace(updated, cache_policy=defaults.cache_policy)
             # timeout: all nodes — a stuck handler should be cancelled the
             # same way a stuck regular node would be.
             if defaults.timeout is not None and spec.timeout is None:
-                spec.timeout = defaults.timeout
+                updated = replace(updated, timeout=defaults.timeout)
+            if updated is not spec:
+                nodes[node_name] = updated
 
         node_error_handler_map = {
             node_name: spec.error_handler_node
-            for node_name, spec in self.nodes.items()
+            for node_name, spec in nodes.items()
             if not spec.is_error_handler and spec.error_handler_node is not None
         }
 
@@ -1371,7 +1379,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         compiled._serde_allowlist = serde_allowlist
 
         compiled.attach_node(START, None)
-        for key, node in self.nodes.items():
+        for key, node in nodes.items():
             compiled.attach_node(key, node)
 
         # Record output/state mappers for v2 stream coercion (pydantic/dataclass only)

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -2497,6 +2497,38 @@ def test_set_node_defaults_error_handler_collides_with_user_node():
         builder.compile()
 
 
+def test_set_node_defaults_error_handler_repeated_compile():
+    """Compiling the same builder twice must not fail or mutate the builder."""
+
+    class State(TypedDict):
+        foo: str
+
+    def boom(state: State) -> State:
+        raise ValueError("boom")
+
+    def default_handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    builder = (
+        StateGraph(State)
+        .add_node("boom", boom)
+        .add_edge(START, "boom")
+        .add_edge("boom", END)
+        .set_node_defaults(error_handler=default_handler)
+    )
+
+    first = builder.compile()
+    assert first.invoke({"foo": ""})["foo"] == "handled"
+
+    second = builder.compile()
+    assert second.invoke({"foo": ""})["foo"] == "handled"
+
+    # The auto-generated handler is an implementation detail of `compile()` and
+    # must not leak into the builder.
+    assert "__default_error_handler__" not in builder.nodes
+    assert builder.nodes["boom"].error_handler_node is None
+
+
 def test_set_node_defaults_retry_policy():
     class State(TypedDict):
         foo: str


### PR DESCRIPTION
Fixes #8612.

`compile()` injected its auto-generated error handler into `self.nodes` and mutated each `StateNodeSpec` in place, so a second `compile()` of the same builder raised `ValueError: Auto-generated default error handler node '__default_error_handler__' already exists`. Apply the defaults to a local copy of the node specs via `dataclasses.replace`, and derive `node_error_handler_map` and the `attach_node` loop from that copy. The collision guard still checks the original `self.nodes`, so a user-authored node named `__default_error_handler__` still raises.

---

## QA

### 1. Builder purity, each default in isolation

Compiling the **same** builder 3× and diffing a full snapshot of the builder (`node names` + every spec's `error_handler_node / retry_policy / cache_policy / timeout`):

| default set | 3× compile | builder unchanged |
| --- | --- | --- |
| `error_handler=` | ✅ | yes |
| `retry_policy=` | ✅ | yes |
| `cache_policy=` | ✅ | yes |
| `timeout=` (async nodes) | ✅ | yes |
| `error_handler` + `retry` + `cache`, 5× compile | ✅ | yes |

This matters beyond the reported crash: the in-place mutation at `state.py:1313-1338` was silently
accumulating **all four** defaults on the builder even when the node-name guard wasn't hit. Fixing
only the `ValueError` would have left that leak in place — `dataclasses.replace` closes both.

### 2. The defaults still work (not silently dropped)

A fix that stops mutating could easily stop applying. Verified it doesn't:

- `retry_policy`: node raises twice, `RetryPolicy(max_attempts=3, retry_on=ValueError)` →
  **attempts = 3**, returns `{'foo': 'ok', 'n': 3}` ✅
- `error_handler`: both compiled graphs route the failure to the handler →
  `{'foo': 'handled'}` and the two graphs return **identical** results ✅

### 3. Guard is not weakened

| case | expected | actual |
| --- | --- | --- |
| user node literally named `__default_error_handler__` | `ValueError` | `ValueError` ✅ (`test_set_node_defaults_error_handler_collides_with_user_node` stays green) |
| builder with no defaults, compiled 3× | works, builder unchanged | ✅ |

### 4. Side effect I checked myself

`CompiledStateGraph` is constructed with `builder=self`, so after this change
`compiled.builder.nodes` no longer contains the injected handler (it previously did, purely as a
side effect of the mutation). `CompiledStateGraph` does read it:

```python
# state.py:1571
if self.builder.nodes[end].defer:                                    # unguarded
# state.py:1609
self.builder.nodes[start].input_schema if start in self.builder.nodes else ...   # guarded
```

Checked: every `end`/`start` comes from `builder.edges` / `builder.waiting_edges`, which are
user-authored and can never name the auto-generated handler (and a same-named user node makes
`compile()` raise before we get here). `compiled.nodes` is unaffected — the handler is still
attached from the local copy. Flagging it rather than letting a reviewer find it.

### 5. Test

`test_set_node_defaults_error_handler_repeated_compile` in `libs/langgraph/tests/test_retry.py`,
placed next to the existing collision test. It compiles the same builder twice, asserts both
invocations route through the handler, then asserts **builder purity**:

```python
assert "__default_error_handler__" not in builder.nodes
assert builder.nodes["boom"].error_handler_node is None
```

Those two lines are the point of the test — without them, any fix that merely swallows the
`ValueError` would pass.

Against `origin/main` it fails with exactly the reported error:

```
FAILED tests/test_retry.py::test_set_node_defaults_error_handler_repeated_compile
E  ValueError: Auto-generated default error handler node
E  `__default_error_handler__` already exists.
=================== 1 failed, 1 passed, 104 deselected ===================
```

### 6. Verification

- `libs/langgraph` full suite: **1998 passed, 4 skipped** (72 s, `-n 4`), 58 snapshots passed
- `ruff check .` → All checks passed
- `ruff format --diff` → already formatted
- Python 3.13.15, Windows 11, upstream `main` @ `c0a13bb`

### Not covered

I did not benchmark `compile()` for a performance regression from copying the node dict. It is one
shallow `dict()` per `compile()` (references only, specs are copied lazily via `replace` only when a
default actually applies), so I expect it to be negligible — but I haven't measured it.

---

Same as #7795: I have a claim comment on the issue but have not been assigned yet. Happy to close
this PR if the direction is not approved.
