### PR TITLE
fix(langgraph): classify requests exceptions correctly in default_retry_on

### DIFF
--- a/libs/langgraph/langgraph/_internal/_retry.py
+++ b/libs/langgraph/langgraph/_internal/_retry.py
@@ -4,10 +4,20 @@ def default_retry_on(exc: Exception) -> bool:
 
     if isinstance(exc, ConnectionError):
         return True
+    # `requests.RequestException` subclasses `OSError`, so requests' transient
+    # network failures would otherwise be swallowed by the non-retryable
+    # `OSError` branch below and never retried.
+    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+        return True
     if isinstance(exc, httpx.HTTPStatusError):
         return 500 <= exc.response.status_code < 600
     if isinstance(exc, requests.HTTPError):
-        return 500 <= exc.response.status_code < 600 if exc.response else True
+        # `Response.__bool__` is an alias for `Response.ok`, so every error
+        # response is falsy. A truthiness check here would send all of them --
+        # 4xx included -- down the `else` branch and retry them.
+        return (
+            500 <= exc.response.status_code < 600 if exc.response is not None else True
+        )
     if isinstance(
         exc,
         (

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -21,6 +21,7 @@ from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResu
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableParallel
 from langgraph.checkpoint.memory import InMemorySaver, MemorySaver
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from requests.models import Response
 from typing_extensions import TypedDict
 
 from langgraph._internal._constants import (
@@ -244,6 +245,71 @@ def test_should_retry_default_retry_on():
         pass
 
     assert _should_retry_on(policy, CustomException("custom error")) is True
+
+
+@pytest.mark.parametrize(
+    ("status_code", "should_retry"),
+    [
+        (400, False),
+        (401, False),
+        (404, False),
+        (422, False),
+        (429, False),
+        (500, True),
+        (502, True),
+        (503, True),
+    ],
+)
+def test_default_retry_on_requests_http_error_real_response(
+    status_code: int, should_retry: bool
+) -> None:
+    """`requests.HTTPError` must be classified by status code, not truthiness.
+
+    `Response.__bool__` is an alias for `Response.ok`, so every error response is
+    falsy. Guarding on `if exc.response` therefore skipped the status check for
+    all of them and retried 4xx responses. A `Mock()` response hides this,
+    because a bare `Mock` is truthy -- so these cases use a real `Response`.
+    """
+    response = Response()
+    response.status_code = status_code
+    assert bool(response) is False, "precondition: error responses are falsy"
+
+    exc = requests.HTTPError(f"status {status_code}")
+    exc.response = response
+
+    assert _should_retry_on(RetryPolicy(), exc) is should_retry
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        requests.ConnectionError("connection refused"),
+        requests.ConnectTimeout("connect timed out"),
+        requests.ReadTimeout("read timed out"),
+        requests.Timeout("timed out"),
+    ],
+    ids=["connection_error", "connect_timeout", "read_timeout", "timeout"],
+)
+def test_default_retry_on_requests_transient_errors(exc: Exception) -> None:
+    """Transient `requests` failures must retry.
+
+    `requests.RequestException` subclasses `OSError`, which is in the
+    non-retryable list, so these were classified as permanent failures even
+    though the builtin `ConnectionError` equivalent retries.
+    """
+    assert isinstance(exc, OSError), "precondition: requests errors are OSErrors"
+    assert _should_retry_on(RetryPolicy(), exc) is True
+
+
+def test_default_retry_on_requests_programming_errors_still_permanent() -> None:
+    """Non-transient `requests` errors must stay non-retryable."""
+    policy = RetryPolicy()
+    assert _should_retry_on(policy, requests.URLRequired("no url")) is False
+    assert (
+        _should_retry_on(policy, requests.exceptions.MissingSchema("no schema"))
+        is False
+    )
+    assert _should_retry_on(policy, requests.exceptions.InvalidURL("bad url")) is False
 
 
 def test_graph_with_single_retry_policy():


### PR DESCRIPTION
## Description

`default_retry_on` — the default for `RetryPolicy.retry_on` — misclassifies `requests`
exceptions in two ways, and the two errors are exact inverses of each other: permanent
failures are retried, and transient ones are not.

### 1. Every `requests.HTTPError` is retried, including 4xx

`requests.Response.__bool__` is an alias for `Response.ok`, so **every error response is
falsy**:

```python
>>> r = requests.models.Response(); r.status_code = 404
>>> bool(r)
False
```

The guard `if exc.response` therefore always takes the `else True` branch, which makes the
`500 <= exc.response.status_code < 600` comparison **unreachable dead code**. A 401, 404 or
422 is retried up to `max_attempts` with backoff — re-sending a request that cannot
succeed, against an API that has already refused it.

| status | intended | on `main` |
|---|---|---|
| 400, 401, 404, 422, 429 | no retry | **retried** |
| 500, 502, 503 | retry | retried |

### 2. `requests` connection errors and timeouts are never retried

`requests.RequestException` subclasses `OSError`, which is in the non-retryable list. So
`requests.ConnectionError`, `ConnectTimeout` and `ReadTimeout` are all classified as
permanent — even though the builtin `ConnectionError` on the first line of the function
retries, and an unrecognised exception falls through to `return True`. These are precisely
the transient failures a retry policy exists for.

```python
>>> isinstance(requests.exceptions.ConnectionError(), ConnectionError)  # builtin
False
>>> isinstance(requests.exceptions.ConnectionError(), OSError)
True
```

## Why the test suite didn't catch it

`test_should_retry_default_retry_on` already asserts the correct intent:

```python
response_req_4xx = Mock()
response_req_4xx.status_code = 400
req_error_4xx = requests.HTTPError("bad request")
req_error_4xx.response = response_req_4xx
assert _should_retry_on(policy, req_error_4xx) is False   # passes
```

A bare `Mock()` is **truthy**, so the test reaches the status-code comparison that
production never reaches. The assertion is right; the fixture just isn't a `Response`.

## Fix

- Compare `exc.response is not None` rather than relying on truthiness.
- Classify `requests.ConnectionError` / `requests.Timeout` as retryable before the `OSError`
  branch.

Non-transient `requests` errors (`URLRequired`, `MissingSchema`, `InvalidURL`) stay
non-retryable, and `httpx` handling is untouched.

## Tests

Added to `libs/langgraph/tests/test_retry.py`, using a real `requests.models.Response`
rather than a `Mock`:

- `test_default_retry_on_requests_http_error_real_response` — parametrised over 400/401/404/422/429/500/502/503
- `test_default_retry_on_requests_transient_errors` — `ConnectionError`, `ConnectTimeout`, `ReadTimeout`, `Timeout`
- `test_default_retry_on_requests_programming_errors_still_permanent` — guards against over-broad retrying

**9 of these fail on `main` and pass with this change.** Full before/after matrix: 9 fixed,
16 unchanged-correct, 0 regressions.

```
$ pytest tests/test_retry.py -k default_retry_on   # without the fix
9 failed, 5 passed

$ pytest tests/test_retry.py                        # with the fix
118 passed
```

`ruff check .`, `ruff format . --diff` and `ruff check --select I .` are all clean.
