### PR TITLE
fix(checkpoint): correct Checkpoint.v docstring (set by LATEST_VERSION)

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -94,7 +94,7 @@ class Checkpoint(TypedDict):
     """State snapshot at a given point in time."""
 
     v: int
-    """The version of the checkpoint format. Currently `1`."""
+    """The version of the checkpoint format. Set by `LATEST_VERSION`."""
     id: str
     """The ID of the checkpoint.
     


### PR DESCRIPTION
Fixes #8803

**Description**

`Checkpoint.v` is a `TypedDict` field whose docstring hardcoded "Currently `1`" as the checkpoint format version. That value is stale - the version is actually written from the `LATEST_VERSION` constant (currently `4` in `libs/langgraph/langgraph/pregel/_checkpoint.py`), and no code produces `1` anymore.

Rather than pin another hardcoded number that would drift again, this change makes the docstring reference the `LATEST_VERSION` constant as the source of truth.

**Checklist**
- `make format` - passed
- `make lint` (ruff check + ty check) - passed
- `make test` (`tests/test_memory.py`) - 16 passed