### PR TITLE
fix(checkpoint-sqlite): honor fields index configuration

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -1490,7 +1490,11 @@ def _ensure_index_config(
     index_config = index_config.copy()
     tokenized: list[tuple[str, Literal["$"] | list[str]]] = []
     tot = 0
-    text_fields = index_config.get("text_fields") or ["$"]
+    fields = index_config.get("fields")
+    if fields is None:
+        # Keep accepting the pre-`fields` name for backwards compatibility.
+        fields = index_config.get("text_fields")
+    text_fields = fields or ["$"]
     if isinstance(text_fields, str):
         text_fields = [text_fields]
     if not isinstance(text_fields, list):

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -477,6 +477,30 @@ def test_vector_store_initialization(fake_embeddings: CharacterEmbeddings) -> No
         assert len(tables) >= 1, "Vector tables were not created"
 
 
+def test_vector_store_respects_fields_config(
+    fake_embeddings: CharacterEmbeddings,
+) -> None:
+    """Test that the documented fields config selects the indexed field."""
+    index_config: SqliteIndexConfig = {
+        "dims": fake_embeddings.dims,
+        "embed": fake_embeddings,
+        "fields": ["text"],
+    }
+    with SqliteStore.from_conn_string(":memory:", index=index_config) as store:
+        store.setup()
+        store.put(
+            ("test",),
+            "doc",
+            {"text": "indexed", "metadata": "not indexed"},
+        )
+
+        vector_fields = [
+            row[0] for row in store.conn.execute("SELECT field_name FROM store_vectors")
+        ]
+
+    assert vector_fields == ["text"]
+
+
 @pytest.mark.parametrize("distance_type", VECTOR_TYPES)
 @pytest.mark.parametrize("conn_type", ["memory", "file"])
 def test_vector_insert_with_auto_embedding(


### PR DESCRIPTION
Fixes #8808 

- Updates the shared SQLite index configuration normalizer to honor the documented `fields` key while retaining `text_fields` as a backward-compatible fallback. 
- Adds regression coverage confirming that the configured field is indexed.

