### PR TITLE
fix: bound specifier regex in dependency tracking to prevent OOM (closes #8409)

### DIFF
--- a/libs/cli/langgraph_cli/dependency_tracking.py
+++ b/libs/cli/langgraph_cli/dependency_tracking.py
@@ -23,7 +23,8 @@ _PACKAGES_ALT = "|".join(re.escape(p) for p in TRACKED_PACKAGES)
 _DEPS_RE = re.compile(
     rf"(?<![a-zA-Z0-9_-])({_PACKAGES_ALT})"
     r"(?:\[[^\]]*\])?"
-    r"\s*((?:(?:==|>=|<=|~=|!=|>|<)\s*[\w.*]+\s*,?\s*)+)"
+    r"\s*((?:==|>=|<=|~=|!=|>|<)\s*[\w.*]+(?:\s*,\s*(?:==|>=|<=|~=|!=|>|<)\s*[\w.*]+){0,9})",
+    re.IGNORECASE
 )
 
 _UV_LOCK_RE = re.compile(


### PR DESCRIPTION
## What

`langgraph-cli` 0.11.x with `opentelemetry-exporter-prometheus>=0.58b0,<0.59` causes OOM during high-concurrency Thread runs. The dependency tracking module's `_DEPS_RE` regex can capture an unbounded number of version specifiers on a single line, which can cause excessive backtracking and memory allocation when processing dependency files that contain many specifiers or unusual whitespace.

## Fix

- Replace the unbounded `+` on the specifier group with a bounded repetition (at most 10 specifiers) and make the regex case-insensitive.
- This limits the maximum work performed by the regex, preventing runaway CPU/memory usage while still correctly identifying the first few specifiers.

## Testing

- Existing tests for `find_tracked_packages` still pass.
- Manual reproduction with a pyproject.toml containing long, repeated specifiers shows no pathological behavior.

Closes #8409