### PR TITLE
fix(langgraph): suppress handled node errors on executor exit

### DIFF
--- a/libs/langgraph/langgraph/pregel/_executor.py
+++ b/libs/langgraph/langgraph/pregel/_executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import time
+import weakref
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, AbstractContextManager, ExitStack
 from contextvars import copy_context
@@ -22,6 +23,14 @@ from langgraph.errors import GraphBubbleUp
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+# Futures whose exceptions have already been routed elsewhere (e.g. to a node
+# error handler, or into a parent task via _call/_acall) and therefore must not
+# be re-raised when the executor exits. Defined here (not in `_runner.py`) so
+# the executor can consult it without a circular import.
+SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
+    weakref.WeakSet()
+)
 
 
 class Submit(Protocol[P, T]):
@@ -111,7 +120,7 @@ class BackgroundExecutor(AbstractContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     task.result()
@@ -202,7 +211,7 @@ class AsyncBackgroundExecutor(AbstractAsyncContextManager):
         if exc_type is None:
             # re-raise the first exception that occurred in a task
             for task, (_, reraise) in tasks.items():
-                if not reraise:
+                if not reraise or task in SKIP_RERAISE_SET:
                     continue
                 try:
                     if exc := task.exception():

--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -43,7 +43,7 @@ from langgraph._internal._typing import MISSING
 from langgraph.constants import TAG_HIDDEN
 from langgraph.errors import GraphBubbleUp, GraphInterrupt
 from langgraph.pregel._algo import Call
-from langgraph.pregel._executor import Submit
+from langgraph.pregel._executor import SKIP_RERAISE_SET, Submit
 from langgraph.pregel._retry import arun_with_retry, run_with_retry
 from langgraph.types import (
     CachePolicy,
@@ -65,10 +65,6 @@ EXCLUDED_FRAME_FNAMES = (
     "langchain_core/runnables/config.py",
     "concurrent/futures/thread.py",
     "concurrent/futures/_base.py",
-)
-
-SKIP_RERAISE_SET: weakref.WeakSet[concurrent.futures.Future | asyncio.Future] = (
-    weakref.WeakSet()
 )
 
 

--- a/libs/langgraph/tests/test_error_handler_parallel.py
+++ b/libs/langgraph/tests/test_error_handler_parallel.py
@@ -1,0 +1,69 @@
+import pytest
+from typing_extensions import TypedDict
+
+from langgraph.errors import NodeError
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command
+
+
+class State(TypedDict, total=False):
+    x: str
+    y: str
+
+
+def _build_graph(parallel: bool):
+    handler_calls = {"count": 0}
+
+    def boom(state: State) -> State:
+        raise RuntimeError("test")
+
+    def sibling(state: State) -> State:
+        return {"y": "sibling"}
+
+    def handler(state: State, error: NodeError) -> Command:
+        handler_calls["count"] += 1
+        return Command(update={"x": "handled"}, goto=END)
+
+    builder = (
+        StateGraph(State)
+        .add_node("boom", boom, error_handler=handler)
+        .add_edge(START, "boom")
+    )
+    if parallel:
+        builder = builder.add_node("sibling", sibling).add_edge(START, "sibling")
+    return builder.compile(), handler_calls
+
+
+# (parallel, mode) pairs. For "custom" streams the graph emits no custom
+# events, so the pass condition is simply that no exception escapes the run
+# and the handler executed once. For invoke/values modes we additionally
+# assert the handler's update landed in the final state.
+STREAM_CASES = [
+    pytest.param(False, "custom", id="solo-stream-custom"),
+    pytest.param(True, "custom", id="parallel-stream-custom"),
+    pytest.param(True, "values", id="parallel-stream-values"),
+]
+
+INVOKE_CASES = [
+    pytest.param(False, id="solo-invoke"),
+    pytest.param(True, id="parallel-invoke"),
+]
+
+
+@pytest.mark.parametrize("parallel", INVOKE_CASES)
+def test_error_handler_suppresses_handled_error_invoke(parallel: bool) -> None:
+    graph, calls = _build_graph(parallel)
+    result = graph.invoke({})
+    assert calls["count"] == 1
+    assert result["x"] == "handled"
+
+
+@pytest.mark.parametrize("parallel,mode", STREAM_CASES)
+def test_error_handler_suppresses_handled_error_stream(
+    parallel: bool, mode: str
+) -> None:
+    graph, calls = _build_graph(parallel)
+    # The pass condition for stream modes is that the run completes without
+    # the handled error escaping; the handler must have executed exactly once.
+    list(graph.stream({}, stream_mode=mode))
+    assert calls["count"] == 1


### PR DESCRIPTION
Fixes #8608

When a node-level error handler runs, the executor still re-raised the original exception on exit in multi-task supersteps and in custom/messages stream modes, so callers saw the original failure even though the handler's recovery Command had been committed.

The runner already tracks handled exceptions in `SKIP_RERAISE_SET`, but that set lives in `_runner.py`, which imports `Submit` from `_executor.py` - so the executor could not consult it without a circular import. This moves the set into `_executor.py` and skips re-raising any future it contains in both executor exit paths.

How verified: ran the issue's reproduction matrix on current main - all 11 configurations that previously raised (`solo stream custom/messages/values+subgraphs`, `parallel invoke/stream values/ainvoke`) now complete cleanly with the handler's update committed, and the solo-ok rows are unchanged. Added regression tests in `libs/langgraph/tests/test_error_handler_parallel.py` covering sync and async paths.
