### PR TITLE
fix(langgraph): correct default_retry_on requests error handling

### DIFF
--- a/libs/langgraph/langgraph/_internal/_retry.py
+++ b/libs/langgraph/langgraph/_internal/_retry.py
@@ -7,7 +7,17 @@ def default_retry_on(exc: Exception) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return 500 <= exc.response.status_code < 600
     if isinstance(exc, requests.HTTPError):
-        return 500 <= exc.response.status_code < 600 if exc.response else True
+        # `requests.Response.__bool__` is an alias for `Response.ok`, so every
+        # error response is falsy. Compare against `None` explicitly to reach
+        # the status-code check for real error responses.
+        if exc.response is not None:
+            return 500 <= exc.response.status_code < 600
+        return True
+    if isinstance(exc, requests.RequestException):
+        # `requests.RequestException` subclasses `OSError`, so connection errors
+        # and timeouts would otherwise fall into the non-retryable `OSError`
+        # branch below. Treat these transient failures as retryable.
+        return True
     if isinstance(
         exc,
         (

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -211,24 +211,42 @@ def test_should_retry_default_retry_on():
     )
     assert _should_retry_on(policy, http_error_4xx) is False
 
-    # Should retry on requests.HTTPError with 5xx status code
-    response_req_5xx = Mock()
+    # Should retry on requests.HTTPError with 5xx status code.
+    # Use a real requests.models.Response: a bare Mock is truthy, but a real
+    # error Response is falsy (`__bool__` aliases `Response.ok`), so a Mock
+    # would exercise a code path production never reaches.
+    response_req_5xx = requests.models.Response()
     response_req_5xx.status_code = 502
-    req_error_5xx = requests.HTTPError("bad gateway")
-    req_error_5xx.response = response_req_5xx
+    req_error_5xx = requests.HTTPError("bad gateway", response=response_req_5xx)
     assert _should_retry_on(policy, req_error_5xx) is True
 
+    response_req_500 = requests.models.Response()
+    response_req_500.status_code = 500
+    req_error_500 = requests.HTTPError("server error", response=response_req_500)
+    assert _should_retry_on(policy, req_error_500) is True
+
     # Should not retry on requests.HTTPError with 4xx status code
-    response_req_4xx = Mock()
-    response_req_4xx.status_code = 400
-    req_error_4xx = requests.HTTPError("bad request")
-    req_error_4xx.response = response_req_4xx
-    assert _should_retry_on(policy, req_error_4xx) is False
+    for status_code in (400, 401, 404, 422):
+        response_req_4xx = requests.models.Response()
+        response_req_4xx.status_code = status_code
+        req_error_4xx = requests.HTTPError("client error", response=response_req_4xx)
+        assert _should_retry_on(policy, req_error_4xx) is False
 
     # Should retry on requests.HTTPError with no response
     req_error_no_resp = requests.HTTPError("connection error")
     req_error_no_resp.response = None
     assert _should_retry_on(policy, req_error_no_resp) is True
+
+    # Should retry on requests connection errors and timeouts. These subclass
+    # OSError, so they must be handled before the non-retryable OSError branch.
+    assert (
+        _should_retry_on(policy, requests.ConnectionError("connection refused")) is True
+    )
+    assert (
+        _should_retry_on(policy, requests.ConnectTimeout("connect timed out")) is True
+    )
+    assert _should_retry_on(policy, requests.ReadTimeout("read timed out")) is True
+    assert _should_retry_on(policy, requests.Timeout("timed out")) is True
 
     # NodeTimeoutError should be retryable by default
     assert (


### PR DESCRIPTION
## Summary

Fixes #8802.

`default_retry_on` misclassified `requests` exceptions, and the two errors were exact inverses of each other: permanent failures were retried and transient failures were not.

1. **Every `requests.HTTPError` was retried, including 4xx.** The guard `if exc.response` relied on `Response.__bool__`, which aliases `Response.ok`, so every error response is falsy. That made the `500 <= status < 600` check unreachable and sent 4xx errors (401, 404, 422, ...) back through retries. Fixed by comparing `exc.response is not None`.

2. **`requests` connection errors and timeouts were never retried.** `requests.RequestException` subclasses `OSError`, which is in the non-retryable list, so `ConnectionError`, `ConnectTimeout` and `ReadTimeout` were treated as permanent. Fixed by adding a `requests.RequestException` branch that returns `True`, placed before the `OSError` catch-all.

Expected behaviour after the change: 4xx is not retried; 5xx, connection errors and timeouts are.

## Tests

- Updated `test_should_retry_default_retry_on` to build responses with a real `requests.models.Response` instead of a `Mock`. A bare `Mock` is truthy, so the previous test reached a code path production never reaches and passed against the bug.
- Added regression assertions for 4xx/5xx `HTTPError` and for `ConnectionError` / `ConnectTimeout` / `ReadTimeout` / `Timeout`.
- `make format`, `make lint`, and the full `tests/test_retry.py` suite (105 tests) pass.

## Reproduction

Before:
```
requests.HTTPError(404)  -> node ran 3 time(s); expected 1
requests.ConnectionError -> node ran 1 time(s); expected 3
```

After:
```
requests.HTTPError(404)  -> node ran 1 time(s); expected 1
requests.ConnectionError -> node ran 3 time(s); expected 3
```
