### PR TITLE
fix(checkpoint): map shared embeddings across duplicate indexed texts in InMemoryStore

### DIFF
--- a/libs/checkpoint/langgraph/store/memory/__init__.py
+++ b/libs/checkpoint/langgraph/store/memory/__init__.py
@@ -448,14 +448,16 @@ class InMemoryStore(BaseStore):
         to_embed: dict[str, list[tuple[tuple[str, ...], str, str]]],
         embeddings: list[list[float]],
     ) -> None:
-        indices = [index for indices in to_embed.values() for index in indices]
-        if len(indices) != len(embeddings):
+        if len(embeddings) != len(to_embed):
             raise ValueError(
                 f"Number of embeddings ({len(embeddings)}) does not"
-                f" match number of indices ({len(indices)})"
+                f" match number of unique texts ({len(to_embed)})"
             )
-        for embedding, (ns, key, path) in zip(embeddings, indices, strict=False):
-            self._vectors[ns][key][path] = embedding
+        for embedding, target_indices in zip(
+            embeddings, to_embed.values(), strict=False
+        ):
+            for ns, key, path in target_indices:
+                self._vectors[ns][key][path] = embedding
 
     def _handle_list_namespaces(self, op: ListNamespacesOp) -> list[tuple[str, ...]]:
         all_namespaces = list(

--- a/libs/checkpoint/tests/test_store.py
+++ b/libs/checkpoint/tests/test_store.py
@@ -1058,3 +1058,55 @@ def test_non_ascii(fake_embeddings: CharacterEmbeddings) -> None:
     assert result3[0].key == "3"
     assert result4[0].key == "4"
     assert result5[0].key == "5"
+
+
+def test_batch_duplicate_texts_indexed(fake_embeddings: CharacterEmbeddings) -> None:
+    """Test that batch() properly handles multiple PutOps containing identical indexed text."""
+    store = InMemoryStore(
+        index={
+            "dims": fake_embeddings.dims,
+            "embed": fake_embeddings,
+            "fields": ["text"],
+        }
+    )
+    operations = [
+        PutOp(("docs",), "doc-a", {"text": "identical text"}),
+        PutOp(("docs",), "doc-b", {"text": "identical text"}),
+        PutOp(("docs",), "doc-c", {"text": "different text"}),
+    ]
+    store.batch(operations)
+
+    results = store.search(("docs",), query="identical text")
+    assert len(results) == 3
+    keys = {r.key for r in results[:2]}
+    assert keys == {"doc-a", "doc-b"}
+    assert results[0].score is not None
+    assert results[1].score is not None
+    assert results[0].score == pytest.approx(results[1].score)
+
+
+async def test_async_batch_duplicate_texts_indexed(
+    fake_embeddings: CharacterEmbeddings,
+) -> None:
+    """Test that abatch() properly handles multiple PutOps containing identical indexed text."""
+    store = InMemoryStore(
+        index={
+            "dims": fake_embeddings.dims,
+            "embed": fake_embeddings,
+            "fields": ["text"],
+        }
+    )
+    operations = [
+        PutOp(("docs",), "doc-a", {"text": "identical text"}),
+        PutOp(("docs",), "doc-b", {"text": "identical text"}),
+        PutOp(("docs",), "doc-c", {"text": "different text"}),
+    ]
+    await store.abatch(operations)
+
+    results = await store.asearch(("docs",), query="identical text")
+    assert len(results) == 3
+    keys = {r.key for r in results[:2]}
+    assert keys == {"doc-a", "doc-b"}
+    assert results[0].score is not None
+    assert results[1].score is not None
+    assert results[0].score == pytest.approx(results[1].score)


### PR DESCRIPTION
Fixes #8822

When multiple `PutOp` instances in `batch()` or `abatch()` contain identical indexed text, `_extract_texts` deduplicates the text values so the embeddings provider generates one embedding per unique text. This PR updates `InMemoryStore._insertinmem_store` to iterate over `to_embed.values()` and assign each embedding across all target index locations that share that text, instead of assuming a 1-to-1 correspondence between embeddings and flattened index targets.

## Summary of Changes

- `libs/checkpoint/langgraph/store/memory/__init__.py`:
  - In `_insertinmem_store()`, validate `len(embeddings) == len(to_embed)` (the number of unique texts passed to `embed_documents()`).
  - Loop over `zip(embeddings, to_embed.values())` and write the embedding to each `(ns, key, path)` target associated with that text.
- `libs/checkpoint/tests/test_store.py`:
  - Added `test_batch_duplicate_texts_indexed` and `test_async_batch_duplicate_texts_indexed` regression tests verifying that items sharing identical indexed text store their vectors properly and return in vector searches.

## Verification

- `uv run pytest tests/test_store.py`: 28/28 passed (including new sync and async tests).
- `uv run ruff check .`: All checks passed.
- `uv run ruff format --check .`: All 26 files formatted.
