### PR TITLE
fix(sqlite-store): read 'fields' instead of 'text_fields' in index config

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -1490,7 +1490,7 @@ def _ensure_index_config(
     index_config = index_config.copy()
     tokenized: list[tuple[str, Literal["$"] | list[str]]] = []
     tot = 0
-    text_fields = index_config.get("text_fields") or ["$"]
+    text_fields = index_config.get("fields") or ["$"]
     if isinstance(text_fields, str):
         text_fields = [text_fields]
     if not isinstance(text_fields, list):


### PR DESCRIPTION
## Summary

Fixes #8808.

SqliteStore ignores the documented `fields` key in the index configuration and only reads the undocumented `text_fields` key. As a result, the entire document is embedded instead of only the configured fields, which can send unnecessary data to external embedding providers and affect search results.

## Root Cause

In `_ensure_index_config` at line 1493, the config normalizer reads `index_config.get("text_fields")` instead of `index_config.get("fields")`. The documented key is `fields`, and the PostgresStore already uses it correctly at line 1459 of postgres/base.py (fixed in #4343/#4345).

## Reproduction

```python
store = SqliteStore.from_conn_string(
    ":memory:",
    index={"dims": 2, "embed": embeddings, "fields": ["text"]},
)
store.setup()
store.put(("docs",), "doc", {"text": "indexed", "metadata": "not indexed"})
# Before: entire document is embedded -> ["metadata", "text"]
# After:  only "text" field is embedded
```

## Fix

Change `index_config.get("text_fields")` to `index_config.get("fields")` to match the PostgresStore behavior and the documented API.

## Changes

- `libs/checkpoint-sqlite/langgraph/store/sqlite/base.py`: 1 line changed