### PR TITLE
fix(langgraph): stop retrying requests 4xx errors in default_retry_on

### DIFF
--- a/libs/langgraph/langgraph/_internal/_retry.py
+++ b/libs/langgraph/langgraph/_internal/_retry.py
@@ -7,7 +7,12 @@ def default_retry_on(exc: Exception) -> bool:
     if isinstance(exc, httpx.HTTPStatusError):
         return 500 <= exc.response.status_code < 600
     if isinstance(exc, requests.HTTPError):
-        return 500 <= exc.response.status_code < 600 if exc.response else True
+        # Note: requests.Response.__bool__ is status_code < 400, so a real
+        # response attached to an HTTPError is always falsy. Compare against
+        # None explicitly instead of relying on truthiness.
+        if exc.response is None:
+            return True
+        return 500 <= exc.response.status_code < 600
     if isinstance(
         exc,
         (

--- a/libs/langgraph/tests/test_retry.py
+++ b/libs/langgraph/tests/test_retry.py
@@ -211,19 +211,34 @@ def test_should_retry_default_retry_on():
     )
     assert _should_retry_on(policy, http_error_4xx) is False
 
-    # Should retry on requests.HTTPError with 5xx status code
-    response_req_5xx = Mock()
+    # Should retry on requests.HTTPError with 5xx status code.
+    # Use a real requests.Response: its __bool__ is `status_code < 400`, so a
+    # real error response is always falsy (a Mock would be truthy and would
+    # mask the truthiness trap in the None check).
+    response_req_5xx = requests.Response()
     response_req_5xx.status_code = 502
     req_error_5xx = requests.HTTPError("bad gateway")
     req_error_5xx.response = response_req_5xx
     assert _should_retry_on(policy, req_error_5xx) is True
 
     # Should not retry on requests.HTTPError with 4xx status code
-    response_req_4xx = Mock()
+    response_req_4xx = requests.Response()
     response_req_4xx.status_code = 400
     req_error_4xx = requests.HTTPError("bad request")
     req_error_4xx.response = response_req_4xx
     assert _should_retry_on(policy, req_error_4xx) is False
+
+    # Should not retry on requests.HTTPError with 4xx status code,
+    # as raised by raise_for_status() on a real response
+    real_response_404 = requests.Response()
+    real_response_404.status_code = 404
+    real_response_404.url = "http://example.com/missing"
+    try:
+        real_response_404.raise_for_status()
+    except requests.HTTPError as real_error_404:
+        assert _should_retry_on(policy, real_error_404) is False
+    else:
+        raise AssertionError("raise_for_status() did not raise for a 404")
 
     # Should retry on requests.HTTPError with no response
     req_error_no_resp = requests.HTTPError("connection error")


### PR DESCRIPTION
Fixes #8840

`default_retry_on` retried every `requests.HTTPError`, including 4xx, because a real `requests.Response` is falsy for any status >= 400 (`Response.__bool__` is `.ok`), so the 5xx check guarded by `if exc.response` never ran. Changed the guard to an explicit `exc.response is None` check so 4xx fails fast, 5xx still retries, and connection-level errors with no response still retry - matching the httpx branch.

Switched the existing test to real `requests.Response` objects (a `Mock()` is truthy and masked the bug) and added a `raise_for_status()` 404 regression case. Verified with `pytest tests/test_retry.py`: 98 passed, 7 skipped (postgres/docker-only).