### PR TITLE
fix(langgraph): apply node timeout to error handler tasks

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -1245,6 +1245,7 @@ def prepare_node_error_handler_task(
         translated_task_path,
         writers=proc.flat_writers,
         subgraphs=proc.subgraphs,
+        timeout=proc.timeout,
     )
 
 

--- a/libs/langgraph/tests/test_pregel_async.py
+++ b/libs/langgraph/tests/test_pregel_async.py
@@ -64,6 +64,7 @@ from langgraph.errors import (
     GraphRecursionError,
     InvalidUpdateError,
     NodeError,
+    NodeTimeoutError,
     ParentCommand,
 )
 from langgraph.func import entrypoint, task
@@ -9716,3 +9717,58 @@ async def test_node_error_handler_handles_subgraph_internal_failure_async() -> N
     assert result["foo"] == "handled_async_subgraph"
     assert captured["from_node_name"] == "subgraph_node"
     assert isinstance(captured["from_node_error"], BaseException)
+
+
+async def test_error_handler_respects_node_default_timeout_async() -> None:
+    """Error-handler tasks must honor the timeout from `set_node_defaults`.
+
+    Regression: `prepare_node_error_handler_task` built the handler's task
+    without the node's `timeout`, so a handler that overran the default
+    timeout was never cancelled - the documented "timeout defaults apply to
+    error-handler nodes" behavior silently did nothing.
+    """
+
+    class State(TypedDict):
+        foo: str
+
+    async def failing_node(state: State) -> State:
+        raise ValueError("boom")
+
+    async def slow_handler(state: State, error: NodeError) -> State:
+        await asyncio.sleep(5)
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .set_node_defaults(timeout=0.1)
+        .add_node("failing", failing_node, error_handler=slow_handler)
+        .add_edge(START, "failing")
+        .compile()
+    )
+
+    with pytest.raises(NodeTimeoutError):
+        await graph.ainvoke({"foo": ""})
+
+
+async def test_error_handler_within_node_default_timeout_async() -> None:
+    """A handler that finishes within the default timeout still runs."""
+
+    class State(TypedDict):
+        foo: str
+
+    async def failing_node(state: State) -> State:
+        raise ValueError("boom")
+
+    async def fast_handler(state: State, error: NodeError) -> State:
+        return {"foo": "handled"}
+
+    graph = (
+        StateGraph(State)
+        .set_node_defaults(timeout=5)
+        .add_node("failing", failing_node, error_handler=fast_handler)
+        .add_edge(START, "failing")
+        .compile()
+    )
+
+    result = await graph.ainvoke({"foo": ""})
+    assert result["foo"] == "handled"


### PR DESCRIPTION
Fixes #8842

`prepare_node_error_handler_task` built the error handler's task without the node's `timeout`, so timeouts from `set_node_defaults(timeout=...)` - documented to apply to error-handler nodes - never reached the task and a stuck async handler ran forever instead of raising `NodeTimeoutError`. Passes the handler node's timeout through, matching `prepare_single_task` and `prepare_push_task_send`.

Verification: added two regression tests in `test_pregel_async.py`. The timeout test fails without the change (handler sleeps past the default timeout and the graph completes) and passes with it (`NodeTimeoutError` at the default timeout); a second test confirms a handler inside the timeout still runs. Ran `test_pregel_async.py` (excluding docker-dependent variants) and the error_handler/timeout subset of `test_pregel.py` - green.