### PR TITLE
fix(langgraph): surface structured details in RemoteException (#2559)

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -110,9 +110,33 @@ def _sanitize_config_value(v: Any) -> Any:
 
 
 class RemoteException(Exception):
-    """Exception raised when an error occurs in the remote graph."""
+    """Exception raised when an error occurs in the remote graph.
 
-    pass
+    The raw server payload is preserved on ``payload``, and the structured
+    fields it carries (error type, message, traceback) are rendered into the
+    message. Previously the payload was flattened into a single line, which
+    made remote failures such as ``InvalidUpdateError`` impossible to diagnose.
+    """
+
+    def __init__(self, payload: Any = None) -> None:
+        self.payload = payload
+        super().__init__(_render_remote_payload(payload))
+
+
+def _render_remote_payload(payload: Any) -> str:
+    """Flatten a remote error payload into a readable, detailed message."""
+    if isinstance(payload, dict):
+        lines: list[str] = []
+        for key in ("error", "message", "type"):
+            value = payload.get(key)
+            if value:
+                lines.append(f"{key}: {value}")
+        traceback = payload.get("traceback")
+        if traceback:
+            lines.append(f"traceback:\n{traceback}")
+        if lines:
+            return "\n".join(lines)
+    return str(payload)
 
 
 class RemoteGraph(PregelProtocol):

--- a/libs/langgraph/tests/test_remote_exception.py
+++ b/libs/langgraph/tests/test_remote_exception.py
@@ -1,0 +1,28 @@
+from langgraph.pregel.remote import RemoteException
+
+
+def test_dict_payload_is_preserved_and_rendered():
+    payload = {
+        "error": "InvalidUpdateError",
+        "message": "bad update for key 'messages'",
+    }
+    exc = RemoteException(payload)
+    assert exc.payload == payload
+    msg = str(exc)
+    assert "InvalidUpdateError" in msg
+    assert "messages" in msg
+
+
+def test_traceback_is_included():
+    exc = RemoteException({"error": "boom", "traceback": "Traceback...\nline 1"})
+    assert "Traceback..." in str(exc)
+
+
+def test_string_payload_unchanged():
+    exc = RemoteException("boom")
+    assert str(exc) == "boom"
+    assert exc.payload == "boom"
+
+
+def test_non_dict_payload_falls_back_to_str():
+    assert str(RemoteException(None)) == "None"


### PR DESCRIPTION
Fixes #2559

`RemoteException` was a bare `pass` subclass of `Exception`, so the structured error payload returned by the server was flattened into a single line and remote failures (e.g. `InvalidUpdateError`) gave no hint about *which* state update or node failed.

This PR:
- preserves the raw server payload on `RemoteException.payload`
- renders the structured fields it carries (`error`, `message`, `type`, `traceback`) into the message when the payload is a dict
- falls back to `str(payload)` for non-dict payloads, so existing raises are unchanged
- adds unit tests for dict / string / None payloads

Client-only, no behavior change beyond a more informative message. The server-side half (including `error.context` in the `/runs` error response) lives in langgraph-api and can follow separately.