### PR TITLE
feat(langgraph): bind context at the graph level (#7990)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        context: Any | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1398,11 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if context is not None:
+            # graph-level context binding: server layers can supply run-scoped
+            # context here instead of seeding the private runtime slot (#7990)
+            compiled.bound_context = context
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2870,7 +2870,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
@@ -3313,7 +3318,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,

--- a/libs/langgraph/tests/test_graph_context_binding.py
+++ b/libs/langgraph/tests/test_graph_context_binding.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import TypedDict
+
+from langgraph.graph import StateGraph
+from langgraph.runtime import Runtime
+
+
+@dataclass
+class Ctx:
+    v: str
+
+
+class State(TypedDict, total=False):
+    out: str
+
+
+def _build(bound: Ctx):
+    def node(state: State, runtime: Runtime[Ctx]) -> State:
+        return {"out": runtime.context.v if runtime.context else None}
+
+    return (
+        StateGraph(State, context_schema=Ctx)
+        .add_node("n", node)
+        .set_entry_point("n")
+        .set_finish_point("n")
+        .compile(context=bound)
+    )
+
+
+def test_bound_context_used_when_invoke_omits_it():
+    graph = _build(Ctx(v="bound"))
+    assert graph.invoke({})["out"] == "bound"
+
+
+def test_invoke_context_overrides_bound_context():
+    graph = _build(Ctx(v="bound"))
+    assert graph.invoke({}, context=Ctx(v="per-invoke"))["out"] == "per-invoke"


### PR DESCRIPTION
Fixes #7990

Adds graph-level `context` binding so server layers no longer need to seed the private `__pregel_runtime` slot.

- `StateGraph.compile(..., context=...)` binds run-scoped context at the graph level (mirrors `store=`)
- `Runtime` construction falls back to the bound context when no per-invoke `context` is passed
- applied on both the sync and async `Runtime` construction paths, so `invoke`/`stream` behave identically
- per-invoke `context` still wins when supplied
- tests cover: bound context used when invoke omits it, and per-invoke overriding the bound value

This removes the need for LangGraph API to poke `CONFIG_KEY_RUNTIME`, and is a step toward dropping the `_coerce_parent_runtime` shim.

**Scope note:** this PR covers `invoke`/`stream`. `update_state` / superstep paths build their runtime separately and are not wired here - worth confirming with maintainers so we avoid the same asymmetry as #6340.