### PR TITLE
feat(langgraph): input validators for client updates (#7119)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        context: Any | None = None,
+        input_validators: Sequence[Callable[[dict[str, Any]], dict[str, Any]]]
+        | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1400,16 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if context is not None:
+            # graph-level context binding: server layers can supply run-scoped
+            # context here instead of seeding the private runtime slot (#7990)
+            compiled.bound_context = context
+
+        if input_validators:
+            # applied to client-supplied updates (e.g. `command.update`), letting
+            # graphs enforce append-only / reject semantics on input (#7119)
+            compiled.input_validators = list(input_validators)
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2523,6 +2523,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return self.bulk_update_state(config, [[StateUpdate(values, as_node, task_id)]])
 
     async def aupdate_state(
@@ -2536,6 +2539,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return await self.abulk_update_state(
             config, [[StateUpdate(values, as_node, task_id)]]
         )
@@ -2870,7 +2876,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
@@ -3313,7 +3324,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,

--- a/libs/langgraph/tests/test_input_validators.py
+++ b/libs/langgraph/tests/test_input_validators.py
@@ -1,0 +1,54 @@
+from typing import TypedDict
+
+import pytest
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict, total=False):
+    out: str
+    forbidden: int
+
+
+def _build(validators):
+    def node(state: State) -> State:
+        return {"out": "done"}
+
+    return (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=InMemorySaver(), input_validators=validators)
+    )
+
+
+def test_validator_can_rewrite_input():
+    def upper(values: dict) -> dict:
+        values["out"] = (values.get("out") or "").upper()
+        return values
+
+    graph = _build([upper])
+    config = {"configurable": {"thread_id": "t1"}}
+    graph.update_state(config, {"out": "hi"})
+    assert graph.get_state(config).values["out"] == "HI"
+
+
+def test_validator_can_reject_input():
+    def reject(values: dict) -> dict:
+        if "forbidden" in values:
+            raise ValueError("forbidden key")
+        return values
+
+    graph = _build([reject])
+    config = {"configurable": {"thread_id": "t2"}}
+    with pytest.raises(ValueError, match="forbidden key"):
+        graph.update_state(config, {"forbidden": 1})
+
+
+def test_without_validators_input_is_untouched():
+    graph = _build(None)
+    config = {"configurable": {"thread_id": "t3"}}
+    graph.update_state(config, {"out": "plain"})
+    assert graph.get_state(config).values["out"] == "plain"


### PR DESCRIPTION
Fixes #7119

Adds an input-time validation hook so `input_schema` is no longer the only knob for restricting what clients may write.

- `compile(..., input_validators=[...])` takes callables `(values) -> values`
- applied in both `update_state` and `aupdate_state`, i.e. the path used by `command.update` on `/threads/{id}/runs/stream`
- a validator may rewrite the update (e.g. normalize) or raise to reject it
- tests cover rewriting, rejecting, and the no-validator no-op path

This enables the append-only `messages` semantics described in #7990: a validator can reject client-submitted messages whose `id` already exists, or `ai`-typed messages sent by clients.

**Note:** this branch also carries the `compile(context=...)` change from #8847 because both add `compile()` arguments and touch the same files. Happy to split or rebase once maintainers indicate which lands first.