### PR TITLE
feat(langgraph): private channels hidden from public state reads (#8644)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        context: Any | None = None,
+        input_validators: Sequence[Callable[[dict[str, Any]], dict[str, Any]]]
+        | None = None,
+        private_channels: Sequence[str] | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1401,20 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if context is not None:
+            # graph-level context binding: server layers can supply run-scoped
+            # context here instead of seeding the private runtime slot (#7990)
+            compiled.bound_context = context
+
+        if input_validators:
+            # applied to client-supplied updates (e.g. `command.update`), letting
+            # graphs enforce append-only / reject semantics on input (#7119)
+            compiled.input_validators = list(input_validators)
+
+        if private_channels:
+            # checkpointed and restorable, but excluded from public state reads (#8644)
+            compiled.private_channels = frozenset(private_channels)
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1142,6 +1142,18 @@ class Pregel(
                 checkpoint["channel_versions"].values()
             )
 
+    def _public_values(self, values: dict[str, Any]) -> dict[str, Any]:
+        """Drop channels that are checkpointed but hidden from public state reads.
+
+        See #8644: large internal payloads (e.g. a REPL heap snapshot) must survive
+        across turns via the checkpointer, but should not appear in `get_state`,
+        `get_state_history`, or the Studio / API thread-state endpoints.
+        """
+        private = getattr(self, "private_channels", frozenset())
+        if not private:
+            return values
+        return {k: v for k, v in values.items() if k not in private}
+
     def _prepare_state_snapshot(
         self,
         config: RunnableConfig,
@@ -1255,7 +1267,7 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._public_values(read_channels(channels, self.stream_channels_asis)),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,
@@ -1379,7 +1391,7 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._public_values(read_channels(channels, self.stream_channels_asis)),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,
@@ -2523,6 +2535,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return self.bulk_update_state(config, [[StateUpdate(values, as_node, task_id)]])
 
     async def aupdate_state(
@@ -2536,6 +2551,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return await self.abulk_update_state(
             config, [[StateUpdate(values, as_node, task_id)]]
         )
@@ -2870,7 +2888,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
@@ -3313,7 +3336,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,

--- a/libs/langgraph/tests/test_private_channels.py
+++ b/libs/langgraph/tests/test_private_channels.py
@@ -1,0 +1,50 @@
+from typing import TypedDict
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict, total=False):
+    visible: str
+    _secret: bytes
+
+
+def _build(private):
+    def node(state: State) -> State:
+        return {"visible": "v", "_secret": b"x" * 8}
+
+    return (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=InMemorySaver(), private_channels=private)
+    )
+
+
+def test_private_channel_hidden_from_get_state():
+    graph = _build(["_secret"])
+    config = {"configurable": {"thread_id": "p1"}}
+    graph.invoke({}, config)
+    values = graph.get_state(config).values
+    assert "visible" in values
+    assert "_secret" not in values
+
+
+def test_without_private_channels_everything_is_visible():
+    graph = _build(None)
+    config = {"configurable": {"thread_id": "p2"}}
+    graph.invoke({}, config)
+    assert "_secret" in graph.get_state(config).values
+
+
+def test_private_channel_still_persisted_for_later_turns():
+    graph = _build(["_secret"])
+    config = {"configurable": {"thread_id": "p3"}}
+    graph.invoke({}, config)
+    # hidden in public reads...
+    assert "_secret" not in graph.get_state(config).values
+    # ...but still present in the persisted checkpoint
+    saved = graph.checkpointer.get(config)
+    assert saved is not None
+    assert "_secret" in saved["channel_values"]


### PR DESCRIPTION
Fixes #8644

Lets a state channel stay checkpointed and restorable across turns while being excluded from public state reads.

- `compile(..., private_channels=["_secret"])` marks channels as private
- filtering happens in `_prepare_state_snapshot`, the single place `values` is assembled for `get_state` / `get_state_history` (both sync and async paths), so the `langgraph-api` thread-state/history endpoints that copy those values inherit it
- the checkpointer is untouched: private channels are still written and restored, so resume/replay keeps working
- tests cover: hidden from `get_state`, visible when not marked private, and still present in the persisted checkpoint

This gives `CodeInterpreterMiddleware` (langchain-quickjs) somewhere to keep its ~1.3 MB QuickJS heap blob across turns without surfacing it through every public state read.

**Note:** this branch also carries the `compile(context=...)` (#8847) and `input_validators` (#8848) changes because all three add `compile()` arguments and touch the same files. The `private_channels` commit is separable - happy to rebase once maintainers indicate ordering.