### PR TITLE
fix(langgraph): prevent consumed resume write replay on subsequent interrupts

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -899,6 +899,21 @@ class PregelLoop:
                 w for w in self.checkpoint_pending_writes if w[1] != RESUME
             ]
 
+        has_null_resume = (
+            input_is_command
+            and (resume := cast(Command, self.input).resume) is not None
+            and not (
+                isinstance(resume, dict)
+                and all(is_xxh3_128_hexdigest(k) for k in resume)
+            )
+        )
+        if not has_null_resume:
+            self.checkpoint_pending_writes = [
+                w
+                for w in self.checkpoint_pending_writes
+                if not (w[0] == NULL_TASK_ID and w[1] == RESUME)
+            ]
+
         # map command to writes
         if input_is_command:
             if (resume := cast(Command, self.input).resume) is not None:

--- a/libs/langgraph/tests/test_interruption.py
+++ b/libs/langgraph/tests/test_interruption.py
@@ -1,9 +1,12 @@
+import operator
+from typing import Annotated
+
 import pytest
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from typing_extensions import TypedDict
 
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import Durability
+from langgraph.types import Command, Durability, interrupt
 
 pytestmark = pytest.mark.anyio
 
@@ -90,3 +93,44 @@ async def test_interruption_without_state_updates_async(
     assert (await graph.aget_state(thread)).next == ()
     n_checkpoints = len([c async for c in graph.aget_state_history(thread)])
     assert n_checkpoints == (5 if durability != "exit" else 3)
+
+
+def test_consumed_resume_not_redelivered_on_null_invoke(
+    sync_checkpointer: BaseCheckpointSaver,
+) -> None:
+    class S(TypedDict):
+        log: Annotated[list[str], operator.add]
+
+    def node(state: S) -> dict:
+        first = interrupt("i1")
+        second = interrupt("i2")
+        return {"log": [f"got:{first!r}+{second!r}"]}
+
+    builder = StateGraph(S)
+    builder.add_node("node", node)
+    builder.add_edge(START, "node")
+    builder.add_edge("node", END)
+    app = builder.compile(checkpointer=sync_checkpointer)
+    thread = {"configurable": {"thread_id": "test_stale_resume"}}
+
+    # Step 1: Initial invoke pauses at i1
+    app.invoke({"log": []}, thread)
+    state = app.get_state(thread)
+    assert [i.value for t in state.tasks for i in t.interrupts] == ["i1"]
+
+    # Step 2: Resume i1 with 'first'; pauses at i2
+    app.invoke(Command(resume="first"), thread)
+    state = app.get_state(thread)
+    assert [i.value for t in state.tasks for i in t.interrupts] == ["i2"]
+
+    # Step 3: Call invoke(None); i2 must remain pending and NOT be auto-answered
+    app.invoke(None, thread)
+    state = app.get_state(thread)
+    assert [i.value for t in state.tasks for i in t.interrupts] == ["i2"]
+    assert state.values.get("log") == [] or "log" not in state.values
+
+    # Step 4: Resume i2 with 'second'; execution finishes
+    app.invoke(Command(resume="second"), thread)
+    state = app.get_state(thread)
+    assert state.next == ()
+    assert state.values["log"] == ["got:'first'+'second'"]


### PR DESCRIPTION
Fixes #8837

Drop stale null-task resume writes from `checkpoint_pending_writes` when an invocation does not supply a null resume (such as `invoke(None)`), preventing stale payloads from auto-answering subsequent interrupts.

### Verification
- Added regression test `test_consumed_resume_not_redelivered_on_null_invoke` in `libs/langgraph/tests/test_interruption.py` verifying behavior on both `InMemorySaver` and `SqliteSaver`.
- Ran unit tests: `pytest libs/langgraph/tests/test_interruption.py` (All passed).
- Ran linters: `ruff check` and `ruff format` (All passed).

## Social handles (optional)
<!-- Optional: agar release notes me mention chahiye toh add karein -->
GitHub: @VimalN2005