### PR TITLE
fix(cli): clarify missing deploy config

### DIFF
--- a/libs/cli/langgraph_cli/deploy.py
+++ b/libs/cli/langgraph_cli/deploy.py
@@ -1603,6 +1603,12 @@ def _deploy_cmd(
 
     # -- 1. Preflight --
     validate_deploy_commands(install_command, build_command)
+    if not config.exists():
+        raise click.ClickException(
+            "We couldn't find a langgraph.json file. Run `langgraph deploy` from "
+            "the root of a LangSmith Deployment project. To get started, visit "
+            "https://docs.langchain.com/langsmith/application-structure."
+        )
     config_json = langgraph_cli.config.validate_config_file(config)
     warn_non_wolfi_distro(config_json, emit=em.note)
 

--- a/libs/cli/langgraph_cli/deploy.py
+++ b/libs/cli/langgraph_cli/deploy.py
@@ -1604,11 +1604,15 @@ def _deploy_cmd(
     # -- 1. Preflight --
     validate_deploy_commands(install_command, build_command)
     if not config.exists():
-        raise click.ClickException(
+        message = (
             "We couldn't find a langgraph.json file. Run `langgraph deploy` from "
             "the root of a LangSmith Deployment project. To get started, visit "
             "https://docs.langchain.com/langsmith/application-structure."
         )
+        if json_output:
+            em.error(message)
+            raise click.exceptions.Exit(1)
+        raise click.ClickException(message)
     config_json = langgraph_cli.config.validate_config_file(config)
     warn_non_wolfi_distro(config_json, emit=em.note)
 

--- a/libs/cli/langgraph_cli/deploy.py
+++ b/libs/cli/langgraph_cli/deploy.py
@@ -1607,7 +1607,7 @@ def _deploy_cmd(
         message = (
             "We couldn't find a langgraph.json file. Run `langgraph deploy` from "
             "the root of a LangSmith Deployment project. To get started, visit "
-            "https://docs.langchain.com/langsmith/application-structure."
+            "https://docs.langchain.com/langsmith/deployment-quickstart."
         )
         if json_output:
             em.error(message)

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -333,6 +333,18 @@ def test_deploy_missing_config_shows_actionable_error(tmp_path, monkeypatch) -> 
     assert "Traceback" not in result.output
 
 
+def test_deploy_missing_config_emits_json_error(tmp_path, monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(cli, ["deploy", "--json"])
+
+    assert result.exit_code == 1
+    events = [json.loads(line) for line in result.output.splitlines()]
+    assert events[-1]["event"] == "error"
+    assert "We couldn't find a langgraph.json file." in events[-1]["message"]
+
+
 def test_dev_command_requires_ssl_certfile_and_keyfile_together(tmp_path) -> None:
     config_path = tmp_path / "langgraph.json"
     config_path.write_text(

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -329,7 +329,7 @@ def test_deploy_missing_config_shows_actionable_error(tmp_path, monkeypatch) -> 
     assert result.exit_code == 1
     assert "We couldn't find a langgraph.json file." in result.output
     assert "Run `langgraph deploy` from the root" in result.output
-    assert "https://docs.langchain.com/langsmith/application-structure" in result.output
+    assert "https://docs.langchain.com/langsmith/deployment-quickstart" in result.output
     assert "Traceback" not in result.output
 
 

--- a/libs/cli/tests/unit_tests/cli/test_cli.py
+++ b/libs/cli/tests/unit_tests/cli/test_cli.py
@@ -320,6 +320,19 @@ def test_top_level_help_truncates_command_descriptions_to_single_line() -> None:
     assert "[Beta] List LangSmith Deployments." in deploy_list_line
 
 
+def test_deploy_missing_config_shows_actionable_error(tmp_path, monkeypatch) -> None:
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(cli, ["deploy"])
+
+    assert result.exit_code == 1
+    assert "We couldn't find a langgraph.json file." in result.output
+    assert "Run `langgraph deploy` from the root" in result.output
+    assert "https://docs.langchain.com/langsmith/application-structure" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_dev_command_requires_ssl_certfile_and_keyfile_together(tmp_path) -> None:
     config_path = tmp_path / "langgraph.json"
     config_path.write_text(


### PR DESCRIPTION
Shows an actionable, docs-linked error when `langgraph deploy` is run without a `langgraph.json` instead of exposing a traceback.

## Testing (manual)
```sh
❯ uv run --project libs/cli langgraph deploy
Uninstalled 6 packages in 34ms
Installed 6 packages in 5ms
Note: 'langgraph deploy' is in beta. Expect frequent updates and improvements.

Error: We couldn't find a langgraph.json file. Run `langgraph deploy` from the root of a LangSmith Deployment project. To get started, visit https://docs.langchain.com/langsmith/deployment-quickstart.
```

```sh
❯ uv run --project libs/cli langgraph deploy --json

{"event": "note", "message": "Note: 'langgraph deploy' is in beta. Expect frequent updates and improvements."}
{"event": "error", "message": "We couldn't find a langgraph.json file. Run `langgraph deploy` from the root of a LangSmith Deployment project. To get started, visit https://docs.langchain.com/langsmith/deployment-quickstart."}
```