### PR TITLE
perf(langgraph): compute UntrackedValue channel check once per loop

### DIFF
--- a/libs/langgraph/langgraph/pregel/_loop.py
+++ b/libs/langgraph/langgraph/pregel/_loop.py
@@ -437,9 +437,17 @@ class PregelLoop:
             writes_to_save = writes
 
         # check if any writes are to an UntrackedValue channel
-        if any(
-            isinstance(channel, UntrackedValue) for channel in self.channels.values()
-        ):
+        # Whether any channel is an UntrackedValue depends only on `channels`,
+        # which is fixed for the lifetime of the loop - compute it once instead of
+        # rescanning every channel on every put_writes (O(tasks * channels)).
+        has_untracked = getattr(self, "_has_untracked_value", None)
+        if has_untracked is None:
+            has_untracked = any(
+                isinstance(channel, UntrackedValue)
+                for channel in self.channels.values()
+            )
+            self._has_untracked_value = has_untracked
+        if has_untracked:
             # we do not persist untracked values in checkpoints
             writes_to_save = [
                 # sanitize UntrackedValues that are nested within Send packets


### PR DESCRIPTION
Fixes #8857

`put_writes` is called once per task and began by rescanning every channel:

```python
if any(isinstance(channel, UntrackedValue) for channel in self.channels.values()):
```

That value depends only on `self.channels`, which is fixed for the lifetime of the loop, so this PR resolves it once and caches it on the loop instance (both sync and async paths).

**Microbenchmark** of the check (rescan per task vs once):

| channels | tasks | before | after | speedup |
|---|---|---|---|---|
| 20 | 800 | 5.03 ms | 0.021 ms | 243x |
| 100 | 800 | 26.20 ms | 0.041 ms | 645x |
| 400 | 800 | 101.96 ms | 0.115 ms | 890x |

**Fan-out profile (150 parallel branches, 8 runs)**

- `_loop.py:440(<genexpr>)`: was the most-called frame at **188,480 calls** - gone from the profile
- `put_writes` cumulative: **1.097 s -> 0.686 s (-37%)**
- total function calls: **2,740,017 -> 1,951,564**

**Compatibility**: cache is per-loop, and `channels` is never reassigned during a loop's lifetime, so behaviour is unchanged; different graphs get their own value.

**Tests**: pregel core 767 passed; `-k "untracked or managed"` 8 passed, 1 skipped.