### PR TITLE
perf(langgraph): check only the newly finished future in on_done (O(n^2) -> O(n))

### DIFF
--- a/libs/langgraph/langgraph/pregel/_runner.py
+++ b/libs/langgraph/langgraph/pregel/_runner.py
@@ -100,6 +100,9 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
         self.should_stop = should_stop
         self.counter = 0
         self.done: set[F] = set()
+        # Set once a stop condition has been detected, so later completions don't
+        # re-run the check.
+        self._stop = False
 
     def __setitem__(
         self,
@@ -128,7 +131,15 @@ class FuturesDict(Generic[F, E], dict[F, PregelExecutableTask | None]):
                 self.counter -= 1
                 # Wake waiter when all tracked futures are done, or when runner-level
                 # stop condition is met (for example, a non-handled fatal exception).
-                if self.counter == 0 or self.should_stop(self.done):
+                #
+                # Only the newly finished future needs checking: futures already in
+                # `done` were checked when they were added and cannot change state
+                # afterwards, so rescanning the whole set on every completion is
+                # O(n^2) in the number of tasks.
+                if self.counter == 0 or self._stop:
+                    self.event.set()
+                elif self.should_stop({fut}):
+                    self._stop = True
                     self.event.set()
 
 


### PR DESCRIPTION
Fixes #8859

`on_done` woke the waiter with `self.should_stop(self.done)`, where `done` is the accumulated set - so the k-th completion rescanned k futures, i.e. **O(tasks^2)** per superstep.

A finished future cannot change state, so only the newly finished one can change the answer. This PR checks just that future and remembers a positive result.

```python
if self.counter == 0 or self._stop:
    self.event.set()
elif self.should_stop({fut}):
    self._stop = True
    self.event.set()
```

**Microbenchmark** (worst case: all futures succeed, so the scan never short-circuits)

| tasks | before | after | speedup |
|---|---|---|---|
| 400 | 142.26 ms | 0.59 ms | 242x |
| 1,200 | 1,182.43 ms | 2.19 ms | 541x |
| 2,400 | 4,153.22 ms | 3.39 ms | 1225x |

Quadratic check (300 -> 1,200 tasks, i.e. 4x): before **17.7x** (~16x = O(n^2)), after **4.2x** (linear).

**Fan-out profile (150 branches x 8 runs)**: `_should_stop_others` (cumtime 0.436 s) and `on_done` (cumtime 0.732 s) disappear from the profile; total 2.212 s -> 1.260 s, calls 2.74M -> 1.07M.

**Tests**: pregel core 767 passed; cancel/timeout/concurrency/stop 113 passed, 1 skipped.