### PR TITLE
fix(checkpoint-postgres): reject stale shallow checkpoints

### DIFF
--- a/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
+++ b/libs/checkpoint-postgres/langgraph/checkpoint/postgres/shallow.py
@@ -126,7 +126,9 @@ UPSERT_CHECKPOINTS_SQL = """
     ON CONFLICT (thread_id, checkpoint_ns)
     DO UPDATE SET
         checkpoint = EXCLUDED.checkpoint,
-        metadata = EXCLUDED.metadata;
+        metadata = EXCLUDED.metadata
+    WHERE checkpoints.checkpoint->>'id' <= EXCLUDED.checkpoint->>'id'
+    RETURNING checkpoint->>'id' AS checkpoint_id;
 """
 
 UPSERT_CHECKPOINT_WRITES_SQL = """
@@ -409,6 +411,7 @@ class ShallowPostgresSaver(BasePostgresSaver):
         checkpoint_ns = configurable.pop("checkpoint_ns")
 
         copy = checkpoint.copy()
+        channel_values = copy.pop("channel_values")
         next_config = {
             "configurable": {
                 "thread_id": thread_id,
@@ -417,7 +420,27 @@ class ShallowPostgresSaver(BasePostgresSaver):
             }
         }
 
-        with self._cursor(pipeline=True) as cur:
+        with self._transaction_cursor() as cur:
+            cur.execute(
+                self.UPSERT_CHECKPOINTS_SQL,
+                (
+                    thread_id,
+                    checkpoint_ns,
+                    Jsonb(copy),
+                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                ),
+            )
+            if cur.fetchone() is None:
+                cur.execute(
+                    """SELECT checkpoint->>'id' AS checkpoint_id
+                    FROM checkpoints
+                    WHERE thread_id = %s AND checkpoint_ns = %s""",
+                    (thread_id, checkpoint_ns),
+                )
+                stored = cur.fetchone()
+                assert stored is not None
+                next_config["configurable"]["checkpoint_id"] = stored["checkpoint_id"]
+                return next_config
             cur.execute(
                 """DELETE FROM checkpoint_writes
                 WHERE thread_id = %s AND checkpoint_ns = %s AND checkpoint_id NOT IN (%s, %s)""",
@@ -434,17 +457,8 @@ class ShallowPostgresSaver(BasePostgresSaver):
                     self.serde,
                     thread_id,
                     checkpoint_ns,
-                    copy.pop("channel_values"),  # type: ignore[misc]
+                    channel_values,
                     new_versions,
-                ),
-            )
-            cur.execute(
-                self.UPSERT_CHECKPOINTS_SQL,
-                (
-                    thread_id,
-                    checkpoint_ns,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
                 ),
             )
         return next_config
@@ -524,6 +538,16 @@ class ShallowPostgresSaver(BasePostgresSaver):
             else:
                 with self.lock, conn.cursor(binary=True, row_factory=dict_row) as cur:
                     yield cur
+
+    @contextmanager
+    def _transaction_cursor(self) -> Iterator[Cursor[DictRow]]:
+        with _internal.get_connection(self.conn) as conn:
+            with (
+                self.lock,
+                conn.transaction(),
+                conn.cursor(binary=True, row_factory=dict_row) as cur,
+            ):
+                yield cur
 
 
 class AsyncShallowPostgresSaver(BasePostgresSaver):
@@ -747,6 +771,7 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
         checkpoint_ns = configurable.pop("checkpoint_ns")
 
         copy = checkpoint.copy()
+        channel_values = copy.pop("channel_values")
         next_config = {
             "configurable": {
                 "thread_id": thread_id,
@@ -755,7 +780,27 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
             }
         }
 
-        async with self._cursor(pipeline=True) as cur:
+        async with self._transaction_cursor() as cur:
+            await cur.execute(
+                self.UPSERT_CHECKPOINTS_SQL,
+                (
+                    thread_id,
+                    checkpoint_ns,
+                    Jsonb(copy),
+                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
+                ),
+            )
+            if await cur.fetchone() is None:
+                await cur.execute(
+                    """SELECT checkpoint->>'id' AS checkpoint_id
+                    FROM checkpoints
+                    WHERE thread_id = %s AND checkpoint_ns = %s""",
+                    (thread_id, checkpoint_ns),
+                )
+                stored = await cur.fetchone()
+                assert stored is not None
+                next_config["configurable"]["checkpoint_id"] = stored["checkpoint_id"]
+                return next_config
             await cur.execute(
                 """DELETE FROM checkpoint_writes
                 WHERE thread_id = %s AND checkpoint_ns = %s AND checkpoint_id NOT IN (%s, %s)""",
@@ -772,17 +817,8 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                     self.serde,
                     thread_id,
                     checkpoint_ns,
-                    copy.pop("channel_values"),  # type: ignore[misc]
+                    channel_values,
                     new_versions,
-                ),
-            )
-            await cur.execute(
-                self.UPSERT_CHECKPOINTS_SQL,
-                (
-                    thread_id,
-                    checkpoint_ns,
-                    Jsonb(copy),
-                    Jsonb(get_serializable_checkpoint_metadata(config, metadata)),
                 ),
             )
         return next_config
@@ -866,6 +902,16 @@ class AsyncShallowPostgresSaver(BasePostgresSaver):
                     conn.cursor(binary=True, row_factory=dict_row) as cur,
                 ):
                     yield cur
+
+    @asynccontextmanager
+    async def _transaction_cursor(self) -> AsyncIterator[AsyncCursor[DictRow]]:
+        async with _ainternal.get_connection(self.conn) as conn:
+            async with (
+                self.lock,
+                conn.transaction(),
+                conn.cursor(binary=True, row_factory=dict_row) as cur,
+            ):
+                yield cur
 
     def list(
         self,

--- a/libs/checkpoint-postgres/tests/test_async.py
+++ b/libs/checkpoint-postgres/tests/test_async.py
@@ -278,6 +278,34 @@ async def test_asearch(saver_name: str, test_data) -> None:
         } == {"", "inner"}
 
 
+async def test_shallow_saver_ignores_stale_checkpoint() -> None:
+    config: RunnableConfig = {
+        "configurable": {
+            "thread_id": "stale-checkpoint",
+            "checkpoint_ns": "",
+        }
+    }
+    stale = empty_checkpoint()
+    stale["id"] = "00000000-0000-0000-0000-000000000001"
+    stale["channel_values"] = {"value": "stale"}
+    stale["channel_versions"] = {"value": "1"}
+    newer = empty_checkpoint()
+    newer["id"] = "00000000-0000-0000-0000-000000000002"
+    newer["channel_values"] = {"value": "newer"}
+    newer["channel_versions"] = {"value": "2"}
+
+    async with _shallow_saver() as saver:
+        await saver.aput(config, newer, {}, {"value": "2"})
+        saved_config = await saver.aput(config, stale, {}, {"value": "1"})
+
+        saved = await saver.aget_tuple(config)
+
+    assert saved_config["configurable"]["checkpoint_id"] == newer["id"]
+    assert saved is not None
+    assert saved.checkpoint["id"] == newer["id"]
+    assert saved.checkpoint["channel_values"] == {"value": "newer"}
+
+
 @pytest.mark.parametrize("saver_name", ["base", "pool", "pipe", "shallow"])
 async def test_null_chars(saver_name: str, test_data) -> None:
     async with _saver(saver_name) as saver:


### PR DESCRIPTION
Fixes #8810

A cancelled `durability="exit"` run can finish writing an older shallow checkpoint after a replacement run has already saved newer state, rolling the thread back to the stale value.

The shallow saver keeps one row per thread and namespace, so the late write simply overwrote the newer one. Checkpoint writes now compare the stored checkpoint ID against the incoming one and reject the older write, leaving checkpoint blobs and pending writes untouched. The accepted update and its dependent rows stay in a single transaction. No breaking changes.

## How did you verify your code works?

A regression test drives two independent PostgreSQL connections and asserts the newer checkpoint survives. It fails on `main` and passes here.

```console
$ cd libs/checkpoint-postgres && make test
tests/test_async.py::test_shallow_saver_ignores_stale_checkpoint FAILED   [100%]
>       assert saved_config["configurable"]["checkpoint_id"] == newer["id"]
E       AssertionError: assert '00000000-0000-0000-0000-000000000001' == '00000000-0000-0000-0000-000000000002'

# on this branch
tests/test_async.py::test_shallow_saver_ignores_stale_checkpoint PASSED   [100%]
All PostgreSQL versions tested successfully
```

## Social handles (optional)
