### PR TITLE
feat(langgraph): restrict stream_mode="messages" to specific state keys (#6798)

### DIFF
--- a/libs/langgraph/langgraph/_internal/_constants.py
+++ b/libs/langgraph/langgraph/_internal/_constants.py
@@ -72,6 +72,9 @@ CONFIG_KEY_RUNTIME = sys.intern("__pregel_runtime")
 CONFIG_KEY_RESUME_MAP = sys.intern("__pregel_resume_map")
 # holds a mapping of task ns -> resume value for resuming tasks
 CONFIG_KEY_STREAM_MESSAGES_V2 = sys.intern("__pregel_stream_messages_v2")
+# Restrict `stream_mode="messages"` to these state keys, so internal message
+# fields are not streamed to the client (#6798).
+CONFIG_KEY_STREAM_MESSAGES_KEYS = sys.intern("__pregel_stream_messages_keys")
 # when True, attach StreamMessagesHandlerV2 so content-block (v2) events
 # flow through stream_mode="messages"; set by StreamingHandler only.
 CONFIG_KEY_NODE_ERROR = sys.intern("__pregel_node_error")

--- a/libs/langgraph/langgraph/pregel/_messages.py
+++ b/libs/langgraph/langgraph/pregel/_messages.py
@@ -35,14 +35,27 @@ T = TypeVar("T")
 Meta = tuple[tuple[str, ...], dict[str, Any]]
 
 
-def _state_values(obj: Any) -> Sequence[Any]:
-    """Extract top-level field values from a state object (dict, BaseModel, or dataclass)."""
+def _state_values(obj: Any, keys: Sequence[str] | None = None) -> Sequence[Any]:
+    """Extract top-level field values from a state object (dict, BaseModel, or dataclass).
+
+    If `keys` is provided, only those fields are returned. This lets
+    `stream_mode="messages"` be restricted to specific state keys, so internal
+    message fields are not leaked to the client (#6798).
+    """
     if isinstance(obj, dict):
-        return list(obj.values())
+        if keys is None:
+            return list(obj.values())
+        return [obj[k] for k in keys if k in obj]
     elif isinstance(obj, BaseModel):
-        return [getattr(obj, k) for k in type(obj).model_fields]
+        field_names = set(type(obj).model_fields)
+        if keys is None:
+            return [getattr(obj, k) for k in type(obj).model_fields]
+        return [getattr(obj, k) for k in keys if k in field_names]
     elif is_dataclass(obj) and not isinstance(obj, type):
-        return [getattr(obj, f.name) for f in fields(obj)]
+        names = {f.name for f in fields(obj)}
+        if keys is None:
+            return [getattr(obj, f.name) for f in fields(obj)]
+        return [getattr(obj, k) for k in keys if k in names]
     return ()
 
 
@@ -63,6 +76,7 @@ class StreamMessagesHandler(BaseCallbackHandler, _StreamingCallbackHandler):
         subgraphs: bool,
         *,
         parent_ns: tuple[str, ...] | None = None,
+        state_keys: Sequence[str] | None = None,
     ) -> None:
         """Configure the handler to stream messages from LLMs and nodes.
 
@@ -93,6 +107,7 @@ class StreamMessagesHandler(BaseCallbackHandler, _StreamingCallbackHandler):
         self.metadata: dict[UUID, Meta] = {}
         self.seen: set[int | str] = set()
         self.parent_ns = parent_ns
+        self.state_keys = state_keys
 
     def _emit(self, meta: Meta, message: BaseMessage, *, dedupe: bool = False) -> None:
         if dedupe and message.id in self.seen:
@@ -111,7 +126,7 @@ class StreamMessagesHandler(BaseCallbackHandler, _StreamingCallbackHandler):
                 if isinstance(value, BaseMessage):
                     self._emit(meta, value, dedupe=True)
         else:
-            for value in _state_values(response):
+            for value in _state_values(response, self.state_keys):
                 if isinstance(value, BaseMessage):
                     self._emit(meta, value, dedupe=True)
                 elif isinstance(value, Sequence):
@@ -321,7 +336,7 @@ class StreamMessagesHandlerV2(StreamMessagesHandler, _V2StreamingCallbackHandler
                 ):
                     self._emit(meta, value, dedupe=True)
         else:
-            for value in _state_values(response):
+            for value in _state_values(response, self.state_keys):
                 if isinstance(value, BaseMessage) and not isinstance(
                     value, ToolMessage
                 ):

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -76,6 +76,7 @@ from langgraph._internal._constants import (
     CONFIG_KEY_RUNTIME,
     CONFIG_KEY_SEND,
     CONFIG_KEY_STREAM,
+    CONFIG_KEY_STREAM_MESSAGES_KEYS,
     CONFIG_KEY_STREAM_MESSAGES_V2,
     CONFIG_KEY_TASK_ID,
     CONFIG_KEY_THREAD_ID,
@@ -2823,6 +2824,7 @@ class Pregel(
                         stream.put,
                         subgraphs,
                         parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
+                        state_keys=config[CONF].get(CONFIG_KEY_STREAM_MESSAGES_KEYS),
                     )
                 )
 
@@ -3251,6 +3253,7 @@ class Pregel(
                         stream_put,
                         subgraphs,
                         parent_ns=tuple(ns_.split(NS_SEP)) if ns_ else None,
+                        state_keys=config[CONF].get(CONFIG_KEY_STREAM_MESSAGES_KEYS),
                     )
                 )
 

--- a/libs/langgraph/tests/test_messages_stream_keys.py
+++ b/libs/langgraph/tests/test_messages_stream_keys.py
@@ -1,0 +1,97 @@
+"""`stream_mode="messages"` can be restricted to specific state keys (#6798).
+
+Default behaviour must stay unchanged: without configuration, every message
+found in the state is streamed.
+"""
+from operator import add
+from typing import Annotated, TypedDict
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.graph import END, START, StateGraph
+
+pytestmark = pytest.mark.anyio
+
+PUBLIC = "public reply"
+SECRET = "internal reasoning - should not leak"
+
+
+class State(TypedDict):
+    messages: Annotated[list, add]
+    agent_messages: Annotated[list, add]
+
+
+def node(state: State) -> State:
+    return {
+        "messages": [AIMessage(content=PUBLIC)],
+        "agent_messages": [AIMessage(content=SECRET)],
+    }
+
+
+def build():
+    b = StateGraph(State)
+    b.add_node("n", node)
+    b.add_edge(START, "n")
+    b.add_edge("n", END)
+    return b.compile()
+
+
+INPUT = {"messages": [], "agent_messages": []}
+
+
+def streamed(config=None):
+    chunks = list(build().stream(INPUT, config=config, stream_mode="messages"))
+    return [c[0].content for c in chunks]
+
+
+async def astreamed(config=None):
+    chunks = [
+        chunk
+        async for chunk in build().astream(INPUT, config=config, stream_mode="messages")
+    ]
+    return [c[0].content for c in chunks]
+
+
+def test_default_streams_every_message_field():
+    """Backwards compatibility: no config means everything is streamed."""
+    contents = streamed()
+    assert PUBLIC in contents
+    assert SECRET in contents
+
+
+def test_restricted_to_configured_keys_only():
+    config = {"configurable": {"__pregel_stream_messages_keys": ["messages"]}}
+    contents = streamed(config)
+    assert PUBLIC in contents
+    assert SECRET not in contents
+
+
+def test_other_key_can_be_selected_instead():
+    config = {"configurable": {"__pregel_stream_messages_keys": ["agent_messages"]}}
+    contents = streamed(config)
+    assert PUBLIC not in contents
+    assert SECRET in contents
+
+
+def test_unknown_key_streams_nothing():
+    config = {"configurable": {"__pregel_stream_messages_keys": ["nope"]}}
+    assert streamed(config) == []
+
+
+async def test_astream_default_streams_every_message_field():
+    """`astream` must behave exactly like `stream` when no keys are configured."""
+    contents = await astreamed()
+    assert PUBLIC in contents
+    assert SECRET in contents
+
+
+async def test_astream_restricted_to_configured_keys_only():
+    config = {"configurable": {"__pregel_stream_messages_keys": ["messages"]}}
+    contents = await astreamed(config)
+    assert PUBLIC in contents
+    assert SECRET not in contents
+
+
+async def test_astream_unknown_key_streams_nothing():
+    config = {"configurable": {"__pregel_stream_messages_keys": ["nope"]}}
+    assert await astreamed(config) == []


### PR DESCRIPTION
## Summary
Closes #6798.

`stream_mode="messages"` currently streams **every** `BaseMessage` found in the state, so an internal reasoning channel (e.g. `agent_messages`) is leaked to the client with no server-side way to prevent it.

This adds a `configurable["__pregel_stream_messages_keys"]` option. When set, only the listed state keys are scanned for messages to stream. When unset, behaviour is exactly as before (covered by a backwards-compat test).

## How it works
- `_state_values(obj, keys=None)` now filters top-level fields when `keys` is given (dict / BaseModel / dataclass).
- `StreamMessagesHandler` / `StreamMessagesHandlerV2` accept `state_keys` and use it when scanning node output for messages.
- Both `Pregel.stream()` and `Pregel.astream()` read `CONFIG_KEY_STREAM_MESSAGES_KEYS` from the run config and pass it to the handler.

Server-side usage (so the leak is preventable without touching client code):
```python
graph.stream(
    input,
    stream_mode="messages",
    config={"configurable": {"__pregel_stream_messages_keys": ["messages"]}},
)
```

`astream()` honours the same option:
```python
async for chunk in graph.astream(
    input,
    stream_mode="messages",
    config={"configurable": {"__pregel_stream_messages_keys": ["messages"]}},
):
    ...
```

## Tests
`tests/test_messages_stream_keys.py` — 7 cases covering both the sync and async paths:
- default streams every message field (sync + async)
- restricted to `["messages"]` — internal `agent_messages` not streamed (sync + async)
- can select the other key instead (sync)
- unknown key streams nothing (sync + async)

The restricted / unknown-key async cases fail without the `astream()` wiring, so both paths are locked in.

## Note on #6878
@mrutunjay-kinagi's PR #6878 implemented a similar idea but has been untouched since 2026-03-24 and currently reports `mergeable_state=dirty`. This PR takes a smaller, config-driven approach with no public signature change. Happy to rework it onto #6878's `messages_key=` kwarg, or to close mine, if that API shape is preferred.
