### PR TITLE
fix(checkpoint): make RedisCache key encoding injective

### DIFF
--- a/libs/checkpoint/langgraph/cache/redis/__init__.py
+++ b/libs/checkpoint/langgraph/cache/redis/__init__.py
@@ -2,9 +2,23 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from typing import Any
+from urllib.parse import quote, unquote
 
 from langgraph.cache.base import BaseCache, FullKey, Namespace, ValueT
 from langgraph.checkpoint.serde.base import SerializerProtocol
+
+
+def _encode_segment(segment: str) -> str:
+    """Percent-encode a namespace segment or cache key.
+
+    Escaping every character outside `[A-Za-z0-9_.~-]` guarantees that an
+    encoded segment can never contain the `:` separator (or the Redis glob
+    metacharacters `*`, `?`, `[` and `]`), which makes the joined key
+    injective: distinct `(namespace, key)` pairs always map to distinct
+    Redis keys. Segments without reserved characters are unchanged, so keys
+    produced by earlier releases remain valid for them.
+    """
+    return quote(segment, safe="")
 
 
 class RedisCache(BaseCache[ValueT]):
@@ -29,9 +43,15 @@ class RedisCache(BaseCache[ValueT]):
         self.prefix = prefix
 
     def _make_key(self, ns: Namespace, key: str) -> str:
-        """Create a Redis key from namespace and key."""
-        ns_str = ":".join(ns) if ns else ""
-        return f"{self.prefix}{ns_str}:{key}" if ns_str else f"{self.prefix}{key}"
+        """Create a Redis key from namespace and key.
+
+        Each namespace segment and the key are percent-encoded before being
+        joined with `:` so that separators occurring inside segments cannot
+        collide with the segment boundaries (e.g. `(("a", "b"), "k")` versus
+        `(("a:b",), "k")`).
+        """
+        parts = [_encode_segment(segment) for segment in (*ns, key)]
+        return f"{self.prefix}{':'.join(parts)}"
 
     def _parse_key(self, redis_key: str) -> tuple[Namespace, str]:
         """Parse a Redis key back to namespace and key."""
@@ -41,13 +61,8 @@ class RedisCache(BaseCache[ValueT]):
             )
 
         remaining = redis_key[len(self.prefix) :]
-        if ":" in remaining:
-            parts = remaining.split(":")
-            key = parts[-1]
-            ns_parts = parts[:-1]
-            return (tuple(ns_parts), key)
-        else:
-            return (tuple(), remaining)
+        *ns_parts, key = remaining.split(":")
+        return (tuple(unquote(part) for part in ns_parts), unquote(key))
 
     def get(self, keys: Sequence[FullKey]) -> dict[FullKey, ValueT]:
         """Get the cached values for the given keys."""
@@ -125,7 +140,9 @@ class RedisCache(BaseCache[ValueT]):
                 # Clear specific namespaces
                 keys_to_delete = []
                 for ns in namespaces:
-                    ns_str = ":".join(ns) if ns else ""
+                    # Encoded segments contain no glob metacharacters, so the
+                    # pattern matches exactly the requested namespace.
+                    ns_str = ":".join(_encode_segment(segment) for segment in ns)
                     pattern = (
                         f"{self.prefix}{ns_str}:*" if ns_str else f"{self.prefix}*"
                     )

--- a/libs/checkpoint/tests/test_redis_cache.py
+++ b/libs/checkpoint/tests/test_redis_cache.py
@@ -1,12 +1,151 @@
 """Unit tests for Redis cache implementation."""
 
+import fnmatch
+import itertools
 import time
+from typing import Any
 
 import pytest
 import redis
 
 from langgraph.cache.base import FullKey
 from langgraph.cache.redis import RedisCache
+
+
+class FakePipeline:
+    """Minimal in-memory stand-in for a Redis pipeline."""
+
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self.store = store
+
+    def set(self, key: str, value: bytes) -> None:
+        self.store[key] = value
+
+    def setex(self, key: str, ttl: int, value: bytes) -> None:
+        self.store[key] = value
+
+    def execute(self) -> list[Any]:
+        return []
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for a Redis client (no server needed)."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    def mget(self, keys: list[str]) -> list[bytes | None]:
+        return [self.store.get(key) for key in keys]
+
+    def pipeline(self) -> FakePipeline:
+        return FakePipeline(self.store)
+
+    def keys(self, pattern: str) -> list[str]:
+        return [key for key in self.store if fnmatch.fnmatchcase(key, pattern)]
+
+    def delete(self, *keys: str) -> None:
+        for key in keys:
+            self.store.pop(key, None)
+
+
+class TestRedisCacheKeyEncoding:
+    """Regression tests for issue #8851: non-injective key encoding.
+
+    These tests exercise the key encoding only and do not require a live
+    Redis server.
+    """
+
+    def make_cache(self) -> tuple[RedisCache, FakeRedis]:
+        client = FakeRedis()
+        return RedisCache(client, prefix="test:cache:"), client
+
+    def test_make_key_is_injective(self) -> None:
+        """Distinct FullKeys must map to distinct Redis keys."""
+        cache, _ = self.make_cache()
+        full_keys: list[FullKey] = [
+            (("a", "b"), "k"),
+            (("a:b",), "k"),
+            (("a",), "b:k"),
+            ((), "a:b"),
+            (("a",), "b"),
+            ((), "a"),
+            (("a", "b", "c"), "k"),
+            (("a:b:c",), "k"),
+        ]
+        redis_keys = [cache._make_key(ns, key) for ns, key in full_keys]
+        for (left_full, left), (right_full, right) in itertools.combinations(
+            zip(full_keys, redis_keys, strict=True), 2
+        ):
+            assert left != right, f"{left_full} and {right_full} both encode to {left}"
+
+    def test_parse_key_round_trip(self) -> None:
+        """_parse_key must invert _make_key exactly."""
+        cache, _ = self.make_cache()
+        full_keys: list[FullKey] = [
+            (("a", "b"), "k"),
+            (("a:b",), "k"),
+            (("a",), "b:k"),
+            ((), "a:b"),
+            (("graph:with:colons", "node"), "key"),
+            (("with space", "with%percent"), "with*glob"),
+            ((), "plain"),
+        ]
+        for ns, key in full_keys:
+            assert cache._parse_key(cache._make_key(ns, key)) == (ns, key)
+
+    def test_plain_segments_keep_legacy_encoding(self) -> None:
+        """Keys without reserved characters keep their pre-fix Redis keys."""
+        cache, _ = self.make_cache()
+        assert (
+            cache._make_key(("graph", "node"), "key1") == "test:cache:graph:node:key1"
+        )
+        assert cache._make_key((), "key1") == "test:cache:key1"
+
+    def test_colliding_logical_keys_store_independent_values(self) -> None:
+        """Logical keys that previously collided must not overwrite each other."""
+        cache, _ = self.make_cache()
+        key1: FullKey = (("a", "b"), "k")
+        key2: FullKey = (("a:b",), "k")
+        key3: FullKey = (("a",), "b:k")
+
+        cache.set(
+            {
+                key1: ({"value": 1}, None),
+                key2: ({"value": 2}, None),
+                key3: ({"value": 3}, None),
+            }
+        )
+
+        result = cache.get([key1, key2, key3])
+        assert result[key1] == {"value": 1}
+        assert result[key2] == {"value": 2}
+        assert result[key3] == {"value": 3}
+
+    def test_clear_namespace_with_colon_is_unambiguous(self) -> None:
+        """clear() must not delete a sibling namespace whose encoded prefix
+        would overlap under the old colon-joined encoding."""
+        cache, client = self.make_cache()
+        nested: FullKey = (("a", "b"), "k")
+        colon: FullKey = (("a:b",), "k")
+        cache.set({nested: ({"value": 1}, None), colon: ({"value": 2}, None)})
+
+        # Clearing ("a:b",) must leave ("a", "b") untouched.
+        cache.clear([("a:b",)])
+        result = cache.get([nested, colon])
+        assert result == {nested: {"value": 1}}
+
+        # And clearing ("a",) must clear the nested namespace, not ("a:b",).
+        cache.set({colon: ({"value": 2}, None)})
+        cache.clear([("a",)])
+        result = cache.get([nested, colon])
+        assert result == {colon: {"value": 2}}
+
+    def test_clear_all_with_fake_client(self) -> None:
+        cache, client = self.make_cache()
+        cache.set({(("a:b",), "k"): ({"value": 1}, None)})
+        assert client.store
+        cache.clear()
+        assert not client.store
 
 
 class TestRedisCache:


### PR DESCRIPTION
Fixes #8851

`RedisCache._make_key` joins namespace segments and the cache key with `:` without escaping, so distinct `FullKey`s such as `(("a", "b"), "k")` and `(("a:b",), "k")` map to the same Redis key — a later `set()` overwrites the other entry, and namespace-targeted `clear()` is ambiguous. This PR percent-encodes each namespace segment and the key before joining, which makes the encoding injective and round-trippable via `_parse_key`.

Backward compatibility: segments without reserved characters encode to themselves, so the Redis keys for typical namespaces/keys are byte-for-byte unchanged and existing cache entries remain valid. Only previously ambiguous keys (containing `:` etc.) change, and those simply miss and are recomputed. As a side effect, encoded segments contain no Redis glob metacharacters, so the `clear()` patterns match exactly the requested namespace.

How I verified:

- Reproduced the issue's collision cases on main (`(("a", "b"), "k")`, `(("a:b",), "k")`, `(("a",), "b:k")`, `((), "a:b")` all encoded to `langgraph:cache:a:b:k` / `langgraph:cache:a:b`), then confirmed all pairs are distinct after the change.
- Added `TestRedisCacheKeyEncoding` to `libs/checkpoint/tests/test_redis_cache.py` (no live Redis server required, per the issue's regression-coverage suggestion): injectivity for the issue's cases, `_parse_key` round-trip, legacy-key stability for plain segments, independent values for previously colliding logical keys via a fake client, and unambiguous `clear()` for namespaces containing `:`. All 6 pass; `ruff format` / `ruff check` (including import sorting) are clean.
