### PR TITLE
feat(langgraph): bind context at the graph level (#7990)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1399,10 +1399,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
 
+        compiled = compiled.validate()
         if context is not None:
-                    compiled.bound_context = context
-
-        return compiled.validate()
+            compiled.bound_context = context
+        return compiled
 
 
 class CompiledStateGraph(

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        context: Any | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1398,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if context is not None:
+                    compiled.bound_context = context
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2870,7 +2870,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,
@@ -3313,7 +3318,12 @@ class Pregel(
             server_info = _build_server_info(config, parent_runtime)
 
             runtime = Runtime(
-                context=_coerce_context(self.context_schema, context),
+                context=_coerce_context(
+                    self.context_schema,
+                    context
+                    if context is not None
+                    else getattr(self, "bound_context", None),
+                ),
                 store=store,
                 stream_writer=stream_writer,
                 previous=None,

--- a/libs/langgraph/tests/test_graph_context_binding.py
+++ b/libs/langgraph/tests/test_graph_context_binding.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import TypedDict
+
+from langgraph.graph import StateGraph
+from langgraph.runtime import Runtime
+
+
+@dataclass
+class Ctx:
+    v: str
+
+
+class State(TypedDict, total=False):
+    out: str
+
+
+def _build(bound: Ctx):
+    def node(state: State, runtime: Runtime[Ctx]) -> State:
+        return {"out": runtime.context.v if runtime.context else None}
+
+    return (
+        StateGraph(State, context_schema=Ctx)
+        .add_node("n", node)
+        .set_entry_point("n")
+        .set_finish_point("n")
+        .compile(context=bound)
+    )
+
+
+def test_bound_context_used_when_invoke_omits_it():
+    graph = _build(Ctx(v="bound"))
+    assert graph.invoke({})["out"] == "bound"
+
+
+def test_invoke_context_overrides_bound_context():
+    graph = _build(Ctx(v="bound"))
+    assert graph.invoke({}, context=Ctx(v="per-invoke"))["out"] == "per-invoke"


### PR DESCRIPTION
## Summary
Allow binding a default context at compile time so graph nodes can read `runtime.context` without callers passing it on every `invoke`.

## Why
Graphs often have a single server-supplied run context; requiring callers to pass `context=` on every invoke is repetitive and error-prone.

## Changes
`StateGraph.compile(context=...)` stores `compiled.bound_context`; `CompiledStateGraph.stream`/`astream` fall back to `bound_context` when no per-invoke `context` is given; per-invoke `context` still overrides the bound default.

## Test plan / QA
- tests/test_graph_context_binding.py - 2 passed (bound context used when invoke omits it; per-invoke context overrides bound).
- All feature branches rebased on `origin/main`; changes are guarded (no-op when the feature is not used), so existing behavior is unchanged.

## Checklist
- [x] Tests added/updated and passing
- [x] Changes are scoped to this issue only
- [x] `Closes #7990`

Closes #7990
