### PR TITLE
feat(langgraph): input validators for client updates (#7119)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,8 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        input_validators: Sequence[Callable[[dict[str, Any]], dict[str, Any]]]
+        | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1399,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if input_validators:
+                    compiled.input_validators = list(input_validators)
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1400,10 +1400,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
 
+        compiled = compiled.validate()
         if input_validators:
-                    compiled.input_validators = list(input_validators)
-
-        return compiled.validate()
+            compiled.input_validators = list(input_validators)
+        return compiled
 
 
 class CompiledStateGraph(

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -2523,6 +2523,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return self.bulk_update_state(config, [[StateUpdate(values, as_node, task_id)]])
 
     async def aupdate_state(
@@ -2536,6 +2539,9 @@ class Pregel(
         node `as_node`. If `as_node` is not provided, it will be set to the last node
         that updated the state, if not ambiguous.
         """
+        if getattr(self, "input_validators", None):
+            for _validator in self.input_validators:
+                values = _validator(values)
         return await self.abulk_update_state(
             config, [[StateUpdate(values, as_node, task_id)]]
         )

--- a/libs/langgraph/tests/test_input_validators.py
+++ b/libs/langgraph/tests/test_input_validators.py
@@ -1,0 +1,54 @@
+from typing import TypedDict
+
+import pytest
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict, total=False):
+    out: str
+    forbidden: int
+
+
+def _build(validators):
+    def node(state: State) -> State:
+        return {"out": "done"}
+
+    return (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=InMemorySaver(), input_validators=validators)
+    )
+
+
+def test_validator_can_rewrite_input():
+    def upper(values: dict) -> dict:
+        values["out"] = (values.get("out") or "").upper()
+        return values
+
+    graph = _build([upper])
+    config = {"configurable": {"thread_id": "t1"}}
+    graph.update_state(config, {"out": "hi"})
+    assert graph.get_state(config).values["out"] == "HI"
+
+
+def test_validator_can_reject_input():
+    def reject(values: dict) -> dict:
+        if "forbidden" in values:
+            raise ValueError("forbidden key")
+        return values
+
+    graph = _build([reject])
+    config = {"configurable": {"thread_id": "t2"}}
+    with pytest.raises(ValueError, match="forbidden key"):
+        graph.update_state(config, {"forbidden": 1})
+
+
+def test_without_validators_input_is_untouched():
+    graph = _build(None)
+    config = {"configurable": {"thread_id": "t3"}}
+    graph.update_state(config, {"out": "plain"})
+    assert graph.get_state(config).values["out"] == "plain"


### PR DESCRIPTION
## Summary
Add input validators to `StateGraph.compile` that transform client-supplied updates before they are written.

## Why
Lets callers enforce append-only / shape / reject semantics on `update_state` at the graph level.

## Changes
`StateGraph.compile(input_validators=[...])` stores `compiled.input_validators`; `update_state`/`aupdate_state` apply each validator to `values` (a validator may rewrite or raise to reject).

## Test plan / QA
- tests/test_input_validators.py - 3 passed (rewrite, reject, and no-validator passthrough).
- All feature branches rebased on `origin/main`; changes are guarded (no-op when the feature is not used), so existing behavior is unchanged.

## Checklist
- [x] Tests added/updated and passing
- [x] Changes are scoped to this issue only
- [x] `Closes #7119`

Closes #7119
