### PR TITLE
feat(langgraph): private channels hidden from public state reads (#8644)

### DIFF
--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1399,10 +1399,10 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
 
+        compiled = compiled.validate()
         if private_channels:
-                    compiled.private_channels = frozenset(private_channels)
-
-        return compiled.validate()
+            compiled.private_channels = frozenset(private_channels)
+        return compiled
 
 
 class CompiledStateGraph(

--- a/libs/langgraph/langgraph/graph/state.py
+++ b/libs/langgraph/langgraph/graph/state.py
@@ -1185,6 +1185,7 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         debug: bool = False,
         name: str | None = None,
         transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
+        private_channels: Sequence[str] | None = None,
     ) -> CompiledStateGraph[StateT, ContextT, InputT, OutputT]:
         """Compiles the `StateGraph` into a `CompiledStateGraph` object.
 
@@ -1397,6 +1398,9 @@ class StateGraph(Generic[StateT, ContextT, InputT, OutputT]):
         for start, branches in self.branches.items():
             for name, branch in branches.items():
                 compiled.attach_branch(start, name, branch)
+
+        if private_channels:
+                    compiled.private_channels = frozenset(private_channels)
 
         return compiled.validate()
 

--- a/libs/langgraph/langgraph/pregel/main.py
+++ b/libs/langgraph/langgraph/pregel/main.py
@@ -1142,6 +1142,13 @@ class Pregel(
                 checkpoint["channel_versions"].values()
             )
 
+    def _public_values(self, values: dict[str, Any]) -> dict[str, Any]:
+        """Hide private channels from public state reads."""
+        channels = getattr(self, "private_channels", None)
+        if not channels:
+            return values
+        return {k: v for k, v in values.items() if k not in channels}
+
     def _prepare_state_snapshot(
         self,
         config: RunnableConfig,
@@ -1255,7 +1262,7 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._public_values(read_channels(channels, self.stream_channels_asis)),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,
@@ -1379,7 +1386,7 @@ class Pregel(
         )
         # assemble the state snapshot
         return StateSnapshot(
-            read_channels(channels, self.stream_channels_asis),
+            self._public_values(read_channels(channels, self.stream_channels_asis)),
             tuple(t.name for t in next_tasks.values() if not t.writes),
             patch_checkpoint_map(saved.config, saved.metadata),
             saved.metadata,

--- a/libs/langgraph/tests/test_private_channels.py
+++ b/libs/langgraph/tests/test_private_channels.py
@@ -1,0 +1,50 @@
+from typing import TypedDict
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict, total=False):
+    visible: str
+    _secret: bytes
+
+
+def _build(private):
+    def node(state: State) -> State:
+        return {"visible": "v", "_secret": b"x" * 8}
+
+    return (
+        StateGraph(State)
+        .add_node("n", node)
+        .add_edge(START, "n")
+        .add_edge("n", END)
+        .compile(checkpointer=InMemorySaver(), private_channels=private)
+    )
+
+
+def test_private_channel_hidden_from_get_state():
+    graph = _build(["_secret"])
+    config = {"configurable": {"thread_id": "p1"}}
+    graph.invoke({}, config)
+    values = graph.get_state(config).values
+    assert "visible" in values
+    assert "_secret" not in values
+
+
+def test_without_private_channels_everything_is_visible():
+    graph = _build(None)
+    config = {"configurable": {"thread_id": "p2"}}
+    graph.invoke({}, config)
+    assert "_secret" in graph.get_state(config).values
+
+
+def test_private_channel_still_persisted_for_later_turns():
+    graph = _build(["_secret"])
+    config = {"configurable": {"thread_id": "p3"}}
+    graph.invoke({}, config)
+    # hidden in public reads...
+    assert "_secret" not in graph.get_state(config).values
+    # ...but still present in the persisted checkpoint
+    saved = graph.checkpointer.get(config)
+    assert saved is not None
+    assert "_secret" in saved["channel_values"]


### PR DESCRIPTION
## Summary
Private channels are hidden from public state reads (`get_state` / `get_state_history`) while still being checkpointed.

## Why
Some channels carry internal state that should not be exposed via public state reads.

## Changes
`StateGraph.compile(private_channels=[...])` stores `compiled.private_channels`; `CompiledStateGraph._public_values` filters them out of the snapshot returned by `_prepare_state_snapshot` (sync and async). The checkpoint still stores them.

## Test plan / QA
- tests/test_private_channels.py - 3 passed (hidden from get_state, still persisted in checkpoint, visible when no private channels declared).
- All feature branches rebased on `origin/main`; changes are guarded (no-op when the feature is not used), so existing behavior is unchanged.

## Checklist
- [x] Tests added/updated and passing
- [x] Changes are scoped to this issue only
- [x] `Closes #8644`

Closes #8644
