### PR TITLE
feat(langgraph): per-node call counting and limits (#5883)

### DIFF
--- a/libs/langgraph/langgraph/pregel/_retry.py
+++ b/libs/langgraph/langgraph/pregel/_retry.py
@@ -613,6 +613,9 @@ def run_with_retry(
         try:
             # clear any writes from previous attempts
             task.writes.clear()
+            # record the call against this node (per-node call limit)
+            if isinstance(runtime, Runtime):
+                runtime.record_node_call(task.name)
             # run the task
             return task.proc.invoke(task.input, config)
         except ParentCommand as exc:

--- a/libs/langgraph/langgraph/runtime.py
+++ b/libs/langgraph/langgraph/runtime.py
@@ -9,6 +9,7 @@ from langgraph_sdk.auth.types import BaseUser
 from typing_extensions import TypedDict, Unpack
 
 from langgraph._internal._constants import CONF, CONFIG_KEY_RUNTIME
+from langgraph.errors import GraphRecursionError
 from langgraph.config import get_config
 from langgraph.types import _DC_KWARGS, StreamWriter
 from langgraph.typing import ContextT
@@ -119,6 +120,13 @@ class _RuntimeOverrides(TypedDict, Generic[ContextT], total=False):
     execution_info: ExecutionInfo
     server_info: ServerInfo | None
     control: RunControl | None
+
+
+class NodeCallLimitError(GraphRecursionError):
+    """Raised when a node exceeds its configured per-node call limit.
+
+    Subclasses `GraphRecursionError` so existing handlers keep working.
+    """
 
 
 @dataclass(**_DC_KWARGS)
@@ -236,6 +244,35 @@ class Runtime(Generic[ContextT]):
     Populated automatically during graph runs. None outside an active
     graph runtime.
     """
+
+    node_call_counts: dict[str, int] = field(default_factory=dict)
+    """Number of times each node has been called during this run.
+
+    Populated by the task execution path, so nodes/guards can read it without
+    threading counters through user state.
+    """
+
+    node_call_limits: dict[str, int] = field(default_factory=dict)
+    """Optional per-node call limits.
+
+    When a node's count exceeds its limit, `record_node_call` raises
+    `NodeCallLimitError`. Nodes without an entry are unlimited.
+    """
+
+    def record_node_call(self, node_name: str) -> int:
+        """Record a call to `node_name` and enforce its limit, if configured.
+
+        Returns the updated call count for `node_name`.
+        """
+        count = self.node_call_counts.get(node_name, 0) + 1
+        self.node_call_counts[node_name] = count
+        limit = self.node_call_limits.get(node_name)
+        if limit is not None and count > limit:
+            raise NodeCallLimitError(
+                f"Node '{node_name}' exceeded its call limit of {limit} "
+                f"(called {count} times)."
+            )
+        return count
 
     def merge(self, other: Runtime[ContextT]) -> Runtime[ContextT]:
         """Merge two runtimes together.

--- a/libs/langgraph/tests/test_node_call_limit.py
+++ b/libs/langgraph/tests/test_node_call_limit.py
@@ -1,0 +1,42 @@
+import pytest
+
+from langgraph.errors import GraphRecursionError
+from langgraph.runtime import NodeCallLimitError, Runtime
+
+
+def test_counts_are_recorded_per_node():
+    rt = Runtime()
+    assert rt.record_node_call("a") == 1
+    assert rt.record_node_call("a") == 2
+    assert rt.record_node_call("b") == 1
+    assert rt.node_call_counts == {"a": 2, "b": 1}
+
+
+def test_limit_is_enforced():
+    rt = Runtime(node_call_limits={"a": 2})
+    rt.record_node_call("a")
+    rt.record_node_call("a")
+    with pytest.raises(NodeCallLimitError):
+        rt.record_node_call("a")
+
+
+def test_unlimited_node_never_raises():
+    rt = Runtime()
+    for _ in range(25):
+        rt.record_node_call("a")
+    assert rt.node_call_counts["a"] == 25
+
+
+def test_limits_only_apply_to_configured_nodes():
+    rt = Runtime(node_call_limits={"a": 1})
+    rt.record_node_call("a")
+    # "b" has no limit configured
+    rt.record_node_call("b")
+    rt.record_node_call("b")
+    assert rt.node_call_counts["b"] == 2
+
+
+def test_error_is_catchable_as_recursion_error():
+    rt = Runtime(node_call_limits={"a": 0})
+    with pytest.raises(GraphRecursionError):
+        rt.record_node_call("a")


### PR DESCRIPTION
## Summary
Per-node call counting and configurable limits, raising `NodeCallLimitError` when exceeded.

## Why
Guard against runaway node invocations.

## Changes
runtime.py adds `NodeCallLimitError` and node call counting (`node_call_counts`, `node_call_limits`, `record_node_call`); _retry.py records calls.

## Test plan / QA
- tests/test_node_call_limit.py - 5 passed.
- All feature branches rebased on `origin/main`; changes are guarded (no-op when the feature is not used), so existing behavior is unchanged.

## Checklist
- [x] Tests added/updated and passing
- [x] Changes are scoped to this issue only
- [x] `Closes #5883`

Closes #5883
