### PR TITLE
perf(langgraph): resolve scratchpad resume lookups once per superstep (#8855)

### DIFF
--- a/libs/langgraph/langgraph/pregel/_algo.py
+++ b/libs/langgraph/langgraph/pregel/_algo.py
@@ -438,6 +438,18 @@ def prepare_next_tasks(
     checkpoint_id_bytes = binascii.unhexlify(checkpoint["id"].replace("-", ""))
     null_version = checkpoint_null_version(checkpoint)
     tasks: list[PregelTask | PregelExecutableTask] = []
+    # Only RESUME writes can match either scratchpad lookup, and the global resume
+    # write is task-independent. Resolve both once per superstep instead of once
+    # per task, so preparing N tasks costs O(writes + N) rather than O(N * writes).
+    null_resume_write: Any = _UNSET
+    resume_writes: list[PendingWrite] = []
+    for w in pending_writes:
+        if w[1] == RESUME:
+            resume_writes.append(w)
+            if w[0] == NULL_TASK_ID and null_resume_write is _UNSET:
+                null_resume_write = w
+    if null_resume_write is _UNSET:
+        null_resume_write = None
     # Consume pending tasks
     tasks_channel = cast(Topic[Send] | None, channels.get(TASKS))
     if tasks_channel and tasks_channel.is_available():
@@ -508,9 +520,15 @@ def prepare_next_tasks(
             input_cache=input_cache,
             cache_policy=cache_policy,
             retry_policy=retry_policy,
+            null_resume_write=null_resume_write,
+            resume_writes=resume_writes,
         ):
             tasks.append(task)
     return {t.id: t for t in tasks}
+
+
+_UNSET: Any = object()
+"""Sentinel for "caller did not supply this", distinct from a supplied `None`."""
 
 
 PUSH_TRIGGER = (PUSH,)
@@ -542,6 +560,8 @@ def prepare_single_task(
     input_cache: dict[INPUT_CACHE_KEY_TYPE, Any] | None = None,
     cache_policy: CachePolicy | None = None,
     retry_policy: Sequence[RetryPolicy] = (),
+    null_resume_write: Any = _UNSET,
+    resume_writes: list[PendingWrite] | None = None,
 ) -> None | PregelTask | PregelExecutableTask:
     """Prepares a single task for the next Pregel step, given a task path, which
     uniquely identifies a PUSH or PULL task within the graph."""
@@ -631,6 +651,8 @@ def prepare_single_task(
                 config[CONF].get(CONFIG_KEY_RESUME_MAP),
                 step,
                 stop,
+                null_resume_write=null_resume_write,
+                resume_writes=resume_writes,
             )
             # create task input
             try:
@@ -1285,28 +1307,36 @@ def _scratchpad(
     resume_map: dict[str, Any] | None,
     step: int,
     stop: int,
+    *,
+    null_resume_write: Any = _UNSET,
+    resume_writes: list[PendingWrite] | None = None,
 ) -> PregelScratchpad:
+    # Only RESUME writes can match either lookup below, so a caller preparing many
+    # tasks at once can pass a pre-filtered list and avoid rescanning every write
+    # once per task (see `prepare_next_tasks`).
+    scan = resume_writes if resume_writes is not None else pending_writes
+    # NOTE: the guard stays on `pending_writes`, not on `scan`, so the `resume_map`
+    # branch below keeps its original behaviour even when there are no RESUME writes.
     if len(pending_writes) > 0:
         # find global resume value
-        for w in pending_writes:
-            if w[0] == NULL_TASK_ID and w[1] == RESUME:
-                null_resume_write = w
-                break
-        else:
-            # None cannot be used as a resume value, because it would be difficult to
-            # distinguish from missing when used over http
-            null_resume_write = None
+        if null_resume_write is _UNSET:
+            for w in scan:
+                if w[0] == NULL_TASK_ID and w[1] == RESUME:
+                    null_resume_write = w
+                    break
+            else:
+                # None cannot be used as a resume value, because it would be difficult to
+                # distinguish from missing when used over http
+                null_resume_write = None
 
         # find task-specific resume value
-        for w in pending_writes:
+        task_resume_write: list[Any] = []
+        for w in scan:
             if w[0] == task_id and w[1] == RESUME:
                 task_resume_write = w[2]
                 if not isinstance(task_resume_write, list):
                     task_resume_write = [task_resume_write]
                 break
-        else:
-            task_resume_write = []
-        del w
 
         # find namespace and task-specific resume value
         if resume_map and namespace_hash in resume_map:

--- a/libs/langgraph/tests/test_scratchpad_precompute.py
+++ b/libs/langgraph/tests/test_scratchpad_precompute.py
@@ -1,0 +1,86 @@
+"""The per-task scratchpad resume lookups can be resolved either by scanning
+`pending_writes` or from values computed once per superstep (#8855).
+
+Both paths must agree in every case - the precomputed path is only an
+optimization, never a behaviour change.
+"""
+import pytest
+
+from langgraph.pregel import _algo
+from langgraph.pregel._algo import _scratchpad
+
+RESUME = _algo.RESUME
+NULL_TASK_ID = _algo.NULL_TASK_ID
+
+
+def _precompute(writes):
+    """Mirror of the hoisted pass in `prepare_next_tasks`."""
+    null_w = None
+    resume_ws = []
+    for w in writes:
+        if w[1] == RESUME:
+            resume_ws.append(w)
+            if w[0] == NULL_TASK_ID and null_w is None:
+                null_w = w
+    return null_w, resume_ws
+
+
+CASES = {
+    "empty": [],
+    "no_resume_writes": [("task0", "chan", 1), ("task1", "chan", 2)],
+    "global_only": [(NULL_TASK_ID, RESUME, "global")],
+    "task_only": [("task0", RESUME, "r0"), ("task1", RESUME, "r1")],
+    "mixed": (
+        [(f"task{i}", "chan", i) for i in range(50)]
+        + [(NULL_TASK_ID, RESUME, "global"), ("task0", RESUME, "r0")]
+    ),
+    "list_values": [(NULL_TASK_ID, RESUME, ["a", "b"]), ("task1", RESUME, ["x"])],
+}
+
+
+@pytest.mark.parametrize("name", list(CASES))
+@pytest.mark.parametrize("resume_map", [None, {"h": "mapped"}, {"other": "mapped"}])
+def test_precomputed_matches_scan(name, resume_map):
+    writes = CASES[name]
+    null_w, resume_ws = _precompute(writes)
+
+    for task_id in ("task0", "task1", "no-such-task"):
+        # fresh copies: consuming a resume value mutates pending_writes
+        scanned = _scratchpad(None, list(writes), task_id, "h", resume_map, 0, 1)
+        precomputed = _scratchpad(
+            None,
+            list(writes),
+            task_id,
+            "h",
+            resume_map,
+            0,
+            1,
+            null_resume_write=null_w,
+            resume_writes=resume_ws,
+        )
+        assert precomputed.resume == scanned.resume, f"{name}/{task_id}"
+        assert precomputed.get_null_resume() == scanned.get_null_resume()
+        assert precomputed.get_null_resume(True) == scanned.get_null_resume(True)
+
+
+def test_resume_map_applies_even_without_resume_writes():
+    """`resume_map` is applied whenever pending writes exist, not only when a
+    RESUME write is present - the precomputed path must preserve that."""
+    writes = [("task0", "chan", 1)]
+    null_w, resume_ws = _precompute(writes)
+    assert resume_ws == []
+
+    scanned = _scratchpad(None, list(writes), "task0", "h", {"h": "mapped"}, 0, 1)
+    precomputed = _scratchpad(
+        None,
+        list(writes),
+        "task0",
+        "h",
+        {"h": "mapped"},
+        0,
+        1,
+        null_resume_write=null_w,
+        resume_writes=resume_ws,
+    )
+    assert scanned.resume == ["mapped"]
+    assert precomputed.resume == scanned.resume


### PR DESCRIPTION
## Summary
Resolve scratchpad resume lookups once per superstep instead of per pending write.

## Why
Perf - avoids O(n) resume-map lookups repeated for every pending write in a superstep.

## Changes
pregel/_algo.py `_scratchpad` computes `null_resume_write`/`resume_writes` once per call.

## Test plan / QA
- tests/test_scratchpad_precompute.py - 19 passed.
- All feature branches rebased on `origin/main`; changes are guarded (no-op when the feature is not used), so existing behavior is unchanged.

## Checklist
- [x] Tests added/updated and passing
- [x] Changes are scoped to this issue only
- [x] `Closes #8855`

Closes #8855
