### PR TITLE
fix(checkpoint): preserve ZoneInfo and fold on datetime round-trip

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -400,6 +400,30 @@ def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
             ),
         )
     elif isinstance(obj, datetime):
+        if obj.tzinfo is not None and not isinstance(obj.tzinfo, timezone):
+            # A real zone (e.g. ZoneInfo), not a fixed UTC offset: isoformat()
+            # would bake in the offset in effect at this instant and lose the
+            # zone rule, so DST arithmetic after a round-trip would be wrong.
+            return ormsgpack.Ext(
+                EXT_CONSTRUCTOR_KW_ARGS,
+                _msgpack_enc(
+                    (
+                        obj.__class__.__module__,
+                        obj.__class__.__name__,
+                        {
+                            "year": obj.year,
+                            "month": obj.month,
+                            "day": obj.day,
+                            "hour": obj.hour,
+                            "minute": obj.minute,
+                            "second": obj.second,
+                            "microsecond": obj.microsecond,
+                            "tzinfo": obj.tzinfo,
+                            "fold": obj.fold,
+                        },
+                    ),
+                ),
+            )
         return ormsgpack.Ext(
             EXT_METHOD_SINGLE_ARG,
             _msgpack_enc(

--- a/libs/checkpoint/tests/test_jsonplus.py
+++ b/libs/checkpoint/tests/test_jsonplus.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import uuid
 from collections import deque
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from enum import Enum
 from ipaddress import IPv4Address
@@ -334,6 +334,80 @@ def test_serde_jsonplus_bytes() -> None:
 
     assert dumped == ("bytes", some_bytes)
     assert serde.loads_typed(dumped) == some_bytes
+
+
+def test_serde_jsonplus_datetime_zoneinfo_survives_dst_boundary() -> None:
+    """A zone-aware datetime must keep its zone rule, not just its instant."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+    tz = ZoneInfo("America/New_York")
+    before = datetime(2026, 3, 7, 9, 0, tzinfo=tz)  # day before US DST starts
+
+    after = serde.loads_typed(serde.dumps_typed(before))
+
+    assert before == after
+    assert isinstance(after.tzinfo, ZoneInfo)
+    assert after.tzinfo.key == "America/New_York"
+    # Same zone arithmetic across the DST boundary must agree, not just the
+    # instant: a fixed-offset restore is off by an hour here.
+    assert (before + timedelta(days=1)).astimezone(tz) == (
+        after + timedelta(days=1)
+    ).astimezone(tz)
+
+
+def test_serde_jsonplus_datetime_fold_preserved() -> None:
+    """`fold` disambiguates the repeated hour at the end of DST."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+    tz = ZoneInfo("America/New_York")
+    ambiguous = datetime(2026, 11, 1, 1, 30, tzinfo=tz, fold=1)
+
+    result = serde.loads_typed(serde.dumps_typed(ambiguous))
+
+    assert result.fold == 1
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        datetime(2024, 1, 1, 12, 0, 0),
+        datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=5, minutes=30))),
+        datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    ],
+    ids=["naive", "fixed_offset", "utc"],
+)
+def test_serde_jsonplus_datetime_non_zone_wire_format_unchanged(
+    value: datetime,
+) -> None:
+    """Naive/fixed-offset/UTC datetimes keep the pre-existing iso encoding."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=True)
+
+    dumped = serde.dumps_typed(value)
+
+    assert serde.loads_typed(dumped) == value
+    assert (
+        _msgpack_enc(
+            (
+                value.__class__.__module__,
+                value.__class__.__name__,
+                value.isoformat(),
+                "fromisoformat",
+            )
+        )
+        in dumped[1]
+    )
+
+
+def test_serde_jsonplus_datetime_zoneinfo_roundtrips_under_strict_allowlist() -> None:
+    """`datetime` and `zoneinfo.ZoneInfo` are both already safe types, so the
+    zone-aware encoding must not require any allowlist change."""
+    serde = JsonPlusSerializer(allowed_msgpack_modules=None)
+    tz = ZoneInfo("America/New_York")
+    aware = datetime(2026, 3, 7, 9, 0, tzinfo=tz)
+
+    result = serde.loads_typed(serde.dumps_typed(aware))
+
+    assert result == aware
+    assert isinstance(result.tzinfo, ZoneInfo)
+    assert result.tzinfo.key == "America/New_York"
 
 
 def test_lc2_json_safe_type_revives_without_allowlist() -> None:


### PR DESCRIPTION
Fixes #8826

`datetime` was encoded via `isoformat()`/`fromisoformat`, which bakes in the UTC offset in effect at that instant instead of the zone rule. A zone-aware `datetime` restored from a checkpoint compares equal to the original but loses `ZoneInfo` (comes back as a fixed-offset `timezone`) and `fold`, so DST arithmetic after a resume is wrong.

## Changes

Emit the same `EXT_CONSTRUCTOR_KW_ARGS` form already used for `time` when `tzinfo` is a real zone (not a fixed offset). Naive, UTC, and fixed-offset `datetime` values keep the existing iso encoding byte-for-byte.

## Test plan

- Added 5 regression tests in `libs/checkpoint/tests/test_jsonplus.py`:
  - DST-boundary zone preservation
  - `fold` preservation
  - Wire-format-unchanged compatibility guard (parametrized: naive/fixed-offset/UTC)
  - Round-trip under strict allowlist
- Verified: `make format`, `make lint` clean
- `TEST=tests/test_jsonplus.py make test` → 105 passed
- Full `libs/checkpoint` suite → 164 passed, 17 skipped
- Manually confirmed byte-identical encoding vs pre-patch for naive/fixed-offset/UTC via `git stash` diff

## Backward compatibility

Naive, UTC, and fixed-offset `datetime` values are byte-identical to `main`. Zone-aware `datetime` values change encoding (~62B → ~130B), but old payloads still decode (as fixed-offset). This fixes new writes; it cannot recover zone info from old checkpoints that already lost it.