### PR TITLE
fix: propagate child command failures in root Makefile aggregate targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/pyproject.toml ]; then \
 			echo "Installing dependencies for $$dir"; \
-			uv pip install -e $$dir; \
+			uv pip install -e $$dir || exit $$?; \
 		fi; \
 	done
 
@@ -23,7 +23,7 @@ lint:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Running lint in $$dir"; \
-			$(MAKE) -C $$dir lint; \
+			$(MAKE) -C $$dir lint || exit $$?; \
 		fi; \
 	done
 
@@ -33,7 +33,7 @@ format:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Running format in $$dir"; \
-			$(MAKE) -C $$dir format; \
+			$(MAKE) -C $$dir format || exit $$?; \
 		fi; \
 	done
 
@@ -43,7 +43,7 @@ lock:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Running lock in $$dir"; \
-			(cd $$dir && uv lock); \
+			(cd $$dir && uv lock) || exit $$?; \
 		fi; \
 	done
 
@@ -53,7 +53,7 @@ lock-upgrade:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Running lock-upgrade in $$dir"; \
-			(cd $$dir && uv lock --upgrade); \
+			(cd $$dir && uv lock --upgrade) || exit $$?; \
 		fi; \
 	done
 
@@ -63,6 +63,6 @@ test:
 	@for dir in $(LIBS_DIRS); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Running test in $$dir"; \
-			$(MAKE) -C $$dir test; \
+			$(MAKE) -C $$dir test || exit $$?; \
 		fi; \
 	done


### PR DESCRIPTION
Fixes #8850

The root Makefile's `install`/`lint`/`format`/`lock`/`lock-upgrade`/`test` targets iterate over `LIBS_DIRS` and invoke per-package commands. Without error propagation, a failed command in an early iteration is overwritten by the exit status of later iterations, causing `make lint` (and others) to return 0 even when a child failed.

## Changes

Add `|| exit $$?` after each child command so the loop exits immediately with the child's status on first failure, ensuring CI and local workflows detect package-level errors correctly.

## Test plan

Verified all failure scenarios now propagate exit status:
- **Bug reproduction** (on `main@0199b519e`): `make lint MAKE=false LIBS_DIRS='libs/checkpoint libs/sdk-js'` returns 0 ✗
- **After fix**: same command returns nonzero ✓
- **first-fails-then-succeeds**: now returns nonzero ✓
- **fail-then-skip** (no-Makefile dir): now returns nonzero ✓
- **all-success**: still returns 0 (no regression) ✓
- **last-fails**: still returns nonzero (already worked) ✓

## Scope

7 insertions in root `Makefile` only (one `|| exit $$?` per loop command). No library implementation, dependency, or workflow changes.