### PR TITLE
fix(langgraph): hydrate message lists in RemoteGraph invoke/ainvoke outputs

### DIFF
--- a/libs/langgraph/langgraph/pregel/remote.py
+++ b/libs/langgraph/langgraph/pregel/remote.py
@@ -12,6 +12,8 @@ from typing import (
 from uuid import UUID
 
 import langsmith as ls
+from langchain_core.messages import BaseMessage
+from langchain_core.messages.utils import convert_to_messages
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.graph import (
     Edge as DrawableEdge,
@@ -1203,10 +1205,10 @@ class RemoteGraph(PregelProtocol):
         try:
             if version == "v2":
                 return GraphOutput(
-                    value=chunk["data"],
+                    value=_hydrate_output_messages(chunk["data"]),
                     interrupts=tuple(chunk.get("interrupts", ())),
                 )
-            return chunk
+            return _hydrate_output_messages(chunk)
         except UnboundLocalError:
             logger.warning("No events received from remote graph")
             return None
@@ -1285,13 +1287,66 @@ class RemoteGraph(PregelProtocol):
         try:
             if version == "v2":
                 return GraphOutput(
-                    value=chunk["data"],
+                    value=_hydrate_output_messages(chunk["data"]),
                     interrupts=tuple(chunk.get("interrupts", ())),
                 )
-            return chunk
+            return _hydrate_output_messages(chunk)
         except UnboundLocalError:
             logger.warning("No events received from remote graph")
             return None
+
+
+# Message type and role names that langchain_core's convert_to_messages
+# understands. Anything outside this set (e.g. Anthropic-style content blocks
+# like {"type": "text"}) is not treated as a message.
+_MESSAGE_TYPE_NAMES = frozenset(
+    {
+        "human",
+        "user",
+        "ai",
+        "assistant",
+        "system",
+        "tool",
+        "function",
+        "chat",
+        "remove",
+        "developer",
+    }
+)
+
+
+def _is_message_like_list(value: Any) -> bool:
+    """True for a list whose items all look like (serialized) chat messages."""
+    if not isinstance(value, list):
+        return False
+    return all(
+        isinstance(item, BaseMessage)
+        or (
+            isinstance(item, dict)
+            and (
+                item.get("type") in _MESSAGE_TYPE_NAMES
+                or item.get("role") in _MESSAGE_TYPE_NAMES
+            )
+        )
+        for item in value
+    )
+
+
+def _hydrate_output_messages(value: Any) -> Any:
+    """Hydrate message-shaped lists in a returned state dict to BaseMessage.
+
+    Local graphs hydrate message channels through the add_messages reducer,
+    but RemoteGraph drains the langgraph-sdk stream and returns the final
+    state as raw JSON, so "messages" (and any other message-shaped list)
+    arrives as plain dicts. Convert those lists with convert_to_messages;
+    every other value passes through untouched.
+    """
+    if not isinstance(value, dict):
+        return value
+    return {
+        key: convert_to_messages(val) if _is_message_like_list(val) else val
+        for key, val in value.items()
+    }
 
 
 def _merge_tracing_headers(headers: dict[str, str] | None) -> dict[str, str] | None:

--- a/libs/langgraph/tests/test_remote_graph.py
+++ b/libs/langgraph/tests/test_remote_graph.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import langsmith as ls
 import pytest
-from langchain_core.messages import AnyMessage, BaseMessage
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langchain_core.runnables.graph import Edge as DrawableEdge
 from langchain_core.runnables.graph import Node as DrawableNode
@@ -841,7 +841,7 @@ def test_invoke():
         {"input": {"messages": [{"type": "human", "content": "hello"}]}}, config
     )
 
-    assert result == {"messages": [{"type": "human", "content": "world"}]}
+    assert result == {"messages": [HumanMessage(content="world")]}
 
 
 def test_invoke_sanitizes_thread_id():
@@ -909,7 +909,102 @@ async def test_ainvoke():
         {"input": {"messages": [{"type": "human", "content": "hello"}]}}, config
     )
 
-    assert result == {"messages": [{"type": "human", "content": "world"}]}
+    assert result == {"messages": [HumanMessage(content="world")]}
+
+
+def test_invoke_hydrates_message_lists():
+    # RemoteGraph returns the drained state as raw JSON; message-shaped lists
+    # must come back as BaseMessage instances (the local-graph contract),
+    # while non-message values pass through untouched.
+    mock_sync_client = MagicMock()
+    mock_sync_client.runs.stream.return_value = [
+        StreamPart(
+            event="values",
+            data={
+                "messages": [
+                    {"type": "human", "content": "hello"},
+                    {"role": "assistant", "content": "hi there"},
+                ],
+                "custom_messages": [{"type": "ai", "content": "custom key"}],
+                "content_blocks": [{"type": "text", "text": "not a message"}],
+                "empty": [],
+                "scalar": 42,
+            },
+        ),
+    ]
+
+    remote_pregel = RemoteGraph(
+        "test_graph_id",
+        sync_client=mock_sync_client,
+    )
+
+    config = {"configurable": {"thread_id": "thread_1"}}
+    result = remote_pregel.invoke({"input": {}}, config)
+
+    assert result["messages"] == [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+    ]
+    assert all(isinstance(m, BaseMessage) for m in result["messages"])
+    # shape detection works for custom keys too
+    assert result["custom_messages"] == [AIMessage(content="custom key")]
+    # anthropic-style content blocks are not messages: untouched
+    assert result["content_blocks"] == [{"type": "text", "text": "not a message"}]
+    assert result["empty"] == []
+    assert result["scalar"] == 42
+
+
+def test_invoke_v2_hydrates_graph_output_value():
+    mock_sync_client = MagicMock()
+    mock_sync_client.runs.stream.return_value = [
+        StreamPart(
+            event="values",
+            data={"messages": [{"type": "human", "content": "hello"}]},
+        ),
+    ]
+
+    remote_pregel = RemoteGraph(
+        "test_graph_id",
+        sync_client=mock_sync_client,
+    )
+
+    config = {"configurable": {"thread_id": "thread_1"}}
+    result = remote_pregel.invoke({"input": {}}, config, version="v2")
+
+    assert result.value["messages"] == [HumanMessage(content="hello")]
+    assert result.interrupts == ()
+
+
+@pytest.mark.anyio
+async def test_ainvoke_hydrates_message_lists():
+    mock_async_client = MagicMock()
+    async_iter = MagicMock()
+    async_iter.__aiter__.return_value = [
+        StreamPart(
+            event="values",
+            data={
+                "messages": [
+                    {"type": "human", "content": "hello"},
+                    {"type": "ai", "content": "hi there"},
+                ],
+            },
+        ),
+    ]
+    mock_async_client.runs.stream.return_value = async_iter
+
+    remote_pregel = RemoteGraph(
+        "test_graph_id",
+        client=mock_async_client,
+    )
+
+    config = {"configurable": {"thread_id": "thread_1"}}
+    result = await remote_pregel.ainvoke({"input": {}}, config)
+
+    assert result["messages"] == [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+    ]
+    assert all(isinstance(m, BaseMessage) for m in result["messages"])
 
 
 def test_stream_context():


### PR DESCRIPTION
Fixes #8885

Originally reported as langchain-ai/langchain#40368

`RemoteGraph.invoke()` / `ainvoke()` drain the langgraph-sdk stream and return the final state chunk verbatim, so message lists come back as raw `list[dict]`. Local `Pregel` execution hydrates message channels through the `add_messages` reducer into `BaseMessage` instances, so consumers that rely on the local-graph output contract - e.g. deepagents' `CompiledSubAgent`, which selects the final AI response via `isinstance(msg, AIMessage)` - silently get empty results.

## Fix

Added a private hydration pass (`_hydrate_output_messages`) applied to the returned state dict in both `invoke` and `ainvoke` (v1 return value and v2 `GraphOutput.value`; interrupts untouched):

- Any list whose items are all message-shaped (`BaseMessage` instances, or dicts with a recognized `type`/`role`) is converted via `langchain_core.messages.utils.convert_to_messages`.
- Shape detection is allow-listed to the message type/role names `convert_to_messages` understands, so non-message dict lists (e.g. Anthropic-style `{"type": "text"}` content blocks), empty lists, scalars, and every other value pass through untouched.

## Tests

- Updated `test_invoke` / `test_ainvoke`, which previously asserted the raw-dict behavior this PR fixes, to assert the hydrated `BaseMessage` contract.
- New mock-only tests: `test_invoke_hydrates_message_lists` (human/ai/`role`-style dicts, custom message keys, content-block passthrough, empty list, scalar passthrough), `test_invoke_v2_hydrates_graph_output_value`, `test_ainvoke_hydrates_message_lists`.

Red-green verified locally: all 5 tests fail against unpatched `main` (e539ac12) and pass with the fix. Run via a standalone harness with identical test bodies, since the repo's `tests/conftest.py` requires redis/docker services not available in this environment; the tests themselves are mock-only and self-contained.

> Built by breken, your AI support engineer - breken.ai - this one's on us.