### PR TITLE
fix(checkpoint): deserialize parameterized pydantic v2 generics in jsonplus

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
+++ b/libs/checkpoint/langgraph/checkpoint/serde/jsonplus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import copy
 import dataclasses
 import decimal
@@ -11,7 +12,7 @@ import pickle
 import re
 import sys
 from collections import deque
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from enum import Enum
 from inspect import isclass
@@ -23,7 +24,15 @@ from ipaddress import (
     IPv6Interface,
     IPv6Network,
 )
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    Optional,
+    Union,
+    cast,
+)
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -300,6 +309,96 @@ EXT_PYDANTIC_V1 = 4
 EXT_PYDANTIC_V2 = 5
 EXT_NUMPY_ARRAY = 6
 EXT_DELTA_SNAPSHOT = 7
+
+
+# Restricted namespace used to resolve type expressions inside parameterized
+# pydantic generic names (e.g. ``MyGeneric[Optional[MyModel]]``). No eval():
+# names resolve only via these typing aliases, builtins, or attributes of the
+# already-allowlisted module.
+_GENERIC_TYPING_NAMES: dict[str, Any] = {
+    "List": list,
+    "Dict": dict,
+    "Set": set,
+    "FrozenSet": frozenset,
+    "Tuple": tuple,
+    "Optional": Optional,
+    "Union": Union,
+    "Literal": Literal,
+    "Annotated": Annotated,
+    "Sequence": Sequence,
+    "Mapping": Mapping,
+    "Any": Any,
+}
+
+
+def _split_generic_args(args: str) -> list[str]:
+    """Split ``A[B, C], D`` on top-level commas, respecting nested brackets."""
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    for i, ch in enumerate(args):
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(args[start:i].strip())
+            start = i + 1
+    tail = args[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def _resolve_type_expr(expr: str, mod: Any) -> Any:
+    """Resolve a dotted, possibly generic type expression without eval()."""
+    expr = expr.strip()
+    if "[" in expr:
+        head, _, rest = expr.partition("[")
+        origin = _resolve_type_expr(head, mod)
+        arg_exprs = _split_generic_args(rest[:-1])  # strip trailing ]
+        args = tuple(_resolve_type_expr(a, mod) for a in arg_exprs)
+        return origin[args]
+    if expr in _GENERIC_TYPING_NAMES:
+        return _GENERIC_TYPING_NAMES[expr]
+    if expr in dir(builtins):
+        return getattr(builtins, expr)
+    target: Any = mod
+    for part in expr.split("."):
+        target = getattr(target, part, None)
+        if target is None:
+            return None
+    return target
+
+
+def _resolve_pydantic_class(module_name: str, qualname: str) -> Any:
+    """Look up the class recorded at encode time.
+
+    Plain names resolve via ``getattr`` as before. Parameterized pydantic
+    generics record ``__name__`` values like ``MyGeneric[MyModel]`` (the
+    parameterized class is a distinct, pydantic-cached subclass), which no
+    ``getattr`` can find; re-apply the type args to the origin class instead.
+    """
+    mod = importlib.import_module(module_name)
+    cls = getattr(mod, qualname, None)
+    if cls is not None or "[" not in qualname:
+        return cls
+    origin_name, _, args_repr = qualname.partition("[")
+    origin = getattr(mod, origin_name, None)
+    if origin is None:
+        return None
+    arg_exprs = _split_generic_args(args_repr[:-1])
+    args = tuple(_resolve_type_expr(a, mod) for a in arg_exprs)
+    if any(a is None for a in args):
+        # A parameter we can no longer resolve (e.g. the class was renamed
+        # since encode time). We can't rebuild the parameterized class, and
+        # constructing the unparameterized origin would silently skip field
+        # validation; degrade to the raw kwargs like any other unknown type.
+        return None
+    try:
+        return origin[args if len(args) > 1 else args[0]]
+    except Exception:
+        return None
 
 
 def _msgpack_default(obj: Any) -> str | ormsgpack.Ext:
@@ -716,7 +815,7 @@ def _create_msgpack_ext_hook(
                 if not _check_allowed(tup[0], tup[1]):
                     return tup[2]
                 # module, name, kwargs, method
-                cls = getattr(importlib.import_module(tup[0]), tup[1])
+                cls = _resolve_pydantic_class(tup[0], tup[1])
                 try:
                     return cls(**tup[2])
                 except Exception:

--- a/libs/checkpoint/tests/test_jsonplus_generic_pytest.py
+++ b/libs/checkpoint/tests/test_jsonplus_generic_pytest.py
@@ -1,0 +1,95 @@
+"""Regression tests for GH #6102: JsonPlusSerializer round-trips of
+parameterized pydantic v2 generic models."""
+
+from typing import Generic, TypeVar
+
+import ormsgpack
+from pydantic import BaseModel
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+TInner = TypeVar("TInner", bound=BaseModel)
+TKey = TypeVar("TKey")
+
+
+class MyModel(BaseModel):
+    hello: str
+
+
+class MyGeneric(BaseModel, Generic[TInner]):
+    inner: TInner
+
+
+class NestedGeneric(BaseModel, Generic[TInner]):
+    items: list[TInner]
+
+
+class TwoParamGeneric(BaseModel, Generic[TKey, TInner]):
+    key: str
+    inner: TInner
+
+
+class OptionalGeneric(BaseModel, Generic[TInner]):
+    inner: TInner | None
+
+
+def test_roundtrip_parameterized_generic():
+    instance = MyGeneric[MyModel](inner=MyModel(hello="hello"))
+    serde = JsonPlusSerializer()
+    dumped = serde.dumps_typed(instance)
+    assert dumped[0] == "msgpack"
+    result = serde.loads_typed(dumped)
+    assert instance == result
+
+
+def test_roundtrip_nested_generic():
+    instance = NestedGeneric[MyModel](items=[MyModel(hello="a"), MyModel(hello="b")])
+    serde = JsonPlusSerializer()
+    result = serde.loads_typed(serde.dumps_typed(instance))
+    assert instance == result
+    assert all(isinstance(item, MyModel) for item in result.items)
+
+
+def test_roundtrip_two_param_generic():
+    instance = TwoParamGeneric[str, MyModel](key="k", inner=MyModel(hello="x"))
+    serde = JsonPlusSerializer()
+    result = serde.loads_typed(serde.dumps_typed(instance))
+    assert instance == result
+
+
+def test_roundtrip_optional_generic():
+    instance = OptionalGeneric[MyModel](inner=MyModel(hello="y"))
+    serde = JsonPlusSerializer()
+    result = serde.loads_typed(serde.dumps_typed(instance))
+    assert instance == result
+
+
+def test_plain_model_still_roundtrips():
+    instance = MyModel(hello="plain")
+    serde = JsonPlusSerializer()
+    result = serde.loads_typed(serde.dumps_typed(instance))
+    assert instance == result
+
+
+def test_unresolvable_param_degrades_to_dict():
+    """If a type arg can't be resolved (class renamed since encode time),
+    we can't rebuild the parameterized class safely; degrade to the raw
+    kwargs dict, exactly like any other type we can't reconstruct."""
+    serde = JsonPlusSerializer(
+        allowed_msgpack_modules=[
+            ("tests.test_jsonplus_generic_pytest", "MyGeneric[DoesNotExist]")
+        ]
+    )
+    instance = MyGeneric[MyModel](inner=MyModel(hello="z"))
+    dumped = serde.dumps_typed(instance)
+    assert dumped[0] == "msgpack"
+    raw = ormsgpack.unpackb(dumped[1], ext_hook=lambda code, data: (code, data))
+    code, payload = raw
+    tup = ormsgpack.unpackb(payload)
+    assert code == 5  # EXT_PYDANTIC_V2
+    broken = ormsgpack.packb((tup[0], "MyGeneric[DoesNotExist]", tup[2], tup[3]))
+    revived = ormsgpack.unpackb(
+        ormsgpack.packb(ormsgpack.Ext(code, broken)), ext_hook=serde._unpack_ext_hook
+    )
+    # Same graceful degradation as unknown non-generic types: raw kwargs.
+    assert revived == {"inner": {"hello": "z"}}


### PR DESCRIPTION
Fixes #6102

## Problem

`JsonPlusSerializer` encodes pydantic v2 models with their `__class__.__name__`. For a **parameterized generic**, pydantic renders that name as e.g. `MyGeneric[MyModel]`, so the decode-side `getattr(module, name)` always raises `AttributeError` and `loads_typed` silently degrades to a raw dict:

```python
instance = MyGeneric[MyModel](inner=MyModel(hello="hello"))
serde = JsonPlusSerializer()
result = serde.loads_typed(serde.dumps_typed(instance))
# before: {'inner': {'hello': 'hello'}}   <- plain dict, model identity lost
# after:  MyGeneric[MyModel](inner=MyModel(hello='hello'))
```

## Fix

When the recorded qualname contains `[`, re-apply the recorded type arguments to the origin class (`origin[args]`), which reuses pydantic's own generic cache so nested fields validate as the concrete param type.

Type-expression parsing is done **without eval()**: names inside the brackets may only resolve to typing aliases (`List`, `Optional`, `Union`, …), builtins (`int`, `str`, …), or attributes of the module that already passed the msgpack allowlist check.

**Degradation semantics:** if a parameter can no longer be resolved at decode time (the class was renamed after the checkpoint was written), we return the raw kwargs dict — the same graceful degradation as any other unreconstructable type — rather than constructing an unvalidated unparameterized origin instance.

## Testing

- 6 new tests in `libs/checkpoint/tests/test_jsonplus_generic_pytest.py`: issue repro, two-param generic, `List[T]` nesting, `Optional[T]` param, plain model unchanged, renamed-param degradation
- Full existing jsonplus suite: **99 passed** (no regressions)
- `ruff check` / `ruff format` clean

```
libs/checkpoint/tests/test_jsonplus_generic_pytest.py ......     [100%] 6 passed
libs/checkpoint/tests/test_jsonplus.py ........................ 99 passed
```