### PR TITLE
fix(sdk-py): un-shadow SyncStreamController._reconnect_shared_stream (locking from #7829 never took effect)

### DIFF
--- a/libs/sdk-py/langgraph_sdk/stream/sync_controller.py
+++ b/libs/sdk-py/langgraph_sdk/stream/sync_controller.py
@@ -199,25 +199,6 @@ class SyncStreamController:
             for sub in self._subscriptions.values():
                 sub.queue.put(None)
 
-    def _reconnect_shared_stream(self) -> bool:
-        with self._lock:
-            base_filter = self._shared_stream_filter
-        if base_filter is None:
-            return False
-        for _ in range(self._max_reconnect_attempts):
-            with self._lock:
-                if self._closed:
-                    return False
-                params = self._filter_with_since(base_filter)
-            try:
-                new_stream = self._transport.open_event_stream(params)
-            except Exception:
-                continue
-            with self._lock:
-                self._shared_stream = new_stream
-            return True
-        return False
-
     def _compute_current_union(
         self, extra: SubscribeParams | None = None
     ) -> dict[str, Any]:
@@ -298,26 +279,37 @@ class SyncStreamController:
         Returns True if a new stream was successfully opened, False if all
         reconnect attempts were exhausted or the controller was closed.
         """
-        base_filter = self._shared_stream_filter
+        with self._lock:
+            base_filter = self._shared_stream_filter
         if base_filter is None:
             return False
         for attempt in range(self._max_reconnect_attempts):
-            if self._closed:
-                return False
             if attempt > 0:
                 self._reconnect_sleep(attempt - 1)
+            with self._lock:
+                if self._closed:
+                    return False
+                params = self._filter_with_since(base_filter)
             try:
-                new_handle = self._transport.open_event_stream(
-                    self._filter_with_since(base_filter)
-                )
-                old = self._shared_stream
-                self._shared_stream = new_handle
-                if old is not None:
-                    with contextlib.suppress(Exception):
-                        old.close()
-                return True
+                new_handle = self._transport.open_event_stream(params)
             except Exception as err:
                 _logger.debug("sync reconnect attempt %d failed: %r", attempt, err)
+                continue
+            with self._lock:
+                # `close()` may have run while the stream was being opened.
+                # Installing the handle now would leak it, so hand it back.
+                stale = self._closed
+                old = None if stale else self._shared_stream
+                if not stale:
+                    self._shared_stream = new_handle
+            if stale:
+                with contextlib.suppress(Exception):
+                    new_handle.close()
+                return False
+            if old is not None:
+                with contextlib.suppress(Exception):
+                    old.close()
+            return True
         return False
 
     def close(self) -> None:


### PR DESCRIPTION
Fixes #8896

### What

`SyncStreamController` binds `_reconnect_shared_stream` twice in the same class body:

| | line | locking | extras |
|---|---|---|---|
| first | `sync_controller.py:202` | takes `self._lock` around every state read/write | — |
| second | `sync_controller.py:295` | **no locking at all** | backoff, closes the old handle, debug logging |

Python evaluates a class body top-to-bottom, so only the **second** one survives in
the class dict. The first is unreachable.

### Where it came from

The file has four commits, all from 2026-05-27:

* `fe1c683f` — feat(sdk-py): add sync thread stream core (#7826) — shipped the
  reconnect that is **live today** (backoff + old-handle close, no locking)
* `4f3ab2f9` — feat(sdk-py): harden streaming reconnects (#7829) — added a
  **second**, lock-taking `_reconnect_shared_stream`, inserting it *above* the
  existing one instead of replacing it

So the locking that #7829 set out to add has never actually run. The `_fanout`
change in that same PR did take effect, which is presumably why it looked fine.

### Why the missing locking matters

`self._lock` is an `RLock` that every other mutator on this class goes through —
`register_subscription`, `unregister_subscription`, `signal_paused`,
`reconcile_stream`, `ensure_fanout_running`, `_fanout`, `_observe_event`,
`_drain_and_close`, `close`. The live `_reconnect_shared_stream` is the only one
that touches `_shared_stream` / `_closed` / `_cursor` (via `_filter_with_since`)
with no lock held — and `_fanout` calls it **outside** the lock:

```python
            with self._lock:
                if self._shared_stream is not shared:
                    continue
            err = shared.error()                      # lock released
            if err is not None and not self._closed:
                if self._reconnect_shared_stream():   # <- unsynchronised
```

The concrete failure is a leaked connection on shutdown:

1. the fanout thread checks `self._closed` (false) and blocks inside
   `open_event_stream()`
2. the main thread calls `close()`, which under the lock sets `_closed = True` and
   captures the *current* `_shared_stream`, then closes that handle and returns
3. the fanout thread comes back and does `self._shared_stream = new_handle`

`close()` has already returned, so the freshly opened SSE connection is never
closed. The same unsynchronised write can also clobber a rotation performed by
`reconcile_stream`.

### The change

* delete the shadowed duplicate (`:202`) — it has never executed
* fold its locking into the implementation that actually runs, keeping that one's
  backoff, old-handle close, and debug logging
* re-check `_closed` under the lock before installing the new handle, and close
  the handle instead of installing it if `close()` won the race

The lock is deliberately *not* held across `open_event_stream()` — same boundaries
the #7829 version used.

### Note on why CI did not catch this

`ruff` (which this package selects `F` for) does **not** report F811 for a method
redefined inside a class body; `pyflakes` does:

```
$ ruff check --isolated --select F811 langgraph_sdk/stream/sync_controller.py
All checks passed!

$ pyflakes langgraph_sdk/stream/sync_controller.py
sync_controller.py:295:5: redefinition of unused '_reconnect_shared_stream' from line 202
```

Might be worth a one-off pyflakes sweep of the SDK for the same shape.

### Verification

`ruff check` with `libs/sdk-py/pyproject.toml` reports exactly the same (empty)
result before and after this patch, and the module parses with a single
`_reconnect_shared_stream` remaining. I have not run the sdk-py test suite
against a live server, so please do give the reconnect path a look — the
behavioural change is limited to locking plus the closed-mid-flight handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
