### PR TITLE
docs(checkpoint): sync Checkpoint.v docstring with LATEST_VERSION

### DIFF
--- a/libs/checkpoint/langgraph/checkpoint/base/__init__.py
+++ b/libs/checkpoint/langgraph/checkpoint/base/__init__.py
@@ -94,7 +94,7 @@ class Checkpoint(TypedDict):
     """State snapshot at a given point in time."""
 
     v: int
-    """The version of the checkpoint format. Currently `1`."""
+    """The version of the checkpoint format. Currently `2` (see `LATEST_VERSION`)."""
     id: str
     """The ID of the checkpoint.
     


### PR DESCRIPTION
Fixes #8803

The `Checkpoint.v` docstring said the format version is `1`, but checkpoints are written with `LATEST_VERSION` (currently `2`) in `empty_checkpoint()`. Updated the docstring and referenced the constant so it stays in sync.

No code paths changed.