### PR TITLE
fix(checkpoint-postgres): pass POSTGRES_VERSION through to compose in the test matrix

### DIFF
--- a/libs/checkpoint-postgres/Makefile
+++ b/libs/checkpoint-postgres/Makefile
@@ -1,11 +1,13 @@
 .PHONY: test test_watch lint type format
 
+POSTGRES_VERSION ?= 16
+
 ######################
 # TESTING AND COVERAGE
 ######################
 
 start-postgres:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) docker compose -f tests/compose-postgres.yml up -V --force-recreate --wait || ( \
 		echo "Failed to start PostgreSQL, printing logs..."; \
 		docker compose -f tests/compose-postgres.yml logs; \
 		exit 1 \
@@ -35,7 +37,7 @@ test:
 
 TEST ?= .
 test_watch:
-	POSTGRES_VERSION=${POSTGRES_VERSION:-16} make start-postgres; \
+	POSTGRES_VERSION=$(POSTGRES_VERSION) make start-postgres; \
 	uv run ptw $(TEST); \
 	EXIT_CODE=$$?; \
 	make stop-postgres; \


### PR DESCRIPTION
Fixes #8664

`${POSTGRES_VERSION:-16}` in the `start-postgres` recipe is shell syntax, but make expands it as a computed variable name, yielding an empty string — so every matrix entry fell back to the compose default and PostgreSQL 16 was tested twice.

Hoisted `POSTGRES_VERSION ?= 16` to the top of the Makefile and passed `$(POSTGRES_VERSION)` through in both `start-postgres` and `test_watch`.

Verified with `make -n`: with the current Makefile, `make -n start-postgres POSTGRES_VERSION=15` expands to `POSTGRES_VERSION= docker compose ...`; with this change it expands to `POSTGRES_VERSION=15 docker compose ...`, and the default without any variable stays 16.