### PR TITLE
fix(checkpoint-sqlite): honor `omit_expired` in store read paths

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -262,6 +262,15 @@ def _group_ops(ops: Iterable[Op]) -> tuple[dict[type, list[tuple[int, Op]]], int
     return grouped_ops, tot
 
 
+# `expires_at` is written in two formats: Python inserts a timezone-aware ISO
+# string (`2026-01-01 00:00:00.123456+00:00`) while the TTL refresh path writes
+# SQLite's `DATETIME()` output (`2026-01-01 00:00:00`). SQLite compares TEXT
+# lexically, so `expires_at > CURRENT_TIMESTAMP` is wrong for rows in the same
+# second as now (the longer string sorts greater). `julianday()` parses both
+# formats to a real number, so the comparison is exact and format-independent.
+_LIVE_ROW_CLAUSE = "(expires_at IS NULL OR julianday(expires_at) > julianday('now'))"
+
+
 class PreparedGetQuery(NamedTuple):
     query: str  # Main query to execute
     params: tuple  # Parameters for the main query
@@ -279,6 +288,11 @@ class BaseSqliteStore:
     index_config: SqliteIndexConfig | None = None
     ttl_config: TTLConfig | None = None
 
+    @property
+    def _omit_expired(self) -> bool:
+        """Whether expired-but-unswept rows should be filtered from reads."""
+        return bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+
     def _get_batch_GET_ops_queries(
         self, get_ops: Sequence[tuple[int, GetOp]]
     ) -> list[PreparedGetQuery]:
@@ -295,6 +309,8 @@ class BaseSqliteStore:
             namespace_groups[op.namespace].append((idx, op.key))
             refresh_ttls[op.namespace].append(getattr(op, "refresh_ttl", False))
 
+        expiry_clause = f"AND {_LIVE_ROW_CLAUSE}" if self._omit_expired else ""
+
         results = []
         for namespace, items in namespace_groups.items():
             _, keys = zip(*items, strict=False)
@@ -306,6 +322,7 @@ class BaseSqliteStore:
                 SELECT key, value, created_at, updated_at, expires_at, ttl_minutes
                 FROM store
                 WHERE prefix = ? AND key IN ({",".join(["?"] * len(keys))})
+                {expiry_clause}
             """
             select_params = (_namespace_to_text(namespace), *keys)
             results.append(
@@ -318,13 +335,15 @@ class BaseSqliteStore:
                 and self.ttl_config
                 and self.ttl_config.get("refresh_on_read", False)
             ):
+                # Same gate as the SELECT so a refresh cannot revive an expired row.
                 placeholders = ",".join(["?"] * len(keys))
                 update_query = f"""
                     UPDATE store
                     SET expires_at = DATETIME(CURRENT_TIMESTAMP, '+' || ttl_minutes || ' minutes')
-                    WHERE prefix = ? 
+                    WHERE prefix = ?
                     AND key IN ({placeholders})
                     AND ttl_minutes IS NOT NULL
+                    {expiry_clause}
                 """
                 update_params = (_namespace_to_text(namespace), *keys)
                 results.append(
@@ -498,6 +517,11 @@ class BaseSqliteStore:
                             # orjson.dumps returns bytes → decode to str so SQLite sees TEXT
                             filter_params.append(orjson.dumps(value).decode())
 
+            if self._omit_expired:
+                # Unaliased `expires_at` is unambiguous in both branches below:
+                # only `store` has the column, `store_vectors` does not.
+                filter_conditions.append(_LIVE_ROW_CLAUSE)
+
             # Vector search branch
             if op.query and self.index_config:
                 embedding_requests.append((idx, op.query))
@@ -614,6 +638,9 @@ class BaseSqliteStore:
         for _, op in list_ops:
             where_clauses: list[str] = []
             params: list[Any] = []
+
+            if self._omit_expired:
+                where_clauses.append(_LIVE_ROW_CLAUSE)
 
             if op.match_conditions:
                 for cond in op.match_conditions:
@@ -878,62 +905,6 @@ class SqliteStore(BaseSqliteStore, BaseStore):
         self.ttl_config = ttl
         self._ttl_sweeper_thread: threading.Thread | None = None
         self._ttl_stop_event = threading.Event()
-
-    def _get_batch_GET_ops_queries(
-        self, get_ops: Sequence[tuple[int, GetOp]]
-    ) -> list[PreparedGetQuery]:
-        """
-        Build queries to fetch (and optionally refresh the TTL of) multiple keys per namespace.
-
-        Returns a list of PreparedGetQuery objects, which may include:
-        - Queries with kind='refresh' for TTL refresh operations
-        - Queries with kind='get' for data retrieval operations
-        """
-        namespace_groups = defaultdict(list)
-        refresh_ttls = defaultdict(list)
-        for idx, op in get_ops:
-            namespace_groups[op.namespace].append((idx, op.key))
-            refresh_ttls[op.namespace].append(getattr(op, "refresh_ttl", False))
-
-        results = []
-        for namespace, items in namespace_groups.items():
-            _, keys = zip(*items, strict=False)
-            this_refresh_ttls = refresh_ttls[namespace]
-            refresh_ttl_any = any(this_refresh_ttls)
-
-            # Always add the main query to get the data
-            select_query = f"""
-                SELECT key, value, created_at, updated_at, expires_at, ttl_minutes
-                FROM store
-                WHERE prefix = ? AND key IN ({",".join(["?"] * len(keys))})
-            """
-            select_params = (_namespace_to_text(namespace), *keys)
-            results.append(
-                PreparedGetQuery(select_query, select_params, namespace, items, "get")
-            )
-
-            # Add a TTL refresh query if needed
-            if (
-                refresh_ttl_any
-                and self.ttl_config
-                and self.ttl_config.get("refresh_on_read", False)
-            ):
-                placeholders = ",".join(["?"] * len(keys))
-                update_query = f"""
-                    UPDATE store
-                    SET expires_at = DATETIME(CURRENT_TIMESTAMP, '+' || ttl_minutes || ' minutes')
-                    WHERE prefix = ? 
-                    AND key IN ({placeholders})
-                    AND ttl_minutes IS NOT NULL
-                """
-                update_params = (_namespace_to_text(namespace), *keys)
-                results.append(
-                    PreparedGetQuery(
-                        update_query, update_params, namespace, items, "refresh"
-                    )
-                )
-
-        return results
 
     def _get_filter_condition(self, key: str, op: str, value: Any) -> tuple[str, list]:
         """Helper to generate filter conditions."""

--- a/libs/checkpoint-sqlite/tests/test_async_store.py
+++ b/libs/checkpoint-sqlite/tests/test_async_store.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import os
 import tempfile
 import uuid
@@ -16,8 +17,8 @@ from langgraph.store.base import (
 )
 
 from langgraph.store.sqlite import AsyncSqliteStore
-from langgraph.store.sqlite.base import SqliteIndexConfig
-from tests.test_store import CharacterEmbeddings
+from langgraph.store.sqlite.base import SqliteIndexConfig, _namespace_to_text
+from tests.test_store import OMIT_TTL_MINUTES, CharacterEmbeddings
 
 
 @pytest.fixture(scope="function", params=["memory", "file"])
@@ -745,3 +746,164 @@ async def test_async_namespace_segment_boundary(store: AsyncSqliteStore) -> None
     assert set(await store.alist_namespaces(suffix=["alice"], limit=100)) == {
         ("uid", "users", "alice"),
     }
+
+
+# --- omit_expired ---------------------------------------------------------
+# Async mirror of the sync tests in test_store.py; see the note there on the
+# two `expires_at` formats.
+
+
+async def _aexpire_now(
+    store: AsyncSqliteStore,
+    ns: tuple[str, ...],
+    key: str,
+    *,
+    sqlite_format: bool = False,
+) -> None:
+    """Backdate a row's expires_at into the past without deleting it (unswept)."""
+    if sqlite_format:
+        await store.conn.execute(
+            "UPDATE store SET expires_at = DATETIME('now', '-1 minute') "
+            "WHERE prefix = ? AND key = ?",
+            (_namespace_to_text(ns), key),
+        )
+    else:
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            minutes=1
+        )
+        await store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (past, _namespace_to_text(ns), key),
+        )
+
+
+async def _arow_exists(store: AsyncSqliteStore, ns: tuple[str, ...], key: str) -> bool:
+    async with store.conn.execute(
+        "SELECT COUNT(*) FROM store WHERE prefix = ? AND key = ?",
+        (_namespace_to_text(ns), key),
+    ) as cur:
+        row = await cur.fetchone()
+    return row is not None and row[0] == 1
+
+
+async def _astored_expires_at(
+    store: AsyncSqliteStore, ns: tuple[str, ...], key: str
+) -> object:
+    async with store.conn.execute(
+        "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+        (_namespace_to_text(ns), key),
+    ) as cur:
+        row = await cur.fetchone()
+    return None if row is None else row[0]
+
+
+async def test_async_omit_expired_filters_read_paths() -> None:
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:", ttl={"default_ttl": OMIT_TTL_MINUTES, "omit_expired": True}
+    ) as store:
+        await store.setup()
+
+        py_ns = ("omit", "expired-python-format")
+        sq_ns = ("omit", "expired-sqlite-format")
+        control_ns = ("omit", "control")
+        await store.aput(py_ns, "e", {"data": "gone"}, ttl=OMIT_TTL_MINUTES)
+        await store.aput(sq_ns, "e", {"data": "gone"}, ttl=OMIT_TTL_MINUTES)
+        await store.aput(control_ns, "c", {"data": "keep"}, ttl=None)
+        await _aexpire_now(store, py_ns, "e")
+        await _aexpire_now(store, sq_ns, "e", sqlite_format=True)
+
+        assert await _arow_exists(store, py_ns, "e")
+        assert await _arow_exists(store, sq_ns, "e")
+
+        assert await store.aget(py_ns, "e") is None
+        assert await store.aget(sq_ns, "e") is None
+        assert await store.aget(control_ns, "c") is not None
+
+        assert await store.asearch(py_ns) == []
+        assert await store.asearch(sq_ns) == []
+        assert [i.key for i in await store.asearch(control_ns)] == ["c"]
+
+        namespaces = await store.alist_namespaces(prefix=("omit",))
+        assert py_ns not in namespaces
+        assert sq_ns not in namespaces
+        assert control_ns in namespaces
+
+
+@pytest.mark.parametrize("omit", [None, False], ids=["default", "explicit-false"])
+async def test_async_omit_expired_disabled_preserves_expired_rows(
+    omit: bool | None,
+) -> None:
+    ttl: dict[str, object] = {"default_ttl": OMIT_TTL_MINUTES}
+    if omit is not None:
+        ttl["omit_expired"] = omit
+    async with AsyncSqliteStore.from_conn_string(":memory:", ttl=ttl) as store:
+        await store.setup()
+
+        ns = ("keep",)
+        await store.aput(ns, "k", {"data": "still-here"}, ttl=OMIT_TTL_MINUTES)
+        await _aexpire_now(store, ns, "k")
+
+        assert await store.aget(ns, "k", refresh_ttl=False) is not None
+        assert [i.key for i in await store.asearch(ns, refresh_ttl=False)] == ["k"]
+        assert ns in await store.alist_namespaces(prefix=("keep",))
+
+
+async def test_async_omit_expired_refresh_ttl_only_refreshes_live_rows() -> None:
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:",
+        ttl={
+            "default_ttl": OMIT_TTL_MINUTES,
+            "refresh_on_read": True,
+            "omit_expired": True,
+        },
+    ) as store:
+        await store.setup()
+
+        ns = ("refresh",)
+        await store.aput(ns, "expired", {"n": 0}, ttl=OMIT_TTL_MINUTES)
+        await store.aput(ns, "live_get", {"n": 1}, ttl=OMIT_TTL_MINUTES)
+        await store.aput(ns, "live_search", {"n": 2}, ttl=OMIT_TTL_MINUTES)
+        await _aexpire_now(store, ns, "expired")
+
+        expired_before = await _astored_expires_at(store, ns, "expired")
+        get_before = await _astored_expires_at(store, ns, "live_get")
+        search_before = await _astored_expires_at(store, ns, "live_search")
+
+        assert await store.aget(ns, "expired", refresh_ttl=True) is None
+        assert "expired" not in [
+            i.key for i in await store.asearch(ns, refresh_ttl=True)
+        ]
+        assert await _astored_expires_at(store, ns, "expired") == expired_before
+
+        assert await store.aget(ns, "live_get", refresh_ttl=True) is not None
+        assert await _astored_expires_at(store, ns, "live_get") != get_before
+        assert "live_search" in [
+            i.key for i in await store.asearch(ns, refresh_ttl=True)
+        ]
+        assert await _astored_expires_at(store, ns, "live_search") != search_before
+
+
+async def test_async_omit_expired_search_pagination() -> None:
+    async with AsyncSqliteStore.from_conn_string(
+        ":memory:", ttl={"default_ttl": OMIT_TTL_MINUTES, "omit_expired": True}
+    ) as store:
+        await store.setup()
+
+        ns = ("page",)
+        for k in ("a", "b", "c"):
+            await store.aput(ns, k, {"k": k}, ttl=OMIT_TTL_MINUTES)
+        await store.aput(ns, "expired", {"k": "x"}, ttl=OMIT_TTL_MINUTES)
+        await _aexpire_now(store, ns, "expired")
+
+        seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+        for key, secs in seconds_ago.items():
+            await store.conn.execute(
+                "UPDATE store SET updated_at = DATETIME('now', ?) "
+                "WHERE prefix = ? AND key = ?",
+                (f"-{secs} seconds", _namespace_to_text(ns), key),
+            )
+
+        page1 = await store.asearch(ns, limit=2, offset=0)
+        page2 = await store.asearch(ns, limit=2, offset=2)
+        assert [i.key for i in page1] == ["a", "b"]
+        assert [i.key for i in page2] == ["c"]

--- a/libs/checkpoint-sqlite/tests/test_store.py
+++ b/libs/checkpoint-sqlite/tests/test_store.py
@@ -1,3 +1,4 @@
+import datetime
 import math
 import os
 import random
@@ -28,6 +29,7 @@ from langgraph.store.sqlite.base import (
     SqliteIndexConfig,
     _escape_glob_literal,
     _namespace_match_pattern,
+    _namespace_to_text,
 )
 
 
@@ -1435,3 +1437,168 @@ def test_list_namespaces_metacharacter_labels(store: SqliteStore) -> None:
         assert set(store.list_namespaces(prefix=[label, "child"], limit=100)) == {
             (label, "child"),
         }
+
+
+# --- omit_expired ---------------------------------------------------------
+#
+# `expires_at` is written in two formats: the insert path stores a Python
+# datetime (`2026-01-01 00:00:00.123456+00:00`) and the TTL refresh path stores
+# SQLite's `DATETIME()` output (`2026-01-01 00:00:00`). The helpers below
+# backdate a row in either format so both are covered without sleeping.
+
+OMIT_TTL_MINUTES = 5
+
+
+def _expire_now(
+    store: SqliteStore, ns: tuple[str, ...], key: str, *, sqlite_format: bool = False
+) -> None:
+    """Backdate a row's expires_at into the past without deleting it (unswept)."""
+    if sqlite_format:
+        store.conn.execute(
+            "UPDATE store SET expires_at = DATETIME('now', '-1 minute') "
+            "WHERE prefix = ? AND key = ?",
+            (_namespace_to_text(ns), key),
+        )
+    else:
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            minutes=1
+        )
+        store.conn.execute(
+            "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+            (past, _namespace_to_text(ns), key),
+        )
+    store.conn.commit()
+
+
+def _row_exists(store: SqliteStore, ns: tuple[str, ...], key: str) -> bool:
+    row = store.conn.execute(
+        "SELECT COUNT(*) FROM store WHERE prefix = ? AND key = ?",
+        (_namespace_to_text(ns), key),
+    ).fetchone()
+    return row[0] == 1
+
+
+def _stored_expires_at(store: SqliteStore, ns: tuple[str, ...], key: str) -> Any:
+    row = store.conn.execute(
+        "SELECT expires_at FROM store WHERE prefix = ? AND key = ?",
+        (_namespace_to_text(ns), key),
+    ).fetchone()
+    return row[0]
+
+
+def test_omit_expired_filters_read_paths() -> None:
+    with SqliteStore.from_conn_string(
+        ":memory:", ttl={"default_ttl": OMIT_TTL_MINUTES, "omit_expired": True}
+    ) as store:
+        store.setup()
+
+        py_ns = ("omit", "expired-python-format")
+        sq_ns = ("omit", "expired-sqlite-format")
+        control_ns = ("omit", "control")
+        store.put(py_ns, "e", {"data": "gone"}, ttl=OMIT_TTL_MINUTES)
+        store.put(sq_ns, "e", {"data": "gone"}, ttl=OMIT_TTL_MINUTES)
+        store.put(control_ns, "c", {"data": "keep"}, ttl=None)
+        _expire_now(store, py_ns, "e")
+        _expire_now(store, sq_ns, "e", sqlite_format=True)
+
+        # Both rows are expired but physically still present (unswept).
+        assert _row_exists(store, py_ns, "e")
+        assert _row_exists(store, sq_ns, "e")
+
+        # get omits them; the never-expiring control is still returned.
+        assert store.get(py_ns, "e") is None
+        assert store.get(sq_ns, "e") is None
+        assert store.get(control_ns, "c") is not None
+
+        # search omits them but returns the control.
+        assert store.search(py_ns) == []
+        assert store.search(sq_ns) == []
+        assert [i.key for i in store.search(control_ns)] == ["c"]
+
+        # list_namespaces drops the expired-only namespaces, keeps the control.
+        namespaces = store.list_namespaces(prefix=("omit",))
+        assert py_ns not in namespaces
+        assert sq_ns not in namespaces
+        assert control_ns in namespaces
+
+
+@pytest.mark.parametrize("omit", [None, False], ids=["default", "explicit-false"])
+def test_omit_expired_disabled_preserves_expired_rows(omit: bool | None) -> None:
+    ttl: dict[str, Any] = {"default_ttl": OMIT_TTL_MINUTES}
+    if omit is not None:
+        ttl["omit_expired"] = omit
+    with SqliteStore.from_conn_string(":memory:", ttl=ttl) as store:
+        store.setup()
+
+        ns = ("keep",)
+        store.put(ns, "k", {"data": "still-here"}, ttl=OMIT_TTL_MINUTES)
+        _expire_now(store, ns, "k")
+
+        assert store.get(ns, "k", refresh_ttl=False) is not None
+        assert [i.key for i in store.search(ns, refresh_ttl=False)] == ["k"]
+        assert ns in store.list_namespaces(prefix=("keep",))
+
+
+def test_omit_expired_refresh_ttl_only_refreshes_live_rows() -> None:
+    with SqliteStore.from_conn_string(
+        ":memory:",
+        ttl={
+            "default_ttl": OMIT_TTL_MINUTES,
+            "refresh_on_read": True,
+            "omit_expired": True,
+        },
+    ) as store:
+        store.setup()
+
+        ns = ("refresh",)
+        store.put(ns, "expired", {"n": 0}, ttl=OMIT_TTL_MINUTES)
+        store.put(ns, "live_get", {"n": 1}, ttl=OMIT_TTL_MINUTES)
+        store.put(ns, "live_search", {"n": 2}, ttl=OMIT_TTL_MINUTES)
+        _expire_now(store, ns, "expired")
+
+        expired_before = _stored_expires_at(store, ns, "expired")
+        get_before = _stored_expires_at(store, ns, "live_get")
+        search_before = _stored_expires_at(store, ns, "live_search")
+
+        # refresh_ttl=True must NOT resurrect the expired row (via get or search)...
+        assert store.get(ns, "expired", refresh_ttl=True) is None
+        assert "expired" not in [i.key for i in store.search(ns, refresh_ttl=True)]
+        assert _stored_expires_at(store, ns, "expired") == expired_before
+
+        # ...but must still extend the live rows that were read. The refresh
+        # rewrites expires_at in SQLite's DATETIME() format, so the stored
+        # value changes as soon as the UPDATE has run.
+        assert store.get(ns, "live_get", refresh_ttl=True) is not None
+        assert _stored_expires_at(store, ns, "live_get") != get_before
+        assert "live_search" in [i.key for i in store.search(ns, refresh_ttl=True)]
+        assert _stored_expires_at(store, ns, "live_search") != search_before
+
+
+def test_omit_expired_search_pagination() -> None:
+    with SqliteStore.from_conn_string(
+        ":memory:", ttl={"default_ttl": OMIT_TTL_MINUTES, "omit_expired": True}
+    ) as store:
+        store.setup()
+
+        ns = ("page",)
+        for k in ("a", "b", "c"):
+            store.put(ns, k, {"k": k}, ttl=OMIT_TTL_MINUTES)
+        store.put(ns, "expired", {"k": "x"}, ttl=OMIT_TTL_MINUTES)
+        _expire_now(store, ns, "expired")
+
+        # updated_at DESC orders these a, expired, b, c, so the expired row sits
+        # inside the first limit=2 window. Filtering before LIMIT yields live
+        # pages [a, b] then [c]; filtering after LIMIT would underfill page 1.
+        seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+        for key, secs in seconds_ago.items():
+            store.conn.execute(
+                "UPDATE store SET updated_at = DATETIME('now', ?) "
+                "WHERE prefix = ? AND key = ?",
+                (f"-{secs} seconds", _namespace_to_text(ns), key),
+            )
+        store.conn.commit()
+
+        page1 = store.search(ns, limit=2, offset=0)
+        page2 = store.search(ns, limit=2, offset=2)
+        assert [i.key for i in page1] == ["a", "b"]
+        assert [i.key for i in page2] == ["c"]


### PR DESCRIPTION
Fixes #8902

`SqliteStore` / `AsyncSqliteStore` accept `TTLConfig.omit_expired` but never apply it, so expired-but-unswept rows are still returned by `get`, `search` and `list_namespaces`. This wires the flag into the three read builders the same way `checkpoint-postgres` does in #8354.

## Changes

- Add `_omit_expired` to `BaseSqliteStore` (same shape as the Postgres one) and a single `_LIVE_ROW_CLAUSE` predicate used by every read path.
- **GET**: predicate on the SELECT *and* the refresh UPDATE, so `refresh_ttl=True` cannot revive an expired row.
- **SEARCH**: predicate added to `filter_conditions`, so it applies inside the vector `scored` CTE and the regular scan before `LIMIT`/`OFFSET`, and gates the refresh UPDATE fed by the results.
- **list_namespaces**: predicate appended to the scan conditions in both the `max_depth` and plain branches.
- Remove the duplicate `_get_batch_GET_ops_queries` on `SqliteStore`; it was byte-identical to the `BaseSqliteStore` method and overrode it.

The predicate uses `julianday(expires_at) > julianday('now')` rather than a text comparison: `expires_at` is written as a Python `datetime` on insert but as `DATETIME()` output on refresh, and SQLite compares TEXT lexically, so a naive `expires_at > CURRENT_TIMESTAMP` mis-orders rows in the same second.

Default / `omit_expired=False` behaviour is unchanged.

## Testing

Sync and async tests mirroring the Postgres ones from #8354: expired row omitted from all three read paths in both stored timestamp formats (with a raw-SQL check that the row is still present), default and explicit `False` still return it, `refresh_ttl=True` leaves an expired row untouched while still extending live rows, and search pagination stays correct when an expired row falls inside the page window. The six behavioural tests fail on `main` and pass with this change.

`make format`, `make lint` (ruff + ty) and `make test` are green for `checkpoint-sqlite` (128 passed, 2 skipped).
