### PR TITLE
fix(checkpoint-sqlite): honor TTLConfig.omit_expired in store read paths

### DIFF
--- a/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
+++ b/libs/checkpoint-sqlite/langgraph/store/sqlite/base.py
@@ -279,6 +279,11 @@ class BaseSqliteStore:
     index_config: SqliteIndexConfig | None = None
     ttl_config: TTLConfig | None = None
 
+    @property
+    def _omit_expired(self) -> bool:
+        """Whether expired-but-unswept rows should be filtered from reads."""
+        return bool(self.ttl_config and self.ttl_config.get("omit_expired"))
+
     def _get_batch_GET_ops_queries(
         self, get_ops: Sequence[tuple[int, GetOp]]
     ) -> list[PreparedGetQuery]:
@@ -295,6 +300,15 @@ class BaseSqliteStore:
             namespace_groups[op.namespace].append((idx, op.key))
             refresh_ttls[op.namespace].append(getattr(op, "refresh_ttl", False))
 
+        # SQLite compares TEXT lexically, so a naive `expires_at > CURRENT_TIMESTAMP`
+        # mis-orders rows once the insert path (Python datetime) and the refresh path
+        # (DATETIME(...)) disagree on formatting. `julianday` parses both correctly.
+        expiry_clause = (
+            "AND (expires_at IS NULL OR julianday(expires_at) > julianday('now'))"
+            if self._omit_expired
+            else ""
+        )
+
         results = []
         for namespace, items in namespace_groups.items():
             _, keys = zip(*items, strict=False)
@@ -306,6 +320,7 @@ class BaseSqliteStore:
                 SELECT key, value, created_at, updated_at, expires_at, ttl_minutes
                 FROM store
                 WHERE prefix = ? AND key IN ({",".join(["?"] * len(keys))})
+                {expiry_clause}
             """
             select_params = (_namespace_to_text(namespace), *keys)
             results.append(
@@ -322,9 +337,10 @@ class BaseSqliteStore:
                 update_query = f"""
                     UPDATE store
                     SET expires_at = DATETIME(CURRENT_TIMESTAMP, '+' || ttl_minutes || ' minutes')
-                    WHERE prefix = ? 
+                    WHERE prefix = ?
                     AND key IN ({placeholders})
                     AND ttl_minutes IS NOT NULL
+                    {expiry_clause}
                 """
                 update_params = (_namespace_to_text(namespace), *keys)
                 results.append(
@@ -449,6 +465,7 @@ class BaseSqliteStore:
         """
         queries = []
         embedding_requests = []
+        omit_expired = self._omit_expired
 
         for idx, (_, op) in enumerate(search_ops):
             # Build filter conditions first
@@ -522,6 +539,11 @@ class BaseSqliteStore:
                     if not filter_conditions
                     else " AND " + " AND ".join(filter_conditions)
                 )
+                if omit_expired:
+                    filter_str += (
+                        " AND (s.expires_at IS NULL OR "
+                        "julianday(s.expires_at) > julianday('now'))"
+                    )
                 if op.namespace_prefix:
                     ns_condition, ns_args_tuple = _namespace_prefix_condition(
                         op.namespace_prefix, column="s.prefix"
@@ -582,6 +604,12 @@ class BaseSqliteStore:
                     params.extend(filter_params)
                     base_query += " AND " + " AND ".join(filter_conditions)
 
+                if omit_expired:
+                    base_query += (
+                        " AND (expires_at IS NULL OR "
+                        "julianday(expires_at) > julianday('now'))"
+                    )
+
                 base_query += " ORDER BY updated_at DESC"
                 base_query += " LIMIT ? OFFSET ?"
                 params.extend([op.limit, op.offset])
@@ -611,9 +639,15 @@ class BaseSqliteStore:
     ) -> list[tuple[str, Sequence]]:
         queries: list[tuple[str, Sequence]] = []
 
+        omit_expired = self._omit_expired
         for _, op in list_ops:
             where_clauses: list[str] = []
             params: list[Any] = []
+
+            if omit_expired:
+                where_clauses.append(
+                    "(expires_at IS NULL OR julianday(expires_at) > julianday('now'))"
+                )
 
             if op.match_conditions:
                 for cond in op.match_conditions:
@@ -878,62 +912,6 @@ class SqliteStore(BaseSqliteStore, BaseStore):
         self.ttl_config = ttl
         self._ttl_sweeper_thread: threading.Thread | None = None
         self._ttl_stop_event = threading.Event()
-
-    def _get_batch_GET_ops_queries(
-        self, get_ops: Sequence[tuple[int, GetOp]]
-    ) -> list[PreparedGetQuery]:
-        """
-        Build queries to fetch (and optionally refresh the TTL of) multiple keys per namespace.
-
-        Returns a list of PreparedGetQuery objects, which may include:
-        - Queries with kind='refresh' for TTL refresh operations
-        - Queries with kind='get' for data retrieval operations
-        """
-        namespace_groups = defaultdict(list)
-        refresh_ttls = defaultdict(list)
-        for idx, op in get_ops:
-            namespace_groups[op.namespace].append((idx, op.key))
-            refresh_ttls[op.namespace].append(getattr(op, "refresh_ttl", False))
-
-        results = []
-        for namespace, items in namespace_groups.items():
-            _, keys = zip(*items, strict=False)
-            this_refresh_ttls = refresh_ttls[namespace]
-            refresh_ttl_any = any(this_refresh_ttls)
-
-            # Always add the main query to get the data
-            select_query = f"""
-                SELECT key, value, created_at, updated_at, expires_at, ttl_minutes
-                FROM store
-                WHERE prefix = ? AND key IN ({",".join(["?"] * len(keys))})
-            """
-            select_params = (_namespace_to_text(namespace), *keys)
-            results.append(
-                PreparedGetQuery(select_query, select_params, namespace, items, "get")
-            )
-
-            # Add a TTL refresh query if needed
-            if (
-                refresh_ttl_any
-                and self.ttl_config
-                and self.ttl_config.get("refresh_on_read", False)
-            ):
-                placeholders = ",".join(["?"] * len(keys))
-                update_query = f"""
-                    UPDATE store
-                    SET expires_at = DATETIME(CURRENT_TIMESTAMP, '+' || ttl_minutes || ' minutes')
-                    WHERE prefix = ? 
-                    AND key IN ({placeholders})
-                    AND ttl_minutes IS NOT NULL
-                """
-                update_params = (_namespace_to_text(namespace), *keys)
-                results.append(
-                    PreparedGetQuery(
-                        update_query, update_params, namespace, items, "refresh"
-                    )
-                )
-
-        return results
 
     def _get_filter_condition(self, key: str, op: str, value: Any) -> tuple[str, list]:
         """Helper to generate filter conditions."""

--- a/libs/checkpoint-sqlite/tests/test_ttl.py
+++ b/libs/checkpoint-sqlite/tests/test_ttl.py
@@ -1,6 +1,7 @@
 """Test SQLite store Time-To-Live (TTL) functionality."""
 
 import asyncio
+import datetime
 import os
 import tempfile
 import time
@@ -12,6 +13,8 @@ from langgraph.store.base import TTLConfig
 from langgraph.store.sqlite import SqliteStore
 from langgraph.store.sqlite.aio import AsyncSqliteStore
 
+OMIT_EXPIRED_TTL_MINUTES = 5  # long enough that no test below races the sweeper
+
 
 @pytest.fixture
 def temp_db_file() -> Generator[str, None, None]:
@@ -20,6 +23,211 @@ def temp_db_file() -> Generator[str, None, None]:
     os.close(fd)
     yield path
     os.unlink(path)
+
+
+def _expire_now(store: SqliteStore, ns: tuple[str, ...], key: str, *, fmt: str) -> None:
+    """Backdate a row's `expires_at` into the past without deleting it (unswept).
+
+    `fmt` selects which of the two text formats `expires_at` can hold in
+    practice: "python" is what the insert path writes (a bound Python
+    `datetime`, with microseconds and a UTC offset); "sql" is what the
+    refresh-on-read path writes (SQLite's `DATETIME(...)`, with neither).
+    """
+    with store._cursor() as cur:
+        if fmt == "python":
+            past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+                minutes=1
+            )
+            cur.execute(
+                "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+                (past, ".".join(ns), key),
+            )
+        else:
+            cur.execute(
+                "UPDATE store SET expires_at = DATETIME(CURRENT_TIMESTAMP, '-1 minutes') "
+                "WHERE prefix = ? AND key = ?",
+                (".".join(ns), key),
+            )
+
+
+def _row_exists(store: SqliteStore, ns: tuple[str, ...], key: str) -> bool:
+    with store._cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM store WHERE prefix = ? AND key = ?",
+            (".".join(ns), key),
+        )
+        return cur.fetchone()[0] == 1
+
+
+def _stored_expires_at(store: SqliteStore, ns: tuple[str, ...], key: str) -> float:
+    """Return `expires_at` as a julian day number, comparable across both text formats."""
+    with store._cursor() as cur:
+        cur.execute(
+            "SELECT julianday(expires_at) FROM store WHERE prefix = ? AND key = ?",
+            (".".join(ns), key),
+        )
+        return cur.fetchone()[0]
+
+
+@pytest.mark.parametrize(
+    "fmt", ["python", "sql"], ids=["datetime-format", "sql-datetime-format"]
+)
+def test_omit_expired_filters_read_paths(temp_db_file: str, fmt: str) -> None:
+    """`omit_expired` must hide expired-but-unswept rows from every read path,
+    regardless of which of the two text formats `expires_at` is stored in.
+    """
+    with SqliteStore.from_conn_string(
+        temp_db_file,
+        ttl={"default_ttl": OMIT_EXPIRED_TTL_MINUTES, "omit_expired": True},
+    ) as store:
+        store.setup()
+
+        expired_ns = ("omit", "expired")
+        control_ns = ("omit", "control")
+        store.put(expired_ns, "e", {"data": "gone"}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        store.put(control_ns, "c", {"data": "keep"}, ttl=None)
+        _expire_now(store, expired_ns, "e", fmt=fmt)
+
+        # The row is expired but physically still present (unswept).
+        assert _row_exists(store, expired_ns, "e")
+
+        # get omits it; the never-expiring control is still returned.
+        assert store.get(expired_ns, "e") is None
+        assert store.get(control_ns, "c") is not None
+
+        # search omits it but returns the control.
+        assert store.search(expired_ns) == []
+        assert [i.key for i in store.search(control_ns)] == ["c"]
+
+        # list_namespaces drops the expired-only namespace, keeps the control.
+        namespaces = store.list_namespaces(prefix=("omit",))
+        assert expired_ns not in namespaces
+        assert control_ns in namespaces
+
+
+@pytest.mark.parametrize("omit", [None, False], ids=["default", "explicit-false"])
+def test_omit_expired_disabled_preserves_expired_rows(
+    temp_db_file: str, omit: bool | None
+) -> None:
+    ttl_config: TTLConfig = {"default_ttl": OMIT_EXPIRED_TTL_MINUTES}
+    if omit is not None:
+        ttl_config["omit_expired"] = omit
+
+    with SqliteStore.from_conn_string(temp_db_file, ttl=ttl_config) as store:
+        store.setup()
+
+        ns = ("keep",)
+        store.put(ns, "k", {"data": "still-here"}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        _expire_now(store, ns, "k", fmt="python")
+
+        assert store.get(ns, "k", refresh_ttl=False) is not None
+        assert [i.key for i in store.search(ns, refresh_ttl=False)] == ["k"]
+        assert ns in store.list_namespaces(prefix=("keep",))
+
+
+def test_omit_expired_refresh_ttl_only_refreshes_live_rows(temp_db_file: str) -> None:
+    with SqliteStore.from_conn_string(
+        temp_db_file,
+        ttl={
+            "default_ttl": OMIT_EXPIRED_TTL_MINUTES,
+            "omit_expired": True,
+            "refresh_on_read": True,
+        },
+    ) as store:
+        store.setup()
+
+        ns = ("refresh",)
+        store.put(ns, "expired", {"n": 0}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        store.put(ns, "live_get", {"n": 1}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        store.put(ns, "live_search", {"n": 2}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        _expire_now(store, ns, "expired", fmt="python")
+
+        expired_before = _stored_expires_at(store, ns, "expired")
+        get_before = _stored_expires_at(store, ns, "live_get")
+        search_before = _stored_expires_at(store, ns, "live_search")
+
+        # The refresh path (DATETIME(...)) has only whole-second precision, unlike
+        # the insert path's microsecond-precision Python datetime. Waiting past a
+        # full second makes the refreshed timestamp unambiguously later despite
+        # that truncation.
+        time.sleep(1.1)
+
+        # refresh_ttl=True must NOT resurrect the expired row (via get or search)...
+        assert store.get(ns, "expired", refresh_ttl=True) is None
+        assert "expired" not in [i.key for i in store.search(ns, refresh_ttl=True)]
+        assert _stored_expires_at(store, ns, "expired") == expired_before
+
+        # ...but must still extend the live rows that were read.
+        assert store.get(ns, "live_get", refresh_ttl=True) is not None
+        assert _stored_expires_at(store, ns, "live_get") > get_before
+        assert _stored_expires_at(store, ns, "live_search") > search_before
+
+
+def test_omit_expired_search_pagination(temp_db_file: str) -> None:
+    """Filtering must happen before LIMIT/OFFSET, not after."""
+    with SqliteStore.from_conn_string(
+        temp_db_file,
+        ttl={"default_ttl": OMIT_EXPIRED_TTL_MINUTES, "omit_expired": True},
+    ) as store:
+        store.setup()
+
+        ns = ("page",)
+        for k in ("a", "b", "c"):
+            store.put(ns, k, {"k": k}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        store.put(ns, "expired", {"k": "x"}, ttl=OMIT_EXPIRED_TTL_MINUTES)
+        _expire_now(store, ns, "expired", fmt="python")
+
+        seconds_ago = {"a": 1, "expired": 2, "b": 3, "c": 4}
+        # updated_at DESC orders these a, expired, b, c, so the expired row sits
+        # inside the first limit=2 window. Correct (pre-LIMIT) filtering yields
+        # live pages [a, b] then [c]; post-LIMIT filtering would underfill page 1.
+        with store._cursor() as cur:
+            for key, secs in seconds_ago.items():
+                cur.execute(
+                    "UPDATE store SET updated_at = DATETIME(CURRENT_TIMESTAMP, ?) "
+                    "WHERE prefix = ? AND key = ?",
+                    (f"-{secs} seconds", ".".join(ns), key),
+                )
+
+        page1 = store.search(ns, limit=2, offset=0)
+        page2 = store.search(ns, limit=2, offset=2)
+        assert [i.key for i in page1] == ["a", "b"]
+        assert [i.key for i in page2] == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_async_omit_expired_filters_read_paths(temp_db_file: str) -> None:
+    async with AsyncSqliteStore.from_conn_string(
+        temp_db_file,
+        ttl={"default_ttl": OMIT_EXPIRED_TTL_MINUTES, "omit_expired": True},
+    ) as store:
+        await store.setup()
+
+        expired_ns = ("omit", "expired")
+        control_ns = ("omit", "control")
+        await store.aput(
+            expired_ns, "e", {"data": "gone"}, ttl=OMIT_EXPIRED_TTL_MINUTES
+        )
+        await store.aput(control_ns, "c", {"data": "keep"}, ttl=None)
+
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            minutes=1
+        )
+        async with store._cursor() as cur:
+            await cur.execute(
+                "UPDATE store SET expires_at = ? WHERE prefix = ? AND key = ?",
+                (past, "omit.expired", "e"),
+            )
+
+        assert await store.aget(expired_ns, "e") is None
+        assert await store.aget(control_ns, "c") is not None
+
+        assert await store.asearch(expired_ns) == []
+        assert [i.key for i in await store.asearch(control_ns)] == ["c"]
+
+        namespaces = await store.alist_namespaces(prefix=("omit",))
+        assert expired_ns not in namespaces
+        assert control_ns in namespaces
 
 
 def test_ttl_basic(temp_db_file: str) -> None:


### PR DESCRIPTION
Fixes #8902

Filters expired-but-unswept rows out of `SqliteStore`/`AsyncSqliteStore` read paths (`GET`, `SEARCH`, `list_namespaces`) when `TTLConfig.omit_expired` is set, matching the existing `checkpoint-postgres` behavior.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangGraph! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

    - feat(langgraph): add multi-tenant support
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langgraph/blob/main/.github/workflows/pr_lint.yml#L19-L43

2. PR description:

  - Write 1-2 sentences summarizing the change.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Added sync and async tests in `libs/checkpoint-sqlite/tests/test_ttl.py` covering all three read paths (`GET`, `SEARCH`, `list_namespaces`) under both `expires_at` text formats, confirming `omit_expired` defaults to off/False (expired rows stay visible), that `refresh_ttl` cannot revive an already-expired row while still extending live rows, and that filtering happens before `LIMIT`/`OFFSET` in search pagination. Confirmed the new tests fail on the pre-fix code and pass after the fix. From `libs/checkpoint-sqlite`, ran `uv run pytest` (125 passed, 2 skipped, one pre-existing unrelated flaky test retried and passed), `uv run ruff check .`, `uv run ruff format . --diff`, and `uv run ty check .` — all clean.

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/

---
AI assistance: this change was drafted with Claude Code.